### PR TITLE
refactor: remove ordering from VectorType children

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,0 +1,2 @@
+export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
+

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -2073,8 +2073,8 @@
 
 (defn write-value-out-code [^VectorType return-type]
   (if (instance? ArrowType$Union (.getArrowType return-type))
-    (let [writer-syms (->> (.getChildren return-type)
-                           (into {} (map (juxt types/field->col-type (fn [_] (gensym 'out-writer))))))]
+    (let [writer-syms (->> (vals (.getChildren return-type))
+                           (into {} (map (juxt types/vec-type->col-type (fn [_] (gensym 'out-writer))))))]
       {:writer-bindings (into []
                               (mapcat (fn [[value-type writer-sym]]
                                         [writer-sym `(.vectorFor ~out-vec-sym

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -234,9 +234,9 @@
                                   (apply types/merge-types))]
 
     (map (->> (.getChildren vec-type)
-              (into {} (map (fn [^Field field]
-                              [(symbol (.getName field))
-                               field]))))
+              (into {} (map (fn [[field-name ^VectorType child-type]]
+                              [(symbol field-name)
+                               (.toField child-type field-name)]))))
          '[depth op explain])))
 
 (def ^:private explain-analyze-fields

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -20,7 +20,9 @@
            (java.util Collection Collections LinkedHashMap Map Set UUID WeakHashMap)
            (java.util.concurrent ExecutionException Executors ThreadFactory)
            (org.apache.arrow.memory BufferAllocator)
+           (org.apache.arrow.vector.types.pojo Field Schema)
            (xtdb Bytes TaggedValue)
+           (xtdb.arrow VectorType)
            (xtdb.log.proto TemporalMetadata TemporalMetadata$Builder)
            (xtdb.util Iid NormalForm)))
 
@@ -47,6 +49,13 @@
                     (TaggedValue. (.getTag ^TaggedValue v) (->clj (.getValue ^TaggedValue v)))
 
                     (bytes? v) (Bytes. v)
+
+                    (instance? Schema v)
+                    (->> (.getFields ^Schema v)
+                         (into {} (map (juxt Field/.getName VectorType/fromField))))
+
+                    (instance? Field v)
+                    {(Field/.getName v) (VectorType/fromField v)}
 
                     :else v))
                 v))

--- a/core/src/main/kotlin/xtdb/arrow/RelationAsStructReader.kt
+++ b/core/src/main/kotlin/xtdb/arrow/RelationAsStructReader.kt
@@ -4,7 +4,8 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.util.ByteFunctionHelpers
 import org.apache.arrow.vector.types.pojo.ArrowType
 import xtdb.api.query.IKeyFn
-import xtdb.arrow.VectorType.Companion.ofType
+import xtdb.arrow.VectorType.Companion.asType
+import xtdb.arrow.VectorType.Companion.structOf
 import xtdb.util.Hasher
 import xtdb.util.closeOnCatch
 
@@ -14,7 +15,7 @@ class RelationAsStructReader(
 ) : VectorReader {
     override val nullable = false
     override val arrowType: ArrowType = VectorType.STRUCT_TYPE
-    override val field get() = name ofType VectorType.structOf(rel.vectors.map { it.field })
+    override val field get() = structOf(rel.vectors.associate { it.name to it.field.asType }).toField(name)
     override val childFields get() = rel.vectors.map { it.field }
 
     override val valueCount get() = rel.rowCount

--- a/core/src/main/kotlin/xtdb/arrow/Vector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Vector.kt
@@ -137,7 +137,8 @@ sealed class Vector : VectorReader, VectorWriter {
         fun open(al: BufferAllocator, field: Field) = field.openVector(al)
 
         @JvmStatic
-        fun open(al: BufferAllocator, name: FieldName, type: VectorType) = open(al, name ofType type)
+        @JvmName("open")
+        fun BufferAllocator.openVector(name: FieldName, type: VectorType) = open(this, name ofType type)
 
         fun Field.openVector(al: BufferAllocator): Vector {
             val name: String = this.name

--- a/core/src/main/kotlin/xtdb/arrow/VectorReader.kt
+++ b/core/src/main/kotlin/xtdb/arrow/VectorReader.kt
@@ -10,6 +10,7 @@ import xtdb.api.query.IKeyFn
 import xtdb.arrow.Vector.Companion.openVector
 import xtdb.arrow.VectorIndirection.Companion.selection
 import xtdb.arrow.VectorIndirection.Companion.slice
+import xtdb.arrow.VectorType.Companion.asType
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.arrow.agg.VectorSummer
 import xtdb.arrow.metadata.MetadataFlavour
@@ -24,7 +25,7 @@ interface VectorReader : ILookup, AutoCloseable {
     val nullable: Boolean
     val arrowType: ArrowType
     val childFields: List<Field>
-    val type get() = VectorType(arrowType, nullable, childFields)
+    val type get() = VectorType(arrowType, nullable, childFields.associate { it.name to it.asType })
     val fieldType: FieldType get() = type.fieldType
     val field get() = name ofType type
 

--- a/core/src/main/kotlin/xtdb/arrow/agg/Variance.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/Variance.kt
@@ -5,6 +5,7 @@ import org.apache.arrow.vector.types.FloatingPointPrecision
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.arrow.vector.types.pojo.Field
 import xtdb.arrow.*
+import xtdb.arrow.Vector.Companion.openVector
 import xtdb.arrow.VectorType.Companion.F64
 import xtdb.arrow.VectorType.Companion.maybe
 import xtdb.arrow.VectorType.Companion.ofType
@@ -29,7 +30,7 @@ sealed class Variance(
         override fun aggregate(inRel: RelationReader, groupMapping: GroupMapping) {
             val inVec = inRel.vectorForOrNull(fromName) ?: return
 
-            Vector.open(al, "x2", maybe(F64))
+            al.openVector("x2", maybe(F64))
                 .closeOnCatch { inVec.squareInto(it) }
                 .use { x2Vec ->
                     sumxAgg.aggregate(inRel, groupMapping)

--- a/core/src/main/kotlin/xtdb/pgwire/PgType.kt
+++ b/core/src/main/kotlin/xtdb/pgwire/PgType.kt
@@ -878,7 +878,7 @@ sealed class PgType(
         })
 
         private fun listPgType(xtType: VectorType): PgType {
-            val elType = xtType.children.firstOrNull()?.type ?: return Default
+            val elType = xtType.firstChildOrNull?.arrowType ?: return Default
 
             return when (elType) {
                 is ArrowType.Int -> when (elType.bitWidth) {

--- a/core/src/main/kotlin/xtdb/trie/MetadataFileWriter.kt
+++ b/core/src/main/kotlin/xtdb/trie/MetadataFileWriter.kt
@@ -19,6 +19,7 @@ import xtdb.arrow.VectorType.Companion.asListOf
 import xtdb.arrow.VectorType.Companion.asStructOf
 import xtdb.arrow.VectorType.Companion.asUnionOf
 import xtdb.arrow.VectorType.Companion.listTypeOf
+import xtdb.arrow.VectorType.Companion.unionOf
 import xtdb.arrow.VectorType.Companion.maybe
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.arrow.schema
@@ -32,21 +33,21 @@ class MetadataFileWriter(
     companion object {
         private val metadataField = listTypeOf(
             VectorType.structOf(
-                "col-name" ofType UTF8,
-                "root-col?" ofType BOOL,
-                "count" ofType I64
+                "col-name" to UTF8,
+                "root-col?" to BOOL,
+                "count" to I64
             ),
             elName = "col"
         )
 
         @JvmField
         val metaRelSchema = schema(
-            "nodes".asUnionOf(
-                "nil" ofType NULL,
+            "nodes" ofType unionOf(
+                "nil" to NULL,
                 "branch-iid" asListOf maybe(I32),
                 "leaf".asStructOf(
-                    "data-page-idx" ofType I32,
-                    "columns" ofType metadataField
+                    "data-page-idx" to I32,
+                    "columns" to metadataField
                 )
             )
         )

--- a/core/src/main/kotlin/xtdb/trie/Trie.kt
+++ b/core/src/main/kotlin/xtdb/trie/Trie.kt
@@ -10,6 +10,7 @@ import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.IID
 import xtdb.arrow.VectorType.Companion.NULL
 import xtdb.arrow.VectorType.Companion.INSTANT
+import xtdb.arrow.VectorType.Companion.asType
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.arrow.schema
 import xtdb.arrow.withName
@@ -116,9 +117,9 @@ object Trie {
             "_valid_to" ofType INSTANT,
             "op" ofType VectorType.unionOf(
                 *(listOfNotNull(
-                    putDocField?.withName("put"),
-                    "delete" ofType NULL,
-                    "erase" ofType NULL
+                    putDocField?.let { "put" to it.asType },
+                    "delete" to NULL,
+                    "erase" to NULL
                 ).toTypedArray())
             )
         )

--- a/core/src/test/kotlin/xtdb/arrow/ListVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/ListVectorTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import xtdb.arrow.VectorType.Companion.asListOf
+import xtdb.arrow.VectorType.Companion.listTypeOf
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.arrow.VectorType.Companion.unionOf
 
@@ -34,7 +34,7 @@ class ListVectorTest {
             assertEquals(listOf(listOf(1, 2, 3), listOf(4, 5, "6")), listVec.asList)
 
             assertEquals(
-                "list" asListOf unionOf("i32" ofType VectorType.I32, "utf8" ofType VectorType.UTF8),
+                "list" ofType listTypeOf(unionOf("i32" to VectorType.I32, "utf8" to VectorType.UTF8)),
                 listVec.field
             )
         }

--- a/core/src/test/kotlin/xtdb/arrow/RelationTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/RelationTest.kt
@@ -10,9 +10,9 @@ import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
 import xtdb.arrow.Relation.Companion.loader
 import xtdb.kw
 import xtdb.arrow.VectorType.Companion.asListOf
-import xtdb.arrow.VectorType.Companion.asUnionOf
 import xtdb.arrow.VectorType.Companion.maybe
 import xtdb.arrow.VectorType.Companion.ofType
+import xtdb.arrow.VectorType.Companion.unionOf
 import java.io.ByteArrayOutputStream
 import java.nio.channels.Channels
 
@@ -253,8 +253,8 @@ class RelationTest {
             assertEquals(
                 schema(
                     "foo" ofType maybe(VectorType.I32),
-                    "bar".asUnionOf(
-                        "utf8" ofType maybe(VectorType.UTF8),
+                    "bar" ofType unionOf(
+                        "utf8" to maybe(VectorType.UTF8),
                         "list" asListOf VectorType.UTF8
                     )
                 ),

--- a/core/src/test/kotlin/xtdb/arrow/StructVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/StructVectorTest.kt
@@ -242,7 +242,7 @@ class StructVectorTest {
             assertEquals(els, structVec.asList)
 
             assertEquals(
-                "struct".asStructOf("i32" ofType maybe(I32), "utf8" ofType maybe(UTF8)),
+                "struct" ofType structOf("i32" to maybe(I32), "utf8" to maybe(UTF8)),
                 structVec.field
             )
         }
@@ -260,7 +260,7 @@ class StructVectorTest {
             )
 
             assertEquals(
-                "struct" ofType maybe(structOf("i32" ofType I32, "utf8" ofType UTF8)),
+                "struct" ofType maybe(structOf("i32" to I32, "utf8" to UTF8)),
                 structVec.field
             )
         }

--- a/core/src/test/kotlin/xtdb/arrow/agg/AggregateTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/agg/AggregateTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import xtdb.arrow.*
 import xtdb.arrow.VectorType.Companion.F64
 import xtdb.arrow.VectorType.Companion.I32
+import xtdb.arrow.VectorType.Companion.just
 import xtdb.arrow.VectorType.Companion.maybe
 import xtdb.arrow.VectorType.Companion.ofType
 import java.math.BigDecimal
@@ -170,7 +171,7 @@ class AggregateTest {
 
     @Test
     fun `Sum aggregates decimal values`() {
-        val decimalType = VectorType(ArrowType.Decimal(10, 2, 128), false, emptyList())
+        val decimalType = just(ArrowType.Decimal(10, 2, 128))
         Vector.fromList(allocator, "values" ofType decimalType,
             listOf(BigDecimal("10.50"), BigDecimal("20.25"), BigDecimal("30.75"), BigDecimal("40.00"))).use { valuesVec ->
             Vector.fromList(allocator, "group-mapping" ofType I32, listOf(0, 0, 1, 1)).use { groupMapping ->
@@ -190,7 +191,7 @@ class AggregateTest {
 
     @Test
     fun `Average calculates mean of decimal values`() {
-        val decimalType = VectorType(ArrowType.Decimal(10, 2, 128), false, emptyList())
+        val decimalType = just(ArrowType.Decimal(10, 2, 128))
         Vector.fromList(allocator, "values" ofType decimalType,
             listOf(BigDecimal("10.00"), BigDecimal("20.00"), BigDecimal("30.00"), BigDecimal("40.00"))).use { valuesVec ->
             Vector.fromList(allocator, "group-mapping" ofType I32, listOf(0, 0, 1, 1)).use { groupMapping ->

--- a/core/src/test/kotlin/xtdb/types/MergeTypesTest.kt
+++ b/core/src/test/kotlin/xtdb/types/MergeTypesTest.kt
@@ -3,7 +3,6 @@ package xtdb.types
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import xtdb.arrow.MergeTypes.Companion.mergeTypes
-import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.BOOL
 import xtdb.arrow.VectorType.Companion.F64
 import xtdb.arrow.VectorType.Companion.I64
@@ -13,7 +12,7 @@ import xtdb.arrow.VectorType.Companion.asStructOf
 import xtdb.arrow.VectorType.Companion.asUnionOf
 import xtdb.arrow.VectorType.Companion.listTypeOf
 import xtdb.arrow.VectorType.Companion.maybe
-import xtdb.arrow.VectorType.Companion.ofType
+import xtdb.arrow.VectorType.Companion.setTypeOf
 import xtdb.arrow.VectorType.Companion.structOf
 import xtdb.arrow.VectorType.Companion.unionOf
 
@@ -26,13 +25,13 @@ class MergeTypesTest {
         assertEquals(UTF8, mergeTypes(UTF8, UTF8), "Same types merge ofType themselves")
 
         assertEquals(
-            unionOf("utf8" ofType UTF8, "i64" ofType I64),
+            unionOf("utf8" to UTF8, "i64" to I64),
             mergeTypes(UTF8, I64),
             "Different types create unions"
         )
 
         assertEquals(
-            unionOf("utf8" ofType UTF8, "i64" ofType I64, "f64" ofType F64),
+            unionOf("utf8" to UTF8, "i64" to I64, "f64" to F64),
             mergeTypes(UTF8, I64, F64),
             "Multiple different types create unions"
         )
@@ -47,7 +46,7 @@ class MergeTypesTest {
         assertEquals(utf8List, mergeTypes(utf8List, utf8List), "Same list types merge")
 
         assertEquals(
-            listTypeOf(unionOf("utf8" ofType UTF8, "i64" ofType I64)),
+            listTypeOf(unionOf("utf8" to UTF8, "i64" to I64)),
             mergeTypes(utf8List, i64List),
             "Different list element types create union"
         )
@@ -61,20 +60,20 @@ class MergeTypesTest {
 
     @Test
     fun `test merges struct types`() {
-        val struct1 = structOf("a" ofType UTF8, "b" ofType UTF8)
-        val struct2 = structOf("a" ofType UTF8, "b" ofType UTF8)
+        val struct1 = structOf("a" to UTF8, "b" to UTF8)
+        val struct2 = structOf("a" to UTF8, "b" to UTF8)
 
         assertEquals(
             struct1, mergeTypes(struct1, struct2),
             "Same structs merge"
         )
 
-        val struct3 = structOf("a" ofType UTF8, "b" ofType I64)
+        val struct3 = structOf("a" to UTF8, "b" to I64)
 
         assertEquals(
             structOf(
-                "a" ofType UTF8,
-                "b".asUnionOf("utf8" ofType UTF8, "i64" ofType I64)
+                "a" to UTF8,
+                "b".asUnionOf("utf8" to UTF8, "i64" to I64)
             ),
             mergeTypes(struct1, struct3),
             "Structs with different field types create union in differing fields"
@@ -85,13 +84,13 @@ class MergeTypesTest {
     fun `test struct merging with different fields`() {
         assertEquals(
             structOf(
-                "a" ofType maybe(UTF8),
-                "b" ofType UTF8,
-                "c" ofType maybe(I64),
+                "a" to maybe(UTF8),
+                "b" to UTF8,
+                "c" to maybe(I64),
             ),
             mergeTypes(
-                structOf("a" ofType UTF8, "b" ofType UTF8),
-                structOf("b" ofType UTF8, "c" ofType I64)
+                structOf("a" to UTF8, "b" to UTF8),
+                structOf("b" to UTF8, "c" to I64)
             ),
             "Struct merging with different fields makes missing fields nullable"
         )
@@ -99,12 +98,12 @@ class MergeTypesTest {
 
     @Test
     fun `test union with struct and float`() {
-        val unionWithStruct = unionOf("f64" ofType F64, "struct".asStructOf("a" ofType I64))
-        val justStruct = structOf("a" ofType UTF8)
+        val unionWithStruct = unionOf("f64" to F64, "struct".asStructOf("a" to I64))
+        val justStruct = structOf("a" to UTF8)
 
         val expected = unionOf(
-            "f64" ofType F64,
-            "struct".asStructOf("a".asUnionOf("i64" ofType I64, "utf8" ofType UTF8))
+            "f64" to F64,
+            "struct".asStructOf("a".asUnionOf("i64" to I64, "utf8" to UTF8))
         )
         assertEquals(
             expected,
@@ -131,13 +130,13 @@ class MergeTypesTest {
         )
 
         assertEquals(
-            unionOf("i64" ofType I64, "utf8" ofType UTF8, "null" ofType NULL),
+            unionOf("i64" to I64, "utf8" to UTF8, "null" to NULL),
             mergeTypes(NULL, I64, UTF8),
             "Null with multiple other types creates union"
         )
 
         assertEquals(
-            unionOf("i64" ofType maybe(I64), "utf8" ofType UTF8),
+            unionOf("i64" to maybe(I64), "utf8" to UTF8),
             mergeTypes(maybe(I64), UTF8),
             "Nullable legs are preserved"
         )
@@ -145,15 +144,15 @@ class MergeTypesTest {
 
     @Test
     fun `test set types`() {
-        val setInt64 = VectorType.setTypeOf(I64)
-        val setUtf8 = VectorType.setTypeOf(UTF8)
+        val setInt64 = setTypeOf(I64)
+        val setUtf8 = setTypeOf(UTF8)
 
         assertEquals(
             setInt64, mergeTypes(setInt64, setInt64),
             "Same set types merge"
         )
 
-        val expectedMergedSet = VectorType.setTypeOf(unionOf("i64" ofType I64, "utf8" ofType UTF8))
+        val expectedMergedSet = setTypeOf(unionOf("i64" to I64, "utf8" to UTF8))
         assertEquals(
             expectedMergedSet, mergeTypes(setInt64, setUtf8),
             "Different set element types create union"
@@ -163,19 +162,19 @@ class MergeTypesTest {
     @Test
     fun `test complex nested struct merging`() {
         val struct0 = structOf(
-            "a" ofType I64,
-            "b".asStructOf("c" ofType UTF8, "d" ofType UTF8)
+            "a" to I64,
+            "b".asStructOf("c" to UTF8, "d" to UTF8)
         )
         val struct1 = structOf(
-            "a" ofType BOOL,
-            "b" ofType UTF8
+            "a" to BOOL,
+            "b" to UTF8
         )
 
         val expected = structOf(
-            "a".asUnionOf("i64" ofType I64, "bool" ofType BOOL),
+            "a".asUnionOf("i64" to I64, "bool" to BOOL),
             "b".asUnionOf(
-                "utf8" ofType UTF8,
-                "struct".asStructOf("c" ofType UTF8, "d" ofType UTF8),
+                "utf8" to UTF8,
+                "struct".asStructOf("c" to UTF8, "d" to UTF8),
             )
         )
         assertEquals(
@@ -187,7 +186,7 @@ class MergeTypesTest {
     @Test
     fun `test multiple nulls with different types`() {
         assertEquals(
-            unionOf("f64" ofType F64, "i64" ofType I64, "null" ofType NULL),
+            unionOf("f64" to F64, "i64" to I64, "null" to NULL),
             mergeTypes(F64, NULL, I64),
             "Multiple types with null creates union including null"
         )
@@ -195,21 +194,21 @@ class MergeTypesTest {
 
     @Test
     fun `test no struct squashing`() {
-        val nestedStruct = structOf("foo".asStructOf("bibble" ofType BOOL))
+        val nestedStruct = structOf("foo".asStructOf("bibble" to BOOL))
         assertEquals(
             nestedStruct, mergeTypes(nestedStruct),
             "Nested structs don't get flattened"
         )
 
-        val mixedStruct = structOf("foo" ofType UTF8, "bar" ofType I64)
+        val mixedStruct = structOf("foo" to UTF8, "bar" to I64)
 
         assertEquals(
             structOf(
                 "foo".asUnionOf(
-                    "utf8" ofType UTF8,
-                    "struct".asStructOf("bibble" ofType BOOL),
+                    "utf8" to UTF8,
+                    "struct".asStructOf("bibble" to BOOL),
                 ),
-                "bar" ofType maybe(I64)
+                "bar" to maybe(I64)
             ),
             mergeTypes(nestedStruct, mixedStruct),
             "Nested struct merging with other fields preserves structure"

--- a/lang/js/test/test.js
+++ b/lang/js/test/test.js
@@ -116,7 +116,7 @@ describe("connects to XT", function() {
 
       res = await conn`select * from information_schema.columns WHERE table_name = 'tagged_nums' AND column_name = 'nest'`
       const type = res[0].data_type;
-      assert.equal('[:struct {"a" :i64} {"b" :i64} {"c" :f64} {"d" :f64}]', type, `data_type is actually ${type}`);
+      assert.equal('[:struct {"a" :i64, "b" :i64, "c" :f64, "d" :f64}]', type, `data_type is actually ${type}`);
     } finally {
       await conn.release()
     }

--- a/src/test/clojure/xtdb/arrow_edn_test.clj
+++ b/src/test/clojure/xtdb/arrow_edn_test.clj
@@ -18,10 +18,7 @@
       ))
 
 (defn read-arrow-edn-file [path-ish]
-  (util/->clj (read-string (slurp (.toFile (util/->path path-ish))))))
-
-(defn ->arrow-edn [^Relation rel]
-  {:schema (.getSchema rel), :data (util/->clj (.getAsMaps rel))})
+  (read-string (slurp (.toFile (util/->path path-ish)))))
 
 (defn- write-arrow-edn-file! [^Path path, data]
   (with-open [out (io/writer (.toFile path))]

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -1643,7 +1643,7 @@
                                 :y [3.4 8.25]})]
     (t/is (= {:res [{:x 1.2, :y 3.4}
                     {:x 3.4, :y 8.25}]
-              :res-type #xt/type [:struct {"x" :f64} {"y" :f64}]}
+              :res-type #xt/type [:struct {"x" :f64, "y" :f64}]}
              (run-projection rel '{:x x, :y y})))
 
     (t/is (= {:res [3.4 8.25], :res-type #xt/type :f64}
@@ -1658,7 +1658,7 @@
                                 :y$y [3.4 8.25]})]
     (t/is (= {:res [{:x/x 1.2, :y/y 3.4}
                     {:x/x 3.4, :y/y 8.25}]
-              :res-type #xt/type [:struct {"x$x" :f64} {"y$y" :f64}]}
+              :res-type #xt/type [:struct {"x$x" :f64, "y$y" :f64}]}
              (run-projection rel '{:x$x x$x, :y$y y$y})))))
 
 (t/deftest test-nested-structs
@@ -1799,7 +1799,7 @@
   (with-open [rel (tu/open-rel {:x [{:a 42, :b 8}, {:a 12, :b 5}]})]
     (t/is (= {:res [{:a 42, :b 8, :sum 50}
                     {:a 12, :b 5, :sum 17}]
-              :res-type #xt/type [:struct {"a" :i64} {"b" :i64} {"sum" :i64}]}
+              :res-type #xt/type [:struct {"a" :i64, "b" :i64, "sum" :i64}]}
              (run-projection rel '{:a (. x a)
                                    :b (. x b)
                                    :sum (+ (. x a) (. x b))})))))
@@ -1817,7 +1817,8 @@
                     {:b 12}
                     {:a 15, :b 25.0}
                     10.0]
-              :res-type #xt/type [:union [:struct {"a" [:? :i64]} {"b" [:union [:? :i64] :f64]}] :f64]}
+              :res-type #xt/type [:union :f64 [:struct {"a" [:? :i64], 
+                                                        "b" [:union [:? :i64] :f64]}]]}
              (run-projection rel 'x)))
 
     (t/is (= {:res [42 12 nil nil 15 nil]
@@ -1830,7 +1831,8 @@
                     {:xb 12}
                     {:xa 15, :xb 25.0}
                     {}],
-              :res-type #xt/type [:struct {"xa" [:? :i64]} {"xb" [:union :f64 :i64 [:? :null]]}]}
+              :res-type #xt/type [:struct {"xa" [:? :i64], 
+                                           "xb" [:union :f64 :i64 [:? :null]]}]}
              (run-projection rel '{:xa (. x a),
                                    :xb (. x b)})))))
 
@@ -1880,14 +1882,15 @@
                     {:sums [nil 11.5]}
                     {:a 15, :sums [40 nil]}
                     {:sums [nil nil]}],
-              :res-type #xt/type [:struct {"a" [:union :f64 :i64 [:? :null]]}
-                                          {"sums" [:list [:union :f64 :i64 [:? :null]]]}]}
+              :res-type #xt/type [:struct {"a" [:union :f64 :i64 [:? :null]],
+                                           "sums" [:list [:union :f64 :i64 [:? :null]]]}]}
              (run-projection rel '{:a (. x a),
                                    :sums [(+ (. x a) (. x b))
                                           (+ (. x b) (nth (. x c) 1))]})))))
 
 (t/deftest absent-handling-2944
-  (with-open [rel (vr/rel-reader [(tu/open-vec #xt/field {"x" [:struct {"maybe-float" [:? :f64]} {"maybe-str" [:? :utf8]}]}
+  (with-open [rel (vr/rel-reader [(tu/open-vec #xt/field {"x" [:struct {"maybe-float" [:? :f64], 
+                                                                        "maybe-str" [:? :utf8]}]}
                                                [{}])])]
 
     (t/is (= {:res [nil], :res-type #xt/type [:? :f64]}

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -235,12 +235,11 @@
           (t/is (= #xt/field {"list" [:? :list [:union :f64 :utf8 :instant :bool]]}
                    (.getField tc #xt/table xt_docs "list")))
 
-          (t/is (= #xt/field {"struct" [:? :struct
-                                        {"a" [:union :i64 :bool]}
-                                        {"b" [:union
-                                              :utf8
-                                              ;; TODO these shouldn't be optional strings, really. #4988
-                                              [:struct {"c" [:? :utf8]} {"d" [:? :utf8]}]]}]}
+          (t/is (= #xt/field {"struct" [:? :struct {"a" [:union :i64 :bool],
+                                                      "b" [:union
+                                                           :utf8
+                                                           ;; TODO these shouldn't be optional strings, really. #4988
+                                                           [:struct {"c" [:? :utf8], "d" [:? :utf8]}]]}]}
                    (.getField tc #xt/table xt_docs "struct"))))))))
 
 (t/deftest drops-nils-on-round-trip

--- a/src/test/clojure/xtdb/log_test.clj
+++ b/src/test/clojure/xtdb/log_test.clj
@@ -34,9 +34,10 @@
 
 
        (with-open [rel (Relation/openFromArrowStream tu/*allocator* actual-bytes)]
-         (t/is (= (aet/read-arrow-edn-file file)
-                  (doto (aet/->arrow-edn rel)
-                    (aet/maybe-write-arrow-edn! file)))
+         (t/is (= (util/->clj (aet/read-arrow-edn-file file))
+                  (util/->clj (doto {:schema (.getSchema rel), 
+                                     :data (util/->clj (.getAsMaps rel))}
+                                (aet/maybe-write-arrow-edn! file))))
                (str "Mismatch in serialized tx-ops for " (.getName file))))))))
 
 (def devices-docs

--- a/src/test/clojure/xtdb/operator/project_test.clj
+++ b/src/test/clojure/xtdb/operator/project_test.clj
@@ -40,7 +40,7 @@
                          :with-types? true}))))
 
 (t/deftest test-project-star
-  (t/is (= {:types '{ret #xt/type [:struct {"b" :i64} {"a" :i64}]}
+  (t/is (= {:types '{ret #xt/type [:struct {"b" :i64, "a" :i64}]}
             :res [[{:ret {:a 12, :b 10}}
                    {:ret {:a 0, :b 15}}]
                   [{:ret {:a 100, :b 83}}]]}

--- a/src/test/clojure/xtdb/types_test.clj
+++ b/src/test/clojure/xtdb/types_test.clj
@@ -100,31 +100,29 @@
                                  #xt/field [:list :i64]))))
 
   (t/testing "merges struct types"
-    (t/is (= #xt/field [:struct {"a" :utf8} {"b" :utf8}]
-             (types/merge-fields #xt/field [:struct {"a" :utf8} {"b" :utf8}]
-                                 #xt/field [:struct {"a" :utf8} {"b" :utf8}])))
+    (t/is (= #xt/field [:struct {"a" :utf8, "b" :utf8}]
+             (types/merge-fields #xt/field [:struct {"a" :utf8, "b" :utf8}]
+                                 #xt/field [:struct {"a" :utf8, "b" :utf8}])))
 
-    (t/is (= #xt/field [:struct {"a" :utf8} {"b" [:union :utf8 :i64]}]
-             (types/merge-fields #xt/field [:struct {"a" :utf8} {"b" :utf8}]
-                                 #xt/field [:struct {"a" :utf8} {"b" :i64}])))
+    (t/is (= #xt/field [:struct {"a" :utf8, "b" [:union :utf8 :i64]}]
+             (types/merge-fields #xt/field [:struct {"a" :utf8, "b" :utf8}]
+                                 #xt/field [:struct {"a" :utf8, "b" :i64}])))
 
-    (t/is (= #xt/field {"a" [:? :struct {"a" :utf8} {"b" [:union :utf8 :i64]}]}
-             (types/merge-fields #xt/field {"a" [:union [:? :null] [:struct {"a" :utf8} {"b" :utf8}]]}
-                                 #xt/field {"a" [:struct {"a" :utf8} {"b" :i64}]})))
+    (t/is (= #xt/field {"a" [:? :struct {"a" :utf8, "b" [:union :utf8 :i64]}]}
+             (types/merge-fields #xt/field {"a" [:union [:? :null] [:struct {"a" :utf8, "b" :utf8}]]}
+                                 #xt/field {"a" [:struct {"a" :utf8, "b" :i64}]})))
 
-    (t/is (= #xt/field [:struct {"a" [:? :utf8]} {"b" :utf8} {"c" [:? :i64]}]
-             (types/merge-fields #xt/field [:struct {"a" :utf8} {"b" :utf8}]
-                                 #xt/field [:struct {"b" :utf8} {"c" :i64}])))
+    (t/is (= #xt/field [:struct {"a" [:? :utf8], "b" :utf8, "c" [:? :i64]}]
+             (types/merge-fields #xt/field [:struct {"a" :utf8, "b" :utf8}]
+                                 #xt/field [:struct {"b" :utf8, "c" :i64}])))
 
     (t/is (= #xt/field [:union :f64 [:struct {"a" [:union :i64 :utf8]}]]
              (types/merge-fields #xt/field [:union :f64 [:struct {"a" :i64}]]
                                  #xt/field [:struct {"a" :utf8}])))
 
-    (t/is (= #xt/field [:struct
-                        {"a" [:union :i64 :bool]}
-                        {"b" [:union :utf8 [:struct {"c" :utf8} {"d" :utf8}]]}]
-             (types/merge-fields #xt/field [:struct {"a" :i64} {"b" [:struct {"c" :utf8} {"d" :utf8}]}]
-                                 #xt/field [:struct {"a" :bool} {"b" :utf8}]))))
+    (t/is (= #xt/field [:struct {"a" [:union :i64 :bool], "b" [:union :utf8 [:struct {"c" :utf8, "d" :utf8}]]}]
+             (types/merge-fields #xt/field [:struct {"a" :i64, "b" [:struct {"c" :utf8, "d" :utf8}]}]
+                                 #xt/field [:struct {"a" :bool, "b" :utf8}]))))
 
   (t/testing "null behaviour"
     (t/is (= #xt/field [:? :null]
@@ -165,9 +163,9 @@
     (t/is (= #xt/field [:struct {"foo" [:struct {"bibble" :bool}]}]
              (types/merge-fields #xt/field [:struct {"foo" [:struct {"bibble" :bool}]}])))
 
-    (t/is (= #xt/field [:struct {"foo" [:union :utf8 [:struct {"bibble" :bool}]]} {"bar" [:? :i64]}]
+    (t/is (= #xt/field [:struct {"foo" [:union :utf8 [:struct {"bibble" :bool}]], "bar" [:? :i64]}]
              (types/merge-fields #xt/field [:struct {"foo" [:struct {"bibble" :bool}]}]
-                                 #xt/field [:struct {"foo" :utf8} {"bar" :i64}])))))
+                                 #xt/field [:struct {"foo" :utf8, "bar" :i64}])))))
 
 (t/deftest test-npe-on-empty-list-children-4721
   (t/testing "merge fields with empty list children shouldn't throw NPE"

--- a/src/test/clojure/xtdb/vector/writer_test.clj
+++ b/src/test/clojure/xtdb/vector/writer_test.clj
@@ -56,9 +56,8 @@
         (.vectorFor a-wtr "utf8" (FieldType/notNullable (.getType Types$MinorType/VARCHAR)))
 
         (t/is (= #xt/field {"my-duv" [:union
-                                       {"struct" [:struct
-                                                  {"a" [:union {"i64" :i64} {"utf8" :utf8}]}
-                                                  {"b" [:union {"f64" :f64}]}]}]}
+                                       {"struct" [:struct {"a" [:union {"i64" :i64, "utf8" :utf8}],
+                                                           "b" [:union {"f64" :f64}]}]}]}
 
                  (.getField duv)))))))
 
@@ -141,7 +140,7 @@
                  (.getField)))
           "new type promotes the struct key")
 
-    (t/is (= #xt/field {"my-struct" [:struct {"foo" :f64} {"bar" :i64}]}
+    (t/is (= #xt/field {"my-struct" [:struct {"foo" :f64, "bar" :i64}]}
              (-> struct-vec
                  (doto (.vectorFor "bar" (FieldType/notNullable #xt.arrow/type :i64)))
                  (doto (.vectorFor "bar" (FieldType/notNullable #xt.arrow/type :i64)))
@@ -157,7 +156,7 @@
                  (.vectorFor "bar")
                  (.getField))))
 
-    (t/is (= #xt/field {"my-struct" [:struct {"foo" :f64} {"bar" [:union :i64 :f64]}]}
+    (t/is (= #xt/field {"my-struct" [:struct {"foo" :f64, "bar" [:union :i64 :f64]}]}
              (-> struct-vec
                  (doto (.vectorFor "bar" (FieldType/notNullable #xt.arrow/type :f64)))
                  (.getField)))))

--- a/src/test/resources/xtdb/compactor-test/compaction-with-erase/data/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/compaction-with-erase/data/l01-rc-b00.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :uuid}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :uuid}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/compaction-with-erase/data/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/compaction-with-erase/data/l01-rc-b01.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :uuid}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :uuid}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/compaction-with-erase/data/l01-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/compaction-with-erase/data/l01-rc-b02.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :uuid}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :uuid}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/compaction-with-erase/meta/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/compaction-with-erase/meta/l01-rc-b00.arrow.edn
@@ -1,21 +1,21 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/compaction-with-erase/meta/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/compaction-with-erase/meta/l01-rc-b01.arrow.edn
@@ -1,21 +1,21 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/compaction-with-erase/meta/l01-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/compaction-with-erase/meta/l01-rc-b02.arrow.edn
@@ -1,21 +1,21 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l00-rc-b00.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put" [:struct {"_id" :utf8} {"a" :i64}]}]}),
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put" [:struct {"_id" :utf8, "a" :i64}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l00-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l00-rc-b01.arrow.edn
@@ -4,7 +4,7 @@
              {"_valid_from" :instant}
              {"_valid_to" :instant}
              {"op"
-              [:union {"delete" [:? :null]} {"erase" [:? :null]}]}),
+              [:union {"delete" [:? :null], "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l00-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l00-rc-b02.arrow.edn
@@ -4,7 +4,7 @@
              {"_valid_from" :instant}
              {"_valid_to" :instant}
              {"op"
-              [:union {"delete" [:? :null]} {"erase" [:? :null]}]}),
+              [:union {"delete" [:? :null], "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "-290308-12-21T19:59:05.224192Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l00-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l00-rc-b03.arrow.edn
@@ -4,7 +4,7 @@
              {"_valid_from" :instant}
              {"_valid_to" :instant}
              {"op"
-              [:union {"delete" [:? :null]} {"erase" [:? :null]}]}),
+              [:union {"delete" [:? :null], "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "-290308-12-21T19:59:05.224192Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l01-r20200106-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l01-r20200106-b01.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :utf8} {"a" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :utf8, "a" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l01-rc-b00.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :utf8} {"a" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :utf8, "a" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l01-rc-b01.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :utf8} {"a" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :utf8, "a" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l01-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l01-rc-b02.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :utf8} {"a" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :utf8, "a" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l01-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/data/l01-rc-b03.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :utf8} {"a" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :utf8, "a" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "-290308-12-21T19:59:05.224192Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l00-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l00-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l00-rc-b01.arrow.edn
@@ -1,21 +1,21 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l00-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l00-rc-b02.arrow.edn
@@ -1,21 +1,21 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l00-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l00-rc-b03.arrow.edn
@@ -1,21 +1,21 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l01-r20200106-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l01-r20200106-b01.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l01-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l01-rc-b01.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l01-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l01-rc-b02.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l01-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/public$docs/meta/l01-rc-b03.arrow.edn
@@ -1,26 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
                       [:?
                        :struct
-                       {"min" [:? :f64]}
-                       {"max" [:? :f64]}]}]}]}]}]}),
+                       {"min" [:? :f64], "max" [:? :f64]}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l00-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l00-rc-b01.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l00-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l00-rc-b02.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l00-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l00-rc-b03.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l01-rc-b00.arrow.edn
@@ -7,13 +7,13 @@
               [:union
                {"put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l01-rc-b01.arrow.edn
@@ -7,13 +7,13 @@
               [:union
                {"put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l01-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l01-rc-b02.arrow.edn
@@ -7,13 +7,13 @@
               [:union
                {"put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l01-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/data/l01-rc-b03.arrow.edn
@@ -7,13 +7,13 @@
               [:union
                {"put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l00-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l00-rc-b01.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l00-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l00-rc-b02.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l00-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l00-rc-b03.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l01-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l01-rc-b01.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l01-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l01-rc-b02.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l01-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/copes-with-missing-put/v06/tables/xt$txs/meta/l01-rc-b03.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/data/l00-rc-b00.arrow.edn
@@ -5,65 +5,65 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put" [:struct {"_id" :i64} {"v" :i64}]}]}),
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put" [:struct {"_id" :i64, "v" :i64}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 10}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 10}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 9}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 9}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 8}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 8}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 7}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 7}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 6}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 6}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 5}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 5}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 4}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 4}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 3}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 3}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 2}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 2}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 1}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 0}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}]
+    :op #xt/tagged [:put {:xt/id 1, :v 0}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/data/l01-r20200106-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/data/l01-r20200106-b00.arrow.edn
@@ -5,35 +5,35 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"v" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "v" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 4}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 4}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 3}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 3}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 2}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 2}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 1}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 0}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}]
+    :op #xt/tagged [:put {:xt/id 1, :v 0}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/data/l01-r20200113-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/data/l01-r20200113-b00.arrow.edn
@@ -5,35 +5,35 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"v" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "v" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 9}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 9}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 8}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 8}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 7}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 7}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 6}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+    :op #xt/tagged [:put {:xt/id 1, :v 6}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 0, :v 5}],
-    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}]
+    :op #xt/tagged [:put {:xt/id 1, :v 5}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/data/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/data/l01-rc-b00.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"v" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "v" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/meta/l00-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/meta/l01-r20200106-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/meta/l01-r20200106-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/meta/l01-r20200113-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/meta/l01-r20200113-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/meta/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/lose-data-on-compaction/meta/l01-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/data/l01-r20200106-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/data/l01-r20200106-b01.arrow.edn
@@ -5,355 +5,395 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :f64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :f64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :price 12.4}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 5, :price 12.4}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :price 12.4}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 28, :price 12.4}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :price 12.4}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 30, :price 12.4}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :price 12.4}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 12.4}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :price 12.4}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 76, :price 12.4}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :price 12.4}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 47, :price 12.4}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :price 12.4}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 58, :price 12.4}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :price 12.4}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 68, :price 12.4}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :price 12.4}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 51, :price 12.4}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :price 12.4}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 25, :price 12.4}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :price 12.4}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 75, :price 12.4}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :price 12.4}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 59, :price 12.4}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :price 12.4}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 64, :price 12.4}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :price 12.4}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 83, :price 12.4}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :price 12.4}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 95, :price 12.4}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :price 12.4}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 54, :price 12.4}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :price 12.4}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 31, :price 12.4}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :price 12.4}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 96, :price 12.4}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :price 12.4}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 49, :price 12.4}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12.4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 6, :price 12.4}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12.4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 92, :price 12.4}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12.4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 39, :price 12.4}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12.4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 21, :price 12.4}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :price 12.4}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 23, :price 12.4}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :price 12.4}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 2, :price 12.4}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :price 12.4}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 40, :price 12.4}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :price 12.4}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 90, :price 12.4}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :price 12.4}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 94, :price 12.4}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :price 12.4}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 8, :price 12.4}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :price 12.4}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 1, :price 12.4}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :price 12.4}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 52, :price 12.4}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :price 12.4}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 32, :price 12.4}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :price 12.4}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 11, :price 12.4}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :price 12.4}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 7, :price 12.4}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :price 12.4}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 60, :price 12.4}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :price 12.4}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 77, :price 12.4}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :price 12.4}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 24, :price 12.4}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :price 12.4}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 63, :price 12.4}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :price 12.4}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 88, :price 12.4}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :price 12.4}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 44, :price 12.4}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :price 12.4}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 12, :price 12.4}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :price 12.4}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 37, :price 12.4}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12.4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 69, :price 12.4}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12.4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 4, :price 12.4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12.4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 10, :price 12.4}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12.4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 57, :price 12.4}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 12.4}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 12.4}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 12.4}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :price 12.4}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 53, :price 12.4}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :price 12.4}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 43, :price 12.4}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :price 12.4}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 41, :price 12.4}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :price 12.4}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 85, :price 12.4}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :price 12.4}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 97, :price 12.4}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :price 12.4}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 79, :price 12.4}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :price 12.4}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 78, :price 12.4}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :price 12.4}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 70, :price 12.4}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :price 12.4}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 34, :price 12.4}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :price 12.4}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 98, :price 12.4}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :price 12.4}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 3, :price 12.4}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :price 12.4}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 73, :price 12.4}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :price 12.4}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 36, :price 12.4}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :price 12.4}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 0, :price 12.4}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :price 12.4}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 81, :price 12.4}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :price 12.4}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 67, :price 12.4}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :price 12.4}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 22, :price 12.4}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :price 12.4}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 87, :price 12.4}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :price 12.4}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 45, :price 12.4}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12.4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 65, :price 12.4}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12.4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 62, :price 12.4}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12.4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 29, :price 12.4}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12.4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 99, :price 12.4}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 12.4}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 12.4}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 12.4}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 12.4}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 12.4}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/data/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/data/l01-rc-b00.arrow.edn
@@ -5,355 +5,395 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :f64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :f64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :price 12.4}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 5, :price 12.4}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :price 12.4}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 28, :price 12.4}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :price 12.4}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 30, :price 12.4}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :price 12.4}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 12.4}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :price 12.4}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 76, :price 12.4}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :price 12.4}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 47, :price 12.4}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :price 12.4}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 58, :price 12.4}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :price 12.4}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 68, :price 12.4}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :price 12.4}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 51, :price 12.4}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :price 12.4}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 25, :price 12.4}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :price 12.4}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 75, :price 12.4}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :price 12.4}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 59, :price 12.4}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :price 12.4}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 64, :price 12.4}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :price 12.4}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 83, :price 12.4}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :price 12.4}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 95, :price 12.4}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :price 12.4}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 54, :price 12.4}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :price 12.4}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 31, :price 12.4}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :price 12.4}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 96, :price 12.4}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :price 12.4}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 49, :price 12.4}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12.4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 6, :price 12.4}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12.4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 92, :price 12.4}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12.4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 39, :price 12.4}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12.4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 21, :price 12.4}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :price 12.4}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 23, :price 12.4}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :price 12.4}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 2, :price 12.4}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :price 12.4}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 40, :price 12.4}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :price 12.4}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 90, :price 12.4}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :price 12.4}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 94, :price 12.4}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :price 12.4}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 8, :price 12.4}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :price 12.4}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 1, :price 12.4}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :price 12.4}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 52, :price 12.4}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :price 12.4}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 32, :price 12.4}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :price 12.4}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 11, :price 12.4}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :price 12.4}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 7, :price 12.4}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :price 12.4}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 60, :price 12.4}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :price 12.4}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 77, :price 12.4}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :price 12.4}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 24, :price 12.4}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :price 12.4}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 63, :price 12.4}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :price 12.4}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 88, :price 12.4}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :price 12.4}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 44, :price 12.4}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :price 12.4}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 12, :price 12.4}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :price 12.4}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 37, :price 12.4}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12.4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 69, :price 12.4}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12.4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 4, :price 12.4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12.4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 10, :price 12.4}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12.4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 57, :price 12.4}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 12.4}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 12.4}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 12.4}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :price 12.4}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 53, :price 12.4}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :price 12.4}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 43, :price 12.4}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :price 12.4}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 41, :price 12.4}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :price 12.4}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 85, :price 12.4}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :price 12.4}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 97, :price 12.4}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :price 12.4}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 79, :price 12.4}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :price 12.4}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 78, :price 12.4}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :price 12.4}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 70, :price 12.4}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :price 12.4}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 34, :price 12.4}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :price 12.4}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 98, :price 12.4}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :price 12.4}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 3, :price 12.4}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :price 12.4}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 73, :price 12.4}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :price 12.4}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 36, :price 12.4}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :price 12.4}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 0, :price 12.4}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :price 12.4}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 81, :price 12.4}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :price 12.4}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 67, :price 12.4}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :price 12.4}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 22, :price 12.4}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :price 12.4}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 87, :price 12.4}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :price 12.4}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 45, :price 12.4}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12.4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 65, :price 12.4}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12.4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 62, :price 12.4}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12.4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 29, :price 12.4}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12.4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 99, :price 12.4}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 12.4}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 12.4}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 12.4}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 12.4}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 12.4}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/data/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/data/l01-rc-b01.arrow.edn
@@ -5,355 +5,395 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :f64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :f64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :price 6.2}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 5, :price 6.2}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :price 6.2}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 28, :price 6.2}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :price 6.2}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 30, :price 6.2}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :price 6.2}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 6.2}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :price 6.2}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 76, :price 6.2}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :price 6.2}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 47, :price 6.2}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :price 6.2}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 58, :price 6.2}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :price 6.2}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 68, :price 6.2}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :price 6.2}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 51, :price 6.2}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :price 6.2}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 25, :price 6.2}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :price 6.2}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 75, :price 6.2}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :price 6.2}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 59, :price 6.2}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :price 6.2}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 64, :price 6.2}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :price 6.2}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 83, :price 6.2}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :price 6.2}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 95, :price 6.2}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :price 6.2}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 54, :price 6.2}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :price 6.2}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 31, :price 6.2}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :price 6.2}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 96, :price 6.2}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :price 6.2}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 49, :price 6.2}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6.2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 6, :price 6.2}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6.2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 92, :price 6.2}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6.2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 39, :price 6.2}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6.2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 21, :price 6.2}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :price 6.2}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 23, :price 6.2}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :price 6.2}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 2, :price 6.2}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :price 6.2}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 40, :price 6.2}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :price 6.2}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 90, :price 6.2}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :price 6.2}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 94, :price 6.2}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :price 6.2}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 8, :price 6.2}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :price 6.2}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 1, :price 6.2}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :price 6.2}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 52, :price 6.2}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :price 6.2}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 32, :price 6.2}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :price 6.2}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 11, :price 6.2}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :price 6.2}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 7, :price 6.2}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :price 6.2}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 60, :price 6.2}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :price 6.2}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 77, :price 6.2}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :price 6.2}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 24, :price 6.2}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :price 6.2}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 63, :price 6.2}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :price 6.2}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 88, :price 6.2}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :price 6.2}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 44, :price 6.2}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :price 6.2}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 12, :price 6.2}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :price 6.2}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 37, :price 6.2}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6.2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 69, :price 6.2}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6.2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 4, :price 6.2}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6.2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 10, :price 6.2}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6.2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 57, :price 6.2}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 6.2}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 6.2}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 6.2}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :price 6.2}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 53, :price 6.2}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :price 6.2}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 43, :price 6.2}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :price 6.2}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 41, :price 6.2}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :price 6.2}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 85, :price 6.2}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :price 6.2}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 97, :price 6.2}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :price 6.2}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 79, :price 6.2}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :price 6.2}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 78, :price 6.2}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :price 6.2}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 70, :price 6.2}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :price 6.2}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 34, :price 6.2}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :price 6.2}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 98, :price 6.2}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :price 6.2}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 3, :price 6.2}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :price 6.2}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 73, :price 6.2}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :price 6.2}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 36, :price 6.2}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :price 6.2}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 0, :price 6.2}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :price 6.2}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 81, :price 6.2}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :price 6.2}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 67, :price 6.2}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :price 6.2}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 22, :price 6.2}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :price 6.2}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 87, :price 6.2}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :price 6.2}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 45, :price 6.2}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6.2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 65, :price 6.2}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6.2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 62, :price 6.2}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6.2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 29, :price 6.2}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6.2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 99, :price 6.2}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 6.2}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 6.2}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 6.2}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 6.2}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 6.2}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/meta/l01-r20200106-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/meta/l01-r20200106-b01.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/meta/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/meta/l01-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/meta/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/prices/meta/l01-rc-b01.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/data/l01-r20200106-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/data/l01-r20200106-b00.arrow.edn
@@ -5,355 +5,395 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :f64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :f64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :reading 8.3}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 8.3}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :reading 8.3}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 8.3}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :reading 8.3}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 8.3}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :reading 8.3}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 8.3}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :reading 8.3}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 76, :reading 8.3}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :reading 8.3}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 47, :reading 8.3}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :reading 8.3}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 58, :reading 8.3}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :reading 8.3}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 68, :reading 8.3}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :reading 8.3}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 51, :reading 8.3}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :reading 8.3}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 8.3}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :reading 8.3}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 75, :reading 8.3}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :reading 8.3}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 59, :reading 8.3}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :reading 8.3}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 64, :reading 8.3}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :reading 8.3}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 83, :reading 8.3}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :reading 8.3}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 8.3}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :reading 8.3}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 8.3}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :reading 8.3}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 8.3}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :reading 8.3}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 8.3}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :reading 8.3}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 8.3}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8.3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 8.3}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8.3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 92, :reading 8.3}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8.3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 8.3}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8.3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 21, :reading 8.3}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :reading 8.3}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 8.3}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :reading 8.3}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 2, :reading 8.3}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :reading 8.3}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 40, :reading 8.3}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :reading 8.3}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 90, :reading 8.3}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :reading 8.3}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 94, :reading 8.3}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :reading 8.3}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 8.3}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :reading 8.3}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 1, :reading 8.3}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :reading 8.3}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 8.3}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :reading 8.3}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 32, :reading 8.3}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :reading 8.3}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 8.3}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :reading 8.3}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 7, :reading 8.3}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :reading 8.3}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 8.3}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :reading 8.3}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 8.3}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :reading 8.3}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 8.3}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :reading 8.3}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 8.3}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :reading 8.3}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 8.3}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :reading 8.3}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 8.3}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :reading 8.3}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 12, :reading 8.3}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :reading 8.3}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 37, :reading 8.3}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8.3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 69, :reading 8.3}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8.3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 4, :reading 8.3}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8.3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 8.3}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8.3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 57, :reading 8.3}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 8.3}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 8.3}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 8.3}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :reading 8.3}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 8.3}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :reading 8.3}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 8.3}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :reading 8.3}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 8.3}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :reading 8.3}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 85, :reading 8.3}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :reading 8.3}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 97, :reading 8.3}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :reading 8.3}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 79, :reading 8.3}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :reading 8.3}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 8.3}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :reading 8.3}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 8.3}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :reading 8.3}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 8.3}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :reading 8.3}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 8.3}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :reading 8.3}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 8.3}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :reading 8.3}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 73, :reading 8.3}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :reading 8.3}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 8.3}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :reading 8.3}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 8.3}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :reading 8.3}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 81, :reading 8.3}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :reading 8.3}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 67, :reading 8.3}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :reading 8.3}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 8.3}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :reading 8.3}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 87, :reading 8.3}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :reading 8.3}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 8.3}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8.3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 65, :reading 8.3}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8.3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 62, :reading 8.3}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8.3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 8.3}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8.3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 99, :reading 8.3}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 8.3}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 8.3}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 8.3}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 8.3}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 8.3}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/data/l01-r20200113-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/data/l01-r20200113-b01.arrow.edn
@@ -5,355 +5,395 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :f64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :f64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :reading 19.0}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 19.0}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :reading 19.0}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 19.0}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :reading 19.0}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 19.0}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :reading 19.0}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 19.0}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :reading 19.0}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 76, :reading 19.0}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :reading 19.0}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 47, :reading 19.0}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :reading 19.0}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 58, :reading 19.0}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :reading 19.0}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 68, :reading 19.0}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :reading 19.0}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 51, :reading 19.0}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :reading 19.0}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 19.0}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :reading 19.0}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 75, :reading 19.0}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :reading 19.0}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 59, :reading 19.0}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :reading 19.0}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 64, :reading 19.0}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :reading 19.0}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 83, :reading 19.0}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :reading 19.0}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 19.0}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :reading 19.0}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 19.0}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :reading 19.0}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 19.0}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :reading 19.0}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 19.0}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :reading 19.0}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 19.0}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19.0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 19.0}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19.0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 92, :reading 19.0}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19.0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 19.0}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19.0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 21, :reading 19.0}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :reading 19.0}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 19.0}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :reading 19.0}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 2, :reading 19.0}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :reading 19.0}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 40, :reading 19.0}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :reading 19.0}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 90, :reading 19.0}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :reading 19.0}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 94, :reading 19.0}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :reading 19.0}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 19.0}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :reading 19.0}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 1, :reading 19.0}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :reading 19.0}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 19.0}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :reading 19.0}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 32, :reading 19.0}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :reading 19.0}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 19.0}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :reading 19.0}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 7, :reading 19.0}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :reading 19.0}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 19.0}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :reading 19.0}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 19.0}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :reading 19.0}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 19.0}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :reading 19.0}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 19.0}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :reading 19.0}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 19.0}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :reading 19.0}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 19.0}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :reading 19.0}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 12, :reading 19.0}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :reading 19.0}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 37, :reading 19.0}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19.0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 69, :reading 19.0}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19.0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 4, :reading 19.0}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19.0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 19.0}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19.0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 57, :reading 19.0}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 19.0}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 19.0}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 19.0}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 93, :reading 19.0}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 19.0}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 56, :reading 19.0}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 19.0}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 26, :reading 19.0}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 19.0}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 55, :reading 19.0}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put {:xt/id 85, :reading 19.0}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 66, :reading 19.0}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put {:xt/id 97, :reading 19.0}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 86, :reading 19.0}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+    :op #xt/tagged [:put {:xt/id 79, :reading 19.0}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 80, :reading 19.0}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 19.0}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 27, :reading 19.0}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 19.0}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 48, :reading 19.0}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 19.0}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 35, :reading 19.0}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 19.0}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 89, :reading 19.0}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 19.0}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 14, :reading 19.0}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put {:xt/id 73, :reading 19.0}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 13, :reading 19.0}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 19.0}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 72, :reading 19.0}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 19.0}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 33, :reading 19.0}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put {:xt/id 81, :reading 19.0}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 18, :reading 19.0}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put {:xt/id 67, :reading 19.0}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 74, :reading 19.0}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 19.0}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 84, :reading 19.0}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put {:xt/id 87, :reading 19.0}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 42, :reading 19.0}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 19.0}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19.0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 65, :reading 19.0}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19.0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 62, :reading 19.0}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19.0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 19.0}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19.0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 99, :reading 19.0}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 19.0}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 19.0}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 19.0}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 19.0}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 19.0}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/data/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/data/l01-rc-b00.arrow.edn
@@ -5,7 +5,7 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :f64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :f64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches ()}

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/data/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/data/l01-rc-b01.arrow.edn
@@ -5,7 +5,7 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :f64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :f64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches ()}

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/meta/l01-r20200106-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/meta/l01-r20200106-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/meta/l01-r20200113-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/meta/l01-r20200113-b01.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/meta/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/meta/l01-rc-b00.arrow.edn
@@ -1,16 +1,16 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64}]}]}]}]}),
  :batches ([])}

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/meta/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction-by-recency/readings/meta/l01-rc-b01.arrow.edn
@@ -1,16 +1,16 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64}]}]}]}]}),
  :batches ([])}

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b00.arrow.edn
@@ -5,145 +5,205 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put #:xt{:id 5}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put #:xt{:id 28}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put #:xt{:id 30}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put #:xt{:id 47}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put #:xt{:id 25}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 31}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 6}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put #:xt{:id 39}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+    :op #xt/tagged [:put #:xt{:id 21}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 23}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 2}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put #:xt{:id 40}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 8}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 32}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 11}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 7}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 24}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 44}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 12}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 37}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 10}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}]
+    :op #xt/tagged [:put #:xt{:id 17}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 38}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 16}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 43}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 41}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 34}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 3}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 36}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 0}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 22}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 45}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 29}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 9}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 15}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 20}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 46}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b01.arrow.edn
@@ -5,355 +5,375 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put #:xt{:id 5}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 28}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put #:xt{:id 30}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put #:xt{:id 71}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put #:xt{:id 76}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put #:xt{:id 47}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put #:xt{:id 58}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 68}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put #:xt{:id 51}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put #:xt{:id 25}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put #:xt{:id 75}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put #:xt{:id 59}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+    :op #xt/tagged [:put #:xt{:id 64}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 83}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put #:xt{:id 95}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 54}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+    :op #xt/tagged [:put #:xt{:id 31}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 49}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put #:xt{:id 6}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put #:xt{:id 92}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put #:xt{:id 39}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 21}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 23}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put #:xt{:id 2}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put #:xt{:id 40}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 90}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put #:xt{:id 94}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 8}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put #:xt{:id 52}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 32}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 11}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 7}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 60}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 77}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 24}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 63}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 88}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 44}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 12}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 37}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 69}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 10}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 57}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 17}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 38}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 16}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 53}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 43}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 41}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put #:xt{:id 85}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 79}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 78}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 70}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 34}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 3}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 73}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 36}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 0}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 81}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 67}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 22}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 87}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 45}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 65}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 62}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 29}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 9}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 15}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 61}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 20}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 46}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b02.arrow.edn
@@ -5,1690 +5,570 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put #:xt{:id 5}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 28}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+    :op #xt/tagged [:put #:xt{:id 30}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 109}],
+    :xt/iid #bytes "025d28748b20143b96259fe559007490"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+    :op #xt/tagged [:put #:xt{:id 71}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
+    :op #xt/tagged [:put #:xt{:id 76}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 47}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 58}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 136}],
+    :xt/iid #bytes "07b04b25f563483782bedfae4ac65d46"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
+    :op #xt/tagged [:put #:xt{:id 68}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put #:xt{:id 51}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 135}],
+    :xt/iid #bytes "0c37cb2407eba7b368e441aca963ae57"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 103}],
+    :xt/iid #bytes "0de886ef47f37c39172042278e44a607"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 115}],
+    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 25}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 75}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 59}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 64}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put #:xt{:id 83}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 95}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+    :op #xt/tagged [:put #:xt{:id 113}],
+    :xt/iid #bytes "22e39313ce5ffdde631491b53c651e95"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 54}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 133}],
+    :xt/iid #bytes "28c5f03785396f16c83e30f375547173"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 123}],
+    :xt/iid #bytes "29ad5232524010a141649064c04b577b"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+    :op #xt/tagged [:put #:xt{:id 111}],
+    :xt/iid #bytes "2bd41b51f30dabd381a01eed5682f3ee"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 31}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 96}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+    :op #xt/tagged [:put #:xt{:id 49}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 129}],
+    :xt/iid #bytes "32034ebe719debc23cec170dc1142a00"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 119}],
+    :xt/iid #bytes "37ad872190ba8744ca6272255b750bdc"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put #:xt{:id 6}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put #:xt{:id 102}],
+    :xt/iid #bytes "3984fdccba95acf4bdb471008298fb62"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+    :op #xt/tagged [:put #:xt{:id 92}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put #:xt{:id 39}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put #:xt{:id 21}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
    {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put #:xt{:id 106}],
+    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
    {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 101}],
+    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 23}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
+    :op #xt/tagged [:put #:xt{:id 2}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+    :op #xt/tagged [:put #:xt{:id 40}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 90}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put #:xt{:id 94}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 8}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 122}],
+    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 52}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 139}],
+    :xt/iid #bytes "56438668c41161b90a2e54d04d7c548a"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 121}],
+    :xt/iid #bytes "56631378e6c99834a66b8a87243eb6b6"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 32}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 11}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 7}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+    :op #xt/tagged [:put #:xt{:id 60}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 77}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put #:xt{:id 24}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+    :op #xt/tagged [:put #:xt{:id 63}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
+    :op #xt/tagged [:put #:xt{:id 88}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 44}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 108}],
+    :xt/iid #bytes "6a1aa9b3dda959ebdc1c325c1395e9db"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put #:xt{:id 12}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 37}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 69}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 132}],
+    :xt/iid #bytes "6c11d1d9d6189c77215258e45dfe1e84"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
    {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 104}],
+    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 10}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put #:xt{:id 105}],
+    :xt/iid #bytes "742c9aaaffbbcf91b2abb64c169a75a2"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put #:xt{:id 57}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 17}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 38}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 16}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
+    :op #xt/tagged [:put #:xt{:id 53}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 43}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 126}],
+    :xt/iid #bytes "83af9257bdf5c6cfc569da5be7e4b734"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 114}],
+    :xt/iid #bytes "84522f4d4e183ac2828b82bd696e9265"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put #:xt{:id 41}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 85}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put #:xt{:id 97}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 79}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 110}],
+    :xt/iid #bytes "8e13b292504ef3283f9ae7dcb423d751"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 134}],
+    :xt/iid #bytes "8e24182ef5d10a199df39946b2525597"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 78}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 137}],
+    :xt/iid #bytes "90c9a4ae9dc74c6b11257b3a1ae1b440"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 118}],
+    :xt/iid #bytes "915113c4275987ec9668610783758a0d"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 124}],
+    :xt/iid #bytes "91a6929e58fd2e866b09892981c062cd"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 70}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 34}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 98}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 107}],
+    :xt/iid #bytes "985e418869572f5ce4f637235b6b0337"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 125}],
+    :xt/iid #bytes "9a377ce780d8b60af7b81a17a7bd11ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 3}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 73}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 128}],
+    :xt/iid #bytes "9cf5d67d71c2b3ec1c50ccdc4b5ead7e"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 36}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 0}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 81}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 67}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 22}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 87}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 45}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 127}],
+    :xt/iid #bytes "aa4400e859fb24dd120cf66e24690c44"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 65}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 62}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 29}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 112}],
+    :xt/iid #bytes "b45eae64b013c9768f8e2bd2f4942811"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 138}],
+    :xt/iid #bytes "b6650f6f12948b660e22dc6ac2cd9c47"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+    :op #xt/tagged [:put #:xt{:id 99}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
+    :op #xt/tagged [:put #:xt{:id 116}],
+    :xt/iid #bytes "b6bf043b51896c2c4963042d726dfcf2"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+    :op #xt/tagged [:put #:xt{:id 9}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+    :op #xt/tagged [:put #:xt{:id 15}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+    :op #xt/tagged [:put #:xt{:id 61}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
+    :op #xt/tagged [:put #:xt{:id 20}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 93}],
-    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 56}],
-    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 26}],
-    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 55}],
-    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 66}],
-    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 86}],
-    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 131}],
-    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 80}],
-    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 27}],
-    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 48}],
-    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 120}],
-    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 35}],
-    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 89}],
-    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
-   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 117}],
-    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 14}],
-    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 13}],
-    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 72}],
-    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 33}],
-    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 18}],
-    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 74}],
-    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 84}],
-    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 130}],
-    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 42}],
-    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put #:xt{:id 46}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b03.arrow.edn
@@ -5,610 +5,910 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 5}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 28}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 30}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 109}],
+    :xt/iid #bytes "025d28748b20143b96259fe559007490"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 71}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 76}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 47}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 58}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 179}],
+    :xt/iid #bytes "079b6f3220e03c3ce2fa74830e4a364c"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 136}],
+    :xt/iid #bytes "07b04b25f563483782bedfae4ac65d46"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
+    :op #xt/tagged [:put #:xt{:id 68}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
+    :op #xt/tagged [:put #:xt{:id 51}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
    {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 146}],
+    :xt/iid #bytes "0afa67ec22e0c723ba955bf8f9841d7e"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put #:xt{:id 135}],
+    :xt/iid #bytes "0c37cb2407eba7b368e441aca963ae57"}
    {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 103}],
+    :xt/iid #bytes "0de886ef47f37c39172042278e44a607"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
+    :op #xt/tagged [:put #:xt{:id 115}],
+    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 25}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 175}],
+    :xt/iid #bytes "12b4423405608303504234d703a14309"}
    {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 151}],
+    :xt/iid #bytes "13aec04d511522b53d63ae07bc39c011"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put #:xt{:id 75}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 59}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 187}],
+    :xt/iid #bytes "162991d14c2b05049e243724aa5d01c6"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 64}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 153}],
+    :xt/iid #bytes "1d9736d725f5f7f72340540fbf47d995"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 83}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 95}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put #:xt{:id 158}],
+    :xt/iid #bytes "213041d1406e2cd4c17da9ff44f4266c"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 113}],
+    :xt/iid #bytes "22e39313ce5ffdde631491b53c651e95"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 54}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 133}],
+    :xt/iid #bytes "28c5f03785396f16c83e30f375547173"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 123}],
+    :xt/iid #bytes "29ad5232524010a141649064c04b577b"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 184}],
+    :xt/iid #bytes "2a4a26457d59d6ac4ef727533b6294cc"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 111}],
+    :xt/iid #bytes "2bd41b51f30dabd381a01eed5682f3ee"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 31}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 96}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 49}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 129}],
+    :xt/iid #bytes "32034ebe719debc23cec170dc1142a00"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 119}],
+    :xt/iid #bytes "37ad872190ba8744ca6272255b750bdc"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 6}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
+    :op #xt/tagged [:put #:xt{:id 102}],
+    :xt/iid #bytes "3984fdccba95acf4bdb471008298fb62"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put #:xt{:id 92}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 39}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put #:xt{:id 21}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
    {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 106}],
+    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 156}],
+    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 101}],
+    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 23}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 2}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
+    :op #xt/tagged [:put #:xt{:id 40}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 185}],
+    :xt/iid #bytes "42bd5212f6e7dd0db68869dfa0034870"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 90}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
+    :op #xt/tagged [:put #:xt{:id 165}],
+    :xt/iid #bytes "4688cfba00431876631eedbcc7469577"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 94}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 8}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 122}],
+    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
+  [{:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
+    :op #xt/tagged [:put #:xt{:id 171}],
+    :xt/iid #bytes "537ac777da79e0b495e126d4792b73d7"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 52}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 139}],
+    :xt/iid #bytes "56438668c41161b90a2e54d04d7c548a"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 121}],
+    :xt/iid #bytes "56631378e6c99834a66b8a87243eb6b6"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
+    :op #xt/tagged [:put #:xt{:id 178}],
+    :xt/iid #bytes "56867341bf1bde4f3979ad563be4b6fc"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 32}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 11}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 7}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 60}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 77}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 24}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 168}],
+    :xt/iid #bytes "64c3762140bc7f68a621713980713f86"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 63}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 174}],
+    :xt/iid #bytes "671a4e7ac7d9bc8c6cdc8ca5e5ff97ad"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 155}],
+    :xt/iid #bytes "67635c6c72af39c3b856a7c8a43cb422"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 88}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 44}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
+    :op #xt/tagged [:put #:xt{:id 108}],
+    :xt/iid #bytes "6a1aa9b3dda959ebdc1c325c1395e9db"}
    {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
+    :op #xt/tagged [:put #:xt{:id 142}],
+    :xt/iid #bytes "6a3044e68acfd26a3500e54ed89d8d3b"}
    {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 150}],
+    :xt/iid #bytes "6b5b1c7d42ed17ef00426336041b774e"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 12}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 37}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 69}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 132}],
+    :xt/iid #bytes "6c11d1d9d6189c77215258e45dfe1e84"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 182}],
+    :xt/iid #bytes "6c1cf16dd9fd2128e49f7b3b5cbd4ca9"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 104}],
+    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 10}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 105}],
+    :xt/iid #bytes "742c9aaaffbbcf91b2abb64c169a75a2"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 57}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 17}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 145}],
+    :xt/iid #bytes "777f8343a5f9263eb40a82a151327576"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 162}],
+    :xt/iid #bytes "7946c195fde566c2a79b7a2448912920"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 38}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 16}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 183}],
+    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put #:xt{:id 53}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 43}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 167}],
+    :xt/iid #bytes "8398334cacd2d9f1710f2b99b65218be"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 126}],
+    :xt/iid #bytes "83af9257bdf5c6cfc569da5be7e4b734"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 114}],
+    :xt/iid #bytes "84522f4d4e183ac2828b82bd696e9265"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 41}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 85}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 157}],
+    :xt/iid #bytes "88ae227fc15633b8677b223e6ffec1ef"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 169}],
+    :xt/iid #bytes "8af2999e4c4cd0ab116832091f382fec"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 97}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 79}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 110}],
+    :xt/iid #bytes "8e13b292504ef3283f9ae7dcb423d751"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 134}],
+    :xt/iid #bytes "8e24182ef5d10a199df39946b2525597"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 78}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 137}],
+    :xt/iid #bytes "90c9a4ae9dc74c6b11257b3a1ae1b440"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 118}],
+    :xt/iid #bytes "915113c4275987ec9668610783758a0d"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 124}],
+    :xt/iid #bytes "91a6929e58fd2e866b09892981c062cd"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 70}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 152}],
+    :xt/iid #bytes "92fdbe74fb7517c030fc3827f77b06e1"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 34}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 98}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 107}],
+    :xt/iid #bytes "985e418869572f5ce4f637235b6b0337"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 166}],
+    :xt/iid #bytes "9960924a9d56a89513754721cf61fe7f"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 125}],
+    :xt/iid #bytes "9a377ce780d8b60af7b81a17a7bd11ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 3}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 73}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 181}],
+    :xt/iid #bytes "9ccf4bfd5b62038f8f8bb39dcb6e6674"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 128}],
+    :xt/iid #bytes "9cf5d67d71c2b3ec1c50ccdc4b5ead7e"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 36}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 159}],
+    :xt/iid #bytes "9ee66bc6ae0f94512a67c902945a544f"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 0}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 147}],
+    :xt/iid #bytes "a52893cff688be57b307c71cffad45ff"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 81}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 67}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 22}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 87}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 45}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 127}],
+    :xt/iid #bytes "aa4400e859fb24dd120cf66e24690c44"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 180}],
+    :xt/iid #bytes "ab5787efa8d3b74d9912631c24636310"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 65}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 62}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 29}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 170}],
+    :xt/iid #bytes "b25ba4fb6402b26347311bb21f7ea5c9"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 112}],
+    :xt/iid #bytes "b45eae64b013c9768f8e2bd2f4942811"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 138}],
+    :xt/iid #bytes "b6650f6f12948b660e22dc6ac2cd9c47"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 99}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 116}],
+    :xt/iid #bytes "b6bf043b51896c2c4963042d726dfcf2"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 163}],
+    :xt/iid #bytes "b824f57e338ef055db4b9af16d4a3982"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 9}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 15}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 61}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 160}],
+    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 20}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 46}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 140}],
+    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 93}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 56}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
+    :op #xt/tagged [:put #:xt{:id 172}],
+    :xt/iid #bytes "c5d70d88672185c14210002a57ed20c4"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 26}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 55}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 66}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 86}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 131}],
+    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 161}],
+    :xt/iid #bytes "cb779086bd0f8cbd6febdf7f8a1e99cc"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 80}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 27}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 154}],
+    :xt/iid #bytes "d019fb00045604c3f731eed3d31e7236"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 144}],
+    :xt/iid #bytes "d07dcc42f0b412ada671f1de2523e58a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 48}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 186}],
+    :xt/iid #bytes "d1a8fcabc030522d2f5755bdcb9cc0b0"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 120}],
+    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 149}],
+    :xt/iid #bytes "d5042580a076c3d537032d05858163c3"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 177}],
+    :xt/iid #bytes "d53cdcbf204ee78f00449edc52d38df6"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 35}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 143}],
+    :xt/iid #bytes "d7f9d3b9763d2f94c1e09a336600afe6"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 173}],
+    :xt/iid #bytes "d9f45d278397c5420b1c144944c8e3a3"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put #:xt{:id 89}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 164}],
+    :xt/iid #bytes "dcbf558b250273262558a0ad69d3ae10"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 117}],
+    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 14}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 13}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 72}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 33}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 18}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put #:xt{:id 74}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 84}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 130}],
+    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 176}],
-    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 91}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put #:xt{:id 42}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b04.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b04.arrow.edn
@@ -5,130 +5,190 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 215}],
+    :xt/iid #bytes "05032986c76fbabb23cd20d9cf1c609a"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
+    :op #xt/tagged [:put #:xt{:id 206}],
+    :xt/iid #bytes "055a3bc0b33ec364467406eb4cbbfc47"}
    {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 210}],
+    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
+    :op #xt/tagged [:put #:xt{:id 200}],
+    :xt/iid #bytes "121e7f6730608b06a81418e44afd5ab1"}
    {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
+    :op #xt/tagged [:put #:xt{:id 220}],
+    :xt/iid #bytes "1b880f6f4cdedd6cf9f73029ee7d3f66"}
    {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 225}],
+    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 194}],
+    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 193}],
+    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
+    :op #xt/tagged [:put #:xt{:id 205}],
+    :xt/iid #bytes "22ccb18777bdfb478ce0ffddee69477d"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 201}],
+    :xt/iid #bytes "38b85365d40ef4e3f2af832dc0f6a663"}
    {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
+    :op #xt/tagged [:put #:xt{:id 211}],
+    :xt/iid #bytes "394cbd71dbe4725b3f5ece063089eb1b"}
    {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
+    :op #xt/tagged [:put #:xt{:id 199}],
+    :xt/iid #bytes "3b87699e1f1e12221b432e9dc17c19fa"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 190}],
+    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}]
+  [{:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 203}],
+    :xt/iid #bytes "45b09127f2425b5ec41915ee6057b859"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 188}],
+    :xt/iid #bytes "492666daf1bb208aa96f4c9326030fcb"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 207}],
+    :xt/iid #bytes "4ae45a44d53d8f7ce92b700d67db2ab7"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 191}],
+    :xt/iid #bytes "4d16fdb13bbc641dfdd6e3274d69daa9"}
    {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 228}],
+    :xt/iid #bytes "51d24967a0eee28228e3e3dabb1fed8f"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
+    :op #xt/tagged [:put #:xt{:id 195}],
+    :xt/iid #bytes "631f7ac51f82df51f0d75dd29939850e"}
    {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
+    :op #xt/tagged [:put #:xt{:id 213}],
+    :xt/iid #bytes "69b6db1996f88790dea98c0f26b58ce7"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 189}],
+    :xt/iid #bytes "6dfe4a17ead7eda309a27032c8e4834d"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 217}],
+    :xt/iid #bytes "733cf7e2dfc2eab15388b92e900eb7d6"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 204}],
+    :xt/iid #bytes "7467fbb0f016b9c9d166b23dc1cebff5"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 197}],
+    :xt/iid #bytes "7558ad61d00500504a38cc300abe05ba"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 226}],
+    :xt/iid #bytes "780f83f7991e70659a63fbaea3c156a9"}]
+  [{:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 221}],
+    :xt/iid #bytes "83866dcd3a70a05808796e799661c779"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 198}],
+    :xt/iid #bytes "84f4f1a388eec75229cdf8ac8b51c3d7"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 230}],
+    :xt/iid #bytes "85ec98e63faed30758221e8141c0d759"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 224}],
+    :xt/iid #bytes "885af4669ce5530d25df24f75cd047f6"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 218}],
+    :xt/iid #bytes "93e0c386af56717c4a5c4179bad812ce"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 202}],
+    :xt/iid #bytes "9699131767e76d78bcf41a819dcbcaf9"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 208}],
+    :xt/iid #bytes "9aba48a24ee4a53f3650adc255a75f06"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 209}],
+    :xt/iid #bytes "9e073579d00b40a59651e9f931c4735b"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 231}],
+    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 229}],
+    :xt/iid #bytes "b056163d4500a9b7c567ea0e880ca843"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 192}],
+    :xt/iid #bytes "b69fb20bf81ad4015c4eda4adb1fd86c"}]
   [{:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b05.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b05.arrow.edn
@@ -5,220 +5,400 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 243}],
+    :xt/iid #bytes "0041b3666c25996df0bf50024075e368"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
+    :op #xt/tagged [:put #:xt{:id 237}],
+    :xt/iid #bytes "02165f0c71e779a40a67aa915d2e31a1"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 270}],
+    :xt/iid #bytes "035fb4c42c869245d66556eba0357ecf"}
    {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
+    :op #xt/tagged [:put #:xt{:id 215}],
+    :xt/iid #bytes "05032986c76fbabb23cd20d9cf1c609a"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 206}],
+    :xt/iid #bytes "055a3bc0b33ec364467406eb4cbbfc47"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 263}],
+    :xt/iid #bytes "06fedcce1ce11f50d14b85f5f6072170"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 210}],
+    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 259}],
+    :xt/iid #bytes "12041210809829867b98fcd15df56585"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 200}],
+    :xt/iid #bytes "121e7f6730608b06a81418e44afd5ab1"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 267}],
+    :xt/iid #bytes "1531b1ae93bfc79761b0c2b6632be5f0"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 241}],
+    :xt/iid #bytes "15f238624b21033900c5f8897a3ffc8e"}
    {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 220}],
+    :xt/iid #bytes "1b880f6f4cdedd6cf9f73029ee7d3f66"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
+    :op #xt/tagged [:put #:xt{:id 247}],
+    :xt/iid #bytes "1eafb972eacca6bbdff95c2f3a6b644b"}
    {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 225}],
+    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 194}],
+    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
+    :op #xt/tagged [:put #:xt{:id 193}],
+    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 205}],
+    :xt/iid #bytes "22ccb18777bdfb478ce0ffddee69477d"}
    {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
+    :op #xt/tagged [:put #:xt{:id 251}],
+    :xt/iid #bytes "24996cb395e558634605430f6d5d0e53"}
    {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
+    :op #xt/tagged [:put #:xt{:id 272}],
+    :xt/iid #bytes "284d4650e9335b60c101d28ac362c7c0"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 242}],
+    :xt/iid #bytes "2a19694c308373113ea6e209baeefaf5"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 233}],
+    :xt/iid #bytes "2e25cc8beae4edc208499bbb57a0a0ff"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 240}],
+    :xt/iid #bytes "3435f6271391eb222b8e0c7662951144"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 201}],
+    :xt/iid #bytes "38b85365d40ef4e3f2af832dc0f6a663"}
    {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 211}],
+    :xt/iid #bytes "394cbd71dbe4725b3f5ece063089eb1b"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 236}],
+    :xt/iid #bytes "3b13a011fb4a72dbebacc8d65310ff05"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
+    :op #xt/tagged [:put #:xt{:id 262}],
+    :xt/iid #bytes "3b2b355dd3ea4da95442e5b0b8ee9721"}
    {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
+    :op #xt/tagged [:put #:xt{:id 199}],
+    :xt/iid #bytes "3b87699e1f1e12221b432e9dc17c19fa"}
    {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 274}],
+    :xt/iid #bytes "3bb262bad78be2bc8d3bf713821c1c47"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 190}],
+    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}]
+  [{:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 203}],
+    :xt/iid #bytes "45b09127f2425b5ec41915ee6057b859"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 276}],
+    :xt/iid #bytes "46bf53a692426c42ebcd55166bd55589"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 260}],
+    :xt/iid #bytes "48d5921deeb3d8e69024a2c3ea11f0bd"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
+    :op #xt/tagged [:put #:xt{:id 188}],
+    :xt/iid #bytes "492666daf1bb208aa96f4c9326030fcb"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 207}],
+    :xt/iid #bytes "4ae45a44d53d8f7ce92b700d67db2ab7"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 279}],
+    :xt/iid #bytes "4bcb1c2cf33853525d97e6a355a03d53"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 191}],
+    :xt/iid #bytes "4d16fdb13bbc641dfdd6e3274d69daa9"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 278}],
+    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
    {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 228}],
+    :xt/iid #bytes "51d24967a0eee28228e3e3dabb1fed8f"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 195}],
+    :xt/iid #bytes "631f7ac51f82df51f0d75dd29939850e"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 232}],
+    :xt/iid #bytes "664b74ffc0f8d86e7a96bccb3f8d772a"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
+    :op #xt/tagged [:put #:xt{:id 239}],
+    :xt/iid #bytes "66ab375a0c928ef9d38d7c4157746680"}
    {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
+    :op #xt/tagged [:put #:xt{:id 213}],
+    :xt/iid #bytes "69b6db1996f88790dea98c0f26b58ce7"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 189}],
+    :xt/iid #bytes "6dfe4a17ead7eda309a27032c8e4834d"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 256}],
+    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 217}],
+    :xt/iid #bytes "733cf7e2dfc2eab15388b92e900eb7d6"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 264}],
+    :xt/iid #bytes "744cc63ddfb14649c4de3a4856fe084f"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 204}],
+    :xt/iid #bytes "7467fbb0f016b9c9d166b23dc1cebff5"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 197}],
+    :xt/iid #bytes "7558ad61d00500504a38cc300abe05ba"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 277}],
+    :xt/iid #bytes "77a51cbe19fc3568904cfc39937e7982"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 249}],
+    :xt/iid #bytes "77f81c1dd9e797d0f07b0737ba531049"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 226}],
+    :xt/iid #bytes "780f83f7991e70659a63fbaea3c156a9"}]
+  [{:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 235}],
+    :xt/iid #bytes "8367fa42508c88bdc3877351c936b567"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 221}],
+    :xt/iid #bytes "83866dcd3a70a05808796e799661c779"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 198}],
+    :xt/iid #bytes "84f4f1a388eec75229cdf8ac8b51c3d7"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 230}],
+    :xt/iid #bytes "85ec98e63faed30758221e8141c0d759"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 224}],
+    :xt/iid #bytes "885af4669ce5530d25df24f75cd047f6"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 238}],
+    :xt/iid #bytes "8ad61a12edc3cd20bf45a476c786fb11"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 257}],
+    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 265}],
+    :xt/iid #bytes "912258de80c24497ed89b1fd886f6c8d"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 258}],
+    :xt/iid #bytes "924760091604846850b078b7f32d81d1"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 218}],
+    :xt/iid #bytes "93e0c386af56717c4a5c4179bad812ce"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 254}],
+    :xt/iid #bytes "94f7fdd99238fc3782f4a739fa4d33f0"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 275}],
+    :xt/iid #bytes "9671d7e86139b807fa027d423de676d4"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 202}],
+    :xt/iid #bytes "9699131767e76d78bcf41a819dcbcaf9"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 208}],
+    :xt/iid #bytes "9aba48a24ee4a53f3650adc255a75f06"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 209}],
+    :xt/iid #bytes "9e073579d00b40a59651e9f931c4735b"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 261}],
+    :xt/iid #bytes "a2eccba01e87c2d3993514279c3af28c"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 234}],
+    :xt/iid #bytes "a32f317d64f7617fb43c01f72d7db735"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 231}],
+    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 252}],
+    :xt/iid #bytes "b04edac037b8f0c58aa6e3cba929be7b"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 229}],
+    :xt/iid #bytes "b056163d4500a9b7c567ea0e880ca843"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 244}],
+    :xt/iid #bytes "b1fec1d08d3466c41015367662f792f5"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 192}],
+    :xt/iid #bytes "b69fb20bf81ad4015c4eda4adb1fd86c"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 248}],
+    :xt/iid #bytes "b95e782e3641975f92a07964af9880fa"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 245}],
+    :xt/iid #bytes "b987787c691234eb44fc769d508ef673"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 255}],
+    :xt/iid #bytes "b9e613a4af1a9cdfa1c1c294888aaf8b"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 271}],
+    :xt/iid #bytes "ba4a5c6bb1e49fa84d4bb75fb918f0bf"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 246}],
+    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
   [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b06.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b06.arrow.edn
@@ -5,1450 +5,590 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 243}],
+    :xt/iid #bytes "0041b3666c25996df0bf50024075e368"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
+    :op #xt/tagged [:put #:xt{:id 237}],
+    :xt/iid #bytes "02165f0c71e779a40a67aa915d2e31a1"}
    {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
+    :op #xt/tagged [:put #:xt{:id 270}],
+    :xt/iid #bytes "035fb4c42c869245d66556eba0357ecf"}
    {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 305}],
+    :xt/iid #bytes "03a293a1ae6a754078406140a65ff6be"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
+    :op #xt/tagged [:put #:xt{:id 319}],
+    :xt/iid #bytes "043e7a2fbf427b598357f715a1a61344"}
    {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
+    :op #xt/tagged [:put #:xt{:id 215}],
+    :xt/iid #bytes "05032986c76fbabb23cd20d9cf1c609a"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 206}],
+    :xt/iid #bytes "055a3bc0b33ec364467406eb4cbbfc47"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 280}],
+    :xt/iid #bytes "05e5ac85e20d91f5431fd118c3cfa4c5"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 312}],
+    :xt/iid #bytes "06cf894ddb2e40263ac798e97ca89abb"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 263}],
+    :xt/iid #bytes "06fedcce1ce11f50d14b85f5f6072170"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 318}],
+    :xt/iid #bytes "07e1672e79caad486aa14eb4f9b7cc49"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 210}],
+    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}]
+  [{:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 259}],
+    :xt/iid #bytes "12041210809829867b98fcd15df56585"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 200}],
+    :xt/iid #bytes "121e7f6730608b06a81418e44afd5ab1"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 267}],
+    :xt/iid #bytes "1531b1ae93bfc79761b0c2b6632be5f0"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 241}],
+    :xt/iid #bytes "15f238624b21033900c5f8897a3ffc8e"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 220}],
+    :xt/iid #bytes "1b880f6f4cdedd6cf9f73029ee7d3f66"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 247}],
+    :xt/iid #bytes "1eafb972eacca6bbdff95c2f3a6b644b"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 225}],
+    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 194}],
+    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 193}],
+    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
+  [{:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 205}],
+    :xt/iid #bytes "22ccb18777bdfb478ce0ffddee69477d"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 251}],
+    :xt/iid #bytes "24996cb395e558634605430f6d5d0e53"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 272}],
+    :xt/iid #bytes "284d4650e9335b60c101d28ac362c7c0"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 242}],
+    :xt/iid #bytes "2a19694c308373113ea6e209baeefaf5"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 300}],
+    :xt/iid #bytes "2cc48a05198a7714e01b281084390a2d"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 233}],
+    :xt/iid #bytes "2e25cc8beae4edc208499bbb57a0a0ff"}]
+  [{:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 240}],
+    :xt/iid #bytes "3435f6271391eb222b8e0c7662951144"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 201}],
+    :xt/iid #bytes "38b85365d40ef4e3f2af832dc0f6a663"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 211}],
+    :xt/iid #bytes "394cbd71dbe4725b3f5ece063089eb1b"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 236}],
+    :xt/iid #bytes "3b13a011fb4a72dbebacc8d65310ff05"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 262}],
+    :xt/iid #bytes "3b2b355dd3ea4da95442e5b0b8ee9721"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 199}],
+    :xt/iid #bytes "3b87699e1f1e12221b432e9dc17c19fa"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 320}],
+    :xt/iid #bytes "3b8a91a71b4815da789b9f43a47b0da0"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 274}],
+    :xt/iid #bytes "3bb262bad78be2bc8d3bf713821c1c47"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 298}],
+    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 190}],
+    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}]
+  [{:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 315}],
+    :xt/iid #bytes "40c649f68755420ec7d3b982fa77131f"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 284}],
+    :xt/iid #bytes "40d8e2558d6aa134d5c236aaae1dae24"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 203}],
+    :xt/iid #bytes "45b09127f2425b5ec41915ee6057b859"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 276}],
+    :xt/iid #bytes "46bf53a692426c42ebcd55166bd55589"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 260}],
+    :xt/iid #bytes "48d5921deeb3d8e69024a2c3ea11f0bd"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 188}],
+    :xt/iid #bytes "492666daf1bb208aa96f4c9326030fcb"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 283}],
+    :xt/iid #bytes "496e01d77d8fafb07fa1fa40ecb57e3b"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 207}],
+    :xt/iid #bytes "4ae45a44d53d8f7ce92b700d67db2ab7"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 297}],
+    :xt/iid #bytes "4b3273a103b59b1fa74064c7341b874a"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 279}],
+    :xt/iid #bytes "4bcb1c2cf33853525d97e6a355a03d53"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 191}],
+    :xt/iid #bytes "4d16fdb13bbc641dfdd6e3274d69daa9"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 322}],
+    :xt/iid #bytes "4e87c935e7c6d2cfc321b9b29ed61f1a"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 278}],
+    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 294}],
+    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}]
+  [{:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 228}],
+    :xt/iid #bytes "51d24967a0eee28228e3e3dabb1fed8f"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 288}],
+    :xt/iid #bytes "552c773456b6d26215274a11c3b8877a"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 313}],
+    :xt/iid #bytes "57a7b3f57475fb1da77d804447beffe6"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 326}],
+    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
+  [{:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 301}],
+    :xt/iid #bytes "60bf8aedc9e0139c0672f14a7e63bba6"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 317}],
+    :xt/iid #bytes "6160ed777981a09ef72c4b769da6ca23"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 316}],
+    :xt/iid #bytes "628926b0e1d424a4c8c7c8de3390e7a7"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 304}],
+    :xt/iid #bytes "63065ba681a3e5e21b32b06405efbf2b"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 195}],
+    :xt/iid #bytes "631f7ac51f82df51f0d75dd29939850e"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 232}],
+    :xt/iid #bytes "664b74ffc0f8d86e7a96bccb3f8d772a"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 239}],
+    :xt/iid #bytes "66ab375a0c928ef9d38d7c4157746680"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 213}],
+    :xt/iid #bytes "69b6db1996f88790dea98c0f26b58ce7"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 189}],
+    :xt/iid #bytes "6dfe4a17ead7eda309a27032c8e4834d"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 256}],
+    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}]
+  [{:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 217}],
+    :xt/iid #bytes "733cf7e2dfc2eab15388b92e900eb7d6"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 264}],
+    :xt/iid #bytes "744cc63ddfb14649c4de3a4856fe084f"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 204}],
+    :xt/iid #bytes "7467fbb0f016b9c9d166b23dc1cebff5"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 197}],
+    :xt/iid #bytes "7558ad61d00500504a38cc300abe05ba"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 277}],
+    :xt/iid #bytes "77a51cbe19fc3568904cfc39937e7982"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 249}],
+    :xt/iid #bytes "77f81c1dd9e797d0f07b0737ba531049"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 226}],
+    :xt/iid #bytes "780f83f7991e70659a63fbaea3c156a9"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 295}],
+    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}]
+  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 325}],
+    :xt/iid #bytes "800a29ad887af0f35e3e5633c6806484"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 287}],
+    :xt/iid #bytes "82c5cb4b05baf4efd1c403a1cd9d22c4"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 311}],
+    :xt/iid #bytes "830b83c7a399b7850da90a39c2d4053c"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 290}],
+    :xt/iid #bytes "8363d0d3d43cf2981e7b731dca4d66fb"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 235}],
+    :xt/iid #bytes "8367fa42508c88bdc3877351c936b567"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 221}],
+    :xt/iid #bytes "83866dcd3a70a05808796e799661c779"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 198}],
+    :xt/iid #bytes "84f4f1a388eec75229cdf8ac8b51c3d7"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 230}],
+    :xt/iid #bytes "85ec98e63faed30758221e8141c0d759"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 224}],
+    :xt/iid #bytes "885af4669ce5530d25df24f75cd047f6"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 238}],
+    :xt/iid #bytes "8ad61a12edc3cd20bf45a476c786fb11"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 257}],
+    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}]
+  [{:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 265}],
+    :xt/iid #bytes "912258de80c24497ed89b1fd886f6c8d"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 258}],
+    :xt/iid #bytes "924760091604846850b078b7f32d81d1"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 218}],
+    :xt/iid #bytes "93e0c386af56717c4a5c4179bad812ce"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 254}],
+    :xt/iid #bytes "94f7fdd99238fc3782f4a739fa4d33f0"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 314}],
+    :xt/iid #bytes "9596858c57e0b8d8616e1d1d220c1e96"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 307}],
+    :xt/iid #bytes "95e393708259538f4aec0ee9c87bec3d"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 275}],
+    :xt/iid #bytes "9671d7e86139b807fa027d423de676d4"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 202}],
+    :xt/iid #bytes "9699131767e76d78bcf41a819dcbcaf9"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 208}],
+    :xt/iid #bytes "9aba48a24ee4a53f3650adc255a75f06"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 285}],
+    :xt/iid #bytes "9cd84006fa93af519dd957a2257ebc8a"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 209}],
+    :xt/iid #bytes "9e073579d00b40a59651e9f931c4735b"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 291}],
+    :xt/iid #bytes "9eac1fbc4b5d453942a38df7a82127e5"}]
+  [{:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 261}],
+    :xt/iid #bytes "a2eccba01e87c2d3993514279c3af28c"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 234}],
+    :xt/iid #bytes "a32f317d64f7617fb43c01f72d7db735"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 299}],
+    :xt/iid #bytes "a45bf7e0122b3deaa89ee5c388bc8421"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 292}],
+    :xt/iid #bytes "aa96051eba0190666442c9e13663dd8b"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 309}],
+    :xt/iid #bytes "aeef4815c98f43631ce3e7fa79c88d5a"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 308}],
+    :xt/iid #bytes "af8b1f927602f6510a2e32f8870dddf2"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 306}],
+    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 231}],
+    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
   [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
+    :op #xt/tagged [:put #:xt{:id 252}],
+    :xt/iid #bytes "b04edac037b8f0c58aa6e3cba929be7b"}
    {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 229}],
+    :xt/iid #bytes "b056163d4500a9b7c567ea0e880ca843"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 323}],
+    :xt/iid #bytes "b1ddb0175d32e2d8deaf8db0acd68081"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
+    :op #xt/tagged [:put #:xt{:id 244}],
+    :xt/iid #bytes "b1fec1d08d3466c41015367662f792f5"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 293}],
+    :xt/iid #bytes "b38a063cbd17de5fee53028cb28cb6c9"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 192}],
+    :xt/iid #bytes "b69fb20bf81ad4015c4eda4adb1fd86c"}
    {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 248}],
+    :xt/iid #bytes "b95e782e3641975f92a07964af9880fa"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
+    :op #xt/tagged [:put #:xt{:id 245}],
+    :xt/iid #bytes "b987787c691234eb44fc769d508ef673"}
    {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
+    :op #xt/tagged [:put #:xt{:id 255}],
+    :xt/iid #bytes "b9e613a4af1a9cdfa1c1c294888aaf8b"}
    {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
-  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 250}],
-    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 273}],
-    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 214}],
-    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 303}],
-    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 296}],
-    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 302}],
-    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 222}],
-    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 268}],
-    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
-   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 196}],
-    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 327}],
-    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 266}],
-    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
-   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 310}],
-    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 324}],
-    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 281}],
-    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
-   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}]
+    :op #xt/tagged [:put #:xt{:id 271}],
+    :xt/iid #bytes "ba4a5c6bb1e49fa84d4bb75fb918f0bf"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 289}],
+    :xt/iid #bytes "ba9b299b96d610b78b388db8c0c4ec2a"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 246}],
+    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
   [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b07.arrow.edn
@@ -5,1135 +5,875 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 243}],
+    :xt/iid #bytes "0041b3666c25996df0bf50024075e368"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
+    :op #xt/tagged [:put #:xt{:id 237}],
+    :xt/iid #bytes "02165f0c71e779a40a67aa915d2e31a1"}
    {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 270}],
+    :xt/iid #bytes "035fb4c42c869245d66556eba0357ecf"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 305}],
+    :xt/iid #bytes "03a293a1ae6a754078406140a65ff6be"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
+    :op #xt/tagged [:put #:xt{:id 319}],
+    :xt/iid #bytes "043e7a2fbf427b598357f715a1a61344"}
    {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 215}],
+    :xt/iid #bytes "05032986c76fbabb23cd20d9cf1c609a"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 206}],
+    :xt/iid #bytes "055a3bc0b33ec364467406eb4cbbfc47"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 280}],
+    :xt/iid #bytes "05e5ac85e20d91f5431fd118c3cfa4c5"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 312}],
+    :xt/iid #bytes "06cf894ddb2e40263ac798e97ca89abb"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 263}],
+    :xt/iid #bytes "06fedcce1ce11f50d14b85f5f6072170"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 318}],
+    :xt/iid #bytes "07e1672e79caad486aa14eb4f9b7cc49"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 210}],
+    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}]
+  [{:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
+    :op #xt/tagged [:put #:xt{:id 259}],
+    :xt/iid #bytes "12041210809829867b98fcd15df56585"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 200}],
+    :xt/iid #bytes "121e7f6730608b06a81418e44afd5ab1"}
    {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 267}],
+    :xt/iid #bytes "1531b1ae93bfc79761b0c2b6632be5f0"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
+    :op #xt/tagged [:put #:xt{:id 241}],
+    :xt/iid #bytes "15f238624b21033900c5f8897a3ffc8e"}
    {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 365}],
+    :xt/iid #bytes "167a8c48ebaa8493033bd6c49987be9a"}
+   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
+    :op #xt/tagged [:put #:xt{:id 353}],
+    :xt/iid #bytes "17664b2d63ac35e2c26e7f7762a3bf52"}
    {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 348}],
+    :xt/iid #bytes "186835a76246498a35c0b5dc51f34b14"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
+    :op #xt/tagged [:put #:xt{:id 220}],
+    :xt/iid #bytes "1b880f6f4cdedd6cf9f73029ee7d3f66"}
    {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
+    :op #xt/tagged [:put #:xt{:id 357}],
+    :xt/iid #bytes "1bce0514332a7a1a9bec4d79a2786c1f"}
    {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
+    :op #xt/tagged [:put #:xt{:id 334}],
+    :xt/iid #bytes "1dd81fb449fc93bfe3313f5945bf14d8"}
    {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 354}],
+    :xt/iid #bytes "1e1b4142f9fe433d893437424841088d"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 247}],
+    :xt/iid #bytes "1eafb972eacca6bbdff95c2f3a6b644b"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 225}],
+    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
+    :op #xt/tagged [:put #:xt{:id 194}],
+    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 193}],
+    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
+  [{:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 352}],
+    :xt/iid #bytes "2077439c0f82ecd2ceb7a6c39b768a38"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 205}],
+    :xt/iid #bytes "22ccb18777bdfb478ce0ffddee69477d"}
    {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 251}],
+    :xt/iid #bytes "24996cb395e558634605430f6d5d0e53"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 272}],
+    :xt/iid #bytes "284d4650e9335b60c101d28ac362c7c0"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 242}],
+    :xt/iid #bytes "2a19694c308373113ea6e209baeefaf5"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 300}],
+    :xt/iid #bytes "2cc48a05198a7714e01b281084390a2d"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 233}],
+    :xt/iid #bytes "2e25cc8beae4edc208499bbb57a0a0ff"}]
+  [{:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
+    :op #xt/tagged [:put #:xt{:id 362}],
+    :xt/iid #bytes "3022d624c0bc8ff8d7da774ccc7b9858"}
    {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 356}],
+    :xt/iid #bytes "333a3ff42f59cf8a01cfa64dfc838671"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
+    :op #xt/tagged [:put #:xt{:id 240}],
+    :xt/iid #bytes "3435f6271391eb222b8e0c7662951144"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 201}],
+    :xt/iid #bytes "38b85365d40ef4e3f2af832dc0f6a663"}
    {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
+    :op #xt/tagged [:put #:xt{:id 211}],
+    :xt/iid #bytes "394cbd71dbe4725b3f5ece063089eb1b"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 236}],
+    :xt/iid #bytes "3b13a011fb4a72dbebacc8d65310ff05"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 262}],
+    :xt/iid #bytes "3b2b355dd3ea4da95442e5b0b8ee9721"}
+   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 339}],
+    :xt/iid #bytes "3b8574e691a90541c7f16605c6ceeae1"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 199}],
+    :xt/iid #bytes "3b87699e1f1e12221b432e9dc17c19fa"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 320}],
+    :xt/iid #bytes "3b8a91a71b4815da789b9f43a47b0da0"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 274}],
+    :xt/iid #bytes "3bb262bad78be2bc8d3bf713821c1c47"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 298}],
+    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 190}],
+    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}]
+  [{:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 315}],
+    :xt/iid #bytes "40c649f68755420ec7d3b982fa77131f"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 284}],
+    :xt/iid #bytes "40d8e2558d6aa134d5c236aaae1dae24"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 203}],
+    :xt/iid #bytes "45b09127f2425b5ec41915ee6057b859"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 329}],
+    :xt/iid #bytes "463324d8c6e8b7957a4d688f589d060a"}
+   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 336}],
+    :xt/iid #bytes "465e616d21e05f4ad00dc6c5f542c414"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 276}],
+    :xt/iid #bytes "46bf53a692426c42ebcd55166bd55589"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 260}],
+    :xt/iid #bytes "48d5921deeb3d8e69024a2c3ea11f0bd"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 188}],
+    :xt/iid #bytes "492666daf1bb208aa96f4c9326030fcb"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 283}],
+    :xt/iid #bytes "496e01d77d8fafb07fa1fa40ecb57e3b"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 207}],
+    :xt/iid #bytes "4ae45a44d53d8f7ce92b700d67db2ab7"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 297}],
+    :xt/iid #bytes "4b3273a103b59b1fa74064c7341b874a"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 279}],
+    :xt/iid #bytes "4bcb1c2cf33853525d97e6a355a03d53"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 331}],
+    :xt/iid #bytes "4c868f1fd3fa6671225e51568bf73be6"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 191}],
+    :xt/iid #bytes "4d16fdb13bbc641dfdd6e3274d69daa9"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 322}],
+    :xt/iid #bytes "4e87c935e7c6d2cfc321b9b29ed61f1a"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 278}],
+    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 294}],
+    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}]
+  [{:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 228}],
+    :xt/iid #bytes "51d24967a0eee28228e3e3dabb1fed8f"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 372}],
+    :xt/iid #bytes "53cc29f9ab57ca2e65dde6503b0abe53"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 288}],
+    :xt/iid #bytes "552c773456b6d26215274a11c3b8877a"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 374}],
+    :xt/iid #bytes "57049942ff3848aaedf2ae7495110726"}
+   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 364}],
+    :xt/iid #bytes "5761f0ca45541fcb053f6ea40a51d85a"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 313}],
+    :xt/iid #bytes "57a7b3f57475fb1da77d804447beffe6"}
+   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 363}],
+    :xt/iid #bytes "5bb136cd532ad7fc665afd9122f1dd9c"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 326}],
+    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
+  [{:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 301}],
+    :xt/iid #bytes "60bf8aedc9e0139c0672f14a7e63bba6"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 317}],
+    :xt/iid #bytes "6160ed777981a09ef72c4b769da6ca23"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 333}],
+    :xt/iid #bytes "616d1bac5b1f7f434d6c0a2ee5fe3da9"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 316}],
+    :xt/iid #bytes "628926b0e1d424a4c8c7c8de3390e7a7"}
    {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 355}],
+    :xt/iid #bytes "62e736178a161c4ef21d1f6464598dd0"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 304}],
+    :xt/iid #bytes "63065ba681a3e5e21b32b06405efbf2b"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 195}],
+    :xt/iid #bytes "631f7ac51f82df51f0d75dd29939850e"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 232}],
+    :xt/iid #bytes "664b74ffc0f8d86e7a96bccb3f8d772a"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 239}],
+    :xt/iid #bytes "66ab375a0c928ef9d38d7c4157746680"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 213}],
+    :xt/iid #bytes "69b6db1996f88790dea98c0f26b58ce7"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
+    :op #xt/tagged [:put #:xt{:id 332}],
+    :xt/iid #bytes "6d29fd85e233a04712a34a13a94e7c61"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 189}],
+    :xt/iid #bytes "6dfe4a17ead7eda309a27032c8e4834d"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 256}],
+    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}]
+  [{:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 337}],
+    :xt/iid #bytes "705bc958047bc9336fd80460114c069d"}
    {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 217}],
+    :xt/iid #bytes "733cf7e2dfc2eab15388b92e900eb7d6"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
+    :op #xt/tagged [:put #:xt{:id 264}],
+    :xt/iid #bytes "744cc63ddfb14649c4de3a4856fe084f"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 204}],
+    :xt/iid #bytes "7467fbb0f016b9c9d166b23dc1cebff5"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 197}],
+    :xt/iid #bytes "7558ad61d00500504a38cc300abe05ba"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 277}],
+    :xt/iid #bytes "77a51cbe19fc3568904cfc39937e7982"}
    {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 249}],
+    :xt/iid #bytes "77f81c1dd9e797d0f07b0737ba531049"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 226}],
+    :xt/iid #bytes "780f83f7991e70659a63fbaea3c156a9"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 369}],
+    :xt/iid #bytes "7ace13fc4cf9e6aed523f660be0bc895"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 295}],
+    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}]
+  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
+    :op #xt/tagged [:put #:xt{:id 325}],
+    :xt/iid #bytes "800a29ad887af0f35e3e5633c6806484"}
    {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 287}],
+    :xt/iid #bytes "82c5cb4b05baf4efd1c403a1cd9d22c4"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 311}],
+    :xt/iid #bytes "830b83c7a399b7850da90a39c2d4053c"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 290}],
+    :xt/iid #bytes "8363d0d3d43cf2981e7b731dca4d66fb"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
+    :op #xt/tagged [:put #:xt{:id 235}],
+    :xt/iid #bytes "8367fa42508c88bdc3877351c936b567"}
    {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
+    :op #xt/tagged [:put #:xt{:id 221}],
+    :xt/iid #bytes "83866dcd3a70a05808796e799661c779"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 198}],
+    :xt/iid #bytes "84f4f1a388eec75229cdf8ac8b51c3d7"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 230}],
+    :xt/iid #bytes "85ec98e63faed30758221e8141c0d759"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 224}],
+    :xt/iid #bytes "885af4669ce5530d25df24f75cd047f6"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 238}],
+    :xt/iid #bytes "8ad61a12edc3cd20bf45a476c786fb11"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 257}],
+    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}]
+  [{:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 344}],
+    :xt/iid #bytes "90cb420d6f3244b22f3f5c9b7fa77af1"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 265}],
+    :xt/iid #bytes "912258de80c24497ed89b1fd886f6c8d"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 258}],
+    :xt/iid #bytes "924760091604846850b078b7f32d81d1"}
    {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
+    :op #xt/tagged [:put #:xt{:id 218}],
+    :xt/iid #bytes "93e0c386af56717c4a5c4179bad812ce"}
    {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 254}],
+    :xt/iid #bytes "94f7fdd99238fc3782f4a739fa4d33f0"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 314}],
+    :xt/iid #bytes "9596858c57e0b8d8616e1d1d220c1e96"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 307}],
+    :xt/iid #bytes "95e393708259538f4aec0ee9c87bec3d"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 275}],
+    :xt/iid #bytes "9671d7e86139b807fa027d423de676d4"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
+    :op #xt/tagged [:put #:xt{:id 202}],
+    :xt/iid #bytes "9699131767e76d78bcf41a819dcbcaf9"}
    {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 208}],
+    :xt/iid #bytes "9aba48a24ee4a53f3650adc255a75f06"}
+   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 342}],
+    :xt/iid #bytes "9ae03d90a477a3619cb9a9227a899c05"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 375}],
+    :xt/iid #bytes "9b9230d99360484e11804744fc3cd833"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 285}],
+    :xt/iid #bytes "9cd84006fa93af519dd957a2257ebc8a"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
+    :op #xt/tagged [:put #:xt{:id 209}],
+    :xt/iid #bytes "9e073579d00b40a59651e9f931c4735b"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 291}],
+    :xt/iid #bytes "9eac1fbc4b5d453942a38df7a82127e5"}]
+  [{:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 350}],
+    :xt/iid #bytes "a24e14008c41eafa1b9d86ddfe18eb12"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 261}],
+    :xt/iid #bytes "a2eccba01e87c2d3993514279c3af28c"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 234}],
+    :xt/iid #bytes "a32f317d64f7617fb43c01f72d7db735"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 299}],
+    :xt/iid #bytes "a45bf7e0122b3deaa89ee5c388bc8421"}
+   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 349}],
+    :xt/iid #bytes "a5d307b96b2b4bd640801787928d33a1"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 292}],
+    :xt/iid #bytes "aa96051eba0190666442c9e13663dd8b"}
+   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 351}],
+    :xt/iid #bytes "aac67940459fe9f1d74ea620f0eb6539"}
+   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 360}],
+    :xt/iid #bytes "aee97d8cbd834162daa98a77b4d5d45b"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 309}],
+    :xt/iid #bytes "aeef4815c98f43631ce3e7fa79c88d5a"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 308}],
+    :xt/iid #bytes "af8b1f927602f6510a2e32f8870dddf2"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 306}],
+    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 231}],
+    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
+  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 252}],
+    :xt/iid #bytes "b04edac037b8f0c58aa6e3cba929be7b"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 229}],
+    :xt/iid #bytes "b056163d4500a9b7c567ea0e880ca843"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 323}],
+    :xt/iid #bytes "b1ddb0175d32e2d8deaf8db0acd68081"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 244}],
+    :xt/iid #bytes "b1fec1d08d3466c41015367662f792f5"}
+   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 367}],
+    :xt/iid #bytes "b21bf2e871caf485affa8bf8257ab7b0"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 371}],
+    :xt/iid #bytes "b2850224fee939d9a34db0ed0a048909"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 293}],
+    :xt/iid #bytes "b38a063cbd17de5fee53028cb28cb6c9"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 373}],
+    :xt/iid #bytes "b3d4b6b25eb711b06bd251b6aa27063b"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 370}],
+    :xt/iid #bytes "b575edc9ba6f2b65bb8879029b210b36"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 368}],
+    :xt/iid #bytes "b697203f7a62cf99032204ab908c03ee"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 192}],
+    :xt/iid #bytes "b69fb20bf81ad4015c4eda4adb1fd86c"}
    {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 248}],
+    :xt/iid #bytes "b95e782e3641975f92a07964af9880fa"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
+    :op #xt/tagged [:put #:xt{:id 245}],
+    :xt/iid #bytes "b987787c691234eb44fc769d508ef673"}
    {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
+    :op #xt/tagged [:put #:xt{:id 255}],
+    :xt/iid #bytes "b9e613a4af1a9cdfa1c1c294888aaf8b"}
    {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 328}],
+    :xt/iid #bytes "b9f134d4acdcdc122d70a47d3c0cd770"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 271}],
+    :xt/iid #bytes "ba4a5c6bb1e49fa84d4bb75fb918f0bf"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 289}],
+    :xt/iid #bytes "ba9b299b96d610b78b388db8c0c4ec2a"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 246}],
+    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
+  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 250}],
+    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
+    :op #xt/tagged [:put #:xt{:id 273}],
+    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
    {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 214}],
+    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
+    :op #xt/tagged [:put #:xt{:id 303}],
+    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
    {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
+    :op #xt/tagged [:put #:xt{:id 340}],
+    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
    {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 282}],
+    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}]
+  [{:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
+    :op #xt/tagged [:put #:xt{:id 296}],
+    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
    {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
+    :op #xt/tagged [:put #:xt{:id 345}],
+    :xt/iid #bytes "d3a037e2077aa958dbf55b25fcb4726b"}
    {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 341}],
+    :xt/iid #bytes "dbe5414720eccb345e777b3b272a4c7d"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
+    :op #xt/tagged [:put #:xt{:id 302}],
+    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
    {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
+    :op #xt/tagged [:put #:xt{:id 366}],
+    :xt/iid #bytes "de057c7061fd92dad090c7fb9d831476"}
    {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
+    :op #xt/tagged [:put #:xt{:id 222}],
+    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}]
+  [{:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 343}],
+    :xt/iid #bytes "e3c8005c1ec50b1fbda9808230b85fb0"}
    {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 268}],
+    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
+    :op #xt/tagged [:put #:xt{:id 196}],
+    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
    {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
+    :op #xt/tagged [:put #:xt{:id 327}],
+    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
    {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
+    :op #xt/tagged [:put #:xt{:id 266}],
+    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 310}],
+    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
    {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
-   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
+    :op #xt/tagged [:put #:xt{:id 346}],
+    :xt/iid #bytes "ec354fb331777f9b941cb9d740706b01"}
    {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 330}],
-    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 219}],
-    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 216}],
-    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 253}],
-    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 361}],
-    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
-   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 223}],
-    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}
-   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 269}],
-    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
-   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 347}],
-    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
+    :op #xt/tagged [:put #:xt{:id 324}],
+    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
    {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 286}],
-    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 281}],
+    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 321}],
-    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
-   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 338}],
-    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 358}],
-    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 335}],
-    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
-   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
+    :op #xt/tagged [:put #:xt{:id 227}],
+    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}]
   [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b08.arrow.edn
@@ -5,175 +5,195 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 410}],
-    :xt/iid #bytes "c5c5ea28b27d81898c571a88382405e6"}
+    :op #xt/tagged [:put #:xt{:id 383}],
+    :xt/iid #bytes "02b8c2b7673c15a95dfd6913f32e8f09"}
    {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 416}],
-    :xt/iid #bytes "cb96947163d263dd6202d400873a0b0e"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 419}],
+    :xt/iid #bytes "08d2b357054853321ffdb148ceb10caf"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 390}],
-    :xt/iid #bytes "cc455aadcaefd61b6feb78e13676303c"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 417}],
+    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 409}],
-    :xt/iid #bytes "d1774c643b3195d04e97f4cea573f097"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 413}],
-    :xt/iid #bytes "d215be82a2ee12542ffcca5897e714df"}
+    :op #xt/tagged [:put #:xt{:id 400}],
+    :xt/iid #bytes "1b1b79a35aeafbc06592176f573e0042"}
    {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 377}],
-    :xt/iid #bytes "d7cf450e4e0f3674c3b16e04ccc2fa5b"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 411}],
-    :xt/iid #bytes "d8ae3f4f6b239bf530e282e2400d3dcf"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 388}],
-    :xt/iid #bytes "da706a0e0a0913f0c1325339a0af3123"}
+    :op #xt/tagged [:put #:xt{:id 376}],
+    :xt/iid #bytes "24834573b46c64c14e8e12b64330ba30"}
    {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 418}],
-    :xt/iid #bytes "dc83a6d8062b13624fba06a8b7ee5b66"}
+    :op #xt/tagged [:put #:xt{:id 420}],
+    :xt/iid #bytes "2adafd3da744bcf5467845ab755d211f"}
    {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 386}],
-    :xt/iid #bytes "dcfe83f89f01bf7858bac6f03be1c14a"}
+    :op #xt/tagged [:put #:xt{:id 389}],
+    :xt/iid #bytes "2bad149c85071b2be11a2a67e2af1e58"}
    {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 399}],
-    :xt/iid #bytes "dd5bfa7db6d104e157973ef63d0ac3cb"}]
-  [{:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 395}],
+    :xt/iid #bytes "306b41bc873028f8e5b0642580fb4521"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 410}],
-    :xt/iid #bytes "c5c5ea28b27d81898c571a88382405e6"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 416}],
-    :xt/iid #bytes "cb96947163d263dd6202d400873a0b0e"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 390}],
-    :xt/iid #bytes "cc455aadcaefd61b6feb78e13676303c"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 409}],
-    :xt/iid #bytes "d1774c643b3195d04e97f4cea573f097"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 413}],
-    :xt/iid #bytes "d215be82a2ee12542ffcca5897e714df"}
+    :op #xt/tagged [:put #:xt{:id 398}],
+    :xt/iid #bytes "32981be2d8883ebc7c548aafe6b666f9"}
    {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 377}],
-    :xt/iid #bytes "d7cf450e4e0f3674c3b16e04ccc2fa5b"}
+    :op #xt/tagged [:put #:xt{:id 379}],
+    :xt/iid #bytes "332e02ea44f791f2334e44bf431d6bd4"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 405}],
+    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}]
+  [{:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 392}],
+    :xt/iid #bytes "4319f3203c52e94f9cd2d55bdc6b1a57"}
    {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 411}],
-    :xt/iid #bytes "d8ae3f4f6b239bf530e282e2400d3dcf"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 388}],
-    :xt/iid #bytes "da706a0e0a0913f0c1325339a0af3123"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 418}],
-    :xt/iid #bytes "dc83a6d8062b13624fba06a8b7ee5b66"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 386}],
-    :xt/iid #bytes "dcfe83f89f01bf7858bac6f03be1c14a"}
+    :op #xt/tagged [:put #:xt{:id 412}],
+    :xt/iid #bytes "4881948f6493423b6f873950d4ab23f1"}
    {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 399}],
-    :xt/iid #bytes "dd5bfa7db6d104e157973ef63d0ac3cb"}]
-  [{:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 410}],
-    :xt/iid #bytes "c5c5ea28b27d81898c571a88382405e6"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 416}],
-    :xt/iid #bytes "cb96947163d263dd6202d400873a0b0e"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 390}],
-    :xt/iid #bytes "cc455aadcaefd61b6feb78e13676303c"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 409}],
-    :xt/iid #bytes "d1774c643b3195d04e97f4cea573f097"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 413}],
-    :xt/iid #bytes "d215be82a2ee12542ffcca5897e714df"}
+    :op #xt/tagged [:put #:xt{:id 397}],
+    :xt/iid #bytes "49a612e5c77e92f21a04cd506048d201"}
    {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 377}],
-    :xt/iid #bytes "d7cf450e4e0f3674c3b16e04ccc2fa5b"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 411}],
-    :xt/iid #bytes "d8ae3f4f6b239bf530e282e2400d3dcf"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 388}],
-    :xt/iid #bytes "da706a0e0a0913f0c1325339a0af3123"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 418}],
-    :xt/iid #bytes "dc83a6d8062b13624fba06a8b7ee5b66"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 386}],
-    :xt/iid #bytes "dcfe83f89f01bf7858bac6f03be1c14a"}
+    :op #xt/tagged [:put #:xt{:id 380}],
+    :xt/iid #bytes "4c78ac06bb228d9e4844029f45591a11"}
    {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 399}],
-    :xt/iid #bytes "dd5bfa7db6d104e157973ef63d0ac3cb"}]
+    :op #xt/tagged [:put #:xt{:id 394}],
+    :xt/iid #bytes "50526f18ac2803b7328d2d03c1792bdf"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 406}],
+    :xt/iid #bytes "537ed1967c0ccdfa9971c7cde00136a1"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 382}],
+    :xt/iid #bytes "5a0a91139ab680056b334c3b47d76fc1"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 421}],
+    :xt/iid #bytes "5da82c952ba1706c2df8f7c60f4f9431"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 385}],
+    :xt/iid #bytes "5e11e8c2103098519bb75c1be90cbb17"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 403}],
+    :xt/iid #bytes "65346aea0c1af23d419e60b7abdf30c6"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 408}],
+    :xt/iid #bytes "6601cf81fa0ec225d224620a8038ce2f"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 423}],
+    :xt/iid #bytes "68432f5d7e1f8a46862f216459b1a55c"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 384}],
+    :xt/iid #bytes "6ca4e00614e81073425d212ab2f70616"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 402}],
+    :xt/iid #bytes "6d5cde261c8cb3a43ed42f6f73c1e2b8"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 404}],
+    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 415}],
+    :xt/iid #bytes "70dfa5a5ebdad27d07b6592700f1a97f"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 396}],
+    :xt/iid #bytes "77b2d5e712ea307e65d8bc8c24b84a0c"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 391}],
+    :xt/iid #bytes "7bd1c224fb28704a51e5de0b8e096bc3"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 414}],
+    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
+  [{:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 381}],
+    :xt/iid #bytes "80d23f470a73bf8ccd8cd2d9dcad9e19"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 407}],
+    :xt/iid #bytes "86c532555d67c47fd793ecd666951da1"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 393}],
+    :xt/iid #bytes "96d10f2161cfbd2b058021591719b1b3"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 422}],
+    :xt/iid #bytes "97af2f69b47d2dc2d3fbcd3cf72d8b05"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 401}],
+    :xt/iid #bytes "994d44aa22e97b07c7ce68afe33aee17"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 378}],
+    :xt/iid #bytes "9d8582da7355a018dedeff22a1941300"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 387}],
+    :xt/iid #bytes "a215a70114030c1c2b1bea5237cca6bb"}]
   [{:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b09.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/data/l01-rc-b09.arrow.edn
@@ -5,550 +5,400 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 470}],
-    :xt/iid #bytes "c49bf28414e3f1da8e39619079a81aee"}
+    :op #xt/tagged [:put #:xt{:id 383}],
+    :xt/iid #bytes "02b8c2b7673c15a95dfd6913f32e8f09"}
    {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 428}],
-    :xt/iid #bytes "c4cc9a0763831b05820c6177cfba9654"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 410}],
-    :xt/iid #bytes "c5c5ea28b27d81898c571a88382405e6"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 467}],
-    :xt/iid #bytes "c67481d53afd3b683b9059a3ac6be7e3"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 416}],
-    :xt/iid #bytes "cb96947163d263dd6202d400873a0b0e"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 390}],
-    :xt/iid #bytes "cc455aadcaefd61b6feb78e13676303c"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 409}],
-    :xt/iid #bytes "d1774c643b3195d04e97f4cea573f097"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 413}],
-    :xt/iid #bytes "d215be82a2ee12542ffcca5897e714df"}
-   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 377}],
-    :xt/iid #bytes "d7cf450e4e0f3674c3b16e04ccc2fa5b"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 411}],
-    :xt/iid #bytes "d8ae3f4f6b239bf530e282e2400d3dcf"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 388}],
-    :xt/iid #bytes "da706a0e0a0913f0c1325339a0af3123"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 418}],
-    :xt/iid #bytes "dc83a6d8062b13624fba06a8b7ee5b66"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 386}],
-    :xt/iid #bytes "dcfe83f89f01bf7858bac6f03be1c14a"}
-   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 399}],
-    :xt/iid #bytes "dd5bfa7db6d104e157973ef63d0ac3cb"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 471}],
-    :xt/iid #bytes "e597b9f0e0afa385c677c7dea7d561b9"}
-   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 433}],
-    :xt/iid #bytes "eda010faad5673847724822d9ee49202"}
-   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 454}],
-    :xt/iid #bytes "f4d7adf88ece397a121abc45d74abfb0"}
+    :op #xt/tagged [:put #:xt{:id 429}],
+    :xt/iid #bytes "053a6977d02b42bea31f3c4f7f3acc79"}
    {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 442}],
-    :xt/iid #bytes "fbe3f7033ca7952bacfbc503d989189f"}]
-  [{:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 447}],
+    :xt/iid #bytes "07ba6fc791d6d1b4a2f6addeec72c973"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 470}],
-    :xt/iid #bytes "c49bf28414e3f1da8e39619079a81aee"}
+    :op #xt/tagged [:put #:xt{:id 419}],
+    :xt/iid #bytes "08d2b357054853321ffdb148ceb10caf"}
    {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 428}],
-    :xt/iid #bytes "c4cc9a0763831b05820c6177cfba9654"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 410}],
-    :xt/iid #bytes "c5c5ea28b27d81898c571a88382405e6"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 467}],
-    :xt/iid #bytes "c67481d53afd3b683b9059a3ac6be7e3"}
+    :op #xt/tagged [:put #:xt{:id 427}],
+    :xt/iid #bytes "08e4e441a456cc34bae06349dd60d5fd"}
    {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 416}],
-    :xt/iid #bytes "cb96947163d263dd6202d400873a0b0e"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 390}],
-    :xt/iid #bytes "cc455aadcaefd61b6feb78e13676303c"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 409}],
-    :xt/iid #bytes "d1774c643b3195d04e97f4cea573f097"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 413}],
-    :xt/iid #bytes "d215be82a2ee12542ffcca5897e714df"}
-   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 377}],
-    :xt/iid #bytes "d7cf450e4e0f3674c3b16e04ccc2fa5b"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 411}],
-    :xt/iid #bytes "d8ae3f4f6b239bf530e282e2400d3dcf"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 388}],
-    :xt/iid #bytes "da706a0e0a0913f0c1325339a0af3123"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 418}],
-    :xt/iid #bytes "dc83a6d8062b13624fba06a8b7ee5b66"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 386}],
-    :xt/iid #bytes "dcfe83f89f01bf7858bac6f03be1c14a"}
-   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 399}],
-    :xt/iid #bytes "dd5bfa7db6d104e157973ef63d0ac3cb"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 471}],
-    :xt/iid #bytes "e597b9f0e0afa385c677c7dea7d561b9"}
+    :op #xt/tagged [:put #:xt{:id 417}],
+    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}
    {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 433}],
-    :xt/iid #bytes "eda010faad5673847724822d9ee49202"}
-   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 454}],
-    :xt/iid #bytes "f4d7adf88ece397a121abc45d74abfb0"}
+    :op #xt/tagged [:put #:xt{:id 434}],
+    :xt/iid #bytes "11d35b86e570d2697398309175ea7a87"}
    {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 442}],
-    :xt/iid #bytes "fbe3f7033ca7952bacfbc503d989189f"}]
-  [{:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 470}],
-    :xt/iid #bytes "c49bf28414e3f1da8e39619079a81aee"}
+    :op #xt/tagged [:put #:xt{:id 443}],
+    :xt/iid #bytes "121f00ced97b4850e336b9b996bdd256"}
    {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 428}],
-    :xt/iid #bytes "c4cc9a0763831b05820c6177cfba9654"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 424}],
+    :xt/iid #bytes "1a9db013c23698996c24054e4689bd2a"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 410}],
-    :xt/iid #bytes "c5c5ea28b27d81898c571a88382405e6"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 467}],
-    :xt/iid #bytes "c67481d53afd3b683b9059a3ac6be7e3"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 416}],
-    :xt/iid #bytes "cb96947163d263dd6202d400873a0b0e"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 390}],
-    :xt/iid #bytes "cc455aadcaefd61b6feb78e13676303c"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 409}],
-    :xt/iid #bytes "d1774c643b3195d04e97f4cea573f097"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 413}],
-    :xt/iid #bytes "d215be82a2ee12542ffcca5897e714df"}
-   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 377}],
-    :xt/iid #bytes "d7cf450e4e0f3674c3b16e04ccc2fa5b"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 411}],
-    :xt/iid #bytes "d8ae3f4f6b239bf530e282e2400d3dcf"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 388}],
-    :xt/iid #bytes "da706a0e0a0913f0c1325339a0af3123"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 418}],
-    :xt/iid #bytes "dc83a6d8062b13624fba06a8b7ee5b66"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 386}],
-    :xt/iid #bytes "dcfe83f89f01bf7858bac6f03be1c14a"}
-   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 399}],
-    :xt/iid #bytes "dd5bfa7db6d104e157973ef63d0ac3cb"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 471}],
-    :xt/iid #bytes "e597b9f0e0afa385c677c7dea7d561b9"}
-   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 433}],
-    :xt/iid #bytes "eda010faad5673847724822d9ee49202"}
+    :op #xt/tagged [:put #:xt{:id 400}],
+    :xt/iid #bytes "1b1b79a35aeafbc06592176f573e0042"}
    {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 454}],
-    :xt/iid #bytes "f4d7adf88ece397a121abc45d74abfb0"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 455}],
+    :xt/iid #bytes "1bdd3ca9d412dd197128b6d27dac0a6b"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 442}],
-    :xt/iid #bytes "fbe3f7033ca7952bacfbc503d989189f"}]
-  [{:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 470}],
-    :xt/iid #bytes "c49bf28414e3f1da8e39619079a81aee"}
+    :op #xt/tagged [:put #:xt{:id 456}],
+    :xt/iid #bytes "1c874f41a08af02077529343929f1b78"}
    {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 428}],
-    :xt/iid #bytes "c4cc9a0763831b05820c6177cfba9654"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 430}],
+    :xt/iid #bytes "1dda28be91aa26e1e5e90397516e57ac"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 410}],
-    :xt/iid #bytes "c5c5ea28b27d81898c571a88382405e6"}
+    :op #xt/tagged [:put #:xt{:id 461}],
+    :xt/iid #bytes "21a706fa6186126cf2a6efcc2a65dad2"}
    {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 467}],
-    :xt/iid #bytes "c67481d53afd3b683b9059a3ac6be7e3"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 465}],
+    :xt/iid #bytes "2229a8ff78688b5d05e15ce9c93932a8"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 416}],
-    :xt/iid #bytes "cb96947163d263dd6202d400873a0b0e"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 390}],
-    :xt/iid #bytes "cc455aadcaefd61b6feb78e13676303c"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 409}],
-    :xt/iid #bytes "d1774c643b3195d04e97f4cea573f097"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 413}],
-    :xt/iid #bytes "d215be82a2ee12542ffcca5897e714df"}
+    :op #xt/tagged [:put #:xt{:id 457}],
+    :xt/iid #bytes "22eb6570812f64897590261a6c14b06d"}
    {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 377}],
-    :xt/iid #bytes "d7cf450e4e0f3674c3b16e04ccc2fa5b"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 411}],
-    :xt/iid #bytes "d8ae3f4f6b239bf530e282e2400d3dcf"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 388}],
-    :xt/iid #bytes "da706a0e0a0913f0c1325339a0af3123"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 418}],
-    :xt/iid #bytes "dc83a6d8062b13624fba06a8b7ee5b66"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 386}],
-    :xt/iid #bytes "dcfe83f89f01bf7858bac6f03be1c14a"}
-   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 399}],
-    :xt/iid #bytes "dd5bfa7db6d104e157973ef63d0ac3cb"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 471}],
-    :xt/iid #bytes "e597b9f0e0afa385c677c7dea7d561b9"}
+    :op #xt/tagged [:put #:xt{:id 376}],
+    :xt/iid #bytes "24834573b46c64c14e8e12b64330ba30"}
    {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 433}],
-    :xt/iid #bytes "eda010faad5673847724822d9ee49202"}
-   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 454}],
-    :xt/iid #bytes "f4d7adf88ece397a121abc45d74abfb0"}
+    :op #xt/tagged [:put #:xt{:id 432}],
+    :xt/iid #bytes "26a40ccf9005c87d3c204bb1324757ed"}
    {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 442}],
-    :xt/iid #bytes "fbe3f7033ca7952bacfbc503d989189f"}]
-  [{:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 440}],
+    :xt/iid #bytes "29b26d263599d9d09708f72720587d5d"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 470}],
-    :xt/iid #bytes "c49bf28414e3f1da8e39619079a81aee"}
+    :op #xt/tagged [:put #:xt{:id 435}],
+    :xt/iid #bytes "29ded64f8fee1492a466acca72be8615"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 420}],
+    :xt/iid #bytes "2adafd3da744bcf5467845ab755d211f"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 389}],
+    :xt/iid #bytes "2bad149c85071b2be11a2a67e2af1e58"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 395}],
+    :xt/iid #bytes "306b41bc873028f8e5b0642580fb4521"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 398}],
+    :xt/iid #bytes "32981be2d8883ebc7c548aafe6b666f9"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 379}],
+    :xt/iid #bytes "332e02ea44f791f2334e44bf431d6bd4"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 439}],
+    :xt/iid #bytes "385d8c524478f9ff13ef582b3728ed64"}
+   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 445}],
+    :xt/iid #bytes "3b9e76139a41541bfbe5a9d78188d6c0"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 458}],
+    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 405}],
+    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}]
+  [{:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 392}],
+    :xt/iid #bytes "4319f3203c52e94f9cd2d55bdc6b1a57"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 436}],
+    :xt/iid #bytes "43caa786a93a2c016c69071b61d77e96"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 412}],
+    :xt/iid #bytes "4881948f6493423b6f873950d4ab23f1"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 397}],
+    :xt/iid #bytes "49a612e5c77e92f21a04cd506048d201"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 380}],
+    :xt/iid #bytes "4c78ac06bb228d9e4844029f45591a11"}]
+  [{:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 394}],
+    :xt/iid #bytes "50526f18ac2803b7328d2d03c1792bdf"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 406}],
+    :xt/iid #bytes "537ed1967c0ccdfa9971c7cde00136a1"}
    {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 428}],
-    :xt/iid #bytes "c4cc9a0763831b05820c6177cfba9654"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 410}],
-    :xt/iid #bytes "c5c5ea28b27d81898c571a88382405e6"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 467}],
-    :xt/iid #bytes "c67481d53afd3b683b9059a3ac6be7e3"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 416}],
-    :xt/iid #bytes "cb96947163d263dd6202d400873a0b0e"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 390}],
-    :xt/iid #bytes "cc455aadcaefd61b6feb78e13676303c"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 409}],
-    :xt/iid #bytes "d1774c643b3195d04e97f4cea573f097"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 413}],
-    :xt/iid #bytes "d215be82a2ee12542ffcca5897e714df"}
-   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 377}],
-    :xt/iid #bytes "d7cf450e4e0f3674c3b16e04ccc2fa5b"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 411}],
-    :xt/iid #bytes "d8ae3f4f6b239bf530e282e2400d3dcf"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 388}],
-    :xt/iid #bytes "da706a0e0a0913f0c1325339a0af3123"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 418}],
-    :xt/iid #bytes "dc83a6d8062b13624fba06a8b7ee5b66"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 386}],
-    :xt/iid #bytes "dcfe83f89f01bf7858bac6f03be1c14a"}
-   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 399}],
-    :xt/iid #bytes "dd5bfa7db6d104e157973ef63d0ac3cb"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 471}],
-    :xt/iid #bytes "e597b9f0e0afa385c677c7dea7d561b9"}
-   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 433}],
-    :xt/iid #bytes "eda010faad5673847724822d9ee49202"}
-   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 454}],
-    :xt/iid #bytes "f4d7adf88ece397a121abc45d74abfb0"}
+    :op #xt/tagged [:put #:xt{:id 425}],
+    :xt/iid #bytes "5405c8a9dc9ddcebfc1c9fdbf481ab8c"}
    {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 442}],
-    :xt/iid #bytes "fbe3f7033ca7952bacfbc503d989189f"}]
-  [{:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 446}],
+    :xt/iid #bytes "57f4b946317bd6164b6f0732fd7f2b62"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 470}],
-    :xt/iid #bytes "c49bf28414e3f1da8e39619079a81aee"}
+    :op #xt/tagged [:put #:xt{:id 451}],
+    :xt/iid #bytes "5888758023a576352a8ca1b8124e2d3b"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 452}],
+    :xt/iid #bytes "58b1511372b6f8a114257bb8c3929d68"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 382}],
+    :xt/iid #bytes "5a0a91139ab680056b334c3b47d76fc1"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 421}],
+    :xt/iid #bytes "5da82c952ba1706c2df8f7c60f4f9431"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 385}],
+    :xt/iid #bytes "5e11e8c2103098519bb75c1be90cbb17"}]
+  [{:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 453}],
+    :xt/iid #bytes "600f440034c740822a8f1f92043e4512"}
+   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 444}],
+    :xt/iid #bytes "608140d56e0a18407c6dc197418e7545"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 403}],
+    :xt/iid #bytes "65346aea0c1af23d419e60b7abdf30c6"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 408}],
+    :xt/iid #bytes "6601cf81fa0ec225d224620a8038ce2f"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 423}],
+    :xt/iid #bytes "68432f5d7e1f8a46862f216459b1a55c"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 463}],
+    :xt/iid #bytes "6c4f27d2fda3e6a6eedf9c94c0674ed0"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 384}],
+    :xt/iid #bytes "6ca4e00614e81073425d212ab2f70616"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 402}],
+    :xt/iid #bytes "6d5cde261c8cb3a43ed42f6f73c1e2b8"}
    {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 428}],
-    :xt/iid #bytes "c4cc9a0763831b05820c6177cfba9654"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 431}],
+    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 404}],
+    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}]
+  [{:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 410}],
-    :xt/iid #bytes "c5c5ea28b27d81898c571a88382405e6"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 467}],
-    :xt/iid #bytes "c67481d53afd3b683b9059a3ac6be7e3"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 416}],
-    :xt/iid #bytes "cb96947163d263dd6202d400873a0b0e"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 390}],
-    :xt/iid #bytes "cc455aadcaefd61b6feb78e13676303c"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 409}],
-    :xt/iid #bytes "d1774c643b3195d04e97f4cea573f097"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 413}],
-    :xt/iid #bytes "d215be82a2ee12542ffcca5897e714df"}
-   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 377}],
-    :xt/iid #bytes "d7cf450e4e0f3674c3b16e04ccc2fa5b"}
-   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 411}],
-    :xt/iid #bytes "d8ae3f4f6b239bf530e282e2400d3dcf"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 388}],
-    :xt/iid #bytes "da706a0e0a0913f0c1325339a0af3123"}
-   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 418}],
-    :xt/iid #bytes "dc83a6d8062b13624fba06a8b7ee5b66"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 386}],
-    :xt/iid #bytes "dcfe83f89f01bf7858bac6f03be1c14a"}
-   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 399}],
-    :xt/iid #bytes "dd5bfa7db6d104e157973ef63d0ac3cb"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 471}],
-    :xt/iid #bytes "e597b9f0e0afa385c677c7dea7d561b9"}
-   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 433}],
-    :xt/iid #bytes "eda010faad5673847724822d9ee49202"}
+    :op #xt/tagged [:put #:xt{:id 415}],
+    :xt/iid #bytes "70dfa5a5ebdad27d07b6592700f1a97f"}
    {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 454}],
-    :xt/iid #bytes "f4d7adf88ece397a121abc45d74abfb0"}
+    :op #xt/tagged [:put #:xt{:id 448}],
+    :xt/iid #bytes "7176d63cfa5755d6a95fca2b08322c05"}
+   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 464}],
+    :xt/iid #bytes "7244cbb7a275a81641f4db80c949130c"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 449}],
+    :xt/iid #bytes "74a1da0e0a4e146d10e3e40495030c9a"}
+   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 426}],
+    :xt/iid #bytes "75f127af00d99ac26209d0f0747438ff"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 437}],
+    :xt/iid #bytes "770c0ba1af7a39304cb3dec9f0e43e81"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 396}],
+    :xt/iid #bytes "77b2d5e712ea307e65d8bc8c24b84a0c"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 391}],
+    :xt/iid #bytes "7bd1c224fb28704a51e5de0b8e096bc3"}
+   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 468}],
+    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 414}],
+    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
+  [{:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 381}],
+    :xt/iid #bytes "80d23f470a73bf8ccd8cd2d9dcad9e19"}
    {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 442}],
-    :xt/iid #bytes "fbe3f7033ca7952bacfbc503d989189f"}]
+    :op #xt/tagged [:put #:xt{:id 441}],
+    :xt/iid #bytes "8229455080f46f622ae870194790fedc"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 407}],
+    :xt/iid #bytes "86c532555d67c47fd793ecd666951da1"}
+   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 469}],
+    :xt/iid #bytes "8796f072cb4553a575599bfef8a3cd7e"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 438}],
+    :xt/iid #bytes "8af0bea47e728fb36c815efab63e2d07"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 459}],
+    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 462}],
+    :xt/iid #bytes "918b6293b2fa3a37dcedfe5b3cf09d22"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 393}],
+    :xt/iid #bytes "96d10f2161cfbd2b058021591719b1b3"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 422}],
+    :xt/iid #bytes "97af2f69b47d2dc2d3fbcd3cf72d8b05"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 401}],
+    :xt/iid #bytes "994d44aa22e97b07c7ce68afe33aee17"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 450}],
+    :xt/iid #bytes "99e7235f9fb06410499cb78f8f954615"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 460}],
+    :xt/iid #bytes "9c1d01c3a71b8f26af17f69bf86ba351"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 378}],
+    :xt/iid #bytes "9d8582da7355a018dedeff22a1941300"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 387}],
+    :xt/iid #bytes "a215a70114030c1c2b1bea5237cca6bb"}
+   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 466}],
+    :xt/iid #bytes "b735cdb86891b96f46826eb00fdc6331"}]
   [{:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b01.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b02.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b03.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b04.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b04.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b05.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b05.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b06.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b06.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b07.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b08.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b09.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l1-compaction/meta/l01-rc-b09.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200106-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200106-b02.arrow.edn
@@ -5,460 +5,800 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 1}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 0}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 1}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 0}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 1}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 0}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 0}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 0}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 1}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 0}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 1}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 0}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 0}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 1}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 0}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 1}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 0}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 0}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 1}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 0}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 0}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 0}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 0}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 1}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 0}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 1}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 0}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 0}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 1}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 0}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 1}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 0}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 0}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 1}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 0}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 1}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 0}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 1}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 0}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 1}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 0}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 1}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 0}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 0}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 0}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 1}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 0}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 0}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 1}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 0}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 1}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 0}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 1}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 0}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 1}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 0}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 1}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 0}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 0}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 1}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 0}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 1}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 0}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 0}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 1}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 0}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 1}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 0}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 1}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 0}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 0}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 1}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 0}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 1}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 0}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 1}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 0}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 1}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 0}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 1}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 0}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 1}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 0}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 1}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 0}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 1}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 0}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 1}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 0}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 0}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 0}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 0}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 0}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 0}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 34, :price 1}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 34, :price 0}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 0}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 3, :price 1}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 3, :price 0}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 73, :price 0}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 1}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 0}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 1}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 0}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 0}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 0}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 1}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 0}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 0}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 1}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 0}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 0}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 1}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 0}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 1}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 0}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 0}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 1}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 0}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 1}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 0}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 1}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 0}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 1}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 0}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 1}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 0}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 0}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 1}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 0}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 1}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 0}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 1}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 55, :price 0}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 0}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 0}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 0}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 1}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 0}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 1}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 0}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 1}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 0}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 0}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 1}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 0}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 1}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 0}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 0}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 1}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 0}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 1}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 0}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 0}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 0}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 1}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 0}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200106-b04.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200106-b04.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 3}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 2}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 3}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 2}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 3}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 2}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 2}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 1}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 2}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 1}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 3}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 2}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 3}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 2}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 2}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 1}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 3}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 2}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 3}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 2}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 2}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 1}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 3}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 2}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 2}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 1}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 2}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 1}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 2}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 1}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 3}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 2}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 3}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 2}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :price 2}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 1}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 3}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 2}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 3}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 2}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 2}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 1}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 3}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 2}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 3}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 2}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 3}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 2}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 3}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 2}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 3}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 2}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 2}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 1}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 2}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 1}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 3}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 2}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 3}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 2}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 3}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 2}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 3}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 2}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 3}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 2}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 3}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 2}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 3}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 2}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 2}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 1}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 3}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 2}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 3}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 2}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :price 2}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 1}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 3}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 2}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 3}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 2}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 3}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 2}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 2}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 1}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 3}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 2}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 3}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 2}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 3}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 2}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 3}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 2}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 3}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 2}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 3}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 2}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 3}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 2}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 3}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 2}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 3}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 2}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 2}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 1}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 2}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 1}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 2}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 1}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 2}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :price 1}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :price 2}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :price 1}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 3}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 2}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 2}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 1}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 3}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 2}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 2}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 1}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 3}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 2}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 3}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 2}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 2}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 1}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 2}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 1}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 3}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 2}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 2}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 1}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 3}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 2}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 2}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 1}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 3}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 2}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 3}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 2}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 2}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 1}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 3}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 2}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 3}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 2}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 3}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 2}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 3}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 2}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 3}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 2}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 2}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 1}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 3}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 2}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 3}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 2}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 3}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :price 2}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 2}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :price 1}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 2}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 1}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 2}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 1}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 3}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 2}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 3}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 2}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 3}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 2}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 2}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 1}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 3}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 2}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 3}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 2}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 2}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 1}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 3}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 2}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 3}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 2}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :price 2}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 1}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 2}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 1}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 3}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 2}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200106-b06.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200106-b06.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 5}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 4}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 5}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 4}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 5}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 4}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 4}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 3}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 4}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 3}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 5}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 4}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 5}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 4}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 4}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 3}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 5}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 4}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 5}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 4}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 4}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 3}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 5}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 4}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 4}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 3}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 4}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 3}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 4}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 3}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 5}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 4}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 5}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 4}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :price 4}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 3}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 5}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 4}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 5}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 4}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 4}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 3}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 5}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 4}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 5}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 4}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 5}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 4}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 5}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 4}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 5}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 4}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 4}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 3}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 4}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 3}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 5}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 4}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 5}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 4}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 5}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 4}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 5}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 4}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 5}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 4}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 5}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 4}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 5}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 4}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 4}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 3}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 5}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 4}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 5}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 4}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :price 4}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 3}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 5}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 4}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 5}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 4}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 5}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 4}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 4}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 3}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 5}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 5}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 4}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 5}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 4}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 5}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 4}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 5}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 4}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 5}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 4}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 5}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 4}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 5}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 4}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 5}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 4}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 4}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 3}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 4}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 3}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 4}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 3}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 4}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :price 3}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :price 4}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :price 3}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 5}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 4}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 4}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 3}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 5}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 4}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 4}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 3}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 5}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 4}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 5}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 4}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 4}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 3}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 4}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 3}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 5}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 4}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 4}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 3}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 5}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 4}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 4}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 3}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 5}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 4}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 5}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 4}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 4}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 3}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 5}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 4}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 5}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 4}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 5}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 4}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 5}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 4}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 5}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 4}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 4}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 3}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 5}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 4}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 5}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 4}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 5}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :price 4}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 4}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :price 3}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 4}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 3}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 4}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 3}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 5}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 4}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 5}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 4}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 5}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 4}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 4}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 3}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 5}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 4}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 5}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 4}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 4}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 3}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 5}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 4}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 5}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 4}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :price 4}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 3}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 4}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 3}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 5}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 4}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200106-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200106-b08.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 7}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 6}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 7}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 6}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 7}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 6}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 6}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 5}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 6}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 5}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 7}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 6}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 7}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 6}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 6}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 5}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 7}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 6}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 7}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 6}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 6}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 5}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 7}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 6}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 6}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 5}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 6}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 5}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 6}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 5}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 7}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 6}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 7}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 6}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :price 6}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 5}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 7}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 6}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 7}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 6}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 6}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 5}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 7}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 6}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 7}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 6}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 7}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 6}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 7}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 6}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 7}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 6}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 6}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 5}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 6}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 5}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 7}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 6}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 7}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 6}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 7}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 6}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 7}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 6}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 7}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 6}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 7}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 6}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 7}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 6}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 6}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 5}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 7}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 6}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 7}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 6}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :price 6}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 5}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 7}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 6}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 7}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 6}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 7}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 6}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 6}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 5}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 7}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 6}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 7}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 6}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 7}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 6}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 7}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 6}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 7}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 6}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 7}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 6}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 7}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 6}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 7}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 6}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 7}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 6}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 6}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 5}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 6}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 5}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 6}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 5}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 6}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :price 5}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :price 6}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :price 5}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 7}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 6}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 6}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 5}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 7}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 6}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 6}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 5}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 7}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 6}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 7}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 6}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 6}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 5}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 6}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 5}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 7}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 6}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 6}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 5}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 7}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 6}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 6}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 5}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 7}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 6}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 7}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 6}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 6}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 5}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 7}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 6}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 7}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 6}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 7}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 6}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 7}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 6}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 7}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 6}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 6}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 5}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 7}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 6}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 7}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 6}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 7}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :price 6}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 6}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :price 5}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 6}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 5}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 6}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 5}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 7}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 6}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 7}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 6}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 7}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 6}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 6}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 5}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 7}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 6}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 7}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 6}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 6}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 5}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 7}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 6}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 7}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 6}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :price 6}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 5}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 6}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 5}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 7}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 6}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200106-b0a.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200106-b0a.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 9}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 8}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 9}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 8}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 9}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 8}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 8}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 7}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 8}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 7}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 9}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 8}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 9}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 8}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 8}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 7}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 9}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 8}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 9}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 8}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 8}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 7}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 9}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 8}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 8}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 7}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 8}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 7}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 8}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 7}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 9}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 8}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 9}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 8}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :price 8}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 7}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 9}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 8}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 9}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 8}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 8}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 7}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 9}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 8}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 9}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 8}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 9}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 8}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 9}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 8}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 9}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 8}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 8}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 7}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 8}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 7}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 9}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 8}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 9}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 8}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 9}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 8}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 9}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 8}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 9}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 8}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 9}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 8}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 9}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 8}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 8}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 7}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 9}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 8}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 9}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 8}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :price 8}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 7}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 9}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 8}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 9}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 8}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 9}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 8}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 8}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 7}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 9}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 8}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 9}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 8}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 9}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 8}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 9}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 8}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 9}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 8}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 9}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 8}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 9}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 8}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 9}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 8}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 9}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 8}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 8}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 7}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 8}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 7}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 8}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 7}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 8}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :price 7}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :price 8}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :price 7}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 9}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 8}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 8}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 7}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 9}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 8}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 8}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 7}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 9}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 8}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 9}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 8}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 8}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 7}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 8}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 7}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 9}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 8}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 8}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 7}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 9}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 8}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 8}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 7}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 9}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 8}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 9}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 8}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 8}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 7}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 9}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 8}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 9}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 8}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 9}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 8}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 9}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 8}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 9}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 8}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 8}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 7}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 9}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 8}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 9}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 8}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 9}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :price 8}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 8}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :price 7}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 8}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 7}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 8}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 7}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 9}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 8}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 9}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 8}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 9}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 8}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 8}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 7}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 9}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 8}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 9}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 8}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 8}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 7}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 9}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 8}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 9}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 8}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :price 8}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 7}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 8}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 7}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 9}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 8}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b0c.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b0c.arrow.edn
@@ -5,460 +5,800 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 11}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 10}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 11}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 10}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 11}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 10}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 10}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 10}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 11}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 10}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 11}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 10}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 10}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 11}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 10}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 11}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 10}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 10}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 11}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 10}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 10}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 10}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 10}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 11}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 10}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 11}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 10}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 10}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 11}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 10}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 11}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 10}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 10}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 11}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 10}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 11}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 10}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 11}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 10}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 11}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 10}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 11}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 10}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 10}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 10}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 11}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 10}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 11}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 10}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 11}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 10}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 11}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 10}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 11}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 10}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 11}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 10}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 11}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 10}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 10}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 11}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 10}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 11}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 10}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 10}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 11}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 10}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 11}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 10}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 11}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 10}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 10}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 11}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 10}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 11}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 10}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 11}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 10}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 11}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 10}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 11}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 10}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 11}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 10}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 11}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 10}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 11}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 10}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 11}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 10}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 10}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 10}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 10}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 10}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 10}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 34, :price 11}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 34, :price 10}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 10}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 3, :price 11}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 3, :price 10}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 73, :price 10}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 11}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 10}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 11}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 10}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 10}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 10}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 11}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 10}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 10}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 11}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 10}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 10}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 11}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 10}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 11}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 10}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 10}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 11}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 10}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 11}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 10}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 11}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 10}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 11}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 10}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 11}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 10}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 10}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 11}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 10}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 11}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 10}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 11}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 55, :price 10}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 10}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 10}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 10}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 11}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 10}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 11}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 10}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 11}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 10}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 10}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 11}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 10}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 11}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 10}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 10}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 11}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 10}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 11}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 10}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 10}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 10}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 11}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 10}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b0e.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b0e.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 13}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 12}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 13}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 12}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 13}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 12}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 12}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 11}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 12}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 11}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 13}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 12}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 13}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 12}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 12}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 11}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 13}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 12}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 13}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 12}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 12}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 11}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 13}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 12}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 12}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 11}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 12}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 11}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 12}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 11}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 13}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 12}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 13}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 12}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :price 12}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 11}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 13}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 12}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 13}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 12}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 12}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 11}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 13}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 12}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 13}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 12}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 13}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 12}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 13}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 12}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 13}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 12}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 12}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 11}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 12}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 11}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 13}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 12}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 13}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 12}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 13}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 12}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 13}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 12}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 13}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 12}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 13}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 12}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 13}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 12}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 12}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 11}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 13}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 12}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 13}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 12}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :price 12}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 11}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 13}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 12}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 13}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 12}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 13}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 12}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 12}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 11}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 13}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 12}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 13}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 12}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 13}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 12}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 13}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 12}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 13}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 12}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 13}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 12}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 13}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 12}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 13}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 12}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 13}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 12}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 12}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 11}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 12}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 11}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 12}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 11}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 12}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :price 11}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :price 12}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :price 11}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 13}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 12}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 12}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 11}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 13}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 12}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 12}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 11}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 13}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 12}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 13}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 12}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 12}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 11}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 12}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 11}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 13}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 12}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 12}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 11}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 13}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 12}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 12}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 11}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 13}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 12}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 13}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 12}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 12}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 11}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 13}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 12}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 13}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 12}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 13}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 12}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 13}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 12}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 13}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 12}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 12}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 11}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 13}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 12}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 13}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 12}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 13}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :price 12}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 12}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :price 11}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 12}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 11}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 12}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 11}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 13}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 12}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 13}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 12}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 13}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 12}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 12}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 11}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 13}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 12}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 13}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 12}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 12}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 11}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 13}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 12}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 13}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 12}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :price 12}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 11}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 12}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 11}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 13}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 12}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b110.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b110.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 15}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 14}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 15}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 14}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 15}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 14}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 14}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 13}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 14}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 13}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 15}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 14}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 15}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 14}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 14}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 13}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 15}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 14}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 15}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 14}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 14}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 13}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 15}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 14}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 14}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 13}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 14}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 13}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 14}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 13}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 15}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 14}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 15}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 14}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :price 14}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 13}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 15}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 14}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 15}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 14}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 14}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 13}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 15}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 14}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 15}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 14}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 15}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 14}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 15}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 14}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 15}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 14}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 14}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 13}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 14}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 13}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 15}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 14}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 15}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 14}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 15}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 14}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 15}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 14}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 15}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 14}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 15}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 14}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 15}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 14}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 14}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 13}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 15}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 14}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 15}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 14}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :price 14}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 13}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 15}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 14}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 15}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 14}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 15}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 14}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 14}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 13}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 15}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 14}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 15}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 14}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 15}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 14}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 15}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 14}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 15}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 14}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 15}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 14}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 15}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 14}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 15}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 14}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 15}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 14}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 14}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 13}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 14}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 13}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 14}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 13}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 14}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :price 13}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :price 14}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :price 13}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 15}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 14}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 14}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 13}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 15}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 14}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 14}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 13}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 15}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 14}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 15}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 14}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 14}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 13}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 14}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 13}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 15}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 14}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 14}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 13}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 15}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 14}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 14}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 13}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 15}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 14}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 15}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 14}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 14}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 13}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 15}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 14}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 15}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 14}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 15}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 14}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 15}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 14}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 15}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 14}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 14}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 13}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 15}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 14}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 15}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 14}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 15}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :price 14}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 14}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :price 13}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 14}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 13}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 14}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 13}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 15}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 14}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 15}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 14}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 15}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 14}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 14}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 13}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 15}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 14}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 15}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 14}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 14}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 13}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 15}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 14}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 15}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 14}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :price 14}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 13}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 14}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 13}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 15}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 14}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b112.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b112.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 17}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 16}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 17}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 16}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 17}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 16}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 16}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 15}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 16}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 15}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 17}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 16}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 17}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 16}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 16}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 15}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 17}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 16}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 17}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 16}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 16}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 15}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 17}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 16}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 16}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 15}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 16}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 15}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 16}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 15}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 17}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 16}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 17}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 16}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :price 16}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 15}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 17}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 16}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 17}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 16}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 16}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 15}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 17}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 16}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 17}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 16}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 17}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 16}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 17}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 16}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 17}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 16}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 16}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 15}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 16}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 15}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 17}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 16}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 17}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 16}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 17}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 16}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 17}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 16}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 17}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 16}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 17}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 16}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 17}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 16}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 16}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 15}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 17}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 16}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 17}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 16}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :price 16}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 15}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 17}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 16}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 17}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 16}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 17}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 16}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 16}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 15}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 17}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 16}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 17}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 16}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 17}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 16}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 17}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 16}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 17}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 16}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 17}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 16}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 17}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 16}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 17}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 16}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 17}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 16}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 16}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 15}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 16}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 15}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 16}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 15}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 16}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :price 15}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :price 16}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :price 15}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 17}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 16}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 16}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 15}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 17}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 16}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 16}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 15}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 17}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 16}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 17}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 16}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 16}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 15}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 16}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 15}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 17}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 16}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 16}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 15}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 17}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 16}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 16}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 15}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 17}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 16}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 17}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 16}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 16}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 15}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 17}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 16}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 17}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 16}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 17}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 16}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 17}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 16}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 17}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 16}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 16}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 15}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 17}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 16}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 17}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 16}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 17}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :price 16}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 16}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :price 15}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 16}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 15}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 16}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 15}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 17}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 16}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 17}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 16}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 17}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 16}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 16}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 15}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 17}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 16}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 17}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 16}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 16}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 15}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 17}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 16}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 17}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 16}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :price 16}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 15}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 16}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 15}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 17}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 16}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b114.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b114.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 19}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 18}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 19}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 18}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 19}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 18}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 18}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 17}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 18}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 17}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 19}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 18}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 19}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 18}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 18}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 17}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 19}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 18}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 19}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 18}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 18}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 17}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 19}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 18}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 18}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 17}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 18}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 17}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 18}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 17}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 19}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 18}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 19}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 18}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :price 18}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 17}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 19}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 18}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 19}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 18}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 18}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 17}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 19}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 18}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 19}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 18}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 19}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 18}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 19}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 18}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 19}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 18}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 18}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 17}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 18}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 17}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 19}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 18}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 19}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 18}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 19}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 18}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 19}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 18}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 19}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 18}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 19}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 18}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 19}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 18}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 18}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 17}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 19}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 18}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 19}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 18}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :price 18}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 17}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 19}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 18}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 19}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 18}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 19}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 18}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 18}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 17}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 19}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 18}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 19}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 18}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 19}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 18}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 19}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 18}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 19}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 18}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 19}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 18}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 19}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 18}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 19}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 18}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 19}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 18}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 18}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 17}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 18}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 17}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 18}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 17}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 18}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :price 17}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :price 18}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :price 17}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 19}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 18}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 18}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 17}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 19}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 18}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 18}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 17}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 19}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 18}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 19}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 18}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 18}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 17}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 18}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 17}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 19}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 18}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 18}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 17}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 19}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 18}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 18}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 17}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 19}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 18}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 19}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 18}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 18}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 17}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 19}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 18}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 19}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 18}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 19}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 18}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 19}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 18}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 19}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 18}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 18}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 17}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 19}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 18}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 19}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 18}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 19}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :price 18}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 18}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :price 17}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 18}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 17}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 18}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 17}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 19}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 18}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 19}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 18}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 19}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 18}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 18}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 17}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 19}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 18}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 19}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 18}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 18}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 17}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 19}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 18}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 19}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 18}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :price 18}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 17}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 18}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 17}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 19}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 18}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b116.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b116.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 21}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 20}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 21}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 20}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 21}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 20}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 20}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 19}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 20}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 19}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 21}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 20}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 21}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 20}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 20}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 19}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 21}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 20}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 21}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 20}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 20}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 19}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 21}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 20}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 20}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 19}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 20}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 19}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 20}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 19}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 21}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 20}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 21}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 20}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :price 20}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 19}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 21}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 20}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 21}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 20}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 20}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 19}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 21}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 20}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 21}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 20}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 21}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 20}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 21}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 20}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 21}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 20}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 20}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 19}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 20}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 19}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 21}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 20}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 21}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 20}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 21}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 20}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 21}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 20}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 21}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 20}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 21}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 20}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 21}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 20}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 20}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 19}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 21}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 20}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 21}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 20}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :price 20}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 19}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 21}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 20}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 21}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 20}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 21}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 20}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 20}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 19}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 21}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 20}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 21}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 20}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 21}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 20}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 21}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 20}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 21}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 20}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 21}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 20}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 21}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 20}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 21}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 20}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 21}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 20}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 20}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 19}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 20}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 19}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 20}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 19}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 20}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :price 19}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :price 20}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :price 19}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 21}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 20}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 20}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 19}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 21}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 20}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 20}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 19}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 21}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 20}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 21}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 20}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 20}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 19}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 20}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 19}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 21}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 20}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 20}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 19}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 21}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 20}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 20}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 19}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 21}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 20}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 21}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 20}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 20}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 19}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 21}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 20}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 21}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 20}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 21}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 20}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 21}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 20}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 21}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 20}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 20}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 19}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 21}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 20}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 21}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 20}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 21}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :price 20}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 20}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :price 19}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 20}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 19}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 20}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 19}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 21}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 20}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 21}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 20}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 21}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 20}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 20}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 19}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 21}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 20}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 21}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 20}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 20}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 19}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 21}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 20}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 21}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 20}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :price 20}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 19}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 20}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 19}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 21}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 20}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b118.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l02-r20200113-b118.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :price 23}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :price 22}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 23}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :price 22}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 23}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :price 22}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :price 22}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :price 21}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 22}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 21}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 23}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 22}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 23}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 22}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 22}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 21}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 23}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 22}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 23}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :price 22}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 22}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 21}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 23}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 22}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 22}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 21}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 22}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 21}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 22}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :price 21}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 23}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :price 22}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 23}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :price 22}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :price 22}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :price 21}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 23}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :price 22}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 23}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 22}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 22}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 21}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 23}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :price 22}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 23}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :price 22}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 23}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :price 22}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 23}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 22}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 23}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 22}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 22}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 21}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 22}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 21}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 23}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :price 22}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 23}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 22}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 23}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :price 22}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 23}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 22}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 23}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :price 22}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 23}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 22}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 23}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :price 22}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 22}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :price 21}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 23}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :price 22}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 23}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :price 22}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :price 22}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :price 21}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 23}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :price 22}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 23}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 22}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 23}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 22}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 22}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 21}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 23}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 22}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 23}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :price 22}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 23}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :price 22}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 23}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 22}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 23}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :price 22}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 23}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :price 22}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 23}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :price 22}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 23}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :price 22}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 23}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :price 22}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 22}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 21}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 22}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 21}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 22}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 21}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :price 22}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :price 21}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :price 22}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :price 21}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 23}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 22}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 22}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :price 21}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 23}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :price 22}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 22}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 21}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 23}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :price 22}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 23}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :price 22}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 22}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 21}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 22}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 21}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 23}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :price 22}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 22}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 21}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 23}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :price 22}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 22}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 21}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 23}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 22}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 23}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 22}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 22}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :price 21}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 23}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :price 22}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 23}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :price 22}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 23}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :price 22}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 23}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :price 22}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 23}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :price 22}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 22}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 21}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 23}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :price 22}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 23}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :price 22}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :price 23}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :price 22}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 22}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :price 21}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 22}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 21}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 22}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 21}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 23}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 22}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 23}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :price 22}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 23}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 22}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 22}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :price 21}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 23}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :price 22}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 23}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :price 22}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 22}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 21}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 23}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :price 22}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 23}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :price 22}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :price 22}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 21}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 22}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :price 21}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :price 23}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 22}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200106-p0-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200106-p0-b08.arrow.edn
@@ -5,410 +5,845 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 7}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 6}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 5}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 4}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 3}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 2}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 1}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 5, :price 0}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 7}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 6}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 5}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 4}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 3}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 2}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 1}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 0}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 7}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 6}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 5}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 4}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 3}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 2}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 1}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 0}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 6}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 5}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 4}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 3}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 2}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 1}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 0}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 6}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 5}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 4}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 3}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 2}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 1}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 0}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 7}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 6}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 5}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 4}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 3}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 2}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 1}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 0}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 7}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 6}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 5}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 4}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 3}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 2}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 1}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 0}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 6}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 5}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 4}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 3}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 2}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 1}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 0}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 7}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 6}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 5}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 4}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 3}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 2}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 1}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 0}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 7}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 6}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 5}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 4}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 3}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 2}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 1}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 25, :price 0}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 6}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 5}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 4}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 3}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 2}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 1}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 0}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 7}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 6}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 5}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 4}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 3}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 2}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 1}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 0}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 6}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 5}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 4}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 3}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 2}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 1}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 0}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 6}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 5}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 4}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 3}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 2}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 1}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 0}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 6}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 5}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 4}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 3}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 2}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 1}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 0}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 7}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 6}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 5}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 4}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 3}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 2}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 1}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 0}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 7}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 6}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 5}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 4}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 3}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 2}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 1}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 0}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 6}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 5}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 4}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 3}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 2}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 1}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 0}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 7}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 6}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 5}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 4}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 3}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 2}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 1}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 49, :price 0}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 7}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 6}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 5}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 4}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 3}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 2}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 1}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 0}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 6}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 5}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 4}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 3}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 2}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 1}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 0}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 7}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 6}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 5}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 4}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 3}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 2}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 1}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 39, :price 0}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200106-p1-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200106-p1-b08.arrow.edn
@@ -5,490 +5,985 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 7}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 6}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 5}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 4}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 3}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 2}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 1}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 23, :price 0}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 7}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 6}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 5}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 4}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 3}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 2}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 1}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 0}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 7}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 6}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 5}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 4}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 3}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 2}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 1}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 0}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 6}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 5}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 4}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 3}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 2}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 1}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 0}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 6}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 5}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 4}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 3}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 2}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 1}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 0}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 7}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 6}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 5}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 4}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 3}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 2}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 1}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 8, :price 0}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 7}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 6}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 5}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 4}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 3}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 2}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 0}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 7}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 6}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 5}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 4}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 3}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 2}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 1}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 52, :price 0}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 7}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 6}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 5}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 4}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 3}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 2}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 1}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 0}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 7}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 6}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 5}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 4}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 3}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 2}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 1}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 11, :price 0}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 7}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 6}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 5}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 4}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 3}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 2}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 1}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 0}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 7}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 6}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 5}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 4}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 3}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 2}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 1}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 60, :price 0}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 6}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 5}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 4}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 3}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 2}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 1}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 0}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 7}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 6}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 5}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 4}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 3}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 2}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 1}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 0}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 7}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 6}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 5}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 4}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 3}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 2}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 1}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 0}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 6}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 5}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 4}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 3}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 2}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 1}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 0}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 7}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 6}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 5}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 4}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 3}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 2}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 1}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 44, :price 0}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 7}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 6}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 5}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 4}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 3}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 2}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 1}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 0}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 7}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 6}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 5}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 4}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 3}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 2}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 1}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 0}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 6}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 5}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 4}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 3}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 2}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 1}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 0}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 7}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 6}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 5}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 3}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 2}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 1}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 0}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 7}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 6}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 5}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 4}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 3}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 2}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 1}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 10, :price 0}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 7}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 6}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 5}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 4}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 3}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 2}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 1}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 57, :price 0}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 7}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 6}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 5}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 4}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 3}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 2}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 1}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 0}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 7}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 6}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 5}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 4}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 3}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 2}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 1}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 38, :price 0}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200106-p2-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200106-p2-b08.arrow.edn
@@ -5,1570 +5,950 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 7}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 6}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 5}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 4}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 3}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 2}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 1}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 0}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 7}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 6}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 5}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 4}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 3}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 2}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 1}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 43, :price 0}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 7}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 6}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 5}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 4}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 3}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 2}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 1}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 0}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 6}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 5}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 4}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 3}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 2}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 1}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 0}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 6}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 5}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 4}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 3}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 2}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 1}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 0}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 6}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 5}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 4}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 3}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 2}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 1}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 0}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 6}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 5}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 4}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 3}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 2}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 1}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 0}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 6}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 5}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 4}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 3}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 2}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 1}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 0}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 7}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 6}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 5}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 4}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 3}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 2}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 1}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 0}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 6}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 5}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 4}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 3}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 2}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 1}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 98, :price 0}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 7}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 6}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 5}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 4}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 3}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 2}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 1}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 0}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 6}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 5}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 4}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 3}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 2}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 1}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 0}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 7}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 6}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 5}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 4}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 3}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 2}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 1}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 36, :price 0}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 7}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 6}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 5}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 4}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 3}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 2}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 1}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 0}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 6}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 5}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 4}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 3}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 2}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 1}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 0}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 6}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 5}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 4}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 3}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 2}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 1}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 0}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 7}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 6}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 5}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 4}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 3}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 2}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 1}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 0}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 6}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 5}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 4}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 3}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 2}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 1}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 0}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 7}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 6}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 5}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 4}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 3}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 2}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 1}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 45, :price 0}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 6}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 5}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 4}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 3}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 2}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 1}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 0}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 7}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 6}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 5}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 4}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 3}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 2}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 1}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 0}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 7}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 6}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 5}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 4}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 3}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 2}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 1}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 0}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 6}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 5}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 4}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 3}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 2}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 1}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 99, :price 0}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 7}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 6}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 5}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 4}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 3}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 2}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 1}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 0}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 7}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 6}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 5}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 4}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 3}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 2}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 1}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 15, :price 0}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200106-p3-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200106-p3-b08.arrow.edn
@@ -5,1510 +5,730 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 6}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 5}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 4}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 3}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 2}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 1}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 0}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 7}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 6}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 5}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 4}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 3}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 2}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 1}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 0}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 7}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 6}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 5}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 4}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 3}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 2}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 1}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 0}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 7}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 6}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 5}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 4}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 3}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 2}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 1}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 55, :price 0}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 6}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 5}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 4}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 3}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 2}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 1}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 0}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 6}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 5}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 4}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 3}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 2}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 1}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 0}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 6}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 5}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 4}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 3}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 2}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 1}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 0}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 7}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 6}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 5}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 4}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 3}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 2}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 1}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 0}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 7}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 6}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 5}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 4}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 3}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 2}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 1}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 0}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 7}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 6}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 5}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 4}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 3}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 2}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 1}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 35, :price 0}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 6}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 5}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 4}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 3}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 2}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 1}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 0}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 7}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 6}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 5}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 4}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 3}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 2}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 1}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 0}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 7}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 6}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 5}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 4}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 3}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 2}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 1}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 13, :price 0}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 6}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 5}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 4}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 3}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 2}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 1}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 0}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 7}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 6}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 5}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 4}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 3}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 2}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 1}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 0}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 7}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 6}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 5}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 4}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 3}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 2}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 1}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 18, :price 0}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 6}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 5}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 4}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 3}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 2}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 1}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 0}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 6}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 5}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 4}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 3}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 2}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 1}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 0}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 7}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 6}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 5}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 4}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 3}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 2}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 1}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 0}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200113-p0-b112.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200113-p0-b112.arrow.edn
@@ -5,410 +5,845 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 17}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 16}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 15}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 14}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 13}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 12}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :price 11}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 5, :price 10}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 17}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 16}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 15}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 14}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 13}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 12}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 11}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :price 10}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 17}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 16}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 15}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 14}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 13}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 12}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 11}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :price 10}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 16}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 15}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 14}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 13}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 12}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 11}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :price 10}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 16}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 15}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 14}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 13}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 12}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 11}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :price 10}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 17}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 16}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 15}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 14}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 13}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 12}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 11}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :price 10}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 17}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 16}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 15}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 14}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 13}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 12}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 11}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :price 10}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 16}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 15}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 14}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 13}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 12}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 11}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :price 10}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 17}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 16}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 15}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 14}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 13}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 12}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 11}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :price 10}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 17}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 16}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 15}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 14}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 13}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 12}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :price 11}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 25, :price 10}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 16}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 15}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 14}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 13}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 12}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 11}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :price 10}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 17}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 16}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 15}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 14}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 13}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 12}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 11}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :price 10}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 16}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 15}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 14}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 13}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 12}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 11}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :price 10}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 16}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 15}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 14}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 13}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 12}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 11}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :price 10}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 16}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 15}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 14}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 13}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 12}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 11}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :price 10}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 17}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 16}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 15}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 14}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 13}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 12}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 11}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :price 10}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 17}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 16}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 15}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 14}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 13}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 12}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 11}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :price 10}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 16}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 15}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 14}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 13}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 12}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 11}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :price 10}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 17}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 16}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 15}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 14}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 13}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 12}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :price 11}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 49, :price 10}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 17}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 16}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 15}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 14}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 13}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 12}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :price 11}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :price 10}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 16}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 15}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 14}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 13}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 12}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 11}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :price 10}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 17}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 16}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 15}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 14}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 13}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 12}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :price 11}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :price 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 39, :price 10}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200113-p1-b112.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200113-p1-b112.arrow.edn
@@ -5,490 +5,985 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 17}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 16}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 15}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 14}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 13}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 12}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :price 11}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 23, :price 10}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 17}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 16}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 15}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 14}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 13}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 12}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 11}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :price 10}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 17}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 16}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 15}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 14}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 13}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 12}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 11}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :price 10}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 16}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 15}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 14}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 13}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 12}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 11}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :price 10}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 16}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 15}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 14}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 13}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 12}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 11}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :price 10}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 17}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 16}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 15}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 14}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 13}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 12}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :price 11}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 8, :price 10}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 17}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 16}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 15}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 14}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 13}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 12}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 11}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :price 10}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 17}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 16}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 15}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 14}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 13}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 12}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :price 11}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 52, :price 10}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 17}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 16}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 15}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 14}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 13}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 12}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 11}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :price 10}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 17}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 16}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 15}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 14}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 13}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 12}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :price 11}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 11, :price 10}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 17}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 16}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 15}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 14}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 13}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 12}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 11}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :price 10}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 17}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 16}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 15}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 14}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 13}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 12}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :price 11}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 60, :price 10}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 16}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 15}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 14}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 13}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 12}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 11}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :price 10}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 17}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 16}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 15}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 14}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 13}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 12}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 11}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :price 10}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 17}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 16}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 15}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 14}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 13}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 12}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 11}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :price 10}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 16}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 15}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 14}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 13}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 12}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 11}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :price 10}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 17}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 16}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 15}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 14}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 13}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 12}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :price 11}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 44, :price 10}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 17}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 16}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 15}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 14}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 13}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 12}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 11}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :price 10}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 17}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 16}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 15}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 14}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 13}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 12}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 11}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :price 10}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 16}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 15}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 14}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 13}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 12}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 11}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :price 10}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 17}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 16}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 15}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 14}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 13}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 12}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 11}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :price 10}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 17}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 16}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 15}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 14}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 13}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 12}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :price 11}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 10, :price 10}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 17}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 16}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 15}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 14}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 13}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 12}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :price 11}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 57, :price 10}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 17}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 16}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 15}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 14}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 13}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 12}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 11}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :price 10}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 17}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 16}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 15}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 14}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 13}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 12}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :price 11}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :price 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 38, :price 10}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200113-p2-b112.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200113-p2-b112.arrow.edn
@@ -5,1570 +5,950 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 17}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 16}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 15}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 14}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 13}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 12}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 11}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :price 10}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 17}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 16}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 15}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 14}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 13}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 12}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :price 11}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 43, :price 10}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 17}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 16}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 15}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 14}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 13}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 12}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 11}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :price 10}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 16}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 15}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 14}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 13}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 12}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 11}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :price 10}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 16}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 15}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 14}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 13}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 12}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 11}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :price 10}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 16}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 15}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 14}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 13}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 12}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 11}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :price 10}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 16}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 15}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 14}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 13}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 12}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 11}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :price 10}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 16}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 15}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 14}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 13}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 12}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 11}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :price 10}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 17}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 16}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 15}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 14}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 13}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 12}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :price 11}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :price 10}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 16}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 15}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 14}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 13}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 12}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :price 11}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 98, :price 10}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 17}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 16}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 15}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 14}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 13}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 12}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 11}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :price 10}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 16}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 15}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 14}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 13}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 12}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 11}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :price 10}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 17}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 16}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 15}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 14}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 13}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 12}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :price 11}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 36, :price 10}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 17}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 16}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 15}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 14}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 13}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 12}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 11}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :price 10}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 16}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 15}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 14}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 13}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 12}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 11}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :price 10}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 16}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 15}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 14}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 13}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 12}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 11}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :price 10}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 17}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 16}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 15}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 14}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 13}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 12}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 11}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :price 10}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 16}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 15}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 14}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 13}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 12}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 11}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :price 10}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 17}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 16}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 15}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 14}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 13}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 12}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :price 11}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 45, :price 10}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 16}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 15}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 14}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 13}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 12}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 11}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :price 10}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 17}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 16}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 15}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 14}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 13}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 12}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 11}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :price 10}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 17}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 16}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 15}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 14}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 13}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 12}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :price 11}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :price 10}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 16}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 15}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 14}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 13}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 12}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :price 11}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 99, :price 10}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 17}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 16}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 15}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 14}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 13}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 12}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 11}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :price 10}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 17}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 16}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 15}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 14}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 13}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 12}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :price 11}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :price 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :price 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :price 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 15, :price 10}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200113-p3-b112.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/data/l03-r20200113-p3-b112.arrow.edn
@@ -5,1510 +5,730 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"price" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "price" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 16}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 15}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 14}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 13}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 12}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 11}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :price 10}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 17}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 16}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 15}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 14}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 13}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 12}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 11}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :price 10}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 17}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 16}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 15}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 14}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 13}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 12}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 11}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :price 10}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 17}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 16}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 15}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 14}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 13}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 12}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :price 11}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 55, :price 10}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 16}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 15}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 14}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 13}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 12}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :price 11}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :price 10}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 16}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 15}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 14}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 13}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 12}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 11}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :price 10}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 16}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 15}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 14}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 13}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 12}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 11}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :price 10}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 17}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 16}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 15}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 14}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 13}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 12}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :price 11}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :price 10}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 17}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 16}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 15}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 14}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 13}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 12}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 11}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :price 10}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :price 17}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 16}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 15}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 14}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 13}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 12}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :price 11}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 35, :price 10}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 16}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 15}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 14}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 13}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 12}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 11}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :price 10}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 17}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 16}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 15}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 14}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 13}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 12}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 11}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :price 10}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 17}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 16}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 15}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 14}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 13}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 12}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :price 11}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 13, :price 10}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 16}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 15}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 14}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 13}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 12}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 11}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :price 10}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 17}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 16}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 15}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 14}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 13}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 12}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 11}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :price 10}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 17}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 16}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 15}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 14}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 13}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 12}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :price 11}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 18, :price 10}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 16}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 15}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 14}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 13}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 12}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 11}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :price 10}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 16}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 15}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 14}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 13}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 12}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 11}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :price 10}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 17}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 16}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 15}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 14}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 13}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 12}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :price 11}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :price 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :price 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :price 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :price 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :price 10}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200106-b02.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200106-b02.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200106-b04.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200106-b04.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200106-b06.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200106-b06.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200106-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200106-b08.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200106-b0a.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200106-b0a.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b0c.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b0c.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b0e.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b0e.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b110.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b110.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b112.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b112.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b114.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b114.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b116.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b116.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b118.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l02-r20200113-b118.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200106-p0-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200106-p0-b08.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200106-p1-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200106-p1-b08.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200106-p2-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200106-p2-b08.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200106-p3-b08.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200106-p3-b08.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200113-p0-b112.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200113-p0-b112.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200113-p1-b112.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200113-p1-b112.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200113-p2-b112.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200113-p2-b112.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200113-p3-b112.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/prices/meta/l03-r20200113-p3-b112.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200106-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200106-b01.arrow.edn
@@ -5,460 +5,800 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 1}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 0}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 1}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 0}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 1}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 0}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 0}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 0}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 1}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 0}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 1}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 0}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 0}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 1}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 0}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 1}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 0}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 0}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 1}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 0}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 0}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 0}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 0}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 1}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 0}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 1}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 0}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 0}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 1}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 0}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 1}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 0}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 0}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 1}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 0}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 1}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 0}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 1}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 0}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 1}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 0}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 1}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 0}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 0}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 0}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 1}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 0}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 0}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 1}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 0}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 1}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 0}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 1}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 0}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 1}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 0}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 1}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 0}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 0}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 1}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 0}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 1}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 0}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 0}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 1}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 0}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 1}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 0}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 1}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 0}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 0}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 1}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 0}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 1}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 0}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 1}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 0}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 1}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 0}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 1}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 0}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 1}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 0}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 1}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 0}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 1}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 0}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 0}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 0}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 0}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 0}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 0}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 1}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 0}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 0}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 1}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 0}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 73, :reading 0}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 1}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 0}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 1}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 0}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 0}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 0}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 1}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 0}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 0}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 1}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 0}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 0}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 1}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 0}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 1}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 0}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 0}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 1}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 0}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 1}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 0}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 0}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 1}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 0}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 1}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 0}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 1}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 55, :reading 0}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 0}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 0}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 0}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 1}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 0}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 1}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 0}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 1}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 0}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 0}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 1}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 0}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 1}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 0}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 0}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 1}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 0}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 1}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 0}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 0}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 0}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 1}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 0}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200106-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200106-b03.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 3}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 2}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 3}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 2}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 3}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 2}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 2}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 1}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 2}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 1}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 3}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 2}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 3}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 2}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 2}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 1}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 3}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 2}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 3}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 2}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 2}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 1}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 3}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 2}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 2}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 1}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 2}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 1}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 2}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 1}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 3}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 2}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 3}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 2}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 2}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 1}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 3}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 2}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 3}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 2}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 2}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 1}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 3}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 2}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 3}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 2}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 3}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 2}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 3}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 2}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 3}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 2}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 2}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 1}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 2}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 1}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 3}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 2}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 3}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 2}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 3}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 2}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 3}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 2}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 3}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 2}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 3}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 2}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 3}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 2}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 2}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 1}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 3}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 2}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 3}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 2}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 2}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 1}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 3}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 2}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 3}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 2}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 3}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 2}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 2}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 1}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 3}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 2}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 3}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 2}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 3}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 2}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 3}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 2}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 3}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 2}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 3}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 2}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 3}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 2}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 3}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 2}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 2}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 1}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 2}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 1}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 2}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 1}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 2}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 1}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 2}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :reading 1}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 3}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 2}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 2}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 1}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 3}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 2}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 2}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 1}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 3}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 2}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 3}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 2}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 2}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 1}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 2}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 1}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 3}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 2}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 2}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 1}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 3}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 2}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 2}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 1}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 3}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 2}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 3}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 2}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 2}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 1}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 3}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 2}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 3}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 2}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 2}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 1}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 3}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 2}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 3}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 2}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 3}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 2}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 2}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :reading 1}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 2}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 1}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 2}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 1}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 3}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 2}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 3}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 2}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 3}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 2}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 2}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 1}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 3}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 2}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 3}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 2}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 2}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 1}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 3}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 2}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 3}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 2}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :reading 2}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 1}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 2}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 1}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 3}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 2}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200106-b05.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200106-b05.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 5}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 4}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 5}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 4}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 5}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 4}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 4}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 3}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 4}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 3}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 5}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 4}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 5}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 4}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 4}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 3}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 5}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 4}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 5}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 4}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 4}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 3}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 5}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 4}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 4}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 3}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 4}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 3}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 4}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 3}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 5}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 4}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 5}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 4}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 4}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 3}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 5}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 4}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 5}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 4}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 4}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 3}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 5}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 4}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 5}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 4}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 5}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 4}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 5}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 4}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 5}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 4}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 4}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 3}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 4}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 3}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 5}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 4}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 5}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 4}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 5}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 4}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 5}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 4}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 5}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 4}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 5}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 4}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 5}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 4}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 4}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 3}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 5}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 4}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 5}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 4}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 4}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 3}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 5}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 4}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 5}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 4}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 5}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 4}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 4}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 3}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 5}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 5}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 4}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 5}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 4}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 5}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 4}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 5}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 4}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 5}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 4}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 5}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 4}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 5}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 4}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 4}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 3}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 4}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 3}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 4}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 3}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 4}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 3}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 4}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :reading 3}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 5}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 4}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 4}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 3}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 5}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 4}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 4}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 3}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 5}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 4}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 5}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 4}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 4}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 3}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 4}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 3}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 5}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 4}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 4}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 3}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 5}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 4}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 4}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 3}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 5}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 4}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 5}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 4}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 4}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 3}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 5}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 4}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 5}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 4}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 4}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 3}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 5}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 4}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 5}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 4}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 5}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 4}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 4}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :reading 3}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 4}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 3}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 4}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 3}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 5}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 4}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 5}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 4}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 5}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 4}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 4}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 3}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 5}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 4}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 5}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 4}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 4}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 3}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 5}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 4}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 5}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 4}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :reading 4}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 3}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 4}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 3}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 5}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 4}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200106-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200106-b07.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 7}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 6}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 7}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 6}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 7}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 6}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 6}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 5}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 6}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 5}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 7}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 6}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 7}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 6}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 6}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 5}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 7}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 6}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 7}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 6}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 6}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 5}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 7}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 6}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 6}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 5}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 6}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 5}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 6}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 5}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 7}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 6}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 7}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 6}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 6}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 5}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 7}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 6}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 7}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 6}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 6}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 5}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 7}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 6}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 7}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 6}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 7}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 6}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 7}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 6}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 7}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 6}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 6}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 5}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 6}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 5}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 7}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 6}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 7}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 6}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 7}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 6}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 7}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 6}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 7}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 6}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 7}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 6}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 7}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 6}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 6}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 5}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 7}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 6}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 7}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 6}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 6}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 5}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 7}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 6}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 7}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 6}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 7}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 6}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 6}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 5}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 7}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 6}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 7}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 6}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 7}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 6}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 7}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 6}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 7}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 6}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 7}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 6}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 7}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 6}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 7}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 6}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 6}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 5}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 6}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 5}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 6}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 5}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 6}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 5}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 6}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :reading 5}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 7}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 6}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 6}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 5}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 7}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 6}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 6}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 5}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 7}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 6}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 7}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 6}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 6}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 5}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 6}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 5}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 7}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 6}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 6}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 5}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 7}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 6}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 6}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 5}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 7}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 6}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 7}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 6}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 6}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 5}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 7}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 6}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 7}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 6}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 6}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 5}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 7}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 6}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 7}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 6}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 7}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 6}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 6}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :reading 5}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 6}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 5}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 6}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 5}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 7}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 6}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 7}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 6}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 7}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 6}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 6}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 5}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 7}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 6}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 7}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 6}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 6}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 5}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 7}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 6}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 7}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 6}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :reading 6}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 5}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 6}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 5}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 7}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 6}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200106-b09.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200106-b09.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 9}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 8}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 9}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 8}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 9}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 8}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 8}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 7}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 8}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 7}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 9}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 8}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 9}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 8}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 8}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 7}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 9}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 8}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 9}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 8}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 8}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 7}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 9}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 8}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 8}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 7}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 8}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 7}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 8}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 7}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 9}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 8}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 9}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 8}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 8}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 7}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 9}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 8}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 9}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 8}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 8}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 7}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 9}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 8}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 9}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 8}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 9}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 8}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 9}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 8}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 9}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 8}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 8}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 7}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 8}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 7}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 9}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 8}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 9}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 8}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 9}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 8}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 9}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 8}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 9}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 8}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 9}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 8}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 9}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 8}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 8}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 7}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 9}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 8}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 9}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 8}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 8}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 7}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 9}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 8}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 9}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 8}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 9}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 8}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 8}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 7}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 9}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 8}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 9}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 8}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 9}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 8}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 9}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 8}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 9}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 8}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 9}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 8}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 9}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 8}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 9}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 8}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 9}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 8}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 8}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 7}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 8}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 7}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 8}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 7}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 8}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 7}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 8}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :reading 7}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 9}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 8}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 8}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 7}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 9}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 8}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 8}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 7}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 9}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 8}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 9}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 8}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 8}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 7}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 8}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 7}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 9}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 8}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 8}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 7}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 9}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 8}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 8}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 7}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 9}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 8}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 9}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 8}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 8}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 7}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 9}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 8}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 9}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 8}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 9}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 8}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 9}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 8}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 9}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 8}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 8}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 7}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 9}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 8}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 9}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 8}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 9}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 8}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 8}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :reading 7}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 8}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 7}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 8}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 7}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 9}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 8}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 9}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 8}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 9}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 8}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 8}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 7}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 9}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 8}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 9}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 8}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 8}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 7}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 9}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 8}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 9}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 8}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :reading 8}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 7}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 8}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 7}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 9}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 8}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 7}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 9}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 8}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 9}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 8}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 8}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 7}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 8}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b0b.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b0b.arrow.edn
@@ -5,460 +5,800 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 11}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 10}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 11}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 10}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 11}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 10}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 10}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 10}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 11}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 10}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 11}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 10}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 10}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 11}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 10}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 11}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 10}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 10}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 11}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 10}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 10}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 10}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 10}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 11}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 10}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 11}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 10}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 10}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 11}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 10}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 11}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 10}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 10}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 11}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 10}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 11}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 10}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 11}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 10}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 11}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 10}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 11}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 10}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 10}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 10}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 11}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 10}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 11}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 10}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 11}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 10}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 11}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 10}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 11}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 10}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 11}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 10}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 11}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 10}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 10}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 11}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 10}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 11}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 10}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 10}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 11}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 10}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 11}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 10}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 11}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 10}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 10}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 11}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 10}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 11}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 10}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 11}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 10}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 11}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 10}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 11}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 10}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 11}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 10}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 11}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 10}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 11}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 10}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 10}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 10}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 10}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 10}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 10}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 11}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 10}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 10}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 11}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 10}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 73, :reading 10}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 11}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 10}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 11}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 10}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 10}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 10}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 11}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 10}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 10}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 11}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 10}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 10}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 11}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 10}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 11}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 10}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 10}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 11}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 10}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 11}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 10}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 10}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 11}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 10}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 11}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 10}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 11}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 55, :reading 10}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 10}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 10}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 10}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 11}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 10}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 11}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 10}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 11}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 10}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 10}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 11}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 10}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 11}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 10}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 10}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 11}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 10}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 11}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 10}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 10}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 10}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 11}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 10}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b0d.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b0d.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 13}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 12}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 13}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 12}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 13}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 12}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 12}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 11}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 12}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 11}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 13}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 12}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 13}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 12}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 12}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 11}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 13}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 12}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 13}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 12}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 12}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 11}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 13}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 12}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 12}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 11}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 12}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 11}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 12}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 11}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 13}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 12}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 13}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 12}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 12}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 11}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 13}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 12}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 13}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 12}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 12}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 11}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 13}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 12}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 13}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 12}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 13}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 12}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 13}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 12}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 13}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 12}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 12}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 11}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 12}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 11}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 13}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 12}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 13}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 12}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 13}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 12}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 13}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 12}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 13}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 12}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 13}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 12}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 13}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 12}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 12}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 11}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 13}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 12}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 13}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 12}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 12}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 11}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 13}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 12}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 13}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 12}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 13}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 12}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 12}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 11}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 13}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 12}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 13}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 12}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 13}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 12}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 13}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 12}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 13}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 12}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 13}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 12}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 13}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 12}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 13}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 12}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 12}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 11}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 12}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 11}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 12}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 11}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 12}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 11}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 12}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :reading 11}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 13}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 12}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 12}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 11}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 13}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 12}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 12}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 11}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 13}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 12}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 13}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 12}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 12}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 11}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 12}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 11}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 13}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 12}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 12}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 11}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 13}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 12}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 12}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 11}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 13}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 12}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 13}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 12}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 12}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 11}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 13}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 12}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 13}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 12}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 12}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 11}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 13}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 12}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 13}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 12}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 13}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 12}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 12}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :reading 11}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 12}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 11}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 12}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 11}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 13}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 12}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 13}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 12}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 13}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 12}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 12}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 11}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 13}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 12}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 13}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 12}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 12}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 11}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 13}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 12}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 13}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 12}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :reading 12}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 11}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 12}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 11}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 13}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 12}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b0f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b0f.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 15}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 14}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 15}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 14}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 15}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 14}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 14}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 13}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 14}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 13}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 15}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 14}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 15}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 14}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 14}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 13}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 15}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 14}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 15}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 14}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 14}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 13}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 15}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 14}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 14}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 13}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 14}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 13}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 14}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 13}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 15}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 14}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 15}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 14}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 14}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 13}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 15}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 14}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 15}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 14}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 14}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 13}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 15}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 14}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 15}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 14}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 15}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 14}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 15}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 14}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 15}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 14}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 14}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 13}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 14}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 13}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 15}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 14}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 15}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 14}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 15}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 14}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 15}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 14}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 15}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 14}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 15}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 14}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 15}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 14}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 14}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 13}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 15}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 14}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 15}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 14}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 14}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 13}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 15}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 14}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 15}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 14}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 15}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 14}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 14}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 13}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 15}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 14}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 15}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 14}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 15}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 14}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 15}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 14}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 15}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 14}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 15}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 14}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 15}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 14}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 15}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 14}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 14}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 13}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 14}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 13}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 14}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 13}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 14}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 13}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 14}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :reading 13}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 15}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 14}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 14}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 13}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 15}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 14}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 14}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 13}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 15}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 14}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 15}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 14}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 14}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 13}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 14}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 13}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 15}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 14}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 14}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 13}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 15}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 14}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 14}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 13}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 15}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 14}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 15}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 14}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 14}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 13}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 15}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 14}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 15}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 14}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 14}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 13}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 15}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 14}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 15}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 14}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 15}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 14}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 14}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :reading 13}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 14}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 13}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 14}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 13}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 15}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 14}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 15}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 14}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 15}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 14}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 14}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 13}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 15}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 14}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 15}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 14}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 14}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 13}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 15}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 14}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 15}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 14}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :reading 14}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 13}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 14}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 13}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 15}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 14}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b111.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b111.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 17}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 16}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 17}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 16}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 17}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 16}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 16}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 15}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 16}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 15}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 17}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 16}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 17}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 16}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 16}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 15}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 17}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 16}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 17}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 16}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 16}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 15}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 17}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 16}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 16}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 15}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 16}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 15}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 16}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 15}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 17}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 16}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 17}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 16}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 16}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 15}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 17}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 16}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 17}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 16}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 16}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 15}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 17}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 16}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 17}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 16}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 17}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 16}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 17}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 16}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 17}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 16}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 16}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 15}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 16}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 15}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 17}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 16}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 17}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 16}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 17}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 16}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 17}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 16}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 17}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 16}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 17}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 16}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 17}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 16}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 16}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 15}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 17}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 16}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 17}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 16}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 16}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 15}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 17}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 16}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 17}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 16}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 17}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 16}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 16}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 15}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 17}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 16}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 17}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 16}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 17}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 16}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 17}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 16}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 17}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 16}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 17}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 16}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 17}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 16}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 17}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 16}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 16}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 15}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 16}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 15}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 16}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 15}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 16}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 15}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 16}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :reading 15}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 17}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 16}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 16}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 15}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 17}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 16}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 16}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 15}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 17}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 16}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 17}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 16}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 16}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 15}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 16}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 15}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 17}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 16}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 16}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 15}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 17}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 16}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 16}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 15}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 17}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 16}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 17}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 16}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 16}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 15}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 17}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 16}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 17}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 16}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 16}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 15}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 17}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 16}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 17}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 16}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 17}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 16}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 16}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :reading 15}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 16}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 15}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 16}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 15}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 17}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 16}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 17}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 16}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 17}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 16}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 16}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 15}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 17}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 16}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 17}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 16}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 16}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 15}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 17}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 16}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 17}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 16}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :reading 16}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 15}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 16}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 15}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 17}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 16}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b113.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b113.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 19}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 18}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 19}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 18}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 19}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 18}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 18}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 17}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 18}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 17}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 19}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 18}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 19}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 18}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 18}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 17}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 19}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 18}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 19}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 18}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 18}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 17}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 19}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 18}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 18}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 17}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 18}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 17}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 18}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 17}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 19}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 18}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 19}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 18}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 18}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 17}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 19}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 18}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 19}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 18}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 18}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 17}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 19}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 18}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 19}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 18}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 19}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 18}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 19}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 18}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 19}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 18}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 18}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 17}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 18}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 17}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 19}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 18}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 19}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 18}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 19}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 18}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 19}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 18}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 19}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 18}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 19}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 18}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 19}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 18}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 18}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 17}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 19}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 18}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 19}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 18}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 18}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 17}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 19}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 18}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 19}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 18}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 19}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 18}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 18}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 17}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 19}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 18}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 19}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 18}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 19}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 18}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 19}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 18}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 19}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 18}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 19}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 18}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 19}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 18}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 19}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 18}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 19}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 18}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 18}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 17}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 18}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 17}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 18}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 17}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 18}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 17}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 18}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :reading 17}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 19}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 18}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 18}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 17}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 19}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 18}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 18}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 17}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 19}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 18}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 19}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 18}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 18}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 17}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 18}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 17}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 19}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 18}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 18}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 17}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 19}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 18}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 18}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 17}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 19}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 18}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 19}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 18}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 18}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 17}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 19}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 18}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 19}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 18}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 19}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 18}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 19}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 18}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 19}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 18}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 18}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 17}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 19}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 18}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 19}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 18}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 19}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 18}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 18}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :reading 17}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 18}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 17}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 18}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 17}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 19}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 18}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 19}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 18}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 19}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 18}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 18}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 17}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 19}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 18}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 19}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 18}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 18}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 17}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 19}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 18}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 19}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 18}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :reading 18}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 17}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 18}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 17}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 19}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 18}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 17}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 19}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 18}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 19}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 18}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 18}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 17}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 18}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b115.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b115.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 21}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 20}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 21}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 20}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 21}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 20}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 20}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 19}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 20}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 19}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 21}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 20}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 21}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 20}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 20}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 19}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 21}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 20}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 21}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 20}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 20}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 19}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 21}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 20}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 20}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 19}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 20}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 19}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 20}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 19}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 21}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 20}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 21}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 20}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 20}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 19}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 21}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 20}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 21}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 20}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 20}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 19}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 21}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 20}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 21}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 20}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 21}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 20}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 21}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 20}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 21}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 20}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 20}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 19}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 20}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 19}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 21}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 20}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 21}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 20}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 21}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 20}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 21}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 20}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 21}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 20}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 21}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 20}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 21}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 20}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 20}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 19}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 21}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 20}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 21}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 20}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 20}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 19}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 21}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 20}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 21}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 20}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 21}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 20}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 20}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 19}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 21}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 20}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 21}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 20}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 21}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 20}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 21}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 20}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 21}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 20}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 21}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 20}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 21}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 20}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 21}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 20}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 21}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 20}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 20}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 19}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 20}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 19}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 20}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 19}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 20}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 19}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 20}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :reading 19}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 21}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 20}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 20}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 19}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 21}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 20}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 20}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 19}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 21}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 20}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 21}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 20}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 20}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 19}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 20}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 19}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 21}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 20}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 20}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 19}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 21}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 20}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 20}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 19}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 21}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 20}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 21}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 20}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 20}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 19}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 21}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 20}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 21}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 20}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 21}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 20}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 21}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 20}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 21}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 20}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 20}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 19}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 21}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 20}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 21}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 20}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 21}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 20}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 20}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :reading 19}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 20}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 19}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 20}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 19}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 21}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 20}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 21}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 20}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 21}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 20}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 20}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 19}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 21}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 20}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 21}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 20}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 20}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 19}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 21}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 20}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 21}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 20}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :reading 20}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 19}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 20}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 19}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 21}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 20}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 19}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 21}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 20}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 21}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 20}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 20}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-10T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 19}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 20}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-11T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b117.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l02-r20200113-b117.arrow.edn
@@ -5,610 +5,970 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 5, :reading 23}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 22}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 23}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 28, :reading 22}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 23}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 30, :reading 22}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 71, :reading 22}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 71, :reading 21}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 22}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 21}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 23}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 22}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 23}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 22}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 22}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 21}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 23}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 22}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 23}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 25, :reading 22}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 22}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 21}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 23}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 22}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 22}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 21}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 22}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 21}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 22}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 95, :reading 21}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 23}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 54, :reading 22}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 23}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 31, :reading 22}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 96, :reading 22}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 96, :reading 21}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 23}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 49, :reading 22}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 23}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 22}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 22}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 21}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 23}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 39, :reading 22}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 23}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 21, :reading 22}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 23}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 23, :reading 22}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 23}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 22}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 23}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 22}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 22}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 21}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 22}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 21}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 23}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 8, :reading 22}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 23}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 22}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 23}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 52, :reading 22}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 23}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 22}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 23}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 11, :reading 22}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 23}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 22}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 23}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 60, :reading 22}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 22}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 77, :reading 21}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 23}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 24, :reading 22}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 23}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 63, :reading 22}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 88, :reading 22}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 88, :reading 21}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 23}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 44, :reading 22}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 23}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 22}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 23}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 22}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 22}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 21}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 23}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 22}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 23}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 10, :reading 22}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 23}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 57, :reading 22}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 23}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 22}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 23}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 38, :reading 22}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 23}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 16, :reading 22}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 23}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 53, :reading 22}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 23}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 43, :reading 22}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 23}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 41, :reading 22}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 22}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 21}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 22}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 21}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 22}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 21}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 22}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 78, :reading 21}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 70, :reading 22}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 70, :reading 21}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 23}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 22}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 22}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 98, :reading 21}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 23}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 3, :reading 22}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 22}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 21}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 23}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 36, :reading 22}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 23}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 0, :reading 22}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 22}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 21}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 22}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 21}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 23}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 22, :reading 22}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 22}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 21}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 23}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 45, :reading 22}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 22}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 21}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 23}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 22}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 23}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 22}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 22}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 99, :reading 21}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 23}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 9, :reading 22}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 23}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 15, :reading 22}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 23}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 61, :reading 22}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 23}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 20, :reading 22}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 23}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 46, :reading 22}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 22}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 21}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 23}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 56, :reading 22}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 23}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 22}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 55, :reading 23}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 22}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 22}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 66, :reading 21}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 22}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 21}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 22}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 21}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 23}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 22}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 23}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 48, :reading 22}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 23}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 22}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 22}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 89, :reading 21}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 23}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 14, :reading 22}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 23}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 13, :reading 22}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 22}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 21}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 23}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 33, :reading 22}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 23}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 22}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 74, :reading 22}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 21}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 22}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 84, :reading 21}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
    {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 23}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 22}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 21}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 23}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 22}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-13T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 23}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 22}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 22}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-12T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 21}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 22}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-12T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200106-p0-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200106-p0-b07.arrow.edn
@@ -5,410 +5,845 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 7}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 6}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 5}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 4}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 3}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 2}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 1}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 5, :reading 0}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 7}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 6}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 5}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 4}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 3}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 2}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 1}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 0}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 7}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 6}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 5}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 4}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 3}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 2}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 1}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 0}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 6}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 5}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 4}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 3}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 2}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 1}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 0}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 6}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 5}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 4}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 3}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 2}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 1}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 0}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 7}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 6}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 5}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 4}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 3}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 2}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 1}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 0}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 7}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 6}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 5}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 4}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 3}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 2}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 1}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 0}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 6}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 5}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 4}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 3}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 2}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 1}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 0}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 7}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 6}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 5}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 4}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 3}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 2}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 1}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 0}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 7}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 6}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 5}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 4}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 3}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 2}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 1}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 25, :reading 0}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 6}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 5}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 4}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 3}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 2}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 1}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 0}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 7}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 6}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 5}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 4}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 3}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 2}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 1}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 0}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 6}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 5}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 4}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 3}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 2}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 1}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 0}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 6}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 5}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 4}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 3}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 2}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 1}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 0}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 6}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 5}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 4}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 3}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 2}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 1}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 0}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 7}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 6}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 5}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 4}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 3}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 2}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 1}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 0}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 7}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 6}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 5}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 4}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 3}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 2}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 1}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 0}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 6}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 5}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 4}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 3}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 2}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 1}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 0}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 7}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 6}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 5}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 4}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 3}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 2}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 1}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 49, :reading 0}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 7}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 6}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 5}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 4}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 3}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 2}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 1}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 0}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 6}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 5}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 4}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 3}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 2}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 1}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 0}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 7}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 6}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 5}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 4}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 3}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 2}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 1}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 7}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 6}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 5}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 4}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 3}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 2}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 1}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 0}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 39, :reading 0}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200106-p1-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200106-p1-b07.arrow.edn
@@ -5,490 +5,985 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 7}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 6}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 5}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 4}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 3}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 2}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 1}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 23, :reading 0}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 7}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 6}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 5}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 4}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 3}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 2}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 1}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 0}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 7}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 6}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 5}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 4}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 3}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 2}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 1}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 0}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 6}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 5}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 4}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 3}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 2}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 1}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 0}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 6}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 5}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 4}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 3}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 2}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 1}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 0}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 7}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 6}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 5}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 4}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 3}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 2}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 1}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 8, :reading 0}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 7}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 6}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 5}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 4}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 3}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 2}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 0}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 7}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 6}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 5}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 4}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 3}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 2}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 1}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 52, :reading 0}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 7}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 6}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 5}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 4}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 3}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 2}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 1}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 0}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 7}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 6}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 5}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 4}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 3}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 2}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 1}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 11, :reading 0}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 7}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 6}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 5}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 4}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 3}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 2}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 1}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 0}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 7}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 6}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 5}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 4}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 3}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 2}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 1}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 60, :reading 0}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 6}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 5}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 4}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 3}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 2}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 1}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 0}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 7}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 6}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 5}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 4}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 3}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 2}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 1}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 0}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 7}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 6}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 5}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 4}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 3}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 2}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 1}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 0}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 6}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 5}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 4}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 3}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 2}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 1}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 0}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 7}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 6}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 5}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 4}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 3}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 2}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 1}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 44, :reading 0}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 7}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 6}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 5}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 4}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 3}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 2}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 1}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 0}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 7}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 6}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 5}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 4}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 3}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 2}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 1}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 0}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 6}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 5}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 4}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 3}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 2}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 1}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 0}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 7}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 6}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 5}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 3}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 2}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 1}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 0}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 7}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 6}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 5}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 4}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 3}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 2}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 1}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 10, :reading 0}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 7}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 6}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 5}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 4}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 3}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 2}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 1}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 57, :reading 0}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 7}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 6}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 5}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 4}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 3}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 2}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 1}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 0}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 7}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 6}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 5}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 4}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 3}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 2}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 1}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 7}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 6}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 5}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 4}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 3}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 2}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 1}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 0}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 38, :reading 0}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200106-p2-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200106-p2-b07.arrow.edn
@@ -5,1570 +5,950 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 7}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 6}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 5}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 4}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 3}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 2}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 1}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 0}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 7}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 6}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 5}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 4}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 3}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 2}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 1}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 43, :reading 0}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 7}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 6}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 5}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 4}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 3}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 2}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 1}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 0}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 6}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 5}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 4}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 3}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 2}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 1}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 0}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 6}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 5}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 4}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 3}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 2}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 1}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 0}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 6}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 5}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 4}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 3}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 2}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 1}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 0}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 6}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 5}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 4}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 3}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 2}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 1}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 0}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 6}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 5}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 4}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 3}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 2}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 1}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 0}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 7}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 6}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 5}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 4}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 3}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 2}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 1}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 0}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 6}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 5}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 4}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 3}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 2}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 1}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 98, :reading 0}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 7}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 6}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 5}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 4}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 3}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 2}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 1}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 0}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 6}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 5}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 4}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 3}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 2}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 1}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 0}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 7}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 6}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 5}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 4}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 3}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 2}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 1}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 36, :reading 0}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 7}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 6}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 5}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 4}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 3}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 2}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 1}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 0}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 6}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 5}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 4}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 3}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 2}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 1}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 0}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 6}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 5}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 4}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 3}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 2}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 1}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 0}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 7}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 6}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 5}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 4}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 3}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 2}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 1}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 0}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 6}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 5}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 4}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 3}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 2}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 1}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 0}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 7}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 6}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 5}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 4}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 3}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 2}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 1}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 45, :reading 0}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 6}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 5}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 4}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 3}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 2}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 1}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 0}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 7}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 6}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 5}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 4}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 3}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 2}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 1}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 0}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 7}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 6}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 5}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 4}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 3}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 2}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 1}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 0}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 6}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 5}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 4}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 3}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 2}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 1}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 99, :reading 0}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 7}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 6}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 5}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 4}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 3}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 2}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 1}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 0}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 7}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 6}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 5}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 4}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 3}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 2}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 1}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 7}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 6}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 5}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 4}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 3}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 2}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 1}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 0}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 7}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 6}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 5}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 4}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 3}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 2}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 1}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 0}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 7}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 6}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 5}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 4}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 3}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 2}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 1}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 0}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 15, :reading 0}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}]
   [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200106-p3-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200106-p3-b07.arrow.edn
@@ -5,1510 +5,730 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 6}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 5}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 4}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 3}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 2}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 1}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 0}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 7}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 6}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 5}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 4}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 3}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 2}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 1}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 0}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 7}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 6}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 5}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 4}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 3}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 2}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 1}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 0}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 7}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 6}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 5}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 4}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 3}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 2}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 1}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 55, :reading 0}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 6}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 5}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 4}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 3}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 2}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 1}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 0}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 6}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 5}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 4}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 3}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 2}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 1}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 0}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 6}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 5}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 4}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 3}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 2}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 1}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 0}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 7}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 6}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 5}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 4}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 3}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 2}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 1}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 0}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 7}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 6}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 5}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 4}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 3}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 2}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 1}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 0}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 7}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 6}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 5}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 4}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 3}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 2}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 1}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 35, :reading 0}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 6}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 5}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 4}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 3}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 2}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 1}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 0}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 7}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 6}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 5}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 4}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 3}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 2}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 1}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 0}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 7}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 6}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 5}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 4}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 3}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 2}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 1}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 13, :reading 0}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 6}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 5}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 4}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 3}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 2}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 1}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 0}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 7}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 6}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 5}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 4}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 3}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 2}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 1}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 0}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 7}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 6}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 5}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 4}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 3}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 2}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 1}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 18, :reading 0}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 6}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 5}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 4}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 3}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 2}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 1}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 0}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 6}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 5}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 4}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 3}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 2}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 1}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 0}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 7}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 6}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 5}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 4}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 3}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 2}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 1}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 6}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 5}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 4}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 3}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 2}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 1}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 0}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 7}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 6}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 5}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 4}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 3}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 2}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 1}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 0}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-05T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 7}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 6}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 5}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 4}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 3}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 2}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 1}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 0}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 6}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 5}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 4}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 3}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 2}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-02T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 1}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-01T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 0}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 0}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-04T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200113-p0-b111.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200113-p0-b111.arrow.edn
@@ -5,410 +5,845 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 17}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 16}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 15}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 14}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 13}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 12}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 5, :reading 11}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 5, :reading 10}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 17}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 16}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 15}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 14}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 13}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 12}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 11}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 28, :reading 10}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 17}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 16}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 15}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 14}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 13}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 12}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 11}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 30, :reading 10}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 16}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 15}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 14}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 13}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 12}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 11}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 71, :reading 10}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 16}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 15}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 14}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 13}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 12}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 11}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 76, :reading 10}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 17}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 16}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 15}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 14}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 13}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 12}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 11}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 47, :reading 10}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 17}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 16}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 15}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 14}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 13}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 12}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 11}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 58, :reading 10}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 16}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 15}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 14}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 13}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 12}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 11}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 68, :reading 10}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 17}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 16}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 15}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 14}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 13}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 12}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 11}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 51, :reading 10}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 17}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 16}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 15}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 14}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 13}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 12}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 25, :reading 11}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 25, :reading 10}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 16}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 15}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 14}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 13}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 12}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 11}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 75, :reading 10}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 17}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 16}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 15}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 14}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 13}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 12}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 11}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 59, :reading 10}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 16}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 15}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 14}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 13}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 12}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 11}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 64, :reading 10}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 16}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 15}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 14}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 13}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 12}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 11}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 83, :reading 10}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 16}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 15}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 14}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 13}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 12}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 11}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 95, :reading 10}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 17}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 16}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 15}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 14}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 13}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 12}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 11}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 54, :reading 10}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 17}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 16}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 15}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 14}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 13}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 12}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 11}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 31, :reading 10}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 16}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 15}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 14}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 13}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 12}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 11}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 96, :reading 10}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 17}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 16}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 15}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 14}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 13}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 12}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 49, :reading 11}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 49, :reading 10}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 17}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 16}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 15}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 14}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 13}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 12}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 6, :reading 11}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 6, :reading 10}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 16}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 15}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 14}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 13}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 12}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 11}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 92, :reading 10}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 17}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 16}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 15}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 14}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 13}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 12}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put {:xt/id 39, :reading 11}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 17}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 16}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 15}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 14}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 13}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 12}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 11}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 21, :reading 10}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+    :op #xt/tagged [:put {:xt/id 39, :reading 10}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200113-p1-b111.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200113-p1-b111.arrow.edn
@@ -5,490 +5,985 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 17}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 16}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 15}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 14}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 13}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 12}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 23, :reading 11}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 23, :reading 10}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 17}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 16}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 15}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 14}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 13}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 12}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 11}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 2, :reading 10}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 17}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 16}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 15}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 14}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 13}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 12}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 11}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 40, :reading 10}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 16}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 15}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 14}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 13}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 12}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 11}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 90, :reading 10}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 16}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 15}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 14}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 13}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 12}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 11}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 94, :reading 10}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 17}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 16}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 15}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 14}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 13}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 12}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 8, :reading 11}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 8, :reading 10}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 17}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 16}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 15}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 14}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 13}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 12}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 11}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 1, :reading 10}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 17}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 16}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 15}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 14}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 13}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 12}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 52, :reading 11}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 52, :reading 10}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 17}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 16}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 15}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 14}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 13}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 12}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 11}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 32, :reading 10}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 17}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 16}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 15}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 14}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 13}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 12}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 11, :reading 11}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 11, :reading 10}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 17}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 16}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 15}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 14}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 13}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 12}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 11}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 7, :reading 10}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 17}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 16}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 15}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 14}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 13}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 12}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 60, :reading 11}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 60, :reading 10}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 16}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 15}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 14}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 13}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 12}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 11}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 77, :reading 10}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 17}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 16}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 15}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 14}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 13}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 12}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 11}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 24, :reading 10}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 17}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 16}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 15}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 14}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 13}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 12}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 11}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 63, :reading 10}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 16}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 15}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 14}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 13}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 12}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 11}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 88, :reading 10}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 17}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 16}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 15}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 14}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 13}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 12}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 44, :reading 11}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 44, :reading 10}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 17}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 16}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 15}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 14}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 13}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 12}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 11}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 12, :reading 10}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 17}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 16}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 15}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 14}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 13}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 12}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 11}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 37, :reading 10}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 16}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 15}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 14}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 13}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 12}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 11}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 69, :reading 10}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 17}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 16}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 15}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 14}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 13}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 12}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 11}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 4, :reading 10}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 17}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 16}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 15}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 14}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 13}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 12}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 10, :reading 11}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 10, :reading 10}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 17}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 16}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 15}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 14}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 13}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 12}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 57, :reading 11}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 57, :reading 10}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 17}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 16}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 15}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 14}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 13}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 12}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 11}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 17, :reading 10}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 17}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 16}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 15}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 14}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 13}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 12}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+    :op #xt/tagged [:put {:xt/id 38, :reading 11}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 17}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 15}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 14}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 13}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 12}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 11}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 16, :reading 10}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}]
+    :op #xt/tagged [:put {:xt/id 38, :reading 10}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200113-p2-b111.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200113-p2-b111.arrow.edn
@@ -5,1570 +5,950 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 17}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 16}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 15}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 14}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 13}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 12}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 11}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 53, :reading 10}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 17}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 16}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 15}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 14}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 13}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 12}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 43, :reading 11}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 43, :reading 10}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 17}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 16}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 15}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 14}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 13}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 12}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 11}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 41, :reading 10}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 16}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 15}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 14}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 13}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 12}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 11}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 85, :reading 10}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 16}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 15}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 14}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 13}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 12}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 11}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 97, :reading 10}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 16}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 15}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 14}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 13}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 12}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 11}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 79, :reading 10}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 16}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 15}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 14}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 13}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 12}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 11}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 78, :reading 10}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 16}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 15}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 14}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 13}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 12}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 11}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 70, :reading 10}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 17}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 16}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 15}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 14}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 13}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 12}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 34, :reading 11}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 34, :reading 10}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 16}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 15}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 14}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 13}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 12}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 98, :reading 11}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 98, :reading 10}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 17}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 16}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 15}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 14}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 13}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 12}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 11}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 3, :reading 10}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 16}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 15}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 14}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 13}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 12}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 11}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 73, :reading 10}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 17}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 16}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 15}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 14}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 13}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 12}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 36, :reading 11}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 36, :reading 10}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 17}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 16}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 15}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 14}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 13}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 12}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 11}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 0, :reading 10}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 16}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 15}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 14}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 13}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 12}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 11}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 81, :reading 10}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 16}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 15}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 14}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 13}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 12}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 11}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 67, :reading 10}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 17}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 16}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 15}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 14}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 13}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 12}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 11}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 22, :reading 10}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 16}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 15}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 14}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 13}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 12}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 11}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 87, :reading 10}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 17}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 16}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 15}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 14}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 13}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 12}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put {:xt/id 45, :reading 11}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 45, :reading 10}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 16}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 15}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 14}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 13}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 12}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 11}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 65, :reading 10}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 17}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 16}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 15}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 14}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 13}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 12}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 11}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 62, :reading 10}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 17}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 16}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 15}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 14}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 13}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 12}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 29, :reading 11}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 29, :reading 10}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 16}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 15}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 14}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 13}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 12}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 99, :reading 11}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 99, :reading 10}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 17}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 16}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 15}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 14}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 13}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 12}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 11}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+    :op #xt/tagged [:put {:xt/id 9, :reading 10}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 17}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 16}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 15}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 14}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 13}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 12}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put {:xt/id 15, :reading 11}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 17}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 16}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 15}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 14}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 13}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 12}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 11}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 61, :reading 10}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 17}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 16}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 15}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 14}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 13}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 12}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 11}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 20, :reading 10}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 17}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 16}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 15}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 14}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 13}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 12}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 11}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 46, :reading 10}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}]
+    :op #xt/tagged [:put {:xt/id 15, :reading 10}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}]
   [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200113-p3-b111.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/data/l03-r20200113-p3-b111.arrow.edn
@@ -5,1510 +5,730 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64} {"reading" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64, "reading" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 16}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 15}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 14}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 13}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 12}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 11}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 93, :reading 10}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 17}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 16}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 15}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 14}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 13}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 12}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 11}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 56, :reading 10}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 17}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 16}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 15}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 14}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 13}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 12}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 11}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 26, :reading 10}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 17}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 16}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 15}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 14}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 13}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 12}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 55, :reading 11}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 55, :reading 10}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 16}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 15}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 14}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 13}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 12}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 66, :reading 11}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 66, :reading 10}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 16}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 15}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 14}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 13}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 12}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 11}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 86, :reading 10}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 16}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 15}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 14}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 13}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 12}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 11}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 80, :reading 10}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 17}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 16}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 15}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 14}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 13}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 12}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 27, :reading 11}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 27, :reading 10}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 17}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 16}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 15}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 14}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 13}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 12}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 11}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 48, :reading 10}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 35, :reading 17}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 16}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 15}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 14}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 13}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 12}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put {:xt/id 35, :reading 11}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 35, :reading 10}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 16}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 15}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 14}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 13}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 12}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 11}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 89, :reading 10}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 17}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 16}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 15}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 14}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 13}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 12}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 11}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 14, :reading 10}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 17}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 16}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 15}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 14}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 13}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 12}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 13, :reading 11}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 13, :reading 10}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 16}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 15}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 14}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 13}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 12}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 11}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+    :op #xt/tagged [:put {:xt/id 72, :reading 10}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 17}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 16}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 15}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 14}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 13}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 12}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 11}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 33, :reading 10}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
    {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 17}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 16}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 15}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 14}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 13}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 12}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+    :op #xt/tagged [:put {:xt/id 18, :reading 11}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 18, :reading 10}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 16}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 15}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 14}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 13}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 12}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 11}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 74, :reading 10}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 16}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 15}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 14}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 13}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 12}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 11}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
+    :op #xt/tagged [:put {:xt/id 84, :reading 10}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 17}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 16}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 15}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 14}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 13}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 12}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put {:xt/id 42, :reading 11}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
    {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
-  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 16}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 15}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 14}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 13}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 12}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 11}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 91, :reading 10}],
-    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 17}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 16}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 15}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 14}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 13}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 12}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 11}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 19, :reading 10}],
-    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
-   {:xt/system-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-10T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 17}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 16}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 15}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 14}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 13}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 12}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 11}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 50, :reading 10}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 16}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 15}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 14}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 13}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 12}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-07T00:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 11}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "2020-01-06T12:00Z[UTC]",
-    :op #xt/tagged [:put {:xt/id 82, :reading 10}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}]
+    :op #xt/tagged [:put {:xt/id 42, :reading 10}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
   [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "2020-01-09T12:00Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200106-b01.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200106-b01.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200106-b03.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200106-b03.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200106-b05.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200106-b05.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200106-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200106-b07.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200106-b09.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200106-b09.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b0b.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b0b.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b0d.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b0d.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b0f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b0f.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b111.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b111.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b113.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b113.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b115.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b115.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b117.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l02-r20200113-b117.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200106-p0-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200106-p0-b07.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200106-p1-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200106-p1-b07.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200106-p2-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200106-p2-b07.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200106-p3-b07.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200106-p3-b07.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200113-p0-b111.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200113-p0-b111.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200113-p1-b111.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200113-p1-b111.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200113-p2-b111.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200113-p2-b111.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200113-p3-b111.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction-by-recency/readings/meta/l03-r20200113-p3-b111.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p0-b11f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p0-b11f.arrow.edn
@@ -5,730 +5,460 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 5}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put #:xt{:id 28}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 243}],
+    :xt/iid #bytes "0041b3666c25996df0bf50024075e368"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 30}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}]
+  [{:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 237}],
+    :xt/iid #bytes "02165f0c71e779a40a67aa915d2e31a1"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 109}],
+    :xt/iid #bytes "025d28748b20143b96259fe559007490"}
+   {:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 383}],
+    :xt/iid #bytes "02b8c2b7673c15a95dfd6913f32e8f09"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 71}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}]
+  [{:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 270}],
+    :xt/iid #bytes "035fb4c42c869245d66556eba0357ecf"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 305}],
+    :xt/iid #bytes "03a293a1ae6a754078406140a65ff6be"}]
+  [{:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 319}],
+    :xt/iid #bytes "043e7a2fbf427b598357f715a1a61344"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 76}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 47}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}]
+  [{:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 215}],
+    :xt/iid #bytes "05032986c76fbabb23cd20d9cf1c609a"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 206}],
+    :xt/iid #bytes "055a3bc0b33ec364467406eb4cbbfc47"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 58}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}
+   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 280}],
+    :xt/iid #bytes "05e5ac85e20d91f5431fd118c3cfa4c5"}]
+  [{:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 312}],
+    :xt/iid #bytes "06cf894ddb2e40263ac798e97ca89abb"}
+   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 263}],
+    :xt/iid #bytes "06fedcce1ce11f50d14b85f5f6072170"}]
+  [{:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 179}],
+    :xt/iid #bytes "079b6f3220e03c3ce2fa74830e4a364c"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 136}],
+    :xt/iid #bytes "07b04b25f563483782bedfae4ac65d46"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 318}],
+    :xt/iid #bytes "07e1672e79caad486aa14eb4f9b7cc49"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 68}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 51}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 146}],
+    :xt/iid #bytes "0afa67ec22e0c723ba955bf8f9841d7e"}]
+  [{:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 135}],
+    :xt/iid #bytes "0c37cb2407eba7b368e441aca963ae57"}
    {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
+    :op #xt/tagged [:put #:xt{:id 103}],
+    :xt/iid #bytes "0de886ef47f37c39172042278e44a607"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 115}],
+    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 210}],
+    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}]
+  [{:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 259}],
+    :xt/iid #bytes "12041210809829867b98fcd15df56585"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 200}],
+    :xt/iid #bytes "121e7f6730608b06a81418e44afd5ab1"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 25}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 175}],
+    :xt/iid #bytes "12b4423405608303504234d703a14309"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 151}],
+    :xt/iid #bytes "13aec04d511522b53d63ae07bc39c011"}]
+  [{:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 75}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 267}],
+    :xt/iid #bytes "1531b1ae93bfc79761b0c2b6632be5f0"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 59}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 241}],
+    :xt/iid #bytes "15f238624b21033900c5f8897a3ffc8e"}
    {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
+    :op #xt/tagged [:put #:xt{:id 187}],
+    :xt/iid #bytes "162991d14c2b05049e243724aa5d01c6"}
+   {:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 365}],
+    :xt/iid #bytes "167a8c48ebaa8493033bd6c49987be9a"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 353}],
+    :xt/iid #bytes "17664b2d63ac35e2c26e7f7762a3bf52"}]
+  [{:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 348}],
+    :xt/iid #bytes "186835a76246498a35c0b5dc51f34b14"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 64}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 220}],
+    :xt/iid #bytes "1b880f6f4cdedd6cf9f73029ee7d3f66"}
+   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 357}],
+    :xt/iid #bytes "1bce0514332a7a1a9bec4d79a2786c1f"}]
+  [{:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 153}],
+    :xt/iid #bytes "1d9736d725f5f7f72340540fbf47d995"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 334}],
+    :xt/iid #bytes "1dd81fb449fc93bfe3313f5945bf14d8"}
+   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 354}],
+    :xt/iid #bytes "1e1b4142f9fe433d893437424841088d"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 83}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 247}],
+    :xt/iid #bytes "1eafb972eacca6bbdff95c2f3a6b644b"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 225}],
+    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 194}],
+    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 193}],
+    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
+  [{:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 352}],
+    :xt/iid #bytes "2077439c0f82ecd2ceb7a6c39b768a38"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 95}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
    {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
+    :op #xt/tagged [:put #:xt{:id 158}],
+    :xt/iid #bytes "213041d1406e2cd4c17da9ff44f4266c"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 205}],
+    :xt/iid #bytes "22ccb18777bdfb478ce0ffddee69477d"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 113}],
+    :xt/iid #bytes "22e39313ce5ffdde631491b53c651e95"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 54}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}]
+  [{:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 376}],
+    :xt/iid #bytes "24834573b46c64c14e8e12b64330ba30"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 251}],
+    :xt/iid #bytes "24996cb395e558634605430f6d5d0e53"}]
+  [{:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 272}],
+    :xt/iid #bytes "284d4650e9335b60c101d28ac362c7c0"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 133}],
+    :xt/iid #bytes "28c5f03785396f16c83e30f375547173"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 123}],
+    :xt/iid #bytes "29ad5232524010a141649064c04b577b"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 242}],
+    :xt/iid #bytes "2a19694c308373113ea6e209baeefaf5"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 184}],
+    :xt/iid #bytes "2a4a26457d59d6ac4ef727533b6294cc"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 111}],
+    :xt/iid #bytes "2bd41b51f30dabd381a01eed5682f3ee"}]
+  [{:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 300}],
+    :xt/iid #bytes "2cc48a05198a7714e01b281084390a2d"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 31}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
    {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 96}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 233}],
+    :xt/iid #bytes "2e25cc8beae4edc208499bbb57a0a0ff"}]
+  [{:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
+    :op #xt/tagged [:put #:xt{:id 362}],
+    :xt/iid #bytes "3022d624c0bc8ff8d7da774ccc7b9858"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 49}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 129}],
+    :xt/iid #bytes "32034ebe719debc23cec170dc1142a00"}
+   {:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 379}],
+    :xt/iid #bytes "332e02ea44f791f2334e44bf431d6bd4"}
+   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 356}],
+    :xt/iid #bytes "333a3ff42f59cf8a01cfa64dfc838671"}]
+  [{:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 240}],
+    :xt/iid #bytes "3435f6271391eb222b8e0c7662951144"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 119}],
+    :xt/iid #bytes "37ad872190ba8744ca6272255b750bdc"}]
+  [{:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 201}],
+    :xt/iid #bytes "38b85365d40ef4e3f2af832dc0f6a663"}]
+  [{:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 211}],
+    :xt/iid #bytes "394cbd71dbe4725b3f5ece063089eb1b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 6}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
    {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
-  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 298}],
-    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 21}],
-    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 106}],
-    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}
-   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 190}],
-    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 156}],
-    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}]
+    :op #xt/tagged [:put #:xt{:id 102}],
+    :xt/iid #bytes "3984fdccba95acf4bdb471008298fb62"}]
+  [{:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 92}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}]
+  [{:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 236}],
+    :xt/iid #bytes "3b13a011fb4a72dbebacc8d65310ff05"}
+   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 262}],
+    :xt/iid #bytes "3b2b355dd3ea4da95442e5b0b8ee9721"}
+   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 339}],
+    :xt/iid #bytes "3b8574e691a90541c7f16605c6ceeae1"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 199}],
+    :xt/iid #bytes "3b87699e1f1e12221b432e9dc17c19fa"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 320}],
+    :xt/iid #bytes "3b8a91a71b4815da789b9f43a47b0da0"}
+   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 274}],
+    :xt/iid #bytes "3bb262bad78be2bc8d3bf713821c1c47"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 39}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}]
   [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p0-b13f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p0-b13f.arrow.edn
@@ -5,470 +5,525 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
+    :op #xt/tagged [:put #:xt{:id 674}],
+    :xt/iid #bytes "0027c5b37f2af83442c795a3345b7476"}
+   {:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 659}],
+    :xt/iid #bytes "0090e554f0832b63fa23fe38773373a0"}]
+  [{:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 585}],
+    :xt/iid #bytes "011d4e3bf2bc19e64c19c3ed88b8b248"}]
+  [{:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 686}],
+    :xt/iid #bytes "023278254c40137c60c918f3b75d6175"}
+   {:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 559}],
+    :xt/iid #bytes "0237f7f4560d6d9b162aa16fd2c4254a"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 707}],
+    :xt/iid #bytes "027f3ba67aea1502628f5b30f081e463"}
+   {:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 579}],
+    :xt/iid #bytes "028e71bfc40ebafb759bd72446f53ce9"}
+   {:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 505}],
+    :xt/iid #bytes "02cde9758f6b1929cfd24d85345b9eb2"}]
+  [{:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 549}],
+    :xt/iid #bytes "033626f56e707c06f8eef9aa79ed8d1a"}
+   {:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 734}],
+    :xt/iid #bytes "034f5f0005b1dde3ad69c1687f74ed09"}]
+  [{:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 729}],
+    :xt/iid #bytes "04bc32788b1631f072fc90b4c5d5ca7a"}
+   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 429}],
+    :xt/iid #bytes "053a6977d02b42bea31f3c4f7f3acc79"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 708}],
+    :xt/iid #bytes "05e8412231f7f98f329e0f26ded53751"}
+   {:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 556}],
+    :xt/iid #bytes "072050e6b895800ab0d439b45c3a4556"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 447}],
+    :xt/iid #bytes "07ba6fc791d6d1b4a2f6addeec72c973"}]
+  [{:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 761}],
+    :xt/iid #bytes "0877d33b3ccaf249d539bde2ff7f1b02"}
+   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 419}],
+    :xt/iid #bytes "08d2b357054853321ffdb148ceb10caf"}
+   {:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 487}],
+    :xt/iid #bytes "08d6c1a46f7f6c694b770e72782da9fe"}
+   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 427}],
+    :xt/iid #bytes "08e4e441a456cc34bae06349dd60d5fd"}
+   {:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 497}],
+    :xt/iid #bytes "0919fa0aa96e55d46fab64b1e42895f9"}
+   {:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 514}],
+    :xt/iid #bytes "0b79b0a87766cad8aca8232d938f8c30"}
+   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 478}],
+    :xt/iid #bytes "0bcb62acf330e279053fbd18c2dd716c"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 722}],
+    :xt/iid #bytes "0bee0a3eee613197a1e001c48bbf5af4"}]
+  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 749}],
+    :xt/iid #bytes "0c0df299a6be10ea75d38a63f18c3335"}
    {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 518}],
+    :xt/iid #bytes "0cfcffa728c2582a4be065fc008ce9c8"}]
+  [{:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 599}],
+    :xt/iid #bytes "0e0a21a75bbbc7674523941795b5d488"}
+   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
+    :op #xt/tagged [:put #:xt{:id 634}],
+    :xt/iid #bytes "0e62b3337f67912c0d7620014dc998f0"}
+   {:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 687}],
+    :xt/iid #bytes "0e81aae7ae5c8da67cf9a9e4c538dea3"}
+   {:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 527}],
+    :xt/iid #bytes "0eec88498770ad276bb0a930f456c6b0"}]
+  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 657}],
+    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
+   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 700}],
+    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
+   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 522}],
+    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
+   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 417}],
+    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
+  [{:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 604}],
+    :xt/iid #bytes "100afcbbfb8d2577e76a1ef7ad4e6d4f"}
+   {:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 653}],
+    :xt/iid #bytes "112a9b116e67af5726ff48f690f682d7"}
+   {:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 434}],
+    :xt/iid #bytes "11d35b86e570d2697398309175ea7a87"}
+   {:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 568}],
+    :xt/iid #bytes "11ee2d38fcd400f90c695a8aa1b077ce"}
+   {:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 443}],
+    :xt/iid #bytes "121f00ced97b4850e336b9b996bdd256"}
+   {:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 671}],
+    :xt/iid #bytes "1227c918eec2c29507e7d27e56ecfd57"}
+   {:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 535}],
+    :xt/iid #bytes "13c73d20616257def8ed6eb8b8e0efa0"}
+   {:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 603}],
+    :xt/iid #bytes "13e4dc20e16aff8e79a9e7048093f298"}]
+  [{:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 620}],
+    :xt/iid #bytes "152876b65e2bc7a9193e7423f2353980"}
+   {:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 580}],
+    :xt/iid #bytes "159c826485a80ab9462e17cabae64d64"}
+   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 667}],
+    :xt/iid #bytes "16613ac6249834e835d0fc7b47901b0a"}
+   {:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 489}],
+    :xt/iid #bytes "16eba33273ccd789e15ec70915ad71d2"}
+   {:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 531}],
+    :xt/iid #bytes "170eb32564ddfb824479633e4c7cfa4a"}
+   {:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 483}],
+    :xt/iid #bytes "1760fc6b2e1d1e02901ca5d9b20f26ce"}
+   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 633}],
+    :xt/iid #bytes "17e9eec02d17408d3041bad1f9b7931f"}]
+  [{:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 632}],
+    :xt/iid #bytes "184703b7cbbb32af82dfd53802b74ca8"}
+   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 629}],
+    :xt/iid #bytes "18a06086f14847a334cd65f9a60fa5cf"}
+   {:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 424}],
+    :xt/iid #bytes "1a9db013c23698996c24054e4689bd2a"}
+   {:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 400}],
+    :xt/iid #bytes "1b1b79a35aeafbc06592176f573e0042"}
+   {:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 567}],
+    :xt/iid #bytes "1bc22c3a1bac2dc20a49b193be83cdda"}
+   {:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 455}],
+    :xt/iid #bytes "1bdd3ca9d412dd197128b6d27dac0a6b"}
+   {:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 481}],
+    :xt/iid #bytes "1be3beb77971f6707dd9954195e3821e"}]
   [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 456}],
+    :xt/iid #bytes "1c874f41a08af02077529343929f1b78"}
+   {:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 691}],
+    :xt/iid #bytes "1cee94064481db1e5a97ed30c46e5f69"}
+   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 430}],
+    :xt/iid #bytes "1dda28be91aa26e1e5e90397516e57ac"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 706}],
+    :xt/iid #bytes "1edd9445dd34269666a5e76238325894"}
+   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 646}],
+    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}]
+  [{:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 610}],
+    :xt/iid #bytes "20cad4f90b9891e72ef921786f99973c"}
+   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 647}],
+    :xt/iid #bytes "20cadea2bbc68c50f2f5f7895177dd96"}
+   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 461}],
+    :xt/iid #bytes "21a706fa6186126cf2a6efcc2a65dad2"}
+   {:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 465}],
+    :xt/iid #bytes "2229a8ff78688b5d05e15ce9c93932a8"}
+   {:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 554}],
+    :xt/iid #bytes "223b4e041cb2687eb4628778cef843fd"}
+   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
-  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 458}],
-    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 520}],
-    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 405}],
-    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
-   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 760}],
-    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}]
+    :op #xt/tagged [:put #:xt{:id 457}],
+    :xt/iid #bytes "22eb6570812f64897590261a6c14b06d"}
+   {:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 651}],
+    :xt/iid #bytes "235f86ba0cac692e01652c39ab0c0f40"}]
+  [{:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 553}],
+    :xt/iid #bytes "245c61d1fd330b5f3420e30865978277"}
+   {:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 552}],
+    :xt/iid #bytes "24d2cc9db1eacb383cb0a7c95fbb035f"}
+   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 745}],
+    :xt/iid #bytes "2582202769516f41cc3b826e3dc27a13"}
+   {:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 715}],
+    :xt/iid #bytes "25b9fb266efba9259be4148737665a37"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 726}],
+    :xt/iid #bytes "263300987c12d04952035b0ec3a51857"}
+   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 590}],
+    :xt/iid #bytes "268951dcef68d89cfe057860d1932674"}
+   {:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 432}],
+    :xt/iid #bytes "26a40ccf9005c87d3c204bb1324757ed"}
+   {:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 754}],
+    :xt/iid #bytes "26e9b135cf244b0b29a623c652c4ee56"}]
+  [{:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 737}],
+    :xt/iid #bytes "285382fd7ed9a7f0a1d321fcd7602152"}]
+  [{:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 639}],
+    :xt/iid #bytes "2901270900c7adbd5819726aea931aba"}
+   {:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 490}],
+    :xt/iid #bytes "29af7bb60feccf5b5095dc5b043d608e"}
+   {:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 440}],
+    :xt/iid #bytes "29b26d263599d9d09708f72720587d5d"}
+   {:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 435}],
+    :xt/iid #bytes "29ded64f8fee1492a466acca72be8615"}]
+  [{:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 679}],
+    :xt/iid #bytes "2a8be7e1600c4dc18194ba3f4a842fbf"}
+   {:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 420}],
+    :xt/iid #bytes "2adafd3da744bcf5467845ab755d211f"}]
+  [{:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 491}],
+    :xt/iid #bytes "2b12feaa9cd82ed48acba13daea3fc24"}
+   {:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 638}],
+    :xt/iid #bytes "2b55a5f925f6ae6f7e9178e40d8700dd"}
+   {:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 389}],
+    :xt/iid #bytes "2bad149c85071b2be11a2a67e2af1e58"}]
+  [{:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 710}],
+    :xt/iid #bytes "2c16943dec2dcefec30747b83edb34c3"}
+   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 703}],
+    :xt/iid #bytes "2c2e3284d0f481b2c3353d3c172daf8b"}
+   {:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 538}],
+    :xt/iid #bytes "2ee574768e4cd290956af6879dd20b2e"}
+   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 616}],
+    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
+  [{:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 395}],
+    :xt/iid #bytes "306b41bc873028f8e5b0642580fb4521"}
+   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 666}],
+    :xt/iid #bytes "31f416a5e09f0c0a82a28f56feefdfba"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 709}],
+    :xt/iid #bytes "3266bffa236ed5b3c3b3127f5ce8fe84"}
+   {:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 398}],
+    :xt/iid #bytes "32981be2d8883ebc7c548aafe6b666f9"}
+   {:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 504}],
+    :xt/iid #bytes "32e4677e77b59d16234fe7b3a15affd7"}
+   {:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 601}],
+    :xt/iid #bytes "336cbb0d875d8fefa872c154853fbf5a"}]
+  [{:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 507}],
+    :xt/iid #bytes "34074814979fb71e1b17fbc926451eeb"}
+   {:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 492}],
+    :xt/iid #bytes "366f31cfe0fe34b925deac1cff579e9a"}
+   {:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 558}],
+    :xt/iid #bytes "372e0648cddeacc2665a833bd4d12d94"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 704}],
+    :xt/iid #bytes "379eb9237c7b941dcb08c66a3c73d4e1"}]
+  [{:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 439}],
+    :xt/iid #bytes "385d8c524478f9ff13ef582b3728ed64"}
+   {:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 689}],
+    :xt/iid #bytes "38c9612f6639c083e244311a3f904625"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 445}],
+    :xt/iid #bytes "3b9e76139a41541bfbe5a9d78188d6c0"}
+   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 475}],
+    :xt/iid #bytes "3bf899b22275a1dcc109ef7d5facd6b3"}]
   [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p0-b162.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p0-b162.arrow.edn
@@ -5,210 +5,530 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
+    :op #xt/tagged [:put #:xt{:id 970}],
+    :xt/iid #bytes "00b6fff7c9fdbadbc3da75bcb0a77b30"}
+   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 794}],
+    :xt/iid #bytes "00e3afd98fab2be1c237fed75fbdfa12"}
+   {:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 904}],
+    :xt/iid #bytes "0185eefe9ce0d4c1765b7003014bf8f0"}
+   {:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1103}],
+    :xt/iid #bytes "0259b245ef3581910a2e0468c80133f8"}
+   {:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1152}],
+    :xt/iid #bytes "02b106c33dd6837e7aacf8eee7cc3085"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 891}],
+    :xt/iid #bytes "03e6a80039ce9e2bd99561390b7ac060"}]
+  [{:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1033}],
+    :xt/iid #bytes "05c96ac8018e6891e201ae762c4bcbeb"}
+   {:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 785}],
+    :xt/iid #bytes "061151ca633755d80696ae5af5d851b8"}
+   {:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 919}],
+    :xt/iid #bytes "064f7a8ee2a0771fd15090a9fc4d76fa"}
+   {:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 816}],
+    :xt/iid #bytes "072d5c923dceec155e11580b6153a3a3"}
+   {:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 979}],
+    :xt/iid #bytes "0741418020febb026bd2b9abbc3e11b9"}
+   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 947}],
+    :xt/iid #bytes "07a1af3ea67e0c85afd9f40f2edce046"}]
+  [{:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 768}],
+    :xt/iid #bytes "0830a3bc6111c4b0188e894d8e0f605c"}
+   {:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1157}],
+    :xt/iid #bytes "089813bea950e6fac18d957c83c91846"}
+   {:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 956}],
+    :xt/iid #bytes "0917be528bc84ced9fa3eabdae270b19"}
+   {:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 858}],
+    :xt/iid #bytes "09ff8069f9dce453adf58a879562e166"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 890}],
+    :xt/iid #bytes "0bb2d1ed1c2ad5447dfa15d27b3e917f"}]
+  [{:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1173}],
+    :xt/iid #bytes "0d045d018d1da366cf9e52bb8263d160"}
+   {:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 965}],
+    :xt/iid #bytes "0d73554a96e896b6561cbdde07950960"}
+   {:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1051}],
+    :xt/iid #bytes "0df406fffa4ec7756de7156ef3cb6e58"}
+   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1061}],
+    :xt/iid #bytes "0e52b2a14edd20b8f3fc4133689c23a8"}
+   {:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1144}],
+    :xt/iid #bytes "0e576653382413d3b9c477776fb4b312"}
+   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 805}],
+    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}]
+  [{:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 997}],
+    :xt/iid #bytes "11cae0149d92be685c3188ae6562edca"}
+   {:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1039}],
+    :xt/iid #bytes "12077e7cfcf2b800cce358376daf0394"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 807}],
+    :xt/iid #bytes "1262f1f17552d2f36d85b2e37ab89449"}
+   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1014}],
+    :xt/iid #bytes "12fb15a07e907db35bd734fe18136eb2"}
+   {:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1129}],
+    :xt/iid #bytes "132391045d3701acaf79c9141f743647"}
+   {:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 977}],
+    :xt/iid #bytes "1346f0c6074d20f19ba2e8f0f9c36426"}]
+  [{:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 780}],
+    :xt/iid #bytes "156dde03324d48890d06bcdfc78efdba"}
+   {:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 887}],
+    :xt/iid #bytes "163eaae1c97db71f595448c8f04937b9"}
+   {:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1132}],
+    :xt/iid #bytes "16658c680e7054d3c0892f1a3937f691"}
+   {:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 782}],
+    :xt/iid #bytes "166d00587df0063868a1561e04042bb2"}
+   {:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 963}],
+    :xt/iid #bytes "167ee8fbd4ed57536ec39c6688a8d42e"}
+   {:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 849}],
+    :xt/iid #bytes "16c230b378daaf49f4bebcefd96fa58d"}
+   {:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1104}],
+    :xt/iid #bytes "170f6341a87c1078bbaed715b3f47844"}
+   {:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 931}],
+    :xt/iid #bytes "1796e6a52fced17027f7d414f68d2ba9"}]
+  [{:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 915}],
+    :xt/iid #bytes "18ecb000537797b1daa4f6a10e272f91"}
+   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 950}],
+    :xt/iid #bytes "19e7ac2c692b839a5ad235ac0685749a"}
+   {:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 905}],
+    :xt/iid #bytes "19ed993452ff4f53ec20b5ca0ae3d2db"}
+   {:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 886}],
+    :xt/iid #bytes "1abd4d367b7a6ecc058d3e99d8dd68eb"}
+   {:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 957}],
+    :xt/iid #bytes "1ad84b07b398bfec0ab338c5b86f8fff"}
+   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 996}],
+    :xt/iid #bytes "1b3362617d3c9ec7d01c4c7ce710501b"}
+   {:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 940}],
+    :xt/iid #bytes "1b6a3c3a3a40c08e378333ec8f222e26"}]
+  [{:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 792}],
+    :xt/iid #bytes "1c41e437efd6fa2e26849444df9af15b"}
+   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 837}],
+    :xt/iid #bytes "1d54b18af8342d34b31f3592a417be23"}
+   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 801}],
+    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
+   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 832}],
+    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
+   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 796}],
+    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}]
+  [{:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1175}],
+    :xt/iid #bytes "202f9773b628551a922824f2210df5ef"}
+   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 826}],
+    :xt/iid #bytes "206d831580f8ca6236edc2224696dd8b"}
+   {:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1077}],
+    :xt/iid #bytes "2071d4ab15dbcb6da0ef6426698e57b3"}
+   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 867}],
+    :xt/iid #bytes "20730e47902b11e398d8201d9682802d"}
+   {:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1081}],
+    :xt/iid #bytes "20858012cf0e1046887c9fd83130893d"}
    {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1100}],
+    :xt/iid #bytes "20a748343837165ee3b9e4854b5fba09"}]
+  [{:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 989}],
+    :xt/iid #bytes "228783ab2dbdf6ba14b040d556eba4f9"}]
+  [{:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 838}],
+    :xt/iid #bytes "23132d20365a6c72390d96705d32e058"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 809}],
+    :xt/iid #bytes "2391929a9974a20e7db35edb78ba4cc0"}
+   {:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 932}],
+    :xt/iid #bytes "23976149812481e1948b9ea3f827781a"}]
+  [{:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 790}],
+    :xt/iid #bytes "2471556afe66422661571f8e1002bf88"}
+   {:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1043}],
+    :xt/iid #bytes "24f9fa339e4fc797ab4ea43b68b581d9"}
+   {:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 852}],
+    :xt/iid #bytes "2538c26296a6d801b00822a29b1b508f"}
+   {:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1042}],
+    :xt/iid #bytes "2619264358dd5188adbd47279e13d227"}
+   {:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 881}],
+    :xt/iid #bytes "277791652e7692f8cb7ae46a4881688c"}
+   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1067}],
+    :xt/iid #bytes "27c96a98ff6a5b0c1116c88df14f6449"}]
+  [{:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1062}],
+    :xt/iid #bytes "28d54128f01db5e65896ee871231c777"}
+   {:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 853}],
+    :xt/iid #bytes "29339c43e6ed948f99bcbd27bff0c468"}
+   {:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1041}],
+    :xt/iid #bytes "29642b6ad6550fd8557470e9dfb03f55"}
+   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 803}],
+    :xt/iid #bytes "29d634a5c2d3c4c0e04bb990945aef6b"}
+   {:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 985}],
+    :xt/iid #bytes "2b0f3153ab6e38b162193e10d6e1f143"}]
+  [{:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 879}],
+    :xt/iid #bytes "2e7558613707426074d9bf31b043912b"}
+   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 898}],
+    :xt/iid #bytes "2e7cb17d934624cfdc306911ad7faebd"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 892}],
+    :xt/iid #bytes "2ec6991dc91d636765adc26abbe51f73"}
+   {:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1001}],
+    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
+   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 772}],
+    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}]
+  [{:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1122}],
+    :xt/iid #bytes "3025eecaa85ddfa1a048537c4dfe42ae"}
+   {:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 964}],
+    :xt/iid #bytes "305a1f922923eee8e1c2e2aadf667d8b"}
+   {:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1008}],
+    :xt/iid #bytes "31237e0541dd67f058898a49ff8f5304"}
+   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1172}],
+    :xt/iid #bytes "3182c550d4a76c8e6284073d1a7d5ed4"}
+   {:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 918}],
+    :xt/iid #bytes "31ea51eec93e48c1b666803ccc563cf7"}
+   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 798}],
+    :xt/iid #bytes "32cac6e038b3d5e1d2bf46c976969aae"}
+   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 969}],
+    :xt/iid #bytes "33610a9a431a6777ba16376c5f6802cc"}
+   {:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 862}],
+    :xt/iid #bytes "33a115d85a12ace28c33f42d0ef645c4"}]
+  [{:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 917}],
+    :xt/iid #bytes "345de83518023372a89ec95ffb6be404"}
+   {:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1161}],
+    :xt/iid #bytes "3628b631044bb1fba492995180b75b4d"}
+   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1054}],
+    :xt/iid #bytes "36e48849438bce7f2d0246f681729da2"}
+   {:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 933}],
+    :xt/iid #bytes "3737b14b8c0266d05b108af2694a5b9c"}
+   {:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1155}],
+    :xt/iid #bytes "3744cf7899fb29a8ba8f7b076b2f5daf"}
+   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 824}],
+    :xt/iid #bytes "37b68bfaf71b1ab5090580d0d9d9d66c"}
+   {:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1002}],
+    :xt/iid #bytes "37b957092aba851289334b71abf3e13f"}]
+  [{:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1171}],
+    :xt/iid #bytes "390ac960a3a1d5451c5443026bc4cc23"}
+   {:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 874}],
+    :xt/iid #bytes "394b7af3d8dfec33c9274f82e16abdc7"}
+   {:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
+    :op #xt/tagged [:put #:xt{:id 1089}],
+    :xt/iid #bytes "3a5da6ec72365b3e6f6f4dfb7bd1ec6a"}
+   {:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 764}],
+    :xt/iid #bytes "3a7d59619dffad1047bb947c70b2f071"}
+   {:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 847}],
+    :xt/iid #bytes "3aa0dbce506902df984bac4b91bda86f"}
+   {:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1110}],
+    :xt/iid #bytes "3ba2bfdc28ffeeb81354288358e49de0"}
+   {:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 962}],
+    :xt/iid #bytes "3bf595580fef8c685c195fb5c1bfd831"}]
+  [{:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1048}],
+    :xt/iid #bytes "3c809656dbb37f07590663d3a173dcab"}]
+  [{:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 907}],
+    :xt/iid #bytes "3d26fa78215f52935861889f579a6c39"}
+   {:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 788}],
+    :xt/iid #bytes "3dfd61638dee7db0dc619b2116f0d4ed"}]
+  [{:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1050}],
+    :xt/iid #bytes "3e0d152db0699204aebf953d45b03dc9"}
+   {:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1131}],
+    :xt/iid #bytes "3e52bea4481f9868fcdccea4927872e6"}
+   {:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1083}],
+    :xt/iid #bytes "3ec69b854dfa9e9c7df1da1c54c5ca6a"}
+   {:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 820}],
+    :xt/iid #bytes "3ef97bf1a7bb70c13d254724ce997cf4"}]
   [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p0-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p0-b182.arrow.edn
@@ -5,745 +5,435 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1544}],
+    :xt/iid #bytes "0079f2d7f1e3243a1625f78db0035582"}
+   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1270}],
+    :xt/iid #bytes "0209c61ac695e5460cbfe3114524a7ca"}]
+  [{:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1292}],
+    :xt/iid #bytes "04db988ab9d9982abce8d32189b314a2"}
+   {:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1430}],
+    :xt/iid #bytes "04ff80349772454d07b4983bb1b54462"}
+   {:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1455}],
+    :xt/iid #bytes "05112293c56c2f2948d6c418bdd6634e"}
+   {:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
+    :op #xt/tagged [:put #:xt{:id 1538}],
+    :xt/iid #bytes "05e04253cc5648d613280bcaf2c7bd6c"}
+   {:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1240}],
+    :xt/iid #bytes "062d4bbc782dcde75c438510e75ae41b"}
+   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1327}],
+    :xt/iid #bytes "0714f95c1b6851785c86c123be2cbaa2"}
+   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1300}],
+    :xt/iid #bytes "07d2e5a94a9404665fddf4cc651d34ad"}]
+  [{:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1456}],
+    :xt/iid #bytes "08690304431344ea3b8e87622ad92324"}]
+  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1272}],
+    :xt/iid #bytes "09279d20ea04e356f5bfa6b038befc74"}
+   {:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1195}],
+    :xt/iid #bytes "09516961e3590ae9d9d02b371ba51e14"}
+   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1363}],
+    :xt/iid #bytes "096c8a860a287a0dc631b41751a6a33b"}
    {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
+    :op #xt/tagged [:put #:xt{:id 1560}],
+    :xt/iid #bytes "09749f40266037ec1e9590931d94186c"}]
+  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1349}],
+    :xt/iid #bytes "0acca092e99855742f71f8cc0cc300ce"}]
+  [{:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1365}],
+    :xt/iid #bytes "0b82286dca05246c2737a7439b17a026"}
+   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1235}],
+    :xt/iid #bytes "0bc5e5b8740341988af1e66e0b2460e6"}
+   {:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1319}],
+    :xt/iid #bytes "0beb02848776942624c9de59a5ba8ce7"}]
+  [{:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1308}],
+    :xt/iid #bytes "0cb148c257063b1a6a0e1cceaa44d946"}
+   {:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1231}],
+    :xt/iid #bytes "0cbd4e673045d3e63f935cc1dc1dc3a3"}
+   {:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1287}],
+    :xt/iid #bytes "0e4ede2735da87fe1e78b078baf9d15d"}
+   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1540}],
+    :xt/iid #bytes "0ecd85ec50ae50d5c354864e5a6dfd32"}
+   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1357}],
+    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}]
+  [{:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1530}],
+    :xt/iid #bytes "10f28cc7f475bf4916c14d5f7febeca3"}
+   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1416}],
+    :xt/iid #bytes "11bc05c812843ca0777eae8843ff901c"}
+   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1317}],
+    :xt/iid #bytes "12fbd3fdf28895c53cf20864a08a5dfd"}
+   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1437}],
+    :xt/iid #bytes "1310eed9fceb10824c951ab6dc42749b"}
+   {:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1450}],
+    :xt/iid #bytes "135b5c34ac1a8129025cbe9942bdcfac"}
+   {:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1293}],
+    :xt/iid #bytes "1363f680c193fa4a2fc1b4dee014f945"}]
+  [{:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1550}],
+    :xt/iid #bytes "145dd636851f47ff75acc6084c32b871"}
+   {:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1227}],
+    :xt/iid #bytes "14dae612d51ae0a31add2f32a9aa1aa5"}]
+  [{:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1359}],
+    :xt/iid #bytes "1503c75578e3f2984cc6e13a199d18a3"}
+   {:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1196}],
+    :xt/iid #bytes "15dba04e1197d283062356b6f9d9336b"}]
+  [{:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1214}],
+    :xt/iid #bytes "164d84b7b5463b846c40a5d023708858"}
+   {:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1481}],
+    :xt/iid #bytes "16bf8c327c336807364f6935cda0215c"}]
+  [{:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1551}],
+    :xt/iid #bytes "17235ccf8c2fe868cb2de1f6f7e774b5"}
+   {:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1180}],
+    :xt/iid #bytes "17642da9b5c0df7bc6d0ef9619bcede1"}
+   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1470}],
+    :xt/iid #bytes "17679de93a68d52b72f5ee9b89b01ef1"}
+   {:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1444}],
+    :xt/iid #bytes "17d97e1c69dc7fec1661538b4f5dcfa5"}]
+  [{:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1222}],
+    :xt/iid #bytes "18ff1d1d45c9524d54d7c91336092d6c"}
+   {:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1453}],
+    :xt/iid #bytes "1901a671c21de9d97755d423917dbcc6"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1391}],
+    :xt/iid #bytes "192a3a738b82547ad1eaa0f7d9c6151e"}
+   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1275}],
+    :xt/iid #bytes "1a2dcf1a63a9c7c398830656964d73c0"}
+   {:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1198}],
+    :xt/iid #bytes "1bef9c5c29b6ab7742a1d3355f4edae7"}]
+  [{:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1283}],
+    :xt/iid #bytes "1c62a74ebf86a04fec9f8efa9eb8063f"}
+   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1346}],
+    :xt/iid #bytes "1c764b2a0eed5c3e892177bc82fae24a"}
+   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1234}],
+    :xt/iid #bytes "1cfcf3ac9623707875f79ce39e0838ec"}
+   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1373}],
+    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}]
+  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1370}],
+    :xt/iid #bytes "2083f926462b3008bbd2dcbc84a188b2"}
+   {:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1522}],
+    :xt/iid #bytes "212311257d144bab3c4d3487f99cf73d"}
+   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1541}],
+    :xt/iid #bytes "223887588f5b339a2880937113eeae4b"}
+   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1462}],
+    :xt/iid #bytes "223bb47418dd4a07d781e2d04bd18686"}
+   {:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1461}],
+    :xt/iid #bytes "22ec0aafd20821acb64d6da177821e56"}
+   {:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1192}],
+    :xt/iid #bytes "2306f6280718cfdc8138f2dac142908a"}]
+  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1271}],
+    :xt/iid #bytes "241991994fc11c54b9ed0dc44d4eb504"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1395}],
+    :xt/iid #bytes "24c23da2922bebf255d276cf92e389c7"}
+   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1514}],
+    :xt/iid #bytes "2535aecc693d7e734298ed0f5224a59f"}
+   {:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1183}],
+    :xt/iid #bytes "2629f8cda88b6c68d3c4fbfedfedbefb"}
+   {:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1507}],
+    :xt/iid #bytes "266b11642e6d84cc6194295c4364c04f"}
+   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1512}],
+    :xt/iid #bytes "279f313c2c016483047f1fc0d2684769"}]
+  [{:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1329}],
+    :xt/iid #bytes "294d0aad126eace83f376ad78ff2d106"}
+   {:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1216}],
+    :xt/iid #bytes "298b03752c7c5eb220d401d829dad210"}
+   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1497}],
+    :xt/iid #bytes "2a292e1c0adaba19bb9004b967993d00"}
+   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1469}],
+    :xt/iid #bytes "2adde2081ee7ae2c9a0bd0160e98322c"}
+   {:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1458}],
+    :xt/iid #bytes "2b4a3f289019b217c0cc7c10e0c33cc7"}
+   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1358}],
+    :xt/iid #bytes "2b76bcbfb46424f3d39e5afe1b5b6895"}
+   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1372}],
+    :xt/iid #bytes "2ba5f0746e4faca5366fe8f1c5715eef"}]
+  [{:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1305}],
+    :xt/iid #bytes "2c0639c8736f3923a0b009c239fbc41a"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1390}],
+    :xt/iid #bytes "2cba200a36c867b0c649c531e02bec11"}
+   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1417}],
+    :xt/iid #bytes "2cdf00d4573af48c8e2482abc6006b73"}
+   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1473}],
+    :xt/iid #bytes "2d8e1ce882ddaf3e7ebf7c6e27b79852"}
+   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1352}],
+    :xt/iid #bytes "2dabdec8bd8edb4fefbf63271ab90b8b"}
+   {:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1499}],
+    :xt/iid #bytes "2ddd70bc5cf8f9737f220ab0cdaa3ead"}
+   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1519}],
+    :xt/iid #bytes "2ded5217f5d60c95fa171d67e5d65ed1"}
+   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1433}],
+    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}]
+  [{:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1250}],
+    :xt/iid #bytes "303d32ade624dec7f099a69a7f295436"}
+   {:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1200}],
+    :xt/iid #bytes "31aaee1e5d2de111004f327658f7ef56"}
+   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1350}],
+    :xt/iid #bytes "321812ae29db928468701955144ab815"}
+   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1521}],
+    :xt/iid #bytes "32787e5739d5df518757d8a2d7fc4240"}
+   {:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1407}],
+    :xt/iid #bytes "32f45f8fc4c842c1d53d80fe9dc1dc7c"}
+   {:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1244}],
+    :xt/iid #bytes "3327472864cf37cae05678b33b3aa89d"}
+   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1338}],
+    :xt/iid #bytes "3350c0f1d1b01d90e3bdd160f1a2530f"}]
+  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1446}],
+    :xt/iid #bytes "34c0c0570b61ab1173374e95ac97f0da"}]
   [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
-  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1440}],
-    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
-   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1298}],
-    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}
-   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1280}],
-    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1261}],
-    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
-   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1212}],
-    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}
-   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}]
+    :op #xt/tagged [:put #:xt{:id 1442}],
+    :xt/iid #bytes "3afd9923868afee2a90ac55a51eee428"}
+   {:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1323}],
+    :xt/iid #bytes "3bbc9d5a707e3a7df5f612967e18a373"}]
   [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p0-b1a4.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p0-b1a4.arrow.edn
@@ -5,780 +5,465 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-09-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1585}],
+    :xt/iid #bytes "0045bfb648bf8f8a7fd32171a7339938"}
+   {:xt/system-from #xt/zdt "2020-11-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1863}],
+    :xt/iid #bytes "00487f69ebcb7781d182a53f893fb291"}
+   {:xt/system-from #xt/zdt "2020-11-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
+    :op #xt/tagged [:put #:xt{:id 1822}],
+    :xt/iid #bytes "00eacdef57408cc7b939a3ebb43d6261"}
+   {:xt/system-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1895}],
+    :xt/iid #bytes "026647f98aceabd69598b6c1edb80a32"}
+   {:xt/system-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1944}],
+    :xt/iid #bytes "03762beee4427e265f6f6d4347ac1505"}
+   {:xt/system-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1899}],
+    :xt/iid #bytes "038affce312cc320d74c910a0d182297"}
+   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1641}],
+    :xt/iid #bytes "03ab5c5fcf1667fd07b65050058bc6b7"}
+   {:xt/system-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1703}],
+    :xt/iid #bytes "03c2df407746c399c77cb51ddd468e71"}]
+  [{:xt/system-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1762}],
+    :xt/iid #bytes "042925d49fe077768c89a3248148f0e8"}
+   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1576}],
+    :xt/iid #bytes "04ef8153798dcb7070dceeeccff2069a"}
    {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1889}],
+    :xt/iid #bytes "0591e7f23359a4e3352eeed5138d9b64"}
+   {:xt/system-from #xt/zdt "2020-11-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1930}],
+    :xt/iid #bytes "066f940969061ab83fe4713d2f5dd6c8"}
+   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1721}],
+    :xt/iid #bytes "06ce0f32737a4eaf21af4376e78a0351"}
+   {:xt/system-from #xt/zdt "2020-10-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1659}],
+    :xt/iid #bytes "06d4b0f83eab7b3348615915689f902b"}
+   {:xt/system-from #xt/zdt "2020-11-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
+    :op #xt/tagged [:put #:xt{:id 1859}],
+    :xt/iid #bytes "0722efc4bf18d15182343692bd206f76"}
+   {:xt/system-from #xt/zdt "2020-10-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1802}],
+    :xt/iid #bytes "07c7c6c0c74177d16016d9ff5dfb9a21"}]
+  [{:xt/system-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1874}],
+    :xt/iid #bytes "08540bd3ddf5bfa896f2605699121c10"}]
+  [{:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1883}],
+    :xt/iid #bytes "093693e1c5cae99f0a56daddd75288fd"}
    {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1646}],
+    :xt/iid #bytes "09c4b07c2267190a0c9d2a1c89c877db"}
+   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
+    :op #xt/tagged [:put #:xt{:id 1637}],
+    :xt/iid #bytes "09cbeeadaaf38f709857a5851d291a7a"}]
+  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1918}],
+    :xt/iid #bytes "0a62a7e6d0d8a4c59b8e82d0391c6c2d"}
+   {:xt/system-from #xt/zdt "2020-09-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1617}],
+    :xt/iid #bytes "0a67601574392b21decf651e5b2beab0"}]
+  [{:xt/system-from #xt/zdt "2020-10-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1813}],
+    :xt/iid #bytes "0b535f6346da587303d9a6af9a878bd7"}
+   {:xt/system-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1718}],
+    :xt/iid #bytes "0b9fad681f79eb3d5a7177ded03f0350"}
+   {:xt/system-from #xt/zdt "2020-11-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1904}],
+    :xt/iid #bytes "0bc4a6fa42fc871065ba7dcf6926b236"}]
+  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1595}],
+    :xt/iid #bytes "0ca8785bd9fb107a9b23b724ea9529f4"}
+   {:xt/system-from #xt/zdt "2020-11-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1957}],
+    :xt/iid #bytes "0d603556b5793d18c1366217eab272c6"}
+   {:xt/system-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1696}],
+    :xt/iid #bytes "0fd26c9065dfe4562c3d627aae814390"}]
+  [{:xt/system-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1719}],
+    :xt/iid #bytes "1011e3e3e884cc39341c4e5b6e2a46fb"}
+   {:xt/system-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1897}],
+    :xt/iid #bytes "112c8aa69bd200ce985019891dd197ab"}
+   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1673}],
+    :xt/iid #bytes "118f6e76c4f2ba20449ac95ff56bfef0"}
+   {:xt/system-from #xt/zdt "2020-10-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1768}],
+    :xt/iid #bytes "12efe539a733e641c5b60d2705d237bd"}
+   {:xt/system-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1969}],
+    :xt/iid #bytes "12f9bfa09719fe999ba2648f5508fb2b"}]
+  [{:xt/system-from #xt/zdt "2020-11-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1848}],
+    :xt/iid #bytes "152b717d281518036484b9f2f9c606cb"}
+   {:xt/system-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1970}],
+    :xt/iid #bytes "1562cb58c7678ce2ea1365008baac21c"}
+   {:xt/system-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1961}],
+    :xt/iid #bytes "15b3fd01bb75df6197d85ab5a9a1c94b"}]
+  [{:xt/system-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1898}],
+    :xt/iid #bytes "1645a00dc31a651fb942e34b0331d0e0"}
+   {:xt/system-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1964}],
+    :xt/iid #bytes "165f97cd474e5c2a227870a870f9a3eb"}
+   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1672}],
+    :xt/iid #bytes "16e87bbcb3b4b5df825095f9d37e41a7"}
+   {:xt/system-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1951}],
+    :xt/iid #bytes "16f5ebab2a728da4c097d34a2a7cf5c3"}]
+  [{:xt/system-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1574}],
+    :xt/iid #bytes "1731d455c7647b2fa677d167d84a455c"}
+   {:xt/system-from #xt/zdt "2020-10-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1775}],
+    :xt/iid #bytes "17c226b6d20b2e947af49ee1f042f9f0"}]
+  [{:xt/system-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1872}],
+    :xt/iid #bytes "18733e4aac561eaafd4acee3b53eeb8d"}
+   {:xt/system-from #xt/zdt "2020-10-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1799}],
+    :xt/iid #bytes "191f5de4fd2f97e484547c1620bc047c"}
+   {:xt/system-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1761}],
+    :xt/iid #bytes "1a7098f9f73e0be489889d6e731511a1"}
    {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1893}],
+    :xt/iid #bytes "1a7dc130e4feb635b1c1e7972ada3729"}
+   {:xt/system-from #xt/zdt "2020-09-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1587}],
+    :xt/iid #bytes "1b0b5676b3c66dad4581b246a8d966d7"}]
+  [{:xt/system-from #xt/zdt "2020-09-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1614}],
+    :xt/iid #bytes "1c3514229574f26f98e102262ee36ed2"}
+   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1629}],
+    :xt/iid #bytes "1cddf36456dc4ed5e183c16c8ccf5ed7"}
+   {:xt/system-from #xt/zdt "2020-11-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1849}],
+    :xt/iid #bytes "1d8bcb6228d5799d6098fdebbe081501"}
+   {:xt/system-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1713}],
+    :xt/iid #bytes "1f29d83d5246f330d2b693d31ec1dcd9"}]
+  [{:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1940}],
+    :xt/iid #bytes "2103cfdd7c0fd92c632dd18f59469e60"}
+   {:xt/system-from #xt/zdt "2020-10-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1771}],
+    :xt/iid #bytes "211c98f33099c6c4a0c22d313eec9b58"}
+   {:xt/system-from #xt/zdt "2020-10-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1682}],
+    :xt/iid #bytes "2205c47404ff9f7d8f734abb5d9f22ae"}]
+  [{:xt/system-from #xt/zdt "2020-10-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1679}],
+    :xt/iid #bytes "24c1e16e9733085e4923f4362a14dda7"}
+   {:xt/system-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1575}],
+    :xt/iid #bytes "24f0f5659a30f3ad6c9365a62a68ace4"}
+   {:xt/system-from #xt/zdt "2020-11-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1855}],
+    :xt/iid #bytes "2639311fbcb0f10cb9c80ad33ee7c7cb"}
+   {:xt/system-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1609}],
+    :xt/iid #bytes "263d2ad7a7fe3c0ceba96f0c959416ef"}
+   {:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1743}],
+    :xt/iid #bytes "270a53a8cc303f78341bd4a785a11143"}
+   {:xt/system-from #xt/zdt "2020-11-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1934}],
+    :xt/iid #bytes "272e720db36fd413bf2a8e18e415c41a"}
+   {:xt/system-from #xt/zdt "2020-11-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1825}],
+    :xt/iid #bytes "274c63344192a9f7b4a93148e753c47f"}
+   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1881}],
+    :xt/iid #bytes "276fc670f4b29f9288cf81722e0ba170"}]
+  [{:xt/system-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1965}],
+    :xt/iid #bytes "280674e8f1a71161a0187e7e39cf4477"}
+   {:xt/system-from #xt/zdt "2020-11-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1932}],
+    :xt/iid #bytes "297665b01a456e57b85ed31dfd89b1b5"}
+   {:xt/system-from #xt/zdt "2020-10-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1815}],
+    :xt/iid #bytes "29887b1401ab31cabf99f59bcfe40b46"}
+   {:xt/system-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1830}],
+    :xt/iid #bytes "2bb92561e7a611cc6e5078dc19a649ec"}]
+  [{:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1579}],
+    :xt/iid #bytes "2c12b7b1f709e4ef63fc5fec5e461016"}
+   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1720}],
+    :xt/iid #bytes "2c6275a0669b0d4289849629c2daa394"}
+   {:xt/system-from #xt/zdt "2020-09-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1584}],
+    :xt/iid #bytes "2cd50dcdabe92bc0bb2f670d51ec6bea"}
+   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1729}],
+    :xt/iid #bytes "2cf5efac0e60baf82dda43ce50076d6f"}]
+  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1919}],
+    :xt/iid #bytes "2dbfdcacc2e72a07d48bc2c74f59da87"}
+   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1623}],
+    :xt/iid #bytes "2dfebc51678e3609facfbde27b5eba53"}]
+  [{:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1886}],
+    :xt/iid #bytes "2e03d44e93a102e09825035abba946e4"}
+   {:xt/system-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1710}],
+    :xt/iid #bytes "2e587e159e0c4b975fa8fc74bb42bbc8"}
+   {:xt/system-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1605}],
+    :xt/iid #bytes "2ef539551824e39a4e6e6d8e1e375d6c"}]
+  [{:xt/system-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1756}],
+    :xt/iid #bytes "3130b1143c16e4c3bb5df5515b7c93de"}
+   {:xt/system-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1687}],
+    :xt/iid #bytes "3195b3a2edcdf762e3e314fa97ea7a5a"}
+   {:xt/system-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1600}],
+    :xt/iid #bytes "32720c6984f42bf4372a88b5d6731dda"}
+   {:xt/system-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1925}],
+    :xt/iid #bytes "32ea8fac90228b336ea5b21ff940fbe7"}]
+  [{:xt/system-from #xt/zdt "2020-11-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1956}],
+    :xt/iid #bytes "35b1ccc4f89b12de5c25a9213263ded5"}
+   {:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1739}],
+    :xt/iid #bytes "35b503363bd32a2a2ac8de0461573c82"}
+   {:xt/system-from #xt/zdt "2020-09-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1612}],
+    :xt/iid #bytes "363601e4fc2932024755705212cb4f2f"}
+   {:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
-  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1749}],
-    :xt/iid #bytes "3cd4ac88dc70c3f9fdfe8a33c2838254"}
-   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1642}],
-    :xt/iid #bytes "3d1ea754f4062d28683bf7d214661b4c"}
-   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1628}],
-    :xt/iid #bytes "3e248998d04e1b6a6c0f6a8e89dd6b62"}
-   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1891}],
-    :xt/iid #bytes "3e290b9740592a67766eb9568ae07577"}
-   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1937}],
-    :xt/iid #bytes "3e9b358dfad71793569030700675631b"}
-   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1783}],
-    :xt/iid #bytes "3f572253ec30a677511007954115be9b"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1632}],
-    :xt/iid #bytes "3f6d740c523d4d61969afc084db8d82f"}]
+    :op #xt/tagged [:put #:xt{:id 1748}],
+    :xt/iid #bytes "364dbdaadebe45078c37f1c81e0fd0ad"}
+   {:xt/system-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1968}],
+    :xt/iid #bytes "367be690739db915649147c4a315b2fe"}
+   {:xt/system-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1666}],
+    :xt/iid #bytes "3787a5217b514b03b45a7d97f981e887"}
+   {:xt/system-from #xt/zdt "2020-09-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1582}],
+    :xt/iid #bytes "37f5a91f8a72e176514c957b809d2740"}]
+  [{:xt/system-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1662}],
+    :xt/iid #bytes "38e46b07cd114782f435e27b7bf6472c"}
+   {:xt/system-from #xt/zdt "2020-11-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1959}],
+    :xt/iid #bytes "3979eab4310d34196af95f2ef90e2246"}
+   {:xt/system-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1607}],
+    :xt/iid #bytes "3a658172a5679dbaeffe7ced38939614"}
+   {:xt/system-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1590}],
+    :xt/iid #bytes "3a93f4ba3d9e984f213c10b781b48de6"}
+   {:xt/system-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1917}],
+    :xt/iid #bytes "3b5fbc9600acbb1e775b48a5327cc041"}]
   [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p1-b11f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p1-b11f.arrow.edn
@@ -5,385 +5,475 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 23}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
+    :op #xt/tagged [:put #:xt{:id 315}],
+    :xt/iid #bytes "40c649f68755420ec7d3b982fa77131f"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 284}],
+    :xt/iid #bytes "40d8e2558d6aa134d5c236aaae1dae24"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 2}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 40}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
    {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
+    :op #xt/tagged [:put #:xt{:id 185}],
+    :xt/iid #bytes "42bd5212f6e7dd0db68869dfa0034870"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 90}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}]
+  [{:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 203}],
+    :xt/iid #bytes "45b09127f2425b5ec41915ee6057b859"}
+   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 329}],
+    :xt/iid #bytes "463324d8c6e8b7957a4d688f589d060a"}
+   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 336}],
+    :xt/iid #bytes "465e616d21e05f4ad00dc6c5f542c414"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 165}],
+    :xt/iid #bytes "4688cfba00431876631eedbcc7469577"}
+   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 276}],
+    :xt/iid #bytes "46bf53a692426c42ebcd55166bd55589"}]
+  [{:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 94}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}
+   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 260}],
+    :xt/iid #bytes "48d5921deeb3d8e69024a2c3ea11f0bd"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 188}],
+    :xt/iid #bytes "492666daf1bb208aa96f4c9326030fcb"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 283}],
+    :xt/iid #bytes "496e01d77d8fafb07fa1fa40ecb57e3b"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 207}],
+    :xt/iid #bytes "4ae45a44d53d8f7ce92b700d67db2ab7"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 297}],
+    :xt/iid #bytes "4b3273a103b59b1fa74064c7341b874a"}
+   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 279}],
+    :xt/iid #bytes "4bcb1c2cf33853525d97e6a355a03d53"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 8}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}
+   {:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 380}],
+    :xt/iid #bytes "4c78ac06bb228d9e4844029f45591a11"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 331}],
+    :xt/iid #bytes "4c868f1fd3fa6671225e51568bf73be6"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}]
+  [{:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 191}],
+    :xt/iid #bytes "4d16fdb13bbc641dfdd6e3274d69daa9"}]
+  [{:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 322}],
+    :xt/iid #bytes "4e87c935e7c6d2cfc321b9b29ed61f1a"}]
+  [{:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 278}],
+    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 294}],
+    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 122}],
+    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
+  [{:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 228}],
+    :xt/iid #bytes "51d24967a0eee28228e3e3dabb1fed8f"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 171}],
+    :xt/iid #bytes "537ac777da79e0b495e126d4792b73d7"}
+   {:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 372}],
+    :xt/iid #bytes "53cc29f9ab57ca2e65dde6503b0abe53"}]
+  [{:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 288}],
+    :xt/iid #bytes "552c773456b6d26215274a11c3b8877a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 52}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}]
+  [{:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 139}],
+    :xt/iid #bytes "56438668c41161b90a2e54d04d7c548a"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 121}],
+    :xt/iid #bytes "56631378e6c99834a66b8a87243eb6b6"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 178}],
+    :xt/iid #bytes "56867341bf1bde4f3979ad563be4b6fc"}]
+  [{:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 374}],
+    :xt/iid #bytes "57049942ff3848aaedf2ae7495110726"}
+   {:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 364}],
+    :xt/iid #bytes "5761f0ca45541fcb053f6ea40a51d85a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 32}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 313}],
+    :xt/iid #bytes "57a7b3f57475fb1da77d804447beffe6"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 11}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 382}],
+    :xt/iid #bytes "5a0a91139ab680056b334c3b47d76fc1"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 7}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 363}],
+    :xt/iid #bytes "5bb136cd532ad7fc665afd9122f1dd9c"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 60}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 326}],
+    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
+  [{:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 301}],
+    :xt/iid #bytes "60bf8aedc9e0139c0672f14a7e63bba6"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 317}],
+    :xt/iid #bytes "6160ed777981a09ef72c4b769da6ca23"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 333}],
+    :xt/iid #bytes "616d1bac5b1f7f434d6c0a2ee5fe3da9"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 316}],
+    :xt/iid #bytes "628926b0e1d424a4c8c7c8de3390e7a7"}
+   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 355}],
+    :xt/iid #bytes "62e736178a161c4ef21d1f6464598dd0"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 304}],
+    :xt/iid #bytes "63065ba681a3e5e21b32b06405efbf2b"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 195}],
+    :xt/iid #bytes "631f7ac51f82df51f0d75dd29939850e"}]
+  [{:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 77}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 24}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 168}],
+    :xt/iid #bytes "64c3762140bc7f68a621713980713f86"}]
+  [{:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 232}],
+    :xt/iid #bytes "664b74ffc0f8d86e7a96bccb3f8d772a"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 239}],
+    :xt/iid #bytes "66ab375a0c928ef9d38d7c4157746680"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 63}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 174}],
+    :xt/iid #bytes "671a4e7ac7d9bc8c6cdc8ca5e5ff97ad"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 155}],
+    :xt/iid #bytes "67635c6c72af39c3b856a7c8a43cb422"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 88}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 44}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 213}],
+    :xt/iid #bytes "69b6db1996f88790dea98c0f26b58ce7"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 108}],
+    :xt/iid #bytes "6a1aa9b3dda959ebdc1c325c1395e9db"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 142}],
+    :xt/iid #bytes "6a3044e68acfd26a3500e54ed89d8d3b"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 150}],
+    :xt/iid #bytes "6b5b1c7d42ed17ef00426336041b774e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 12}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 37}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 69}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 132}],
+    :xt/iid #bytes "6c11d1d9d6189c77215258e45dfe1e84"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 182}],
+    :xt/iid #bytes "6c1cf16dd9fd2128e49f7b3b5cbd4ca9"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 332}],
+    :xt/iid #bytes "6d29fd85e233a04712a34a13a94e7c61"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 189}],
+    :xt/iid #bytes "6dfe4a17ead7eda309a27032c8e4834d"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 256}],
+    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 104}],
+    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}]
+  [{:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 337}],
+    :xt/iid #bytes "705bc958047bc9336fd80460114c069d"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 217}],
+    :xt/iid #bytes "733cf7e2dfc2eab15388b92e900eb7d6"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 10}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}]
+  [{:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 105}],
+    :xt/iid #bytes "742c9aaaffbbcf91b2abb64c169a75a2"}
+   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 264}],
+    :xt/iid #bytes "744cc63ddfb14649c4de3a4856fe084f"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 204}],
+    :xt/iid #bytes "7467fbb0f016b9c9d166b23dc1cebff5"}]
+  [{:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 197}],
+    :xt/iid #bytes "7558ad61d00500504a38cc300abe05ba"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 57}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
-  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 16}],
-    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 295}],
-    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}]
+    :op #xt/tagged [:put #:xt{:id 17}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}]
+  [{:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 145}],
+    :xt/iid #bytes "777f8343a5f9263eb40a82a151327576"}
+   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 277}],
+    :xt/iid #bytes "77a51cbe19fc3568904cfc39937e7982"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 249}],
+    :xt/iid #bytes "77f81c1dd9e797d0f07b0737ba531049"}]
+  [{:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 226}],
+    :xt/iid #bytes "780f83f7991e70659a63fbaea3c156a9"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 162}],
+    :xt/iid #bytes "7946c195fde566c2a79b7a2448912920"}
+   {:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 369}],
+    :xt/iid #bytes "7ace13fc4cf9e6aed523f660be0bc895"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 38}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}]
   [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p1-b13f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p1-b13f.arrow.edn
@@ -5,220 +5,470 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
+    :op #xt/tagged [:put #:xt{:id 648}],
+    :xt/iid #bytes "40222420ca7aa65eb661de755db40239"}
+   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 750}],
+    :xt/iid #bytes "41d13b3b4b49d6be3fc2a7a90e1c6c48"}
+   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 698}],
+    :xt/iid #bytes "422da4692ddddd1c613b93ceddf36f0b"}
+   {:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 392}],
+    :xt/iid #bytes "4319f3203c52e94f9cd2d55bdc6b1a57"}
+   {:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 436}],
+    :xt/iid #bytes "43caa786a93a2c016c69071b61d77e96"}
+   {:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 605}],
+    :xt/iid #bytes "43ef552746ccb5cc46fc2e1c30618f3e"}]
+  [{:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 678}],
+    :xt/iid #bytes "47f94f49d3b1895a102005c901e365e2"}]
+  [{:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 412}],
+    :xt/iid #bytes "4881948f6493423b6f873950d4ab23f1"}
+   {:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 597}],
+    :xt/iid #bytes "489340f2d054d212de8a8efa5f965d91"}
+   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 594}],
+    :xt/iid #bytes "48ea67ed89baddf8e9a8a581755f3524"}
+   {:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 557}],
+    :xt/iid #bytes "498c7e58ce641670525e2026d7519c7e"}
+   {:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 688}],
+    :xt/iid #bytes "49950d367a7c1e19a1fd6dafe928d912"}
+   {:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 397}],
+    :xt/iid #bytes "49a612e5c77e92f21a04cd506048d201"}
+   {:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 623}],
+    :xt/iid #bytes "49b2ecc8ba67968d146c891b475089b5"}
+   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 561}],
+    :xt/iid #bytes "49b7378595e981fc54a70545fd2805b1"}]
+  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 751}],
+    :xt/iid #bytes "4c98ca651fd1bbb0908c121c0e59a2a1"}
+   {:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 510}],
+    :xt/iid #bytes "4cff160e64247db2d274db632bc50f9c"}
+   {:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 480}],
+    :xt/iid #bytes "4d1d12a5fe76cf17ea918594fa95e4d7"}
+   {:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 598}],
+    :xt/iid #bytes "4db9a886949a7b18a31c373c9026c113"}
+   {:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 525}],
+    :xt/iid #bytes "4e030508df6dc244ee5c0377c0fa9051"}
+   {:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 488}],
+    :xt/iid #bytes "4e7e4056a708f7030d05e2099a263b43"}
+   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 631}],
+    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}]
+  [{:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 394}],
+    :xt/iid #bytes "50526f18ac2803b7328d2d03c1792bdf"}
+   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 645}],
+    :xt/iid #bytes "5135b5be89800da2b572bee4895f795a"}
+   {:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 532}],
+    :xt/iid #bytes "51598c8dc435ede1ed10284dcbf7eac3"}
+   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 563}],
+    :xt/iid #bytes "52c5de7d0873a3e2470a9a60c227ef2e"}
+   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 740}],
+    :xt/iid #bytes "531ac4bb2da2e44fb2eac301b684f196"}
+   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 406}],
+    :xt/iid #bytes "537ed1967c0ccdfa9971c7cde00136a1"}]
+  [{:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 425}],
+    :xt/iid #bytes "5405c8a9dc9ddcebfc1c9fdbf481ab8c"}
+   {:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 752}],
+    :xt/iid #bytes "565ece949d9a20f529ce87ef63b9b42b"}
+   {:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 496}],
+    :xt/iid #bytes "571a88ff05f21217ed296e133879fdf7"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 446}],
+    :xt/iid #bytes "57f4b946317bd6164b6f0732fd7f2b62"}]
+  [{:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 578}],
+    :xt/iid #bytes "58871807fd4f75c7611879d5870d780c"}
+   {:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 451}],
+    :xt/iid #bytes "5888758023a576352a8ca1b8124e2d3b"}
+   {:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 452}],
+    :xt/iid #bytes "58b1511372b6f8a114257bb8c3929d68"}
+   {:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 621}],
+    :xt/iid #bytes "591e5d19f970ce07767cc273b2fa9834"}]
+  [{:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 562}],
+    :xt/iid #bytes "5c9c90b87e6212e528322610a4be8d1c"}]
+  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 576}],
+    :xt/iid #bytes "5d3cb1ba7183842a0ad37b855ed26607"}
+   {:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 716}],
+    :xt/iid #bytes "5d68886e0db65c298c6b6b9f8f42d43f"}
+   {:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 421}],
+    :xt/iid #bytes "5da82c952ba1706c2df8f7c60f4f9431"}]
+  [{:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 385}],
+    :xt/iid #bytes "5e11e8c2103098519bb75c1be90cbb17"}
+   {:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 655}],
+    :xt/iid #bytes "5e991e0ddad3bcdf65f7b15825dcee5b"}
+   {:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 680}],
+    :xt/iid #bytes "5eca39d5c12aa1aba099b1d5cba1aa8a"}]
+  [{:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 618}],
+    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
+   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 741}],
+    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}]
+  [{:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 533}],
+    :xt/iid #bytes "6006439e6a4bc5d90e2f289eccc70d5a"}
+   {:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 453}],
+    :xt/iid #bytes "600f440034c740822a8f1f92043e4512"}
+   {:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 732}],
+    :xt/iid #bytes "6027546bab40cf0a016586a191a5a387"}
+   {:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 642}],
+    :xt/iid #bytes "602d23cfde4e3a8d823a171d3fd2c26c"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 444}],
+    :xt/iid #bytes "608140d56e0a18407c6dc197418e7545"}
+   {:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 693}],
+    :xt/iid #bytes "61bc18ba999048ee76debfd4cae1ea96"}
+   {:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 486}],
+    :xt/iid #bytes "636245b9345b35a3a8e83f3101eff063"}]
+  [{:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 699}],
+    :xt/iid #bytes "645e6862f209e43c17b44fde86887893"}
+   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 403}],
+    :xt/iid #bytes "65346aea0c1af23d419e60b7abdf30c6"}
+   {:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 548}],
+    :xt/iid #bytes "657c4d5fd60ecff3e9c227de1a2c5030"}
+   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 664}],
+    :xt/iid #bytes "65d53e3f56b49e0d4a4f3742f3847e90"}
+   {:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 408}],
+    :xt/iid #bytes "6601cf81fa0ec225d224620a8038ce2f"}
+   {:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 730}],
+    :xt/iid #bytes "6675d564c86214cc17c78a57a1113160"}
+   {:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 524}],
+    :xt/iid #bytes "67349f0bdcbbcd2ee0a2028b1525c41c"}
+   {:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 696}],
+    :xt/iid #bytes "676350721000ba7785d236cf3e5019c8"}]
+  [{:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 423}],
+    :xt/iid #bytes "68432f5d7e1f8a46862f216459b1a55c"}
+   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 758}],
+    :xt/iid #bytes "68bc2bfda96723a7218c4dd8cb6a48c3"}
+   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 593}],
+    :xt/iid #bytes "698b78433d7268bd8ab610527e6db722"}]
+  [{:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 669}],
+    :xt/iid #bytes "6c48b78a81245a8f3514287c23a3d26e"}
+   {:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 463}],
+    :xt/iid #bytes "6c4f27d2fda3e6a6eedf9c94c0674ed0"}
+   {:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 756}],
+    :xt/iid #bytes "6c7a0d2696cc305ddc978246c45f1cbd"}
+   {:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 384}],
+    :xt/iid #bytes "6ca4e00614e81073425d212ab2f70616"}]
+  [{:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 402}],
+    :xt/iid #bytes "6d5cde261c8cb3a43ed42f6f73c1e2b8"}
+   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 617}],
+    :xt/iid #bytes "6d6905a25d3408d339eccf394887bfbb"}
+   {:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 516}],
+    :xt/iid #bytes "6dd940ca157f019abe8d51df7f8aa313"}]
+  [{:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 720}],
+    :xt/iid #bytes "6e33e0e8898f27ddf79cec8d9e007219"}]
+  [{:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 431}],
+    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
+   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 404}],
+    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}]
+  [{:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 676}],
+    :xt/iid #bytes "709d09e8c8c91937bcdf8e16173e8506"}
    {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 415}],
+    :xt/iid #bytes "70dfa5a5ebdad27d07b6592700f1a97f"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 448}],
+    :xt/iid #bytes "7176d63cfa5755d6a95fca2b08322c05"}
+   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 619}],
+    :xt/iid #bytes "718f34db3e393e15a7529ba80a1fcf44"}
+   {:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 464}],
+    :xt/iid #bytes "7244cbb7a275a81641f4db80c949130c"}
+   {:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 652}],
+    :xt/iid #bytes "725e0fbf04e3ff3a3e5e5df61ef93da7"}
+   {:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 719}],
+    :xt/iid #bytes "72867f2fa76d9d4a5ae26e3a71028e2a"}
+   {:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 677}],
+    :xt/iid #bytes "73d5a58a640f071b23da3a8a6177caed"}]
+  [{:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 519}],
+    :xt/iid #bytes "7449d5ea558f4368f298ed517841751b"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 449}],
+    :xt/iid #bytes "74a1da0e0a4e146d10e3e40495030c9a"}
+   {:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 718}],
+    :xt/iid #bytes "74dd37f983138181aff8002651984308"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 727}],
+    :xt/iid #bytes "75b4314225afe40d30f63031972be5ad"}
+   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 426}],
+    :xt/iid #bytes "75f127af00d99ac26209d0f0747438ff"}
+   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 635}],
+    :xt/iid #bytes "7672ffece1d683de1971be1b4b07243e"}
+   {:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 437}],
+    :xt/iid #bytes "770c0ba1af7a39304cb3dec9f0e43e81"}
+   {:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 396}],
+    :xt/iid #bytes "77b2d5e712ea307e65d8bc8c24b84a0c"}]
+  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 574}],
+    :xt/iid #bytes "7906b88a9c05d25ff8f531dda905d859"}
+   {:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 656}],
+    :xt/iid #bytes "7ae9669166b614c9f2fe07e6b86e5233"}
+   {:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
-  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 468}],
-    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 414}],
-    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
+    :op #xt/tagged [:put #:xt{:id 391}],
+    :xt/iid #bytes "7bd1c224fb28704a51e5de0b8e096bc3"}]
   [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p1-b162.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p1-b162.arrow.edn
@@ -5,685 +5,535 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 968}],
+    :xt/iid #bytes "41a93fe908b8c939603a084f360b7f77"}
+   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
+    :op #xt/tagged [:put #:xt{:id 925}],
+    :xt/iid #bytes "4261ecf79169314174d0bc40a317b3da"}
+   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 799}],
+    :xt/iid #bytes "435e7b740cbffe36e3f8d99b05da26d9"}]
+  [{:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 829}],
+    :xt/iid #bytes "455b674698aa9879464a48e05c5eed5d"}
+   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 944}],
+    :xt/iid #bytes "47030834345fab9e652735ae1eec85b2"}
+   {:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1160}],
+    :xt/iid #bytes "47901386a46a309e8f7a58d776d5b151"}]
+  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1003}],
+    :xt/iid #bytes "484949301a19e8b552618de3ca32b136"}
+   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 825}],
+    :xt/iid #bytes "485a47fb56a2bbc92dc0342f3f7d6aba"}
+   {:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 937}],
+    :xt/iid #bytes "485ed5fd087fe3b3c5ab07e72fdf5a43"}
+   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 955}],
+    :xt/iid #bytes "49853d794df29c0c5cc52159b961bef5"}
+   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 770}],
+    :xt/iid #bytes "4b0cd19026208a0f557c1b19677590ad"}
+   {:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 766}],
+    :xt/iid #bytes "4b2cea2a4dc31b0b7bdc0e6d46af524c"}]
+  [{:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 993}],
+    :xt/iid #bytes "4c9e0f6298977a635f994b4b127eb223"}
+   {:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 823}],
+    :xt/iid #bytes "4cee63f69325e9636d25cb5a61919ef1"}
+   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1124}],
+    :xt/iid #bytes "4cf8d3329b7ef10b292f13ac2d50c200"}
+   {:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1026}],
+    :xt/iid #bytes "4d1a64d36ddda1832adec174f982db1e"}
+   {:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 930}],
+    :xt/iid #bytes "4d3cecf65b04017e6223ac7d19f55c07"}
+   {:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1109}],
+    :xt/iid #bytes "4ea02f80851aef5b3b89c714bb60790c"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 893}],
+    :xt/iid #bytes "4ea0755c114f61b32ad4e353e73781ad"}]
+  [{:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 848}],
+    :xt/iid #bytes "501c71a482a4c07e95acc3e35b6b4cf2"}
+   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 910}],
+    :xt/iid #bytes "506172ffd001e98d3adb5d249fc7dd6b"}
+   {:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1094}],
+    :xt/iid #bytes "50e1bebf6819b16f0f398727c04df9d9"}
+   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 773}],
+    :xt/iid #bytes "50e8d314a9fd998d8b28c2749f675a1a"}
+   {:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1159}],
+    :xt/iid #bytes "52dbf9187e17ad10ef6469a395dea1dd"}
+   {:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 984}],
+    :xt/iid #bytes "537b9add1589d26e7261cb3810d07932"}
+   {:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1133}],
+    :xt/iid #bytes "53e8f35973d42c431998fd3d25eca4b7"}]
+  [{:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 896}],
+    :xt/iid #bytes "5483a35c0af3da1fe5251ca86ec5875c"}
+   {:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 966}],
+    :xt/iid #bytes "54950626f8ac0dcb805d0d7e6164388a"}
+   {:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1128}],
+    :xt/iid #bytes "54ec52da84050c86009c5d2e235db837"}
+   {:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 813}],
+    :xt/iid #bytes "54f5e7c7a71fd4c6f7cc0df3445e41c6"}]
+  [{:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 871}],
+    :xt/iid #bytes "552058523b000209038aa1a935ea0819"}
+   {:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1113}],
+    :xt/iid #bytes "5521120dc91d344bb740fb36ab828560"}]
+  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1021}],
+    :xt/iid #bytes "56843e733dbb9615049c7002e9d0683e"}
+   {:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 902}],
+    :xt/iid #bytes "56897c443e1685b28ded0c32bf089710"}]
+  [{:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1078}],
+    :xt/iid #bytes "577153846210cd622448fa71293f087a"}]
+  [{:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1156}],
+    :xt/iid #bytes "5896a71dcb637196623a318b97abb140"}
+   {:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 857}],
+    :xt/iid #bytes "59c1df9d2df13f64f51427de8b885fc8"}
+   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1068}],
+    :xt/iid #bytes "59d23a0a1445e26ca1ee1ffcdf877ec2"}
+   {:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1153}],
+    :xt/iid #bytes "59f437f9ae4f715c10bf5d833ba09eb8"}
+   {:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 880}],
+    :xt/iid #bytes "5bbb607251a9fab8d9c99bbb6a903c89"}]
+  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 929}],
+    :xt/iid #bytes "5c71467ecdf097c02d04d9c19fe4cb1a"}
+   {:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 846}],
+    :xt/iid #bytes "5d75a8963505f7ae903ca9f6bcb9e90a"}
+   {:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 784}],
+    :xt/iid #bytes "5e4d344ae378a0825e703521271a29c7"}
+   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 992}],
+    :xt/iid #bytes "5e5b37826ef6c76b0de6f31fd9d90a6e"}
+   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1069}],
+    :xt/iid #bytes "5eb022beb9dc3b07d65af680e4e67ebe"}]
+  [{:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 835}],
+    :xt/iid #bytes "60f168b716d2538928f9c9940f03c026"}
+   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 830}],
+    :xt/iid #bytes "61c50a422e40aca268fcb5066462bb16"}
+   {:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 935}],
+    :xt/iid #bytes "61f913ffe99961268860c8ab4770b1c3"}
+   {:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 986}],
+    :xt/iid #bytes "6236bc6976e6729275ac4f8bd045627a"}
+   {:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1044}],
+    :xt/iid #bytes "6247cba854b1831184fe5f1270e582f5"}
+   {:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 882}],
+    :xt/iid #bytes "62c8ab318c2329509597753815bcdfc1"}
+   {:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 859}],
+    :xt/iid #bytes "6378ac6249e165f5484f7e3d787e774e"}
+   {:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 903}],
+    :xt/iid #bytes "63d0f36929ec7cb6bc297f5d49777742"}]
+  [{:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1121}],
+    :xt/iid #bytes "66a0a7a1a00d7e73ba1785d707c2752e"}
    {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1013}],
+    :xt/iid #bytes "6732e78eab6c85a717389785c6ae4100"}]
+  [{:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 934}],
+    :xt/iid #bytes "682be373604e915849b575e75757251c"}
+   {:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 889}],
+    :xt/iid #bytes "68d07050c64afb8fd3dfedd8e4927536"}
+   {:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 844}],
+    :xt/iid #bytes "6990b860deec19a9db5b84aac0038512"}
+   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1020}],
+    :xt/iid #bytes "6a9a0a38a823eab7770578660e9fdfec"}
+   {:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 850}],
+    :xt/iid #bytes "6b516724372570f2c5b51164fa4b87ae"}
+   {:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1150}],
+    :xt/iid #bytes "6bbbc7ece478ee6ce6629713d6f3a788"}]
+  [{:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1149}],
+    :xt/iid #bytes "6c40209843f309f91dad1041f6220cf5"}]
+  [{:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 864}],
+    :xt/iid #bytes "6d364536fa0e73c59cc806754980f70d"}
+   {:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 906}],
+    :xt/iid #bytes "6d3d09c3b2ef19bddde2404db2fbc254"}
+   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 908}],
+    :xt/iid #bytes "6d7e572b44a1f3dcfc8f2370756934d6"}]
+  [{:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1176}],
+    :xt/iid #bytes "6e72faf9a547bc1585571a5fa5b4f9ca"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 806}],
+    :xt/iid #bytes "6ee85278fc66b4ba09cb1efb6ecde219"}]
+  [{:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1016}],
+    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
+   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 840}],
+    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
+   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
+    :op #xt/tagged [:put #:xt{:id 951}],
+    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
+  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 872}],
+    :xt/iid #bytes "70167d050b7b3ff0c1ead1bab1dfd2f2"}
    {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1058}],
+    :xt/iid #bytes "703942c87a6bf0869bf2ee23839c06e5"}
+   {:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 786}],
+    :xt/iid #bytes "70bea1e1fef46fd418aa799804f603f5"}
+   {:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1135}],
+    :xt/iid #bytes "70d50483f8b75c5c2c1831070832322b"}]
+  [{:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1052}],
+    :xt/iid #bytes "71b3f3727d363d42c8d2de4b3c04e455"}
+   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 841}],
+    :xt/iid #bytes "71c726f53b6d117a4cf1db5162d2dce4"}
+   {:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 967}],
+    :xt/iid #bytes "71db8d6154c6d5e331e0e8a63113239f"}
+   {:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 787}],
+    :xt/iid #bytes "71f44d138b8f5bec2169a6ef6d49d6a5"}]
+  [{:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 818}],
+    :xt/iid #bytes "7221a760ce88a04770f8f6b1d6cf7315"}
+   {:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1075}],
+    :xt/iid #bytes "72dd08cda327dff65718579f7eb3a1bf"}]
+  [{:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 958}],
+    :xt/iid #bytes "7334e0dc07a26bd20ae3888118cd078b"}
+   {:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1080}],
+    :xt/iid #bytes "73364f9bcb4597d9116db92b1b6fcdcf"}
+   {:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 938}],
+    :xt/iid #bytes "7385526b6e5f7c2d2ae225cfd66e7cd2"}]
+  [{:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1142}],
+    :xt/iid #bytes "74921b661bd59d9b5523323de5760107"}
+   {:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 987}],
+    :xt/iid #bytes "754788184e412b7b44c2bb69ace6e756"}
+   {:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 845}],
+    :xt/iid #bytes "759d76b66454a93bfd59c8a2dc74b038"}
+   {:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1177}],
+    :xt/iid #bytes "76682978de217388c80d3dd3b7582a4a"}
+   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 948}],
+    :xt/iid #bytes "76c9d6bd57ad6842d84680f1dd8efc80"}
+   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 899}],
+    :xt/iid #bytes "771092568a2c83d5ece8daf370d19aa5"}
+   {:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1147}],
+    :xt/iid #bytes "77a9ff3eaa93c8ab15f13f894bff486f"}
+   {:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1045}],
+    :xt/iid #bytes "77d78e79d05c2a1dc4a429a2d7dbedbb"}]
+  [{:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1117}],
+    :xt/iid #bytes "7810a89b072916f708965c84a30eeb93"}
+   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 800}],
+    :xt/iid #bytes "781b665b49f3a5a7fe007c1e07f7cd4a"}
+   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
-  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 924}],
-    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1017}],
-    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 973}],
-    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
-   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1141}],
-    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}]
+    :op #xt/tagged [:put #:xt{:id 923}],
+    :xt/iid #bytes "784c3d4c0600c84274de7b10b48279b8"}]
+  [{:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1086}],
+    :xt/iid #bytes "79355cae7f0bc4b322e4924fb4203638"}
+   {:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1151}],
+    :xt/iid #bytes "79541411763b3bd9fa828743ca76249f"}]
+  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1018}],
+    :xt/iid #bytes "7a22cc2cdc876361b240f36351a74563"}
+   {:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 842}],
+    :xt/iid #bytes "7a345dbc8207c6b7fb8a947c994842ac"}
+   {:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 854}],
+    :xt/iid #bytes "7a3b80490054a07aec644a3eff364727"}
+   {:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 860}],
+    :xt/iid #bytes "7a46c06c9b7d1d0af6e2137a19928176"}]
+  [{:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1145}],
+    :xt/iid #bytes "7b723565b03839392a7b0a628ba3b380"}
+   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1060}],
+    :xt/iid #bytes "7be33a2d000df27c8c36b8f7bac75a11"}
+   {:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 974}],
+    :xt/iid #bytes "7bf1400f5eba818d77b6edc53f58e117"}
+   {:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1178}],
+    :xt/iid #bytes "7bf156d209401a30cddff1daaa5336d2"}
+   {:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 878}],
+    :xt/iid #bytes "7bf9f983104792130db82b4ef9b323fc"}]
   [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p1-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p1-b182.arrow.edn
@@ -5,730 +5,415 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1548}],
+    :xt/iid #bytes "404f0b424afa3b6a0f96530819720a12"}]
+  [{:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
+    :op #xt/tagged [:put #:xt{:id 1225}],
+    :xt/iid #bytes "44192742f402e45e124e968946d7462e"}
+   {:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1546}],
+    :xt/iid #bytes "446c64175a89504ab81797b67345c5f0"}
+   {:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1330}],
+    :xt/iid #bytes "46397fcec413188067d703c2795868b1"}
+   {:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1387}],
+    :xt/iid #bytes "4752e9834f801be1c203fcb09fc18d8f"}
+   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1281}],
+    :xt/iid #bytes "4783468c906dc4cbc5be2dd4d8481812"}
+   {:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1218}],
+    :xt/iid #bytes "4783e948b3eecabd69098da29df1b849"}
+   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1351}],
+    :xt/iid #bytes "47b02735926c4c21e5c868afb26f886d"}]
+  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1445}],
+    :xt/iid #bytes "4892d76bad36c6f95b3fef8af34503b0"}
+   {:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1264}],
+    :xt/iid #bytes "48d8e86d202087dd62507a8ad6a861ac"}
+   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1556}],
+    :xt/iid #bytes "49967c4f6e8a2b20efb6818c7966c633"}
+   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1515}],
+    :xt/iid #bytes "49dc604a36fb2a324ac4f6457c8e8762"}
+   {:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1478}],
+    :xt/iid #bytes "4b5e67e4ab46ed426a8f6cede9a65b6a"}
+   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1237}],
+    :xt/iid #bytes "4b87344e4d8a50002d1aded05fd398dd"}]
+  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1368}],
+    :xt/iid #bytes "4c7014120ed8128361a6b49f1a9330ea"}
+   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1236}],
+    :xt/iid #bytes "4c91d1050b783741d17a517f1eb968cf"}
    {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1463}],
+    :xt/iid #bytes "4db752c43a3d414741a1f4015fdca465"}
+   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1559}],
+    :xt/iid #bytes "4e2d04c8e0f5658db48ec229c23cd1c2"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
+    :op #xt/tagged [:put #:xt{:id 1394}],
+    :xt/iid #bytes "4ee616dc7b9c02c9b9874eab7a058f23"}]
+  [{:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1277}],
+    :xt/iid #bytes "5030159c89741211d735bd88144053a5"}
+   {:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1230}],
+    :xt/iid #bytes "50b76db07fe75c776046e5cf8c076332"}
+   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1493}],
+    :xt/iid #bytes "50b77d8e66e4222bf40556f635b538cf"}
    {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1542}],
+    :xt/iid #bytes "51b9c1b2d7e1599384776a490d2785dd"}
+   {:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1428}],
+    :xt/iid #bytes "53c7bdfbdd16b290cab46968578540b9"}]
+  [{:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1532}],
+    :xt/iid #bytes "542d1ccdda7bfece61d22166a02ee820"}
+   {:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
+    :op #xt/tagged [:put #:xt{:id 1426}],
+    :xt/iid #bytes "54d83964b626ce68856b8a491e04900b"}
+   {:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1402}],
+    :xt/iid #bytes "560eb275e2f5331ea55d712f222dfee4"}
+   {:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1454}],
+    :xt/iid #bytes "56a4a3f2b5ecddd3736b12f52ee1ef88"}
+   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1324}],
+    :xt/iid #bytes "571c9f31cd98e558ce3c381580f96a7d"}]
+  [{:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1460}],
+    :xt/iid #bytes "584d8e5cd114dfbd74d9807a45b71577"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1208}],
+    :xt/iid #bytes "5aa450727b7b30f9c5bbcf1ab35def24"}
+   {:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1475}],
+    :xt/iid #bytes "5ae03f076202757aa4ebfd1491c2942a"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1207}],
+    :xt/iid #bytes "5bc86897b9e4ad8dd855bb3ddb0a25b0"}
+   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1400}],
+    :xt/iid #bytes "5bffb928414c36f1cf3f992cdbb5a910"}]
+  [{:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1242}],
+    :xt/iid #bytes "5da9e213a257694f9a0d535071cf1340"}
    {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1516}],
+    :xt/iid #bytes "5db63c7e966d166ca6c4e90fd7aa542e"}
+   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1309}],
+    :xt/iid #bytes "5ea4e25d868a06d0be450b741f7dcc61"}
+   {:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
+    :op #xt/tagged [:put #:xt{:id 1451}],
+    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
+   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1303}],
+    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}]
+  [{:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1547}],
+    :xt/iid #bytes "608104a935e34630896281cdab273543"}
+   {:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1366}],
+    :xt/iid #bytes "628fa1a141c69ea45f11d56613806015"}
+   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1337}],
+    :xt/iid #bytes "63c8225ec4c22621d6d03d1967fdcac4"}]
+  [{:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1420}],
+    :xt/iid #bytes "64ef0ecc8102fb88a7e2f964bffc87ce"}
+   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1301}],
+    :xt/iid #bytes "665f5fe38f4605683a469e1c38316b1a"}
+   {:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1527}],
+    :xt/iid #bytes "6775513c964650f08cc7a2b5a6fa774f"}]
+  [{:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1314}],
+    :xt/iid #bytes "683c195f694ba7aaf7cdbbaf3cf2d4fa"}
+   {:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1448}],
+    :xt/iid #bytes "6869a1ecba7fb0007836258025b35480"}
+   {:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1248}],
+    :xt/iid #bytes "69b7808e0186b92ba051c1830563a3cb"}
+   {:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1509}],
+    :xt/iid #bytes "6a0c8469c402149c478b938004343976"}
+   {:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1528}],
+    :xt/iid #bytes "6aa4d3746ebfdcdc900a4f5e8b52fa35"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1412}],
+    :xt/iid #bytes "6ad7bb85b693dfafe4a746fd0bfa7452"}
+   {:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1219}],
+    :xt/iid #bytes "6b222c1a2e26dda9f4cdc217c14ceef9"}
+   {:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1384}],
+    :xt/iid #bytes "6bd2c7ba960bb8a95182519fd4efd512"}]
+  [{:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1508}],
+    :xt/iid #bytes "6c213577ae253d011b102e13a3eef934"}
+   {:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1254}],
+    :xt/iid #bytes "6c69f1957eeb03a6a461e9d530ec9366"}
+   {:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1181}],
+    :xt/iid #bytes "6d17985c8cc1d87df94391c47fe533bf"}
+   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1302}],
+    :xt/iid #bytes "6d51cee5f2bb7c0fb8952148f28128b2"}
+   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1510}],
+    :xt/iid #bytes "6dd6dfd279ac6d1fca07637df1a89477"}
+   {:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1485}],
+    :xt/iid #bytes "6e3147e5613d9c05218a917aabfab7e0"}
+   {:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1447}],
+    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}]
+  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1353}],
+    :xt/iid #bytes "70532d5b8b4368296d9802ed933579c2"}
+   {:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1505}],
+    :xt/iid #bytes "7080da6fceb591e5778afd46974c6c2f"}]
+  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1449}],
+    :xt/iid #bytes "7127e1c9f7f4d2886be4752920ae858b"}
+   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1379}],
+    :xt/iid #bytes "71284f2ced6aa80574d3b1506734b09a"}
+   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1211}],
+    :xt/iid #bytes "71506750e162831a6c1a3d2b9b85b8a1"}
    {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1328}],
+    :xt/iid #bytes "71d93b9ec89788010b613871412eeba3"}]
+  [{:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1501}],
+    :xt/iid #bytes "72fc514be0a1911f4693da5d40c6d3af"}]
+  [{:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
+    :op #xt/tagged [:put #:xt{:id 1375}],
+    :xt/iid #bytes "731c9527e5653b31f23ca6b4a3800ed0"}
+   {:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1252}],
+    :xt/iid #bytes "7323389f356960a035ff0a903541cf8d"}]
+  [{:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1197}],
+    :xt/iid #bytes "7431cea748e438510e89f401d89b2307"}
    {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1190}],
+    :xt/iid #bytes "769f1c5319142593cb939b6096006f04"}
+   {:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1531}],
+    :xt/iid #bytes "76d46c5bbdc88e80a196e80b6429535a"}
+   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1378}],
+    :xt/iid #bytes "76f2ae325e3ce32a878cf350f0c7d81c"}
+   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1380}],
+    :xt/iid #bytes "778bac64184cb9aac60abc394330f689"}]
+  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1443}],
+    :xt/iid #bytes "78431d0bdc59c550ea11c1acecca689c"}
+   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1495}],
+    :xt/iid #bytes "78c3f403d1fa11bd0911642584bb6812"}
+   {:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1486}],
-    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
-   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1518}],
-    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}
-   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1467}],
-    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
-   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1342}],
-    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
-   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1325}],
-    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
-   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1543}],
-    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}
-   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
+    :op #xt/tagged [:put #:xt{:id 1489}],
+    :xt/iid #bytes "78dc07cf9aa90dd9064807f4ae452551"}
+   {:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1506}],
+    :xt/iid #bytes "7917017cd277f7fc99ddf62d53139c50"}
+   {:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1247}],
+    :xt/iid #bytes "79db30954d1f466442274ca844358d03"}
+   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1554}],
+    :xt/iid #bytes "79f3bbc3b55f1fb8d1f1be329d04d962"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1411}],
+    :xt/iid #bytes "7aa97567f72adb20ea6bb229948c0012"}]
   [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p1-b1a4.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p1-b1a4.arrow.edn
@@ -5,535 +5,465 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-10-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1814}],
+    :xt/iid #bytes "4021a5a4becce3d93afc8f3c5edd9ef5"}
+   {:xt/system-from #xt/zdt "2020-10-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
+    :op #xt/tagged [:put #:xt{:id 1807}],
+    :xt/iid #bytes "40538623bed5b88d3c71a0961acd4d29"}
+   {:xt/system-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1660}],
+    :xt/iid #bytes "40f9dce94d4c9dee682975f33a352706"}
+   {:xt/system-from #xt/zdt "2020-10-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1655}],
+    :xt/iid #bytes "411f4f85314c19092e10e3528adf727a"}
+   {:xt/system-from #xt/zdt "2020-11-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1860}],
+    :xt/iid #bytes "42753e123f5889e44a4f339e923287f4"}
+   {:xt/system-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1732}],
+    :xt/iid #bytes "42c2cc39f1b83857d1dbe2561577450c"}
+   {:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1742}],
+    :xt/iid #bytes "4313fe49af2ea070ee6ca3050ee8d668"}
+   {:xt/system-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1786}],
+    :xt/iid #bytes "43395d5c6bb9619ed81bc303f769f508"}]
+  [{:xt/system-from #xt/zdt "2020-11-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1903}],
+    :xt/iid #bytes "44952b80dad6885e653c8361152ef81c"}
    {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
-  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1922}],
-    :xt/iid #bytes "7e4855020d85b18579177e397147fd45"}
-   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1727}],
-    :xt/iid #bytes "7e9511a90618b71c54b81bbc9c1c928b"}
-   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1577}],
-    :xt/iid #bytes "7eb28dc4250580155278c06d55b0cde5"}
-   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1724}],
-    :xt/iid #bytes "7ee7737bb36229245781ee4160b5a32d"}
-   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1674}],
-    :xt/iid #bytes "7f414acc3f5b554bfc2f7086d2d78a5f"}]
+    :op #xt/tagged [:put #:xt{:id 1580}],
+    :xt/iid #bytes "45e986d8b526a4801ce3f1c9e18bf886"}
+   {:xt/system-from #xt/zdt "2020-10-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1658}],
+    :xt/iid #bytes "47421117394664e7330130843f62a728"}
+   {:xt/system-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1788}],
+    :xt/iid #bytes "475176164046df7b502629a8ac2a3baf"}
+   {:xt/system-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1962}],
+    :xt/iid #bytes "4793eb21816014b4652cb6b3827cc314"}
+   {:xt/system-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1736}],
+    :xt/iid #bytes "47c8fd0f70f293fdeeb53505c8bc68ad"}
+   {:xt/system-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1953}],
+    :xt/iid #bytes "47f698627322ad8a1697a89290b4ad78"}]
+  [{:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1630}],
+    :xt/iid #bytes "4a703a6f9558b59e1809e39f0a5fe99d"}]
+  [{:xt/system-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1750}],
+    :xt/iid #bytes "4c23824b109bb605cf3dd91fa85cad68"}
+   {:xt/system-from #xt/zdt "2020-11-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1935}],
+    :xt/iid #bytes "4c9540cd1ba20037ed366a7951e9fd54"}
+   {:xt/system-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1906}],
+    :xt/iid #bytes "4cb7af0c61ebdcfdd9fc34051c29d8de"}
+   {:xt/system-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1817}],
+    :xt/iid #bytes "4d31072116534f1d8f01dd2be0447ac4"}
+   {:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1738}],
+    :xt/iid #bytes "4d90c61be6a3ab3cf65e8730988813ef"}
+   {:xt/system-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1767}],
+    :xt/iid #bytes "4fbbc9e6feb11b6690ae408537234d5d"}
+   {:xt/system-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1915}],
+    :xt/iid #bytes "4ff924c026d7e39bdc47ff170ff4dd19"}]
+  [{:xt/system-from #xt/zdt "2020-10-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1796}],
+    :xt/iid #bytes "50aee414715c93c0e43b42faccc2cc05"}
+   {:xt/system-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1755}],
+    :xt/iid #bytes "5178585be5fff1040557353a6b37ae55"}
+   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1784}],
+    :xt/iid #bytes "528f6c8a4042be4e17031cf1753bb342"}
+   {:xt/system-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1942}],
+    :xt/iid #bytes "535a3471e1805d811c228e936cdb4de7"}]
+  [{:xt/system-from #xt/zdt "2020-11-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1857}],
+    :xt/iid #bytes "54d91a2960a774defdacbaa9cfdc0dca"}
+   {:xt/system-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1601}],
+    :xt/iid #bytes "555f64845281f50d2dad1039244c39b8"}
+   {:xt/system-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1845}],
+    :xt/iid #bytes "55b95101f1ee1c7b1ec5b9b3afb890e0"}
+   {:xt/system-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1603}],
+    :xt/iid #bytes "564a9bbe65a7495d8ff013b1511015cb"}
+   {:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1746}],
+    :xt/iid #bytes "57a7425d73321bef8e6528a54b4a8d8a"}]
+  [{:xt/system-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1665}],
+    :xt/iid #bytes "5987a2df1781a881d686f210b4ca7cdd"}
+   {:xt/system-from #xt/zdt "2020-10-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1804}],
+    :xt/iid #bytes "59b33ee954db0c8f6317da767fb39fe0"}
+   {:xt/system-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1790}],
+    :xt/iid #bytes "5b303042dbb9dbd565764cdf6528fd3d"}]
+  [{:xt/system-from #xt/zdt "2020-11-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1824}],
+    :xt/iid #bytes "5c99a3955dc09ca21051067e2f759d49"}
+   {:xt/system-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1913}],
+    :xt/iid #bytes "5cad6d770579487e5bab6f04e2bc1818"}]
+  [{:xt/system-from #xt/zdt "2020-11-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1900}],
+    :xt/iid #bytes "5d345e59f93cafd03c4055e92c0ea060"}
+   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1876}],
+    :xt/iid #bytes "5d9d79d02c292a8037a6bcdd417345e4"}]
+  [{:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1624}],
+    :xt/iid #bytes "5e3b65bb57c777892b576e4695ef57a6"}
+   {:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1599}],
+    :xt/iid #bytes "5e967d4d37dcfcb3192ce6e0e457ef42"}
+   {:xt/system-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1952}],
+    :xt/iid #bytes "5ed815f737d3915ae016906161ec7d1a"}]
+  [{:xt/system-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1608}],
+    :xt/iid #bytes "5f83570086f54a325bde4a9c8b3bfe81"}
+   {:xt/system-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1759}],
+    :xt/iid #bytes "5fa3e6aac7617e20bc7790b43ac12bc4"}
+   {:xt/system-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1711}],
+    :xt/iid #bytes "5ff1a08f04f54996ae70687489be39ba"}]
+  [{:xt/system-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1686}],
+    :xt/iid #bytes "6004552bec48208575667661f16942c1"}
+   {:xt/system-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1916}],
+    :xt/iid #bytes "6024d078e4a5d1749b567c4b2940d307"}
+   {:xt/system-from #xt/zdt "2020-10-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1657}],
+    :xt/iid #bytes "607db4683033c6affb5616d92404a66a"}
+   {:xt/system-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1950}],
+    :xt/iid #bytes "60e580583221f6d9ea9d564e4273ff15"}]
+  [{:xt/system-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1866}],
+    :xt/iid #bytes "61262d11f44a1639e7403b8da6af6659"}
+   {:xt/system-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1787}],
+    :xt/iid #bytes "612c5b13d50fe3dc8a2515cdfa1c9295"}
+   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1785}],
+    :xt/iid #bytes "61458f93b7023f9f6bf021060aed93de"}]
+  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1747}],
+    :xt/iid #bytes "62c935688d482748c298ea08f71e56e6"}]
+  [{:xt/system-from #xt/zdt "2020-11-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1933}],
+    :xt/iid #bytes "63c66233636eccc154bfe777482e791d"}
+   {:xt/system-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1606}],
+    :xt/iid #bytes "63f65761dc3de62ea89acd305979e41b"}
+   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1887}],
+    :xt/iid #bytes "63fc7f75033a4be1e2627d783c59fd85"}]
+  [{:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1745}],
+    :xt/iid #bytes "642812e7bca3101f053c4ab0b76f5b61"}
+   {:xt/system-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1865}],
+    :xt/iid #bytes "644e85df66aa75c82f1054e3ea04b97a"}
+   {:xt/system-from #xt/zdt "2020-11-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1861}],
+    :xt/iid #bytes "66457f01ae382344fb25e41801f72a73"}
+   {:xt/system-from #xt/zdt "2020-09-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1583}],
+    :xt/iid #bytes "671637dc4342af197c49276b0f776a94"}
+   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1880}],
+    :xt/iid #bytes "67f699a59cb2f8de960bb476a77f97dd"}]
+  [{:xt/system-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1611}],
+    :xt/iid #bytes "6918fd03889daec787bedc677c833c9e"}
+   {:xt/system-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1695}],
+    :xt/iid #bytes "6a1e894fbe44952d38cb5a519d98b4db"}
+   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1888}],
+    :xt/iid #bytes "6a2078fdee3b28feac5a66709803c4b0"}
+   {:xt/system-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1688}],
+    :xt/iid #bytes "6a9407725a04a8810647e97dd5c03451"}
+   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1634}],
+    :xt/iid #bytes "6b9916624b9d442ad27e7a52f96e38e3"}]
+  [{:xt/system-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1671}],
+    :xt/iid #bytes "6c94d235b956780436cf307f25a48f11"}
+   {:xt/system-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1752}],
+    :xt/iid #bytes "6e94e107a25c7eec7bbec601e33190fa"}
+   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1569}],
+    :xt/iid #bytes "6e9c7e236aa6e8c9ffd8c530654036a6"}
+   {:xt/system-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1734}],
+    :xt/iid #bytes "6f40443936a9feb1646995bf35924f4e"}]
+  [{:xt/system-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1650}],
+    :xt/iid #bytes "7129346ef143243fbee579a9c8b0a1fd"}
+   {:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1741}],
+    :xt/iid #bytes "71712a7110bebf8e2c75160f9cb7d7e2"}
+   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1938}],
+    :xt/iid #bytes "723917ae1ad4814a320c4ec1c1d932e7"}
+   {:xt/system-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1588}],
+    :xt/iid #bytes "73769f8410cad8ae286c3134e9ce7192"}
+   {:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1941}],
+    :xt/iid #bytes "73e04d9c12ef1b997f448f5d8b0620e4"}
+   {:xt/system-from #xt/zdt "2020-11-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1847}],
+    :xt/iid #bytes "73fc76d73ff39446b5eb3c4d8a66ea5f"}]
+  [{:xt/system-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1924}],
+    :xt/iid #bytes "7407c037572483bf524c35fc6aff739f"}
+   {:xt/system-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1912}],
+    :xt/iid #bytes "741dadb4aa1211712ef5f8b0b4517875"}
+   {:xt/system-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1971}],
+    :xt/iid #bytes "74ced1ac3ef32ff70a072c67180ec53d"}
+   {:xt/system-from #xt/zdt "2020-11-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1955}],
+    :xt/iid #bytes "75df52daa86637f51015dd2bcec0b816"}
+   {:xt/system-from #xt/zdt "2020-10-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1792}],
+    :xt/iid #bytes "76210167b0e8871e3e51db3334ad665b"}
+   {:xt/system-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1871}],
+    :xt/iid #bytes "775aae29766cc964d8dc7f9364addc2c"}
+   {:xt/system-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1926}],
+    :xt/iid #bytes "77630c1e5a4f95e0459f3c911f84a740"}
+   {:xt/system-from #xt/zdt "2020-10-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1797}],
+    :xt/iid #bytes "777a339a3eef16bf8693b09f270ce868"}]
+  [{:xt/system-from #xt/zdt "2020-10-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1805}],
+    :xt/iid #bytes "786fbbd340d441cddf14956165802a1a"}
+   {:xt/system-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1693}],
+    :xt/iid #bytes "78d3cf240ec2b52ebf416bb877d451c7"}
+   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1627}],
+    :xt/iid #bytes "7916fa9faa5ff86c6af96263b9f7d28c"}
+   {:xt/system-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1699}],
+    :xt/iid #bytes "7a8f3e8a82ab03509c51f033fe986378"}
+   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1878}],
+    :xt/iid #bytes "7ae5fbe70c8a6770f74ca92fb0bd7eda"}
+   {:xt/system-from #xt/zdt "2020-10-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1812}],
+    :xt/iid #bytes "7b44d5c1228322b1ad989bc91bb405df"}
+   {:xt/system-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1832}],
+    :xt/iid #bytes "7bdccee47f023cefeac865b22aa99cc4"}]
   [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p2-b11f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p2-b11f.arrow.edn
@@ -5,850 +5,545 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 325}],
+    :xt/iid #bytes "800a29ad887af0f35e3e5633c6806484"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+    :op #xt/tagged [:put #:xt{:id 53}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
    {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 43}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 381}],
+    :xt/iid #bytes "80d23f470a73bf8ccd8cd2d9dcad9e19"}]
+  [{:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
+    :op #xt/tagged [:put #:xt{:id 287}],
+    :xt/iid #bytes "82c5cb4b05baf4efd1c403a1cd9d22c4"}]
+  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 311}],
+    :xt/iid #bytes "830b83c7a399b7850da90a39c2d4053c"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 290}],
+    :xt/iid #bytes "8363d0d3d43cf2981e7b731dca4d66fb"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 235}],
+    :xt/iid #bytes "8367fa42508c88bdc3877351c936b567"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 221}],
+    :xt/iid #bytes "83866dcd3a70a05808796e799661c779"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 167}],
+    :xt/iid #bytes "8398334cacd2d9f1710f2b99b65218be"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 126}],
+    :xt/iid #bytes "83af9257bdf5c6cfc569da5be7e4b734"}]
+  [{:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 114}],
+    :xt/iid #bytes "84522f4d4e183ac2828b82bd696e9265"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 198}],
+    :xt/iid #bytes "84f4f1a388eec75229cdf8ac8b51c3d7"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 230}],
+    :xt/iid #bytes "85ec98e63faed30758221e8141c0d759"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 41}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 85}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}]
+  [{:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 224}],
+    :xt/iid #bytes "885af4669ce5530d25df24f75cd047f6"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 157}],
+    :xt/iid #bytes "88ae227fc15633b8677b223e6ffec1ef"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 238}],
+    :xt/iid #bytes "8ad61a12edc3cd20bf45a476c786fb11"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 169}],
+    :xt/iid #bytes "8af2999e4c4cd0ab116832091f382fec"}]
+  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 97}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 79}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 110}],
+    :xt/iid #bytes "8e13b292504ef3283f9ae7dcb423d751"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 134}],
+    :xt/iid #bytes "8e24182ef5d10a199df39946b2525597"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 257}],
+    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}]
+  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 78}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 137}],
+    :xt/iid #bytes "90c9a4ae9dc74c6b11257b3a1ae1b440"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 344}],
+    :xt/iid #bytes "90cb420d6f3244b22f3f5c9b7fa77af1"}]
+  [{:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 265}],
+    :xt/iid #bytes "912258de80c24497ed89b1fd886f6c8d"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 118}],
+    :xt/iid #bytes "915113c4275987ec9668610783758a0d"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 124}],
+    :xt/iid #bytes "91a6929e58fd2e866b09892981c062cd"}]
+  [{:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 258}],
+    :xt/iid #bytes "924760091604846850b078b7f32d81d1"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 70}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 152}],
+    :xt/iid #bytes "92fdbe74fb7517c030fc3827f77b06e1"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 34}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 218}],
+    :xt/iid #bytes "93e0c386af56717c4a5c4179bad812ce"}]
+  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 254}],
+    :xt/iid #bytes "94f7fdd99238fc3782f4a739fa4d33f0"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 314}],
+    :xt/iid #bytes "9596858c57e0b8d8616e1d1d220c1e96"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 307}],
+    :xt/iid #bytes "95e393708259538f4aec0ee9c87bec3d"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 98}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}
+   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 275}],
+    :xt/iid #bytes "9671d7e86139b807fa027d423de676d4"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 202}],
+    :xt/iid #bytes "9699131767e76d78bcf41a819dcbcaf9"}]
+  [{:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 107}],
+    :xt/iid #bytes "985e418869572f5ce4f637235b6b0337"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 166}],
+    :xt/iid #bytes "9960924a9d56a89513754721cf61fe7f"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 125}],
+    :xt/iid #bytes "9a377ce780d8b60af7b81a17a7bd11ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 3}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 208}],
+    :xt/iid #bytes "9aba48a24ee4a53f3650adc255a75f06"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 342}],
+    :xt/iid #bytes "9ae03d90a477a3619cb9a9227a899c05"}
+   {:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 375}],
+    :xt/iid #bytes "9b9230d99360484e11804744fc3cd833"}]
+  [{:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 73}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 181}],
+    :xt/iid #bytes "9ccf4bfd5b62038f8f8bb39dcb6e6674"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 285}],
+    :xt/iid #bytes "9cd84006fa93af519dd957a2257ebc8a"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 128}],
+    :xt/iid #bytes "9cf5d67d71c2b3ec1c50ccdc4b5ead7e"}]
+  [{:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 378}],
+    :xt/iid #bytes "9d8582da7355a018dedeff22a1941300"}]
+  [{:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 209}],
+    :xt/iid #bytes "9e073579d00b40a59651e9f931c4735b"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 291}],
+    :xt/iid #bytes "9eac1fbc4b5d453942a38df7a82127e5"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 36}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 159}],
+    :xt/iid #bytes "9ee66bc6ae0f94512a67c902945a544f"}]
+  [{:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 350}],
+    :xt/iid #bytes "a24e14008c41eafa1b9d86ddfe18eb12"}
+   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 261}],
+    :xt/iid #bytes "a2eccba01e87c2d3993514279c3af28c"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 234}],
+    :xt/iid #bytes "a32f317d64f7617fb43c01f72d7db735"}]
+  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 299}],
+    :xt/iid #bytes "a45bf7e0122b3deaa89ee5c388bc8421"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 0}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 147}],
+    :xt/iid #bytes "a52893cff688be57b307c71cffad45ff"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 81}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 349}],
+    :xt/iid #bytes "a5d307b96b2b4bd640801787928d33a1"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 67}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 22}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}]
+  [{:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 87}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 45}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 127}],
+    :xt/iid #bytes "aa4400e859fb24dd120cf66e24690c44"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 292}],
+    :xt/iid #bytes "aa96051eba0190666442c9e13663dd8b"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 351}],
+    :xt/iid #bytes "aac67940459fe9f1d74ea620f0eb6539"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 180}],
+    :xt/iid #bytes "ab5787efa8d3b74d9912631c24636310"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 65}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 62}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 360}],
+    :xt/iid #bytes "aee97d8cbd834162daa98a77b4d5d45b"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 309}],
+    :xt/iid #bytes "aeef4815c98f43631ce3e7fa79c88d5a"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+    :op #xt/tagged [:put #:xt{:id 308}],
+    :xt/iid #bytes "af8b1f927602f6510a2e32f8870dddf2"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 306}],
+    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 231}],
+    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
+  [{:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 252}],
+    :xt/iid #bytes "b04edac037b8f0c58aa6e3cba929be7b"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 229}],
+    :xt/iid #bytes "b056163d4500a9b7c567ea0e880ca843"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 29}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 323}],
+    :xt/iid #bytes "b1ddb0175d32e2d8deaf8db0acd68081"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 244}],
+    :xt/iid #bytes "b1fec1d08d3466c41015367662f792f5"}]
+  [{:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 367}],
+    :xt/iid #bytes "b21bf2e871caf485affa8bf8257ab7b0"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 170}],
+    :xt/iid #bytes "b25ba4fb6402b26347311bb21f7ea5c9"}
+   {:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 371}],
+    :xt/iid #bytes "b2850224fee939d9a34db0ed0a048909"}]
+  [{:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 293}],
+    :xt/iid #bytes "b38a063cbd17de5fee53028cb28cb6c9"}
+   {:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 373}],
+    :xt/iid #bytes "b3d4b6b25eb711b06bd251b6aa27063b"}]
+  [{:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 112}],
+    :xt/iid #bytes "b45eae64b013c9768f8e2bd2f4942811"}
+   {:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 370}],
+    :xt/iid #bytes "b575edc9ba6f2b65bb8879029b210b36"}
    {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 138}],
+    :xt/iid #bytes "b6650f6f12948b660e22dc6ac2cd9c47"}
+   {:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 368}],
+    :xt/iid #bytes "b697203f7a62cf99032204ab908c03ee"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 99}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 192}],
+    :xt/iid #bytes "b69fb20bf81ad4015c4eda4adb1fd86c"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 116}],
+    :xt/iid #bytes "b6bf043b51896c2c4963042d726dfcf2"}]
+  [{:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 163}],
+    :xt/iid #bytes "b824f57e338ef055db4b9af16d4a3982"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 9}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}]
+  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
-  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 61}],
-    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
-   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 160}],
-    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
-   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 20}],
-    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
-   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 46}],
-    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 140}],
-    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}
-   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}]
+    :op #xt/tagged [:put #:xt{:id 248}],
+    :xt/iid #bytes "b95e782e3641975f92a07964af9880fa"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 245}],
+    :xt/iid #bytes "b987787c691234eb44fc769d508ef673"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 255}],
+    :xt/iid #bytes "b9e613a4af1a9cdfa1c1c294888aaf8b"}
+   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 328}],
+    :xt/iid #bytes "b9f134d4acdcdc122d70a47d3c0cd770"}]
+  [{:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 271}],
+    :xt/iid #bytes "ba4a5c6bb1e49fa84d4bb75fb918f0bf"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 289}],
+    :xt/iid #bytes "ba9b299b96d610b78b388db8c0c4ec2a"}]
+  [{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 15}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}]
   [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p2-b13f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p2-b13f.arrow.edn
@@ -5,250 +5,470 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
+    :op #xt/tagged [:put #:xt{:id 668}],
+    :xt/iid #bytes "812110c9464108bcfb7b7cfbf44d5dec"}
+   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 560}],
+    :xt/iid #bytes "814cd3099783496b39947082ba91d871"}
+   {:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 731}],
+    :xt/iid #bytes "8172156d63912a21b61d76d0b720108b"}
+   {:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 441}],
+    :xt/iid #bytes "8229455080f46f622ae870194790fedc"}]
+  [{:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 536}],
+    :xt/iid #bytes "845efee28fccb97892245c962e9397cb"}]
+  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 695}],
+    :xt/iid #bytes "853e3a1432eab73720812e9a90eaeb8a"}
+   {:xt/system-from #xt/zdt "2020-03-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 498}],
+    :xt/iid #bytes "8588e7f07d4a51d09a48a96a24ef8b1c"}
+   {:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 588}],
+    :xt/iid #bytes "859697b8124006a66c0d06f454682b65"}]
+  [{:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 763}],
+    :xt/iid #bytes "867d7e01f596f559e2056f5005b9e019"}
+   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 407}],
+    :xt/iid #bytes "86c532555d67c47fd793ecd666951da1"}
+   {:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 681}],
+    :xt/iid #bytes "86d488b421d359acf11b6d781e574855"}]
+  [{:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 650}],
+    :xt/iid #bytes "872e3048ec41f00ccd640862913c76f5"}
+   {:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 602}],
+    :xt/iid #bytes "87731d88f7bf55a3d7ef21b9af67a02f"}
+   {:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 469}],
+    :xt/iid #bytes "8796f072cb4553a575599bfef8a3cd7e"}
+   {:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 735}],
+    :xt/iid #bytes "87e432805966670029302623c03a9b7b"}]
+  [{:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 600}],
+    :xt/iid #bytes "8aed1ff18761fa231265d7d643987ee9"}
+   {:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 438}],
+    :xt/iid #bytes "8af0bea47e728fb36c815efab63e2d07"}
+   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 476}],
+    :xt/iid #bytes "8b475299fd2b2dfb8c9d74b1bd222445"}
+   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 759}],
+    :xt/iid #bytes "8bbbc2676e071bf75ad8a57cc7090a10"}]
+  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 692}],
+    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
+   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 477}],
+    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
+   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 459}],
+    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}]
+  [{:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 625}],
+    :xt/iid #bytes "901e247776559db1b38351cc48860fc4"}
+   {:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 587}],
+    :xt/iid #bytes "90aacb8f0d764fcd865cdff9e73da150"}
+   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 572}],
+    :xt/iid #bytes "90c33ddbb688e6b69da5eeb37f6f3887"}
+   {:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 462}],
+    :xt/iid #bytes "918b6293b2fa3a37dcedfe5b3cf09d22"}
+   {:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 484}],
+    :xt/iid #bytes "932be9a97cb8519ff7b25c5a94936422"}
+   {:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 586}],
+    :xt/iid #bytes "9351edcc68355aeb4cc2273e2b6b1082"}
+   {:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 537}],
+    :xt/iid #bytes "93ab625c85e0117d96e747e7b6cb4831"}]
+  [{:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 493}],
+    :xt/iid #bytes "9450520be6cd51269c58157b1f7a2192"}
+   {:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 542}],
+    :xt/iid #bytes "94885b1c940412d07072686b9285edaa"}]
+  [{:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 612}],
+    :xt/iid #bytes "952b30206f4fa5333a076308fd3e152e"}]
+  [{:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 622}],
+    :xt/iid #bytes "960d8176f47eb03fc88a7187fcbde9c0"}
+   {:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 613}],
+    :xt/iid #bytes "96640026a4426b3f31c8faac3c691752"}
+   {:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 624}],
+    :xt/iid #bytes "9674a02fa7f10d465b044f0dd97c61d5"}
+   {:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 393}],
+    :xt/iid #bytes "96d10f2161cfbd2b058021591719b1b3"}]
+  [{:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 682}],
+    :xt/iid #bytes "973092d67c53d14147eafcd0453bd267"}
+   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 762}],
+    :xt/iid #bytes "9787299149959b12161d7d9ba0d9a02b"}
+   {:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 422}],
+    :xt/iid #bytes "97af2f69b47d2dc2d3fbcd3cf72d8b05"}]
+  [{:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 528}],
+    :xt/iid #bytes "98b52ad453a3f2ac9e1acd8b5486b9e9"}
    {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
+    :op #xt/tagged [:put #:xt{:id 665}],
+    :xt/iid #bytes "98f181aea5d380d2fd6790a11f93ff92"}
+   {:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 401}],
+    :xt/iid #bytes "994d44aa22e97b07c7ce68afe33aee17"}
+   {:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 714}],
+    :xt/iid #bytes "9976acb756194856dab9216db9e47721"}
+   {:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 450}],
+    :xt/iid #bytes "99e7235f9fb06410499cb78f8f954615"}
+   {:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 503}],
+    :xt/iid #bytes "9a1aa7f4dad145e60b52fbf855711a27"}
+   {:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 502}],
+    :xt/iid #bytes "9b423ae665568d2b726a858007f0f5f4"}]
+  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 460}],
+    :xt/iid #bytes "9c1d01c3a71b8f26af17f69bf86ba351"}
+   {:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 571}],
+    :xt/iid #bytes "9c35d52ace5ea45a12645ceefec31e0d"}
+   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 637}],
+    :xt/iid #bytes "9d4a3753d474612e60e9f23913043423"}
+   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 702}],
+    :xt/iid #bytes "9d929ac7af446ac507a856f666de807f"}
+   {:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 757}],
+    :xt/iid #bytes "9e553c6a8843de3ca2f9946a020e616d"}
+   {:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 697}],
+    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}]
+  [{:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 717}],
+    :xt/iid #bytes "a08727ac2600c3724a65ad28ad52f23e"}
+   {:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 690}],
+    :xt/iid #bytes "a0cb0db3cc32b86b6038766acca3c98b"}
+   {:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 753}],
+    :xt/iid #bytes "a13a58e67b7036bc9c5d201415c29d7d"}
+   {:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 530}],
+    :xt/iid #bytes "a17ff30a055461636f40721156dad785"}
+   {:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 387}],
+    :xt/iid #bytes "a215a70114030c1c2b1bea5237cca6bb"}
+   {:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 513}],
+    :xt/iid #bytes "a2e4093fcd6665b64733dd626f9a16b8"}]
+  [{:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 606}],
+    :xt/iid #bytes "a40fd2f5fe7b8b120faa3159700e4360"}
+   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 577}],
+    :xt/iid #bytes "a42903d1a59cfd0fe5afe0d9dd419950"}
+   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 748}],
+    :xt/iid #bytes "a5865b6c0aa571798d5e1b4707ace0d1"}
+   {:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 755}],
+    :xt/iid #bytes "a7a3dedcdb63e70755d8d9cd8eccdd4a"}]
+  [{:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 546}],
+    :xt/iid #bytes "a8e0b048e645cb1af371a1c46c318bd2"}
+   {:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 500}],
+    :xt/iid #bytes "aa9c86944e06907c4dbf560d8fc3bb0b"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 705}],
+    :xt/iid #bytes "aae60dc7bb7ace3b06e2d99604ba6cea"}]
+  [{:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 649}],
+    :xt/iid #bytes "ac032ffcefc03131f3311993f314d7e4"}
+   {:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 728}],
+    :xt/iid #bytes "acb357383f2744c6351c29daaa95f33e"}
+   {:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 508}],
+    :xt/iid #bytes "ae788347c539a30db8cea79875585e8d"}]
+  [{:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 543}],
+    :xt/iid #bytes "b03fd594a74b18c2c9e5b47ba54c6764"}
+   {:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 541}],
+    :xt/iid #bytes "b16dad523dfa19463a754a7de31dc904"}
+   {:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 494}],
+    :xt/iid #bytes "b3005854db99127e345c7ec06d40dad7"}
+   {:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 654}],
+    :xt/iid #bytes "b33e78adf0904307bcd4a7f6c62504d9"}]
+  [{:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 684}],
+    :xt/iid #bytes "b54f5659862cb83cdd897b5d912e5e46"}
+   {:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 517}],
+    :xt/iid #bytes "b5b030435852dcb452011d2024127ef7"}
+   {:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 544}],
+    :xt/iid #bytes "b612e17d4b633b648bf338631c1fdff4"}
+   {:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 670}],
+    :xt/iid #bytes "b6eae9e6340c4920c00b67e11ab38769"}
+   {:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 466}],
+    :xt/iid #bytes "b735cdb86891b96f46826eb00fdc6331"}
+   {:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 550}],
+    :xt/iid #bytes "b78739f27410bcdefb01731e40b142f6"}
+   {:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 581}],
+    :xt/iid #bytes "b7b326928d55095d6e149ae536cdae10"}]
   [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 746}],
+    :xt/iid #bytes "b91b9642f9183004c38ec4af6ce737d9"}
+   {:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 685}],
+    :xt/iid #bytes "b93e86471af43d20a751f4860e723fd1"}
+   {:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 661}],
+    :xt/iid #bytes "b9704ad0122ae5caf916551b0111195d"}
+   {:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 529}],
+    :xt/iid #bytes "b9a964c6edb486713c4d4afdaec0033b"}
+   {:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 694}],
+    :xt/iid #bytes "baae5e64c4947fddbc91480463491200"}
+   {:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 675}],
+    :xt/iid #bytes "bbb00d800bbed8b0f33491780fbceb3f"}]
+  [{:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 641}],
+    :xt/iid #bytes "bc3704d593a6dc2aba23d65345ff5cc1"}
+   {:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 584}],
+    :xt/iid #bytes "bcd439697aa49f7f0610ac15a813ffb0"}]
+  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 472}],
+    :xt/iid #bytes "bd0a22785e44d5d697d63a5f68af1cb1"}
+   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 615}],
+    :xt/iid #bytes "bde83a7359a35b81f150446c2748a6a1"}]
+  [{:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 743}],
+    :xt/iid #bytes "be07cb97aaecff6a3e38ad2e74a0b915"}
+   {:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 673}],
+    :xt/iid #bytes "be16c9b58b35f3d2be936166cf4eeba6"}
+   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
+    :op #xt/tagged [:put #:xt{:id 630}],
+    :xt/iid #bytes "be4ffd24496211dfaaedf76154addedf"}]
   [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p2-b162.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p2-b162.arrow.edn
@@ -5,815 +5,455 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1167}],
+    :xt/iid #bytes "8097924dbed9c6ab777bc557f485a848"}
+   {:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 975}],
+    :xt/iid #bytes "8391f1364411ce50c88bf09acbc9ffc4"}
+   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1012}],
+    :xt/iid #bytes "83af55ac0937f0df532b84ec755127fd"}]
+  [{:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1066}],
+    :xt/iid #bytes "849e58da16f338b0312f5353742c6bb4"}
+   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 836}],
+    :xt/iid #bytes "85a1b7efb4f3ea4de0596a5b05fbda3d"}
+   {:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 916}],
+    :xt/iid #bytes "85d7f7dd8adec1bebe1529da05e170a0"}
+   {:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 988}],
+    :xt/iid #bytes "85ed7490e69db3886e661881e7ef4ddf"}
+   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1162}],
+    :xt/iid #bytes "865043e140e2dbf99ba31f433a5e2862"}]
+  [{:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 900}],
+    :xt/iid #bytes "8809e3d5c2098edee4fb55b6129afed0"}
+   {:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1090}],
+    :xt/iid #bytes "88699338f6a7fcc8d9121bf9fe75676c"}
+   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 897}],
+    :xt/iid #bytes "8873db68f6cb9d981308c251308b0a9d"}
+   {:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1005}],
+    :xt/iid #bytes "88f79e8dc4fdb2245f63ea63741dcda7"}
+   {:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1107}],
+    :xt/iid #bytes "89aa429eb9e1080036ff17298f7bdb86"}
+   {:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 815}],
+    :xt/iid #bytes "89cf5f0ed6b92e06868a9832a09498c1"}
+   {:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1106}],
+    :xt/iid #bytes "8ae085bb506d3c42d9117bdc4be7d544"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 894}],
+    :xt/iid #bytes "8b4a50c84d1bc3c5fe2890ecc5fe4905"}]
+  [{:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1154}],
+    :xt/iid #bytes "8d47eda297542c6133576857180a3a1d"}
+   {:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1116}],
+    :xt/iid #bytes "8d7d119fd4ef9ffc1389fbb14f3352eb"}
+   {:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1074}],
+    :xt/iid #bytes "8d971334a5a4a8a4008d970401ab2991"}
+   {:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1102}],
+    :xt/iid #bytes "8db6927d8f5d121f458e8df534d49277"}
+   {:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1049}],
+    :xt/iid #bytes "8dc5cd4709e7f77a474dbb78c5ff24cf"}]
+  [{:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
+    :op #xt/tagged [:put #:xt{:id 1123}],
+    :xt/iid #bytes "8efbeec0877c4c0711fd1b6923df9483"}]
+  [{:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1064}],
+    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
+   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 952}],
+    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
+   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 839}],
+    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
+  [{:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 976}],
+    :xt/iid #bytes "905c7673a182ee3d6740e44b3ef571eb"}
+   {:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 980}],
+    :xt/iid #bytes "906982e7d636ec7c737283fbb6865d97"}
+   {:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 936}],
+    :xt/iid #bytes "90f24db1418596ea161dc19c4df4f242"}
+   {:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1027}],
+    :xt/iid #bytes "921b55d7817cab792eb544973228be79"}
+   {:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1073}],
+    :xt/iid #bytes "925fb64e4b029ad4c1814f6b76127e06"}
+   {:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 884}],
+    :xt/iid #bytes "9369c3f17ebeafa51ce76a51b21e6a8b"}]
+  [{:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1119}],
+    :xt/iid #bytes "9422235d9b3190242cec27fabd4615f0"}
+   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1138}],
+    :xt/iid #bytes "9497a282e4e76b377193060769e6cc8e"}]
+  [{:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1076}],
+    :xt/iid #bytes "953579fa3bba372705569728cd26d60d"}
+   {:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 883}],
+    :xt/iid #bytes "9589c1fa91ca9624a1ce583e01652db0"}]
+  [{:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1057}],
+    :xt/iid #bytes "964d2fdf433479a5e9b24b9dc560c887"}
+   {:xt/system-from #xt/zdt "2020-06-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 998}],
+    :xt/iid #bytes "96810d92662e4cc1adcffbe3e795c96b"}
+   {:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1079}],
+    :xt/iid #bytes "96a2e5d03bee885f71bc083c882a417a"}]
+  [{:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 833}],
+    :xt/iid #bytes "971d7cd3d9dd8f45f73df9143b934ed0"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 808}],
+    :xt/iid #bytes "979ae284e76765bfbfea6dd27efdac92"}
+   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 774}],
+    :xt/iid #bytes "97bd539874c066712d617431ff1253c2"}]
+  [{:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 994}],
+    :xt/iid #bytes "982cdd931b5e3ebe4f9b0226b47b0bc0"}
    {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 912}],
+    :xt/iid #bytes "98e48acb280ba6fad4a468559dafdb7d"}
+   {:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 928}],
+    :xt/iid #bytes "990f1e2b92e826476a3ce5a2a0257537"}
+   {:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1040}],
+    :xt/iid #bytes "99965102b7acaf7b4e2db1e84c8180cd"}]
+  [{:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
+    :op #xt/tagged [:put #:xt{:id 1164}],
+    :xt/iid #bytes "9e83ee3b1f8efeee0f40fbe0bb83d31b"}
+   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 870}],
+    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
+  [{:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 819}],
+    :xt/iid #bytes "a2785b2867c2b7782692b5e321b89bcd"}
+   {:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1000}],
+    :xt/iid #bytes "a3346d18105ef801c3598fec426dcc5d"}
+   {:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 990}],
+    :xt/iid #bytes "a3d50e10f80745d141c5c8cc5ca827e2"}]
+  [{:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1139}],
+    :xt/iid #bytes "a47062881429b128274c8bdce80f2af4"}
+   {:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1010}],
+    :xt/iid #bytes "a4816f21f132216d27db0e2760f9bf15"}
+   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1065}],
+    :xt/iid #bytes "a49d63d06ddec9016167cd9cebcd21c0"}]
+  [{:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 945}],
+    :xt/iid #bytes "a57bb5fa2df628602403e7af6bbc1411"}]
+  [{:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1158}],
+    :xt/iid #bytes "a65ec105846fa82d533b801cec57c357"}
+   {:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 767}],
+    :xt/iid #bytes "a6d23d1be770bb3c2040d52d76709829"}]
+  [{:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 779}],
+    :xt/iid #bytes "a71078ef348a3d6c349359c7c12728f1"}
+   {:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1091}],
+    :xt/iid #bytes "a73a196108327c96d69e80c7b7c03a00"}
+   {:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 812}],
+    :xt/iid #bytes "a7d5dc072a67e71d285b13b5b1d0a7ea"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 811}],
+    :xt/iid #bytes "a7d5f9e0b573a57b77decf4bf2616068"}
+   {:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 791}],
+    :xt/iid #bytes "a7e71e89e924c602f1bef7630a79bd86"}]
+  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1037}],
+    :xt/iid #bytes "aa06de0d4778d109ff076f36f16980d9"}
+   {:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 982}],
+    :xt/iid #bytes "aa720e882ae76340e66b40a8b5eddb7a"}
+   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 954}],
+    :xt/iid #bytes "aa7329b06ff7b08bb5371e4564bc3be1"}
+   {:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1072}],
+    :xt/iid #bytes "ab5f710d4134ab277b531a92e70a956f"}
+   {:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 863}],
+    :xt/iid #bytes "abcd086e5caf765678b9c3fae2d1427c"}
+   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 869}],
+    :xt/iid #bytes "abed18a468a580b8da1253276afd382e"}]
+  [{:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 822}],
+    :xt/iid #bytes "aca7d1a77d4e0ee3a901f87962ec1c1a"}
+   {:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 885}],
+    :xt/iid #bytes "ad75c9b167aa780c4fb810661838763f"}
+   {:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1085}],
+    :xt/iid #bytes "ada70e9aeea5454c5ea572c34c90bd9b"}
+   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 831}],
+    :xt/iid #bytes "af2c66373327ec99c2c4299da4f2c2fc"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 810}],
+    :xt/iid #bytes "af92d5b4c6062a24cec7a54265400be8"}
+   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 995}],
+    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
+   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 901}],
+    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}]
+  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1023}],
+    :xt/iid #bytes "b0d76bfc2f21f849d4220eacb83aee20"}
+   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1163}],
+    :xt/iid #bytes "b0dbe49ead4e373e085ffb690880acc5"}
+   {:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1004}],
+    :xt/iid #bytes "b30f9215ea97a47838d74c7ade092e30"}]
+  [{:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 793}],
+    :xt/iid #bytes "b4769920960722b58165eee43df17237"}
+   {:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 943}],
+    :xt/iid #bytes "b4dcb1074f602362c1f0d0c8bd77e8f4"}
+   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 775}],
+    :xt/iid #bytes "b6080303815b4c1267b465881a148813"}
+   {:xt/system-from #xt/zdt "2020-06-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 999}],
+    :xt/iid #bytes "b6085134d55fc33c5fa83f9a1814a151"}
+   {:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 789}],
+    :xt/iid #bytes "b627c76af0ccd00b72f08403a928bbda"}
+   {:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1046}],
+    :xt/iid #bytes "b66fb65c915fd71deb32727d5dc6df0c"}
+   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1143}],
+    :xt/iid #bytes "b76c2ae40023ce7de3ede52644cc53ad"}]
+  [{:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 959}],
+    :xt/iid #bytes "b8447a0d40caccc587e73a4a6d944625"}
+   {:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 814}],
+    :xt/iid #bytes "b880aacecdef54ddb068786c213a03cb"}
+   {:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 888}],
+    :xt/iid #bytes "b8a8f2ed046ef3de2bd7b30867233e06"}
+   {:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1092}],
+    :xt/iid #bytes "b8d17e2d2e9b69d4fa3059c3403e9a81"}
    {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 802}],
-    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1125}],
-    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}
-   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 909}],
-    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
-   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 971}],
-    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
-   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 827}],
-    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
-   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 920}],
-    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}]
+    :op #xt/tagged [:put #:xt{:id 1034}],
+    :xt/iid #bytes "b9f2706e50ce24602aad5732a5808f0f"}]
   [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p2-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p2-b182.arrow.edn
@@ -5,640 +5,480 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1425}],
+    :xt/iid #bytes "803d5ef35af86e88da18b1c209529551"}
+   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1561}],
+    :xt/iid #bytes "804be72cdb0aaba25c940a39d0bc1619"}
+   {:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
+    :op #xt/tagged [:put #:xt{:id 1403}],
+    :xt/iid #bytes "829cafb726cfe02f002c3d6d4862f055"}
+   {:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1228}],
+    :xt/iid #bytes "831c1e2e269ad99806755021e6481506"}
+   {:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1427}],
+    :xt/iid #bytes "83ba6e28bd53f694494586037d1b8319"}
+   {:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1199}],
+    :xt/iid #bytes "83df44e10c3d6c48addf6342c6557a7c"}]
+  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1191}],
+    :xt/iid #bytes "8449e4dc7cc8cb9cd08b32dd0c1fbe6e"}
+   {:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1524}],
+    :xt/iid #bytes "84af0f04aa93e32c0e38ed69eab08a63"}
+   {:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1202}],
+    :xt/iid #bytes "84b0feb45d99a8e9a561d688e96fad1c"}
+   {:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1184}],
+    :xt/iid #bytes "85cc79daf0ad1fbfc580b94559385cd3"}
+   {:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1221}],
+    :xt/iid #bytes "866d567522a0eb819870e2d1560c8cc4"}]
+  [{:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1220}],
+    :xt/iid #bytes "88f43d7982fa56956893cfb0b826b9da"}
+   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1558}],
+    :xt/iid #bytes "8b2683498fd3b9eadf5e6ae141944818"}
+   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1377}],
+    :xt/iid #bytes "8b578746f4acd153a275c1908a0118ff"}
+   {:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1282}],
+    :xt/iid #bytes "8b59667c8e47e9e6cd1f5a41ec03f003"}
+   {:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1318}],
+    :xt/iid #bytes "8b5f8000ababa1e8a2ebe62fb7eb68c1"}
+   {:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1253}],
+    :xt/iid #bytes "8bc7acbfee30d3c95cd80a0b73f78a2f"}
+   {:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1233}],
+    :xt/iid #bytes "8be62e4f4d6938ad7b37e44f1f8cac73"}
+   {:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1423}],
+    :xt/iid #bytes "8bf2748ed899e8616a582dc075499313"}]
+  [{:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1295}],
+    :xt/iid #bytes "8c0a92f8c0e1918106288c9c781bbffc"}
+   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1464}],
+    :xt/iid #bytes "8ca9a7e3f489ba4a842aa432873d3c7f"}
    {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1310}],
+    :xt/iid #bytes "8d1c7148c5358f46f35ac16662e86b42"}
+   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
+    :op #xt/tagged [:put #:xt{:id 1434}],
+    :xt/iid #bytes "8d5d28f682ec5511910d0cb09dc28a7d"}
    {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
+    :op #xt/tagged [:put #:xt{:id 1396}],
+    :xt/iid #bytes "8d9aa9f717acb521ab1874174d33dcdc"}
+   {:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1256}],
+    :xt/iid #bytes "8dbb60f3c077742724a74f53c5e3c194"}
+   {:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1266}],
+    :xt/iid #bytes "8e23fe4c260d46131c7a27d9fd5dcad8"}]
+  [{:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1562}],
+    :xt/iid #bytes "9034d544cd133cbad4b705fbd51acc36"}
+   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1297}],
+    :xt/iid #bytes "90c841d17bc0f165e1112cfc02a8fd40"}
+   {:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1226}],
+    :xt/iid #bytes "9171dca7b4c819b8238de7bb1d696f39"}
    {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
+    :op #xt/tagged [:put #:xt{:id 1315}],
+    :xt/iid #bytes "925dc36023b77749391da9e1cfb79258"}
+   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1238}],
+    :xt/iid #bytes "9302a13b6d63f90478d19c15ddc6f0cf"}
+   {:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1249}],
+    :xt/iid #bytes "93c3a33bf86bc5dcb897fc40a6b76f09"}]
+  [{:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1517}],
+    :xt/iid #bytes "946ba2b54766aebb512c08f8dbc4690e"}
+   {:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1321}],
+    :xt/iid #bytes "950155f2f433cd6a5d2c328b9266fc93"}
+   {:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1193}],
+    :xt/iid #bytes "960be47f606ed8f11bf83750f7f83af4"}
+   {:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1333}],
+    :xt/iid #bytes "968326f8f611b63ec00402757154defb"}
+   {:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1289}],
+    :xt/iid #bytes "96e1124565e24634e6d47e2370e5a520"}
+   {:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1267}],
+    :xt/iid #bytes "972219268ca754a96d1bcb3f82ecb3ac"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1209}],
+    :xt/iid #bytes "97ba6aa99a5fa12fef38fbb43c0a88d5"}]
+  [{:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1545}],
+    :xt/iid #bytes "98197ef6c8633881f1f941f3034ff81a"}
+   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1336}],
+    :xt/iid #bytes "988baa53f1c4fb44f4dbcdef0b9f04d5"}
+   {:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1549}],
+    :xt/iid #bytes "994490cc9c4b0a6e4d39122c60a5bdc1"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1393}],
+    :xt/iid #bytes "9aadcf0279ec8ac533fb47844b645c2a"}
+   {:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1285}],
+    :xt/iid #bytes "9b99767817ca6e9f0c0ea9aaf3ce9f4b"}
+   {:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1291}],
+    :xt/iid #bytes "9bab2fd02d33b725ca76f94b09ae313f"}]
+  [{:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1382}],
+    :xt/iid #bytes "9eff0b9a11a86dce9332134040e8fb68"}]
+  [{:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1213}],
+    :xt/iid #bytes "a0cbdf08ebb9aa43a0718f75d1411d91"}
+   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1263}],
+    :xt/iid #bytes "a15dfb8158c69e546dca959b32782c2e"}
    {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1306}],
+    :xt/iid #bytes "a217340d8ddfe62424267cf5d11e9506"}
+   {:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
+    :op #xt/tagged [:put #:xt{:id 1385}],
+    :xt/iid #bytes "a24661d1d967c6a1552db79bc6b443ad"}
    {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1398}],
+    :xt/iid #bytes "a24ef88a59074bc9cf22654c346164c3"}
+   {:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
+    :op #xt/tagged [:put #:xt{:id 1286}],
+    :xt/iid #bytes "a2f4ec56efb3a814cb9d88c912f28170"}
    {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1439}],
+    :xt/iid #bytes "a360f7de992625c294c7282379a9d703"}
+   {:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1269}],
+    :xt/iid #bytes "a3694651e49a021785ccad1a3f42244e"}]
+  [{:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1251}],
+    :xt/iid #bytes "a407c53851cbae68d7db684db56108bd"}
+   {:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1479}],
+    :xt/iid #bytes "a4fc63eb666313974a1d15ad511633df"}]
+  [{:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1279}],
+    :xt/iid #bytes "a50c92fd039c2df6f433bec65078a39a"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1205}],
+    :xt/iid #bytes "a51809c4ad2dea42ae40e787890094e4"}
+   {:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1203}],
+    :xt/iid #bytes "a57efacb02fb6b7286b64c3c1c04feb6"}
+   {:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1487}],
+    :xt/iid #bytes "a586eb6138484c2785449b2b8c577683"}]
+  [{:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1374}],
+    :xt/iid #bytes "a67c85751c4879ac78a82aa48caecc17"}]
+  [{:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1432}],
+    :xt/iid #bytes "a712855b82acbdd73f1f09ade44c0b77"}
+   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1276}],
+    :xt/iid #bytes "a724fd3dcc2a16f00fee4f293098656f"}
+   {:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1369}],
+    :xt/iid #bytes "a7bfaede2108c9cb88300e4f58a0bbda"}]
+  [{:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1494}],
+    :xt/iid #bytes "a899a35cc9e439bc980af33e3bb7ef3f"}
+   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1354}],
+    :xt/iid #bytes "a91ab56e12d98477068ce58aa28ca125"}
+   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1344}],
+    :xt/iid #bytes "a94de982c2fdf9d6d02663e23882afb6"}
+   {:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
+    :op #xt/tagged [:put #:xt{:id 1536}],
+    :xt/iid #bytes "a9d247ea776c77ead0c065604767d08b"}]
+  [{:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1262}],
+    :xt/iid #bytes "ac4e92bf41bff0d10e4a342a32a3e93d"}
+   {:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1483}],
+    :xt/iid #bytes "add8ac43b55b51efdf1742f375ef59d8"}
+   {:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1290}],
+    :xt/iid #bytes "ae92ea06538e84081916a24ab0a3e652"}
+   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1186}],
+    :xt/iid #bytes "aefee6147213a99198d041a06da049fa"}
+   {:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1246}],
+    :xt/iid #bytes "af1c35f8d635369c22aeb87860e9c022"}
+   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1259}],
+    :xt/iid #bytes "af22d33143ca9c13eb2689a2a9145eb0"}
+   {:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1424}],
+    :xt/iid #bytes "af6573f511c1ce322ac3e13dbf6d79dc"}
+   {:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1223}],
+    :xt/iid #bytes "af83a33722c4a030ffd878b9f5d25084"}]
+  [{:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1381}],
+    :xt/iid #bytes "b1b21162b8c55fc74a3a80f52c51cc92"}
+   {:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1500}],
+    :xt/iid #bytes "b1fc09dcb5928d91bd36d2bcb6250bc6"}
+   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1492}],
+    :xt/iid #bytes "b33986d09e595b38015ae0b7e945f17d"}
    {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
+    :op #xt/tagged [:put #:xt{:id 1401}],
+    :xt/iid #bytes "b35985fea2bfed2033fe41be809e9e56"}
+   {:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1477}],
+    :xt/iid #bytes "b35f5f5c6adc4117f889ee3cee3fde69"}]
+  [{:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1296}],
+    :xt/iid #bytes "b4c6f4aa29afa49fa274ae288676757c"}
+   {:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1185}],
+    :xt/iid #bytes "b57f4ac25f4bac538315ad3d21636701"}
+   {:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1194}],
+    :xt/iid #bytes "b58b8c0361d0df67c759f1703cb5cec9"}
    {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
-  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1537}],
-    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}
-   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1397}],
-    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}
-   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1316}],
-    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1311}],
-    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
-   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1468}],
-    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}
-   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1360}],
-    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}]
+    :op #xt/tagged [:put #:xt{:id 1313}],
+    :xt/iid #bytes "b695017ebf29d3ae1e01fc9229be354a"}
+   {:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1490}],
+    :xt/iid #bytes "b69cffbb2e6a1394122c6725e8c72413"}
+   {:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1504}],
+    :xt/iid #bytes "b7101dcb778e078e4b22d0baddf96cf0"}]
+  [{:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1465}],
+    :xt/iid #bytes "b8b78998d3e8f050201cc67288f64a3f"}
+   {:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1503}],
+    :xt/iid #bytes "b917c8765697d662af06020483753aa1"}
+   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1210}],
+    :xt/iid #bytes "b9c20db0400f9aebda42fff4973579fb"}
+   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1347}],
+    :xt/iid #bytes "baabe377517ab8ff69ac106359fabd38"}
+   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1555}],
+    :xt/iid #bytes "bb52238908a3dd451e7b16d3468bbba0"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1204}],
+    :xt/iid #bytes "bb839acb244dc9962d71ae203d5a9d22"}
+   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1215}],
+    :xt/iid #bytes "bba322a30dbe27dc6b9cf73b7ac63853"}]
   [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p2-b1a4.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p2-b1a4.arrow.edn
@@ -5,355 +5,590 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1740}],
-    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1621}],
-    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
-  [{:xt/system-from #xt/zdt "2020-10-24T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1764}],
+    :xt/iid #bytes "8091f8e039f74db56f5c6d2ad083de71"}
+   {:xt/system-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1753}],
+    :xt/iid #bytes "80ec6fe62cfbc31c6531a1f70aa96024"}
+   {:xt/system-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1945}],
+    :xt/iid #bytes "8197e85be1e706ee6620dd5106246879"}
+   {:xt/system-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1705}],
+    :xt/iid #bytes "82803c4807f15dd744070ddedabab952"}]
+  [{:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1939}],
+    :xt/iid #bytes "841ea212bfb33d9bbbb45e3e4ffb960c"}
+   {:xt/system-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1706}],
+    :xt/iid #bytes "8563e52fbc6a29d265a070bfece3c674"}
+   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1728}],
+    :xt/iid #bytes "863cdc1eb5a59f4fbc5da46dedf9cff8"}
+   {:xt/system-from #xt/zdt "2020-10-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1680}],
+    :xt/iid #bytes "865ac4ebfb4668db18fa72b7ab223aa7"}]
+  [{:xt/system-from #xt/zdt "2020-10-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1793}],
+    :xt/iid #bytes "8809bb3c69646a4d74f65dc31b84e79c"}
+   {:xt/system-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1670}],
+    :xt/iid #bytes "89c46caf23ceac776100840a7f14406e"}
+   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1722}],
+    :xt/iid #bytes "89ddc5cc5e70061fab3af8e13457a11d"}
+   {:xt/system-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1751}],
+    :xt/iid #bytes "8a45da5112675f9359da191d18e9f64d"}]
+  [{:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1625}],
+    :xt/iid #bytes "8c83802c464e871b5a02d073558d6fa2"}
+   {:xt/system-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1894}],
+    :xt/iid #bytes "8ced5586e629f20a52f4f416caa5249a"}]
+  [{:xt/system-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1816}],
+    :xt/iid #bytes "8d19f7bff8a0c46fb58fc201a1da9ec4"}
+   {:xt/system-from #xt/zdt "2020-10-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1811}],
+    :xt/iid #bytes "8da91d8b259d326eedae4c4a07c369d8"}]
+  [{:xt/system-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1604}],
+    :xt/iid #bytes "8e2e110aec5854afd6c1d413fde7a4b5"}
+   {:xt/system-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1842}],
+    :xt/iid #bytes "8e43e5a86de4c9220ab3aac7a4a36ac8"}
+   {:xt/system-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1873}],
+    :xt/iid #bytes "8e4e4e42d699334a3a2a1aca60a42996"}
+   {:xt/system-from #xt/zdt "2020-10-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1806}],
+    :xt/iid #bytes "8e8e3c450975319569fbbe80b308a359"}
+   {:xt/system-from #xt/zdt "2020-10-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1681}],
+    :xt/iid #bytes "8e9295f0f27cc5f5c64ee0a98051598d"}
+   {:xt/system-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1661}],
+    :xt/iid #bytes "8ee7ca17d01076987d6eeeca893be00d"}]
+  [{:xt/system-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1835}],
+    :xt/iid #bytes "8f290aa28e386f1b3189a658a4561439"}
+   {:xt/system-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1735}],
+    :xt/iid #bytes "8fa0c77368995fcbb0738f8cd333ea25"}
+   {:xt/system-from #xt/zdt "2020-10-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-10-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1774}],
-    :xt/iid #bytes "bf89a194be7578c88b536a132705d08f"}
-   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1778}],
+    :xt/iid #bytes "8ff7378f977aa6496bc9009298ed665a"}]
+  [{:xt/system-from #xt/zdt "2020-11-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1618}],
-    :xt/iid #bytes "bf90e630d3e17fd373a0d43977ab941b"}
-   {:xt/system-from #xt/zdt "2020-10-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-28T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1856}],
+    :xt/iid #bytes "901217f4760f056f1616cf5dea839579"}
+   {:xt/system-from #xt/zdt "2020-11-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1801}],
-    :xt/iid #bytes "bf9c0985ed25cec02e97317922923bc3"}
+    :op #xt/tagged [:put #:xt{:id 1850}],
+    :xt/iid #bytes "90953c16365c95e512a1d0af93aa3e39"}
+   {:xt/system-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1702}],
+    :xt/iid #bytes "90ca7a7794158b7b9cc9c63cb937f769"}
+   {:xt/system-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1704}],
+    :xt/iid #bytes "91a32d63918d85e121888362ac70d492"}
+   {:xt/system-from #xt/zdt "2020-11-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1853}],
+    :xt/iid #bytes "92a0d7dc65f0623c1cb3fe72e63bf385"}
    {:xt/system-from #xt/zdt "2020-09-27T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1616}],
-    :xt/iid #bytes "bfb5d23ace6d92d3ce036701061709f3"}
-   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1615}],
+    :xt/iid #bytes "931ecd793b9ddbf8d27ab6adda18c8b7"}]
+  [{:xt/system-from #xt/zdt "2020-11-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1631}],
-    :xt/iid #bytes "bfdc40eca96e09cc7101e78ab099355e"}]
+    :op #xt/tagged [:put #:xt{:id 1901}],
+    :xt/iid #bytes "949fa95f80935a203697c23c6f07e2d5"}
+   {:xt/system-from #xt/zdt "2020-11-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1827}],
+    :xt/iid #bytes "958fd7aa2a46b4b6a08c26000a475464"}
+   {:xt/system-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1911}],
+    :xt/iid #bytes "95a927bc9139880714c51cd80dc7dd3a"}
+   {:xt/system-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1664}],
+    :xt/iid #bytes "9622a538dc0b4450fd488d23d3043a1f"}
+   {:xt/system-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1869}],
+    :xt/iid #bytes "96ff46f50dd6a254b7a0faa6ededead8"}
+   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1647}],
+    :xt/iid #bytes "973ec29009bb52513889b83154baec99"}
+   {:xt/system-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1946}],
+    :xt/iid #bytes "9777b49e06340d7b357b4560dbd3f9c0"}]
+  [{:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1731}],
+    :xt/iid #bytes "9818504ac98c46687e91f96f91de9ec8"}
+   {:xt/system-from #xt/zdt "2020-10-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1777}],
+    :xt/iid #bytes "9841c6f184e8894acde0d2d66d75cddf"}
+   {:xt/system-from #xt/zdt "2020-10-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1770}],
+    :xt/iid #bytes "986893f59764cf3f1c75155b988916fe"}
+   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1645}],
+    :xt/iid #bytes "98cb3aee8c64a3646c028deb44c10488"}
+   {:xt/system-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1819}],
+    :xt/iid #bytes "98d26f9db4d9a26b0a82517bd828fc51"}]
+  [{:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1622}],
+    :xt/iid #bytes "997bdd4b50820686664abe9dc9796384"}
+   {:xt/system-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1571}],
+    :xt/iid #bytes "999a80041a3afc4ca69b8f7b599800f0"}
+   {:xt/system-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1715}],
+    :xt/iid #bytes "99e9063783b298000b31a2deff4ffb98"}]
+  [{:xt/system-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1967}],
+    :xt/iid #bytes "9a5b72db8cd1292867e7dbbe7ba5f009"}
+   {:xt/system-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1717}],
+    :xt/iid #bytes "9af256f11eafa591bb2cafbf4ac0a439"}]
+  [{:xt/system-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1716}],
+    :xt/iid #bytes "9bc1fdf696ee5f19b0b1a2ad3f6cf02a"}]
+  [{:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1638}],
+    :xt/iid #bytes "9c4425019d256ed70d63691875cd6dd7"}
+   {:xt/system-from #xt/zdt "2020-11-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1862}],
+    :xt/iid #bytes "9ca23e7b3fa72476f0745f5b08886e7c"}
+   {:xt/system-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1663}],
+    :xt/iid #bytes "9d82c7125aafb40fc4cc93be00eb5b81"}
+   {:xt/system-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1626}],
+    :xt/iid #bytes "9ef49e26247247c4044d8839d7bf6b48"}
+   {:xt/system-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1868}],
+    :xt/iid #bytes "9f546ef389a97fd23755da15686d4229"}
+   {:xt/system-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1754}],
+    :xt/iid #bytes "9fb64a97a8ddd2917d20450c4b15ca4a"}]
+  [{:xt/system-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1669}],
+    :xt/iid #bytes "a00cfe0162ab9a6764c48f8f9f5b94ad"}
+   {:xt/system-from #xt/zdt "2020-10-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1794}],
+    :xt/iid #bytes "a0b467902fbc0ee5a19f0dbdc4ef4bb2"}
+   {:xt/system-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1714}],
+    :xt/iid #bytes "a0d38153c740a6408dad873e1c4e1b2a"}]
+  [{:xt/system-from #xt/zdt "2020-10-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1803}],
+    :xt/iid #bytes "a1c24c99402a7b056f9d3dfdf58d960e"}]
+  [{:xt/system-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1712}],
+    :xt/iid #bytes "a2cf103483c56b254fbbfa4c9256e4b0"}
+   {:xt/system-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1948}],
+    :xt/iid #bytes "a2d2b49e676099c0e907e28adaf563c1"}
+   {:xt/system-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1592}],
+    :xt/iid #bytes "a2f12b8641841d6d45d1b302e7b7a5d8"}]
+  [{:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1564}],
+    :xt/iid #bytes "a37e4be5e65aa2f87761e5c17705b59c"}
+   {:xt/system-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1821}],
+    :xt/iid #bytes "a3e8f60b64a92e757ed27ca93a7945c1"}]
+  [{:xt/system-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1929}],
+    :xt/iid #bytes "a44d8521ce973be49262df43135813ea"}
+   {:xt/system-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1589}],
+    :xt/iid #bytes "a49644b965c2b356605a0296d4efdca0"}]
+  [{:xt/system-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1766}],
+    :xt/iid #bytes "a52f51b7b2d78676f915e4dbb769ec34"}
+   {:xt/system-from #xt/zdt "2020-10-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1769}],
+    :xt/iid #bytes "a57a02478b041cb9d48a14fffa2eb88b"}
+   {:xt/system-from #xt/zdt "2020-11-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1851}],
+    :xt/iid #bytes "a5822023a9c4fff31496cf31ed1057ae"}]
+  [{:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1568}],
+    :xt/iid #bytes "a60ff9d75cd49d847f22fd435353a344"}
+   {:xt/system-from #xt/zdt "2020-11-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1958}],
+    :xt/iid #bytes "a677240f4109a2d81df0cfd5b9360532"}
+   {:xt/system-from #xt/zdt "2020-09-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1613}],
+    :xt/iid #bytes "a687c01318bf8c50812e3f49e5f059a5"}
+   {:xt/system-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1709}],
+    :xt/iid #bytes "a68dcda6613d72bb96710bfd70eef84c"}
+   {:xt/system-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1698}],
+    :xt/iid #bytes "a6e4ef0968719797a84334461f4460ac"}]
+  [{:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1782}],
+    :xt/iid #bytes "a70924b43a04fe6d85eae3aa5a306192"}
+   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1619}],
+    :xt/iid #bytes "a7d21a1d4a21be1ad1260949cebd98b7"}
+   {:xt/system-from #xt/zdt "2020-11-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1858}],
+    :xt/iid #bytes "a7d503d21b1f1706261dec553f74bde7"}
+   {:xt/system-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1828}],
+    :xt/iid #bytes "a7f38d005770f8da8cdf46229d798b82"}]
+  [{:xt/system-from #xt/zdt "2020-10-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1779}],
+    :xt/iid #bytes "a822d6a7c5e961da92e1ef50120a9ecc"}]
+  [{:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1620}],
+    :xt/iid #bytes "a957606343dd46bb5f29c7602949ce88"}
+   {:xt/system-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1843}],
+    :xt/iid #bytes "a9ca5afeb1b8d5a7cf9c4ed9285b7e25"}]
+  [{:xt/system-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1818}],
+    :xt/iid #bytes "aa059d90a2b484c634c3dd3b0818496e"}
+   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1639}],
+    :xt/iid #bytes "aa6896bee17e890bf9e3d86bda0cf1fa"}
+   {:xt/system-from #xt/zdt "2020-10-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1683}],
+    :xt/iid #bytes "aa85c361f1cb8a8198c07941dd11004b"}
+   {:xt/system-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1760}],
+    :xt/iid #bytes "aae0c3fa17381c38dbdda910865831b6"}]
+  [{:xt/system-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1763}],
+    :xt/iid #bytes "ab0e6cbb1111b46f71b61928e0772a42"}
+   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1677}],
+    :xt/iid #bytes "ab29a97a1472551863c60f94c4069568"}
+   {:xt/system-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1653}],
+    :xt/iid #bytes "ab876eea319a519397bd2a1bdb1d7c70"}
+   {:xt/system-from #xt/zdt "2020-10-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1656}],
+    :xt/iid #bytes "ab91f0e72134878208d087208d36d3d7"}]
+  [{:xt/system-from #xt/zdt "2020-09-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1586}],
+    :xt/iid #bytes "acad4fd27f919a01698fccbbbfb00305"}
+   {:xt/system-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1839}],
+    :xt/iid #bytes "aec375c2fa5cfd66e218e4fa44ebc939"}
+   {:xt/system-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1963}],
+    :xt/iid #bytes "aec7d6f4082b97709b44ac2be9cf54bf"}
+   {:xt/system-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1733}],
+    :xt/iid #bytes "afca5233b75cd4d32fc95cceefaa8d0a"}]
+  [{:xt/system-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1829}],
+    :xt/iid #bytes "b0adc34a6fafad5085169e8a497acf12"}
+   {:xt/system-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1864}],
+    :xt/iid #bytes "b1c59b3eb8dfdbd8785b76a14fdda59e"}
+   {:xt/system-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1649}],
+    :xt/iid #bytes "b2347a422cd553d7c6c82360bddb4503"}
+   {:xt/system-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1758}],
+    :xt/iid #bytes "b24f55998cbeb9486219d00ba3c6fc36"}
+   {:xt/system-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1834}],
+    :xt/iid #bytes "b2c36c31c59b8a81ecbc4fa179d8e228"}]
+  [{:xt/system-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1907}],
+    :xt/iid #bytes "b43b08ebfbf176adc13e589e192b517c"}
+   {:xt/system-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1652}],
+    :xt/iid #bytes "b570ab84fb766bc038c6fa18ed5bbf73"}
+   {:xt/system-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1928}],
+    :xt/iid #bytes "b65edc9a857dabda5baf5040de5288d6"}
+   {:xt/system-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1908}],
+    :xt/iid #bytes "b7cd8510781546e584af45a1adb6e825"}]
+  [{:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1923}],
+    :xt/iid #bytes "b88d4b44d124b953c7c3a1f305ecce91"}
+   {:xt/system-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1765}],
+    :xt/iid #bytes "b93f930253706d4552d5ceeabc6bf7d6"}
+   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1877}],
+    :xt/iid #bytes "b9c04c1917c7aac44f10b958a36c7d76"}
+   {:xt/system-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1700}],
+    :xt/iid #bytes "b9d00f1c3ca8522c9ee87d6cc7b6e9df"}
+   {:xt/system-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1667}],
+    :xt/iid #bytes "bad62ae695d0e14f3e99ed40c23d7292"}
+   {:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1675}],
+    :xt/iid #bytes "bb156f2f94c53fa4f898278cfcb50e80"}
+   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1643}],
+    :xt/iid #bytes "bb47ca89fe887782d9adc4b61a775fc6"}
+   {:xt/system-from #xt/zdt "2020-10-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1744}],
+    :xt/iid #bytes "bb6d4141dd4df3b7a4d149222698fe5e"}]
+  [{:xt/system-from #xt/zdt "2020-10-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1798}],
+    :xt/iid #bytes "bc0e4809922a22a29a98b7e5bf4af2a6"}
+   {:xt/system-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1691}],
+    :xt/iid #bytes "bcd56cc1ee8ee8f03e756965a01dfbee"}
+   {:xt/system-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1927}],
+    :xt/iid #bytes "bce3793c38e171445e518bfdae62425b"}]
+  [{:xt/system-from #xt/zdt "2020-11-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1905}],
+    :xt/iid #bytes "bd0ad7d0f2f460002be83d966a546a90"}]
+  [{:xt/system-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1740}],
+    :xt/iid #bytes "be9377a8d5cd409e45d2aa16944084fc"}
+   {:xt/system-from #xt/zdt "2020-09-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1621}],
+    :xt/iid #bytes "bed2b68ff13773e5854475948e3b93ea"}]
   [{:xt/system-from #xt/zdt "2020-10-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-10-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p3-b11f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p3-b11f.arrow.edn
@@ -5,640 +5,370 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 250}],
+    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 93}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 56}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+    :op #xt/tagged [:put #:xt{:id 172}],
+    :xt/iid #bytes "c5d70d88672185c14210002a57ed20c4"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 26}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 55}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}]
+  [{:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 273}],
+    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 66}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 86}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 131}],
+    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 161}],
+    :xt/iid #bytes "cb779086bd0f8cbd6febdf7f8a1e99cc"}
    {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 80}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}]
+  [{:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 214}],
+    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 303}],
+    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 27}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
+    :op #xt/tagged [:put #:xt{:id 340}],
+    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 282}],
+    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}]
+  [{:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 154}],
+    :xt/iid #bytes "d019fb00045604c3f731eed3d31e7236"}
    {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
+    :op #xt/tagged [:put #:xt{:id 144}],
+    :xt/iid #bytes "d07dcc42f0b412ada671f1de2523e58a"}
    {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 48}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 186}],
+    :xt/iid #bytes "d1a8fcabc030522d2f5755bdcb9cc0b0"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 120}],
+    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 296}],
+    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
+    :op #xt/tagged [:put #:xt{:id 345}],
+    :xt/iid #bytes "d3a037e2077aa958dbf55b25fcb4726b"}]
+  [{:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 149}],
+    :xt/iid #bytes "d5042580a076c3d537032d05858163c3"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 177}],
+    :xt/iid #bytes "d53cdcbf204ee78f00449edc52d38df6"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 35}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 377}],
+    :xt/iid #bytes "d7cf450e4e0f3674c3b16e04ccc2fa5b"}
    {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 143}],
+    :xt/iid #bytes "d7f9d3b9763d2f94c1e09a336600afe6"}]
+  [{:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 173}],
+    :xt/iid #bytes "d9f45d278397c5420b1c144944c8e3a3"}
+   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 341}],
+    :xt/iid #bytes "dbe5414720eccb345e777b3b272a4c7d"}]
+  [{:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 89}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
+    :op #xt/tagged [:put #:xt{:id 302}],
+    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 164}],
+    :xt/iid #bytes "dcbf558b250273262558a0ad69d3ae10"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 117}],
+    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
+   {:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 366}],
+    :xt/iid #bytes "de057c7061fd92dad090c7fb9d831476"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 222}],
+    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 14}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 13}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
+  [{:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 72}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 343}],
+    :xt/iid #bytes "e3c8005c1ec50b1fbda9808230b85fb0"}]
+  [{:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 33}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 18}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}]
+  [{:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 268}],
+    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 196}],
+    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}]
+  [{:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 74}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 84}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 327}],
+    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 130}],
+    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}]
+  [{:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 266}],
+    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}]
+  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 310}],
+    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 42}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}]
+  [{:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 346}],
+    :xt/iid #bytes "ec354fb331777f9b941cb9d740706b01"}
+   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 324}],
+    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
+   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 281}],
+    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 227}],
+    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}]
+  [{:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 330}],
+    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 176}],
+    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 219}],
+    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 216}],
+    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 253}],
+    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 91}],
+    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+   {:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 361}],
+    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 223}],
+    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}]
+  [{:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 269}],
+    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 347}],
+    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 286}],
+    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}]
+  [{:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 321}],
+    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
+   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 338}],
+    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 19}],
+    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
    {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 100}],
-    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}
-   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 141}],
-    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
-   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 148}],
-    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
-   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 50}],
-    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
-   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
+    :op #xt/tagged [:put #:xt{:id 358}],
+    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 335}],
+    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}]
   [{:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p3-b13f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p3-b13f.arrow.edn
@@ -5,430 +5,415 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 566}],
+    :xt/iid #bytes "c071573cb669f27552064703e4f2623a"}
+   {:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 551}],
+    :xt/iid #bytes "c11f6a546ad5e5490cf61a79e267c7b5"}
+   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
+    :op #xt/tagged [:put #:xt{:id 614}],
+    :xt/iid #bytes "c12a4adc39554a01cfb2f4b92a6fbcd8"}
+   {:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 495}],
+    :xt/iid #bytes "c2531412c0d9ec323d47372765797238"}
+   {:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 506}],
+    :xt/iid #bytes "c3d65d6722dd965d1524e195c93b07ca"}]
+  [{:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 640}],
+    :xt/iid #bytes "c488e43ddb5bc74004780c18a85963bd"}
+   {:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 470}],
+    :xt/iid #bytes "c49bf28414e3f1da8e39619079a81aee"}
+   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 428}],
+    :xt/iid #bytes "c4cc9a0763831b05820c6177cfba9654"}
+   {:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 611}],
+    :xt/iid #bytes "c587497dad64e1777db3d56925d77a45"}
+   {:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 589}],
+    :xt/iid #bytes "c5a52f52af8623b88fc104b1813f1d2d"}
+   {:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 410}],
+    :xt/iid #bytes "c5c5ea28b27d81898c571a88382405e6"}
+   {:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 467}],
+    :xt/iid #bytes "c67481d53afd3b683b9059a3ac6be7e3"}]
+  [{:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 701}],
+    :xt/iid #bytes "c82bac33a1947011082bd04dadd08b8b"}
+   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 595}],
+    :xt/iid #bytes "c8c4ab8b87707035ab439094842df548"}
+   {:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 569}],
+    :xt/iid #bytes "cb00a196c7c66edb80ca38f9f1c0893a"}
+   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 644}],
+    :xt/iid #bytes "cb1fadb9cd56fc400cedf8bf1fdeb2e0"}
+   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 416}],
+    :xt/iid #bytes "cb96947163d263dd6202d400873a0b0e"}]
+  [{:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 512}],
+    :xt/iid #bytes "cc384704239b17bf39c473f9282bd0af"}
+   {:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 390}],
+    :xt/iid #bytes "cc455aadcaefd61b6feb78e13676303c"}
+   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 592}],
+    :xt/iid #bytes "cd4dceb84c2fc686632cf39e85de49ae"}
+   {:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 482}],
+    :xt/iid #bytes "cd76effee842013ba2382d4f29138bd7"}
+   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 565}],
+    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}]
+  [{:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 511}],
+    :xt/iid #bytes "d03482d8f47a9431f0837d627916983c"}
+   {:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 658}],
+    :xt/iid #bytes "d1143da230bf7726315eec0307227100"}
+   {:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 660}],
+    :xt/iid #bytes "d169ef0ae2b68a04c4524d57b2f94905"}
+   {:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 409}],
+    :xt/iid #bytes "d1774c643b3195d04e97f4cea573f097"}
+   {:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 413}],
+    :xt/iid #bytes "d215be82a2ee12542ffcca5897e714df"}
+   {:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 509}],
+    :xt/iid #bytes "d3d1c6b0b8c419353dbab7158506921a"}]
+  [{:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 547}],
+    :xt/iid #bytes "d4e989bda4c14099043b26c838d057ea"}]
+  [{:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 501}],
+    :xt/iid #bytes "d502a8bcdf6aacd8583262397070df49"}
+   {:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 570}],
+    :xt/iid #bytes "d5f16f4e7a2c8db702891e1c708ecf3f"}]
+  [{:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 643}],
+    :xt/iid #bytes "d61f03822f2fed747d675b17c04fe743"}
+   {:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 596}],
+    :xt/iid #bytes "d63de56fb35800598286fedf72241b3c"}
+   {:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 738}],
+    :xt/iid #bytes "d6d928f2b6ed8213a30070232c09e740"}
+   {:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 540}],
+    :xt/iid #bytes "d6f4873ea974aebbc76c9711b18f914f"}]
+  [{:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 564}],
+    :xt/iid #bytes "d74730c4be7a95cee46acaa7fca51b9b"}
+   {:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 683}],
+    :xt/iid #bytes "d75a2e41871c8eb236c02897b5e69e08"}
+   {:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 583}],
+    :xt/iid #bytes "d7c56137ca862456cd83d3b0356fb6f9"}]
+  [{:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 713}],
+    :xt/iid #bytes "d83695deb0698e8f7d77031d6fbd525d"}
+   {:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 411}],
+    :xt/iid #bytes "d8ae3f4f6b239bf530e282e2400d3dcf"}
+   {:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 526}],
+    :xt/iid #bytes "d9386163628673f0da0accae29a276e7"}
+   {:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 388}],
+    :xt/iid #bytes "da706a0e0a0913f0c1325339a0af3123"}
+   {:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 711}],
+    :xt/iid #bytes "db3516156d4e1e3369a368e8cef4a13b"}]
+  [{:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 418}],
+    :xt/iid #bytes "dc83a6d8062b13624fba06a8b7ee5b66"}
    {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
-  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 575}],
-    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
-   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 636}],
-    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}]
+    :op #xt/tagged [:put #:xt{:id 744}],
+    :xt/iid #bytes "dcb52a07d5743f79b4b8f299132dc308"}
+   {:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 386}],
+    :xt/iid #bytes "dcfe83f89f01bf7858bac6f03be1c14a"}
+   {:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 607}],
+    :xt/iid #bytes "dd403eefe9e87cba438fcd83ca225cb1"}
+   {:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 399}],
+    :xt/iid #bytes "dd5bfa7db6d104e157973ef63d0ac3cb"}
+   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 521}],
+    :xt/iid #bytes "de8095a4abbca3a35df3b5d0cf55d8f9"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 723}],
+    :xt/iid #bytes "dee6de4c42687bd07e60bc6ecd4a4cfc"}]
+  [{:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 721}],
+    :xt/iid #bytes "e2370a7cfb720aa5acfefb651f60d8c5"}
+   {:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 555}],
+    :xt/iid #bytes "e2fd48103712fba06ffd4789b75efa7d"}]
+  [{:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 582}],
+    :xt/iid #bytes "e48a3b8492619cc562c70e6276b1b3fa"}
+   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 626}],
+    :xt/iid #bytes "e4992e080eddf69d86ffcde8e4beecc9"}
+   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 662}],
+    :xt/iid #bytes "e4c395d8e7a2cf0779d465b51e5f58ac"}]
+  [{:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 545}],
+    :xt/iid #bytes "e53c5aae29a001e40daae166f7bcdb95"}
+   {:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 471}],
+    :xt/iid #bytes "e597b9f0e0afa385c677c7dea7d561b9"}
+   {:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 608}],
+    :xt/iid #bytes "e5d4a6b1c8507248a846866dd71f533d"}]
+  [{:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 672}],
+    :xt/iid #bytes "e63773fb84b44f6b2cc946b62fdd0906"}
+   {:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 736}],
+    :xt/iid #bytes "e67a420810558dcc1e901e7e4b682df6"}]
+  [{:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 479}],
+    :xt/iid #bytes "e76c2326a20cf63aca7a9b8d905f9e73"}
+   {:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 739}],
+    :xt/iid #bytes "e79390794a005f906a5825bb4e58f9e7"}
+   {:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 534}],
+    :xt/iid #bytes "e7e350138f070863de1cb4922d65a2da"}]
+  [{:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 523}],
+    :xt/iid #bytes "e8162dbd25e441ad111e9d643fa1c7c2"}
+   {:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 609}],
+    :xt/iid #bytes "e90fba10241986d6b048cacebce95d49"}]
+  [{:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 433}],
+    :xt/iid #bytes "eda010faad5673847724822d9ee49202"}
+   {:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 539}],
+    :xt/iid #bytes "ee9db4e85f07bf98243ffbbea532dedb"}
+   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 627}],
+    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
+   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 591}],
+    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
+  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 628}],
+    :xt/iid #bytes "f320854101207655a62e71a9514c81b3"}]
+  [{:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 454}],
+    :xt/iid #bytes "f4d7adf88ece397a121abc45d74abfb0"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 724}],
+    :xt/iid #bytes "f4e376b4bff204d910068d4c7d2befa6"}
+   {:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 733}],
+    :xt/iid #bytes "f58a9c96ea4299d5f9021f10daf21a2a"}
+   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 474}],
+    :xt/iid #bytes "f68c75093ab4b6e3cd6e9e5598801a94"}
+   {:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 515}],
+    :xt/iid #bytes "f7ad6127d217caa174a5fcae80acd634"}]
+  [{:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 485}],
+    :xt/iid #bytes "f884e42658a5467179a67e0407f99e06"}
+   {:xt/system-from #xt/zdt "2020-03-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 499}],
+    :xt/iid #bytes "f8d4ecc936be1a8b581037943c3ca5b6"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 725}],
+    :xt/iid #bytes "f92f68d8792e507ffd288edd19dca64f"}
+   {:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 473}],
+    :xt/iid #bytes "f972632ebad2f019d9a4b26485e0e365"}
+   {:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 712}],
+    :xt/iid #bytes "faf9f86ec4325c3d77afdb4bf049abbf"}
+   {:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 442}],
+    :xt/iid #bytes "fbe3f7033ca7952bacfbc503d989189f"}]
   [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p3-b162.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p3-b162.arrow.edn
@@ -5,530 +5,510 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1118}],
+    :xt/iid #bytes "c01de328fb266bc76af51881801da40c"}
+   {:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1112}],
+    :xt/iid #bytes "c0cb655d3671888a66310e5edfad417a"}
+   {:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1082}],
+    :xt/iid #bytes "c10bfcf4ad5856f6ea6e23182be81395"}
+   {:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 960}],
+    :xt/iid #bytes "c2b97fd8d6677def5922bd30931511df"}
+   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1096}],
+    :xt/iid #bytes "c328a24753f5bba97775f87dffc02668"}]
+  [{:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 868}],
+    :xt/iid #bytes "c4222f6ef3cb1d6d80410c45dbe90c04"}
+   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 953}],
+    :xt/iid #bytes "c4e67e6664c6299908f7165adc2ff486"}
+   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1056}],
+    :xt/iid #bytes "c6010fbf34f9668a22d990c95d1e2fa3"}
+   {:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1011}],
+    :xt/iid #bytes "c6815df8420ffbcb80127d288d70899e"}
+   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 921}],
+    :xt/iid #bytes "c6efa157ec2645594b9fee164a47753b"}
+   {:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 865}],
+    :xt/iid #bytes "c6f6c7b5ef5ab0cc41ce73ad58937c97"}
+   {:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 855}],
+    :xt/iid #bytes "c719c33a111b9b3c39e09c0ee6ebf07c"}
+   {:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1009}],
+    :xt/iid #bytes "c78823b69ac506f37ec494f9952b623b"}]
+  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 927}],
+    :xt/iid #bytes "c8f74955cd99a75656cb4ff8cd8544d4"}
+   {:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1093}],
+    :xt/iid #bytes "ca1f23447023f906d74eff8cac133cd5"}
+   {:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1108}],
+    :xt/iid #bytes "cac86d0649183cf4f4d496f71a579557"}
+   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 771}],
+    :xt/iid #bytes "cba8015057d39c67e85af79c44272dc4"}]
+  [{:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 972}],
+    :xt/iid #bytes "cc1aa391666ba816fab1afebc0666c97"}
+   {:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1105}],
+    :xt/iid #bytes "ccc84347f4bf33a244c6edb5c518399b"}
+   {:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 856}],
+    :xt/iid #bytes "cd5d3bd1702ecf00f06defbdf4898f1a"}
+   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1098}],
+    :xt/iid #bytes "cd9d92ee12534ce7e1369643813dcdea"}
+   {:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 939}],
+    :xt/iid #bytes "cda30a803175d8d8d0940cc29f0738b6"}
+   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1169}],
+    :xt/iid #bytes "cec74ddfc15430df08407492b9cea7b0"}
+   {:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1084}],
+    :xt/iid #bytes "cee947cafcb41d1f8b0f13bde8e59874"}
+   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 866}],
+    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}]
+  [{:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1028}],
+    :xt/iid #bytes "d24a49238eb94e96d3c42569806b7992"}
+   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 828}],
+    :xt/iid #bytes "d25d4bb9635ac51cc09c1f2991c1da0a"}
+   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 913}],
+    :xt/iid #bytes "d282a2de932275bc57ea37a2d6da99ca"}]
+  [{:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1134}],
+    :xt/iid #bytes "d40f9efdc53f8254693264e5cd09caef"}
+   {:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 876}],
+    :xt/iid #bytes "d415cdf1dbe9a653ec181d2b8543da43"}]
+  [{:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 783}],
+    :xt/iid #bytes "daa434e8e0c093c17dafb218ab1ca451"}
+   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 949}],
+    :xt/iid #bytes "dad3ea40cdcad389b3e01bcdae7a1095"}
+   {:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 875}],
+    :xt/iid #bytes "db367fd089072c62dd2927e3361e56ff"}]
+  [{:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1111}],
+    :xt/iid #bytes "dc7010669d835861436fae4fabd20d7e"}
+   {:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 981}],
+    :xt/iid #bytes "dc8be01a7a9b90f2d93d8e9e7c0c5f5f"}
+   {:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1007}],
+    :xt/iid #bytes "dcbfaf869ee5dc0ec95bac212d9a9f5e"}
+   {:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1137}],
+    :xt/iid #bytes "dcda3757603a66089409d718c10f8964"}
+   {:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 765}],
+    :xt/iid #bytes "dcdf79d371f4a1614c9dccd482677fb9"}]
+  [{:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1136}],
+    :xt/iid #bytes "dd4defe91c1642764b0c16a65a0c87ea"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 895}],
+    :xt/iid #bytes "dd58c4e3823da502d099588524ec17e2"}
+   {:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
+    :op #xt/tagged [:put #:xt{:id 1038}],
+    :xt/iid #bytes "dd5f27847bd1c6553030e6892c3cda2e"}
+   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 804}],
+    :xt/iid #bytes "ddc49dc5dc0baff33bf007a0a714103a"}]
+  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 873}],
+    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
+   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1170}],
+    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
+   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1070}],
+    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
+  [{:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1030}],
+    :xt/iid #bytes "e059e27c0b0511f08c995ac04d04240b"}
+   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1140}],
+    :xt/iid #bytes "e0e76e3cac7a90e387ff71b1a918f55e"}
+   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1101}],
+    :xt/iid #bytes "e1e093f556de5ca0062492d7ab98e728"}
+   {:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1115}],
+    :xt/iid #bytes "e263686fe38f48aba6021d6027fa47f1"}
+   {:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1179}],
+    :xt/iid #bytes "e2cc2683708e67f0e6fd1d88196a8dcc"}
+   {:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1174}],
+    :xt/iid #bytes "e32cc262b5e4882844aa0294fb0df0bb"}]
+  [{:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1130}],
+    :xt/iid #bytes "e4395b37a8257c514e1b3cd5042d13b3"}
+   {:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 777}],
+    :xt/iid #bytes "e45c67ffb16d0c87f2e1886afc6c5ba6"}
+   {:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1087}],
+    :xt/iid #bytes "e4e24feaad7d17ac9ceec72a67801aa2"}]
+  [{:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 961}],
+    :xt/iid #bytes "e5a03e0cdb5d900af07881fa010da2d2"}]
+  [{:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 914}],
+    :xt/iid #bytes "e6727bd79ca7f1f7a8ed577fe19c9909"}
+   {:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 851}],
+    :xt/iid #bytes "e69292b5daa255e4c485fcc3b7d91f4b"}]
+  [{:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1114}],
+    :xt/iid #bytes "e7af728016bbb232aea49d5ae014c4d5"}
+   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1059}],
+    :xt/iid #bytes "e7bd9f61a89aced68ea2c6133660cc31"}
    {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1166}],
+    :xt/iid #bytes "e7bfb1c9dce18edc3656219404d2478c"}]
+  [{:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
-  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1036}],
-    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
-   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1165}],
-    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
-   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1120}],
-    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}]
+    :op #xt/tagged [:put #:xt{:id 795}],
+    :xt/iid #bytes "e82df4876b7e54841a7ec7ca18686203"}
+   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1032}],
+    :xt/iid #bytes "e89d0ba24302d8de650efa7ff158b4a6"}
+   {:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1029}],
+    :xt/iid #bytes "e8a049f1186fc4e64ef952372ed5bb86"}]
+  [{:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1024}],
+    :xt/iid #bytes "e9ae62fcab9bcf5f87353fc642ed2d41"}
+   {:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 817}],
+    :xt/iid #bytes "e9f0220f414de38223010377818f40ab"}]
+  [{:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 911}],
+    :xt/iid #bytes "ea28fea65a2536e49c8993834d396b8d"}]
+  [{:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 769}],
+    :xt/iid #bytes "eb0c008d1b6a4e0f137736a8533b7812"}
+   {:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1088}],
+    :xt/iid #bytes "eb1e4129314aa5ffbfb3508a1b0f148c"}
+   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1097}],
+    :xt/iid #bytes "eb27beda39cfd5f8da3afce4347b40d9"}
+   {:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 991}],
+    :xt/iid #bytes "ebc561621992718d5ed89b4e83fca32c"}
+   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1063}],
+    :xt/iid #bytes "ebcb2049f066632c3d7b2c355e029f0a"}]
+  [{:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 834}],
+    :xt/iid #bytes "ec40857e2207fde746327c59bd2bc06e"}
+   {:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 778}],
+    :xt/iid #bytes "ed3f85bb07e2aec29991080cff9e262f"}
+   {:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1127}],
+    :xt/iid #bytes "edf7fc70e521fba5bca32e68f7a5de61"}
+   {:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1006}],
+    :xt/iid #bytes "ee4e5a3c82e2cbb10b04fe550d0dec75"}
+   {:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 926}],
+    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
+   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 946}],
+    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}]
+  [{:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1047}],
+    :xt/iid #bytes "f0006b31914d22b8acb097d28092bd72"}
+   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1168}],
+    :xt/iid #bytes "f0d1f95dad8ef9f3a99d84a2c087c4c5"}
+   {:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 941}],
+    :xt/iid #bytes "f0f13d56e470df7f7d1de8752453e6a2"}]
+  [{:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1053}],
+    :xt/iid #bytes "f10524027d8faee1887f870ffadd7534"}
+   {:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 776}],
+    :xt/iid #bytes "f1c118ff0c888dad409139ea3464c3d1"}]
+  [{:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1146}],
+    :xt/iid #bytes "f295c77d09fd48cf159f7a1ac690434e"}
+   {:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1126}],
+    :xt/iid #bytes "f2a440378c50af26a30d677053033af8"}]
+  [{:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1031}],
+    :xt/iid #bytes "f30377604f899ba7460cacb6770a883c"}
+   {:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 821}],
+    :xt/iid #bytes "f32d079825fc9e7de7deafbeb1ffd496"}
+   {:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1025}],
+    :xt/iid #bytes "f3cb55a22977c1dd195633a0eed304dd"}]
+  [{:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1095}],
+    :xt/iid #bytes "f4627d75c2688f5ea07abc765d28822e"}
+   {:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 983}],
+    :xt/iid #bytes "f4f1ef4153984a463d5e9df57575915f"}
+   {:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 942}],
+    :xt/iid #bytes "f56c0d6b112281c441df021e380f4747"}
+   {:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 781}],
+    :xt/iid #bytes "f5f41cf1a94dc2302f8df3c1c100ca2e"}
+   {:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 978}],
+    :xt/iid #bytes "f6387c9fee44bb13319167dac1b75715"}
+   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1071}],
+    :xt/iid #bytes "f751c85474814cdd299eeb319ab7a44a"}
+   {:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 877}],
+    :xt/iid #bytes "f7f8580728ab6523ae32a4c516eda16f"}]
+  [{:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 843}],
+    :xt/iid #bytes "f8265282ea0fe344b9a66d806f4117c8"}
+   {:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 861}],
+    :xt/iid #bytes "f8a4746fb474de0d472dff2a885b5eb8"}
+   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1022}],
+    :xt/iid #bytes "f939c179178a0a272346b9c977bca501"}
+   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1015}],
+    :xt/iid #bytes "f9cbfeefc90e4bf8401b224da5193438"}
+   {:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1148}],
+    :xt/iid #bytes "fa03b53805fe1ce5394359c77bc91aba"}
+   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 922}],
+    :xt/iid #bytes "fb0be7dc7ab02633c26f36f769728fc0"}]
   [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p3-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p3-b182.arrow.edn
@@ -5,790 +5,490 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1525}],
+    :xt/iid #bytes "c100785ce24586ed6323d972e671ed47"}
+   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1436}],
+    :xt/iid #bytes "c1fd92fba995351e416bf36fd5e0ab45"}]
+  [{:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
+    :op #xt/tagged [:put #:xt{:id 1376}],
+    :xt/iid #bytes "c407f42a4aaf9721a6f582bc79a1e848"}
    {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1415}],
+    :xt/iid #bytes "c44f5f818283d5d1eaf9ab7e9d464941"}
+   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1189}],
+    :xt/iid #bytes "c454f4d569be65b381a481c4103f2c07"}
+   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1355}],
+    :xt/iid #bytes "c4ae3f94fc9634bb588133ff779d0e27"}
+   {:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1284}],
+    :xt/iid #bytes "c53917d1861182f4530fabba2f0ff58a"}
+   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1520}],
+    :xt/iid #bytes "c54cd120ff430563837348cba6e7cb7b"}
+   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1326}],
+    :xt/iid #bytes "c5e91590450eec7ffb5a03a2240aea31"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1409}],
+    :xt/iid #bytes "c7824c61918490b922c019c2efa5bd0f"}]
+  [{:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1322}],
+    :xt/iid #bytes "ca80aff827af9b969dac4fbcc5b59ebe"}
+   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1471}],
+    :xt/iid #bytes "cb1c744caf9f6536fd4ddf755284e2e5"}
+   {:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1484}],
+    :xt/iid #bytes "cb8e26b328d937ca2c961d40a82f28f6"}
+   {:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1217}],
+    :xt/iid #bytes "cbca0311f02bf4a1f12ecfa8239522d0"}
+   {:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1268}],
+    :xt/iid #bytes "cbcd956fdfaf97345ccfa3135e4b3494"}
+   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1364}],
+    :xt/iid #bytes "cbed176d27e44fd9803662691dd5aa37"}]
+  [{:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1299}],
+    :xt/iid #bytes "cdd1e0aa920e91aa09d1d1c5f43bb3db"}
+   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1188}],
+    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
+   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1383}],
+    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
+  [{:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1331}],
+    :xt/iid #bytes "d05baa9770a4bd49c0d87f6fcf167f0e"}
+   {:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1201}],
+    :xt/iid #bytes "d067a4a2353bcc0344db8dbe27d86674"}
+   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1435}],
+    :xt/iid #bytes "d1230bae90bb0a792e992affa35fbb5c"}
+   {:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1482}],
+    :xt/iid #bytes "d250e9a30d21741d340bfefe583badfe"}
+   {:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1491}],
+    :xt/iid #bytes "d2c8d5328a64c53c0fe1d9f096e6e6bd"}
+   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1304}],
+    :xt/iid #bytes "d2fe658dee0d1d0cc999e5529a605b1f"}
+   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1345}],
+    :xt/iid #bytes "d38435ce6dc2deab50176e3494246d41"}]
+  [{:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1288}],
+    :xt/iid #bytes "d43a445887ca62b989147dd1b427c2e3"}
+   {:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1476}],
+    :xt/iid #bytes "d4fe1e984b0d12f881f75d9acf7ada95"}
+   {:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1529}],
+    :xt/iid #bytes "d6f854291a5b62075a891366907dc9c0"}
+   {:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1371}],
+    :xt/iid #bytes "d70a0edd79815fa087ba036cfa5537ab"}
+   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1472}],
+    :xt/iid #bytes "d74418a3893e92f6f7e75e552979f441"}]
+  [{:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1229}],
+    :xt/iid #bytes "d8b1861060bae869a30f40be0597a988"}
+   {:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1243}],
+    :xt/iid #bytes "d8e63a33e21d7570c96d76937332673b"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
+    :op #xt/tagged [:put #:xt{:id 1392}],
+    :xt/iid #bytes "d8e787847aa7261ea160f9d7b9fd129b"}
+   {:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1334}],
+    :xt/iid #bytes "dab24678de02074144374bd83d9240da"}]
+  [{:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1343}],
+    :xt/iid #bytes "dc031a66bbb79a8b4cdd926879bb8618"}
+   {:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1535}],
+    :xt/iid #bytes "dc97f31dc43a83996087b082bf7bde78"}
+   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1258}],
+    :xt/iid #bytes "ddf3ada42cd3ece118e40d7553a72765"}
+   {:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1389}],
+    :xt/iid #bytes "de42b6ed35cbe1d88e01613409437c90"}
+   {:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1526}],
+    :xt/iid #bytes "dec409d6d307ec508273c382de9b2a87"}
+   {:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1332}],
+    :xt/iid #bytes "ded87671e7aa8547c4eb58d5529052d9"}
+   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1307}],
+    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
+   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1260}],
+    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}]
+  [{:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1340}],
+    :xt/iid #bytes "e032b2fb8dba589ebb19295cbad95c38"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1413}],
+    :xt/iid #bytes "e04047bc794fc3ebb2aca388189176ee"}
    {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1419}],
+    :xt/iid #bytes "e0fea6ddad64fe6bd57dd3b20b7b6dfd"}]
+  [{:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1241}],
+    :xt/iid #bytes "e1099f860a9cfb3a779bdde46b7140ac"}
+   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1356}],
+    :xt/iid #bytes "e137085ee491c9abbfb2ae90c0381782"}
+   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1274}],
+    :xt/iid #bytes "e18aafb3253261773b0859a7dfd815ab"}]
+  [{:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1339}],
+    :xt/iid #bytes "e254184a247cf64c96fb9c0499f9ed68"}
+   {:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
+    :op #xt/tagged [:put #:xt{:id 1406}],
+    :xt/iid #bytes "e2751ffa054c751d80ab185ef4ca329b"}]
+  [{:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1459}],
+    :xt/iid #bytes "e3309fa880f84189f46336c185c34bae"}
+   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1312}],
+    :xt/iid #bytes "e375d448e5aaa930af0753a50993b000"}]
+  [{:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1320}],
+    :xt/iid #bytes "e459b39d57f6a3a514518260a63ba3bb"}
+   {:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1388}],
+    :xt/iid #bytes "e7aa467ff7d2603b54786ad0b88f1a1d"}]
+  [{:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1278}],
+    :xt/iid #bytes "e808af43fdf54c90ef7104e911bad6cf"}
+   {:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1404}],
+    :xt/iid #bytes "e88c0b9236640cbaf666dcbcd0b28461"}
+   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1466}],
+    :xt/iid #bytes "e8b2a0f890bf369848264e58a475ce4d"}
+   {:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1182}],
+    :xt/iid #bytes "e901c808d294e6e0c348fbb40931f22f"}
+   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1399}],
+    :xt/iid #bytes "e94e9e0abd7663188066c2c90119b006"}]
+  [{:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1474}],
+    :xt/iid #bytes "ec018b2afa1bfc758e87e1fd2a84dda4"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1410}],
+    :xt/iid #bytes "ec4f7060cd456777fcdd8ac0d1cfe471"}
+   {:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1405}],
+    :xt/iid #bytes "ec630f0481f3758091aeec242305895d"}
+   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1361}],
+    :xt/iid #bytes "ec6b51aaf78930a40f804d1bd7f54861"}]
+  [{:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1480}],
+    :xt/iid #bytes "ed18038019a62a738047c4a842671a56"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1408}],
+    :xt/iid #bytes "ed2db5d94792bdcf0ec37b0bad3372bc"}
+   {:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1502}],
+    :xt/iid #bytes "ed9408668b3fd58a9866838bf05af096"}]
+  [{:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1341}],
+    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
+   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1511}],
+    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}]
+  [{:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1265}],
+    :xt/iid #bytes "f1882dd3f81dac26dcbce3e10983579e"}
+   {:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1523}],
+    :xt/iid #bytes "f18bc76b55cfd68596420cb9d210478a"}
+   {:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1431}],
+    :xt/iid #bytes "f1b7e92f416a5458fb486de25b90637e"}
+   {:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1255}],
+    :xt/iid #bytes "f1bfeba094103d7b110f6ae4a4a14c24"}
+   {:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1422}],
+    :xt/iid #bytes "f22cf744667ecdbebbb5b16026e9f013"}
+   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1362}],
+    :xt/iid #bytes "f30be5b0b9970aa60d8caccb262fd7f9"}
+   {:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1498}],
+    :xt/iid #bytes "f3b8e7ff45037e83b658edc7a5e54b0b"}]
+  [{:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1429}],
+    :xt/iid #bytes "f4026070bc8dc82f99b055ec82af3eed"}
+   {:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1534}],
+    :xt/iid #bytes "f4039cf4021dd491d6c5b6b9bde24db8"}
    {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1418}],
+    :xt/iid #bytes "f46a03bf7921ca24c18d9576269060ba"}]
+  [{:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
+    :op #xt/tagged [:put #:xt{:id 1513}],
+    :xt/iid #bytes "f506af2f6295532c102aa00c8caaa170"}
+   {:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1335}],
+    :xt/iid #bytes "f5352beda276f51f91cdd313415579e3"}
+   {:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1533}],
+    :xt/iid #bytes "f5ceede563a350d71874c13b60ab2e87"}]
+  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1539}],
+    :xt/iid #bytes "f62ef8a9725e3a488f3894830d153a56"}
+   {:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1224}],
+    :xt/iid #bytes "f69ffa8f3c0affd2fc365866056bd73d"}]
+  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1452}],
+    :xt/iid #bytes "f75ad965487edd9d0b10511aa94c572e"}
+   {:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1457}],
+    :xt/iid #bytes "f7f27d8460995685652657b60bb9762a"}]
+  [{:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1294}],
+    :xt/iid #bytes "f894acc5a963360157d04720cae38971"}
+   {:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1245}],
+    :xt/iid #bytes "f8a2498739d1245a825f7f5c5012a278"}]
+  [{:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1421}],
+    :xt/iid #bytes "f919dbc8ec04dbe6c14bf2408c552013"}
    {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1552}],
+    :xt/iid #bytes "f98841a3bd1929bcabcf2e4f8586d2ee"}
+   {:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1386}],
+    :xt/iid #bytes "f9b44a447db5e92c5ad65a50ee563acd"}]
+  [{:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
-  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1367}],
-    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
-   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1553}],
-    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
-   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1496}],
-    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
-   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1239}],
-    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1441}],
-    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}
-   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1414}],
-    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}]
+    :op #xt/tagged [:put #:xt{:id 1557}],
+    :xt/iid #bytes "fa8aeba984ababfcd8d4e08317532fa8"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1206}],
+    :xt/iid #bytes "fac5ddf5defdc0c25cffefef7fc412f4"}]
+  [{:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1488}],
+    :xt/iid #bytes "fb1cf0756f40594e62f1b3e3bf0d8401"}
+   {:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1232}],
+    :xt/iid #bytes "fb1fbd089d89b030a28d4768af84d5e8"}
+   {:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1257}],
+    :xt/iid #bytes "fb5b10fbaea7ac3fd1fe578afeca840e"}]
   [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p3-b1a4.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l02-rc-p3-b1a4.arrow.edn
@@ -5,585 +5,450 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1910}],
+    :xt/iid #bytes "c0dd583064a71837be00551725ce0bf3"}
+   {:xt/system-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1870}],
+    :xt/iid #bytes "c0fd4d3d8f7c6cdc37259f3fc37b5f34"}
+   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1578}],
+    :xt/iid #bytes "c1248f9b7fb266fc43ea915941dd8e6a"}
+   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1635}],
+    :xt/iid #bytes "c23256c9832ffce2df170b28c74e92ca"}]
+  [{:xt/system-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1591}],
+    :xt/iid #bytes "c420fbf3676bd02b9a3292b1c60fd6b4"}
+   {:xt/system-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1572}],
+    :xt/iid #bytes "c4687d8ceeef7756af57a5443403d3e0"}
+   {:xt/system-from #xt/zdt "2020-10-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1808}],
+    :xt/iid #bytes "c48f0b86df30d0e00325a2dd127b6219"}
+   {:xt/system-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1685}],
+    :xt/iid #bytes "c4985ad1f564fba2ae0d5168e3953265"}
+   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1892}],
+    :xt/iid #bytes "c5eb7ee498a72443908642991ef749d1"}
+   {:xt/system-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1692}],
+    :xt/iid #bytes "c609308b3edd77272d045713cba383f4"}
+   {:xt/system-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1820}],
+    :xt/iid #bytes "c66c176eacb9c78ec1fbe0636c2f4721"}
+   {:xt/system-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1836}],
+    :xt/iid #bytes "c6c8d6df6eaffbcf1c17598db28e8d90"}]
+  [{:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1780}],
+    :xt/iid #bytes "cc3c29674753c419facc7754270efdf0"}
+   {:xt/system-from #xt/zdt "2020-11-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1852}],
+    :xt/iid #bytes "cc7a442876668521cf73d6b6de5b2f1e"}
+   {:xt/system-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1689}],
+    :xt/iid #bytes "ccf9a6e7b79700ceaf4214450ac2e6a2"}
+   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1730}],
+    :xt/iid #bytes "cdc520122a5c7b89692a0aae0846a58d"}
+   {:xt/system-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1833}],
+    :xt/iid #bytes "ce31fd113bdabce385ed47e30cc37ebc"}
+   {:xt/system-from #xt/zdt "2020-09-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1633}],
+    :xt/iid #bytes "ce4c79bc5995dbd789a68024eab7556a"}
+   {:xt/system-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1837}],
+    :xt/iid #bytes "ceab62900f28c7695eaf7da900f3409b"}
+   {:xt/system-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1844}],
+    :xt/iid #bytes "cec872185c8b576c43e43f0a3191c6f7"}]
+  [{:xt/system-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1960}],
+    :xt/iid #bytes "d215544079bbedbe72927f6c4886c39e"}
+   {:xt/system-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1791}],
+    :xt/iid #bytes "d2e1de85967de4d145a45f28e9175798"}
+   {:xt/system-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1602}],
+    :xt/iid #bytes "d329b2f92d1d5613b6e4723c819bd591"}]
+  [{:xt/system-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1909}],
+    :xt/iid #bytes "d54ff578a2e208ad42331891764702e0"}
+   {:xt/system-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1949}],
+    :xt/iid #bytes "d5d179700823ec1ff5cd45670d282bbb"}
+   {:xt/system-from #xt/zdt "2020-11-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1890}],
+    :xt/iid #bytes "d7c7640b8000a93357251d96fea25525"}]
+  [{:xt/system-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1943}],
+    :xt/iid #bytes "d8629c7585ab2a493eed5dbdfe401500"}
+   {:xt/system-from #xt/zdt "2020-09-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1581}],
+    :xt/iid #bytes "d9a4d8be5f4cfbf1f538ec629dc564b7"}
+   {:xt/system-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1838}],
+    :xt/iid #bytes "da8c327af1d3ceed4820d8c92eadec18"}
+   {:xt/system-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1570}],
+    :xt/iid #bytes "daf5171126df9ed88785430b55d13dd7"}
+   {:xt/system-from #xt/zdt "2020-11-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1902}],
+    :xt/iid #bytes "db77103cd6c73538915e400af8e9cb10"}]
+  [{:xt/system-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1789}],
+    :xt/iid #bytes "dcce36c99ced89e76589559cad55d1e9"}
+   {:xt/system-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1697}],
+    :xt/iid #bytes "dd1e2cdc9201fd0497ed1f9a309c9a28"}
+   {:xt/system-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1610}],
+    :xt/iid #bytes "dd5131e15ae63f9892b6b862387c2f70"}
+   {:xt/system-from #xt/zdt "2020-10-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1809}],
+    :xt/iid #bytes "dd5b465108b74f7e191accd431f28ef5"}
+   {:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1597}],
+    :xt/iid #bytes "df1a6545f2e46cd887d526a3118586f7"}
+   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1723}],
+    :xt/iid #bytes "dfaf285a07b1ccd2ac7799d15cd747c3"}
+   {:xt/system-from #xt/zdt "2020-11-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
+    :op #xt/tagged [:put #:xt{:id 1954}],
+    :xt/iid #bytes "dffd2b8f478b0955d9c4d2b9a265e57f"}]
+  [{:xt/system-from #xt/zdt "2020-10-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1773}],
+    :xt/iid #bytes "e06eebc48522b78b9decfbd6548cdfff"}
+   {:xt/system-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1841}],
+    :xt/iid #bytes "e1ecf8b6ec3f1eeea7fd1c90cad90731"}]
+  [{:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1636}],
+    :xt/iid #bytes "e45475079f5ae1295d61f50592da4241"}
+   {:xt/system-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1648}],
+    :xt/iid #bytes "e4822f72f00ada9ccb777fdc4d32d4c4"}
+   {:xt/system-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1914}],
+    :xt/iid #bytes "e4a53a2fd8b54c1469bf1fc9b0dfca64"}]
+  [{:xt/system-from #xt/zdt "2020-11-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1936}],
+    :xt/iid #bytes "e506b097363a27f7e98a25a2684a05de"}
    {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1884}],
+    :xt/iid #bytes "e513cb460de17fd8b657f9bb86fd43fa"}
+   {:xt/system-from #xt/zdt "2020-10-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
+    :op #xt/tagged [:put #:xt{:id 1800}],
+    :xt/iid #bytes "e58176ad0c0ddc94a5c06d4b2a9f3d92"}
+   {:xt/system-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1690}],
+    :xt/iid #bytes "e5c3d63a61a348157681558871461b9c"}]
+  [{:xt/system-from #xt/zdt "2020-10-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1676}],
+    :xt/iid #bytes "e6255d55abbb1ec83cf375c807c8b0d6"}]
+  [{:xt/system-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1708}],
+    :xt/iid #bytes "e745fccf50bc78ad98a6a0981b71367a"}]
+  [{:xt/system-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1573}],
+    :xt/iid #bytes "e80a5d7bd25a95cedc1bd61eb72c8a8f"}
+   {:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1921}],
+    :xt/iid #bytes "e90b84717983bbd35fdf0880046e0898"}
+   {:xt/system-from #xt/zdt "2020-10-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1644}],
+    :xt/iid #bytes "ea4ebd2f6a70025f516473297d39e1ee"}
+   {:xt/system-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1831}],
+    :xt/iid #bytes "ea7260e9c7b632b9f324b1c3543a3b98"}
+   {:xt/system-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1757}],
+    :xt/iid #bytes "eb21b425a104d8e5a9dc2c214cddb8a9"}
+   {:xt/system-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1694}],
+    :xt/iid #bytes "eb70b136f0f607b98a9cb1dcba23c37a"}]
+  [{:xt/system-from #xt/zdt "2020-10-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1678}],
+    :xt/iid #bytes "ec7affcbb0cac8bd8e45c6563da813a4"}
+   {:xt/system-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1840}],
+    :xt/iid #bytes "ed6fc24dda80c943b56142fc7245ffc9"}
+   {:xt/system-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1781}],
+    :xt/iid #bytes "ee1c9f0aae665a63de4ed419afdaf5dd"}
+   {:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1594}],
+    :xt/iid #bytes "ee874371d050cd044e9ec42f5da72101"}
+   {:xt/system-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1947}],
+    :xt/iid #bytes "ef46b89a6b88ddc2d4b961072774e743"}
+   {:xt/system-from #xt/zdt "2020-10-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1810}],
+    :xt/iid #bytes "ef6cf01a927328a6211e8d9b7cb2dd18"}
+   {:xt/system-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1651}],
+    :xt/iid #bytes "ef985e7b71d22c3ba7162fb9438050b3"}
+   {:xt/system-from #xt/zdt "2020-10-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1776}],
+    :xt/iid #bytes "efb244ab9c5ee2b5657e0b6d455d093a"}]
+  [{:xt/system-from #xt/zdt "2020-11-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1823}],
+    :xt/iid #bytes "f0919d455e17f8270a5f3e03115ad104"}
+   {:xt/system-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1875}],
+    :xt/iid #bytes "f0b266ece43bdd5deb6e1f7eb1682a01"}]
+  [{:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1566}],
+    :xt/iid #bytes "f14426b5d31c5d43ad697e75d39896a5"}
+   {:xt/system-from #xt/zdt "2020-11-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1854}],
+    :xt/iid #bytes "f1d0bdc4849a0e366a7e29b0eb58f039"}]
+  [{:xt/system-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1737}],
+    :xt/iid #bytes "f2466c7ff2b301e7a49ce0def117199b"}]
+  [{:xt/system-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1707}],
+    :xt/iid #bytes "f3000cfa301371d272aea4266ea02ff5"}
+   {:xt/system-from #xt/zdt "2020-11-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1920}],
+    :xt/iid #bytes "f36d95ced525db1b63e7f4b64779f819"}
+   {:xt/system-from #xt/zdt "2020-11-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1931}],
+    :xt/iid #bytes "f385234cce7878d0614f0a8d208cc37d"}
+   {:xt/system-from #xt/zdt "2020-11-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1826}],
+    :xt/iid #bytes "f3f8bcaebb2906e59004efb997b72d84"}]
+  [{:xt/system-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1867}],
+    :xt/iid #bytes "f48b6e56ff7fec1b68a0c10887bea2e6"}]
+  [{:xt/system-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1668}],
+    :xt/iid #bytes "f544ca88ebc5489b948f24a0afe8a659"}
+   {:xt/system-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1966}],
+    :xt/iid #bytes "f5538d92d8e008b1c89ddd8e2a65728d"}]
+  [{:xt/system-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1593}],
+    :xt/iid #bytes "f63d0007e0997ce4f0bbc0d76cfae92e"}
+   {:xt/system-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1684}],
+    :xt/iid #bytes "f647c78e7af06c72c889a36a26363baa"}
+   {:xt/system-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1701}],
+    :xt/iid #bytes "f6e906611385026b1e7f35f3b4bc6520"}]
   [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1596}],
+    :xt/iid #bytes "f7409aee4d3e0dc7a85089b55d5e6cb7"}
+   {:xt/system-from #xt/zdt "2020-10-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1654}],
+    :xt/iid #bytes "f764ee28e0d1a290a9ca7dd51720b78d"}
+   {:xt/system-from #xt/zdt "2020-10-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
+    :op #xt/tagged [:put #:xt{:id 1726}],
+    :xt/iid #bytes "f7f828c4f2fc616e26729c13939dbac1"}]
+  [{:xt/system-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1896}],
+    :xt/iid #bytes "f86ac9001577732436297a33a7537845"}
+   {:xt/system-from #xt/zdt "2020-11-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-11-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1846}],
+    :xt/iid #bytes "f89f1c41a14f9c54235676be0e1ee49c"}
+   {:xt/system-from #xt/zdt "2020-10-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1725}],
+    :xt/iid #bytes "f8ea5d70e64503fa799a91757ff0a560"}
+   {:xt/system-from #xt/zdt "2020-10-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1772}],
+    :xt/iid #bytes "faa312aff415147759d8dfbce9d16a49"}
    {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1882}],
+    :xt/iid #bytes "fad19fd2436191225a5ff6399b14715f"}
+   {:xt/system-from #xt/zdt "2020-10-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-10-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
+    :op #xt/tagged [:put #:xt{:id 1795}],
+    :xt/iid #bytes "fae7a77bd10cd96debcb4dc8e567626c"}
    {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
-  [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1598}],
-    :xt/iid #bytes "fc95067d861bf2e75b46cde34360c69d"}
-   {:xt/system-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1879}],
-    :xt/iid #bytes "fc9e1d6bd8637fb937a6d9a647f9c6dc"}
-   {:xt/system-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1567}],
-    :xt/iid #bytes "fdfdc6b544274064acda5d382423f97e"}
-   {:xt/system-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-11-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1885}],
-    :xt/iid #bytes "ff5bdbf935abdf91eb975e00cd0115df"}
-   {:xt/system-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-10-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1640}],
-    :xt/iid #bytes "ff9e379e5d5f1a64b46583e2e81177db"}]
+    :op #xt/tagged [:put #:xt{:id 1565}],
+    :xt/iid #bytes "fb65bbe9c63c9ef867a99c1193e2fa5f"}]
   [{:xt/system-from #xt/zdt "2020-09-24T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-09-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p00-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p00-b182.arrow.edn
@@ -5,970 +5,510 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 5}],
+    :xt/iid #bytes "0016cf5ed68e5a5349722594ae8f5926"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 28}],
+    :xt/iid #bytes "001e832ee50bb5bd3dab482eb130abf1"}
+   {:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 674}],
+    :xt/iid #bytes "0027c5b37f2af83442c795a3345b7476"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 243}],
+    :xt/iid #bytes "0041b3666c25996df0bf50024075e368"}
+   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1544}],
+    :xt/iid #bytes "0079f2d7f1e3243a1625f78db0035582"}
+   {:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 659}],
+    :xt/iid #bytes "0090e554f0832b63fa23fe38773373a0"}
+   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 970}],
+    :xt/iid #bytes "00b6fff7c9fdbadbc3da75bcb0a77b30"}
+   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 794}],
+    :xt/iid #bytes "00e3afd98fab2be1c237fed75fbdfa12"}]
+  [{:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 585}],
+    :xt/iid #bytes "011d4e3bf2bc19e64c19c3ed88b8b248"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 30}],
+    :xt/iid #bytes "013e780f1691e21ab35ada14901804e8"}
+   {:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 904}],
+    :xt/iid #bytes "0185eefe9ce0d4c1765b7003014bf8f0"}]
+  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1270}],
+    :xt/iid #bytes "0209c61ac695e5460cbfe3114524a7ca"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 237}],
+    :xt/iid #bytes "02165f0c71e779a40a67aa915d2e31a1"}
+   {:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 686}],
+    :xt/iid #bytes "023278254c40137c60c918f3b75d6175"}
+   {:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 559}],
+    :xt/iid #bytes "0237f7f4560d6d9b162aa16fd2c4254a"}]
+  [{:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1103}],
+    :xt/iid #bytes "0259b245ef3581910a2e0468c80133f8"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 109}],
+    :xt/iid #bytes "025d28748b20143b96259fe559007490"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 707}],
+    :xt/iid #bytes "027f3ba67aea1502628f5b30f081e463"}]
+  [{:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 579}],
+    :xt/iid #bytes "028e71bfc40ebafb759bd72446f53ce9"}
+   {:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1152}],
+    :xt/iid #bytes "02b106c33dd6837e7aacf8eee7cc3085"}
+   {:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 383}],
+    :xt/iid #bytes "02b8c2b7673c15a95dfd6913f32e8f09"}]
+  [{:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 505}],
+    :xt/iid #bytes "02cde9758f6b1929cfd24d85345b9eb2"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 71}],
+    :xt/iid #bytes "02d8dd8ed45a8e9e324aac15c2cb9ac6"}]
+  [{:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 549}],
+    :xt/iid #bytes "033626f56e707c06f8eef9aa79ed8d1a"}
+   {:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 734}],
+    :xt/iid #bytes "034f5f0005b1dde3ad69c1687f74ed09"}
+   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 270}],
+    :xt/iid #bytes "035fb4c42c869245d66556eba0357ecf"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 305}],
+    :xt/iid #bytes "03a293a1ae6a754078406140a65ff6be"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 891}],
+    :xt/iid #bytes "03e6a80039ce9e2bd99561390b7ac060"}]
+  [{:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 319}],
+    :xt/iid #bytes "043e7a2fbf427b598357f715a1a61344"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 76}],
+    :xt/iid #bytes "048066d7281598725150e49f6b3e1b70"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 47}],
+    :xt/iid #bytes "0497abf957f6100ef2c9a66da82e13c2"}
+   {:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 729}],
+    :xt/iid #bytes "04bc32788b1631f072fc90b4c5d5ca7a"}
+   {:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1292}],
+    :xt/iid #bytes "04db988ab9d9982abce8d32189b314a2"}
+   {:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1430}],
+    :xt/iid #bytes "04ff80349772454d07b4983bb1b54462"}]
+  [{:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 215}],
+    :xt/iid #bytes "05032986c76fbabb23cd20d9cf1c609a"}
+   {:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
+    :op #xt/tagged [:put #:xt{:id 1455}],
+    :xt/iid #bytes "05112293c56c2f2948d6c418bdd6634e"}
+   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 429}],
+    :xt/iid #bytes "053a6977d02b42bea31f3c4f7f3acc79"}]
+  [{:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 206}],
+    :xt/iid #bytes "055a3bc0b33ec364467406eb4cbbfc47"}]
+  [{:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 58}],
+    :xt/iid #bytes "05ab9c45fc4f720f1a88cd9715580e88"}]
+  [{:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1033}],
+    :xt/iid #bytes "05c96ac8018e6891e201ae762c4bcbeb"}
+   {:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1538}],
+    :xt/iid #bytes "05e04253cc5648d613280bcaf2c7bd6c"}
+   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 280}],
+    :xt/iid #bytes "05e5ac85e20d91f5431fd118c3cfa4c5"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 708}],
+    :xt/iid #bytes "05e8412231f7f98f329e0f26ded53751"}]
+  [{:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 785}],
+    :xt/iid #bytes "061151ca633755d80696ae5af5d851b8"}
+   {:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1240}],
+    :xt/iid #bytes "062d4bbc782dcde75c438510e75ae41b"}
+   {:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 919}],
+    :xt/iid #bytes "064f7a8ee2a0771fd15090a9fc4d76fa"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 312}],
+    :xt/iid #bytes "06cf894ddb2e40263ac798e97ca89abb"}
+   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 263}],
+    :xt/iid #bytes "06fedcce1ce11f50d14b85f5f6072170"}]
+  [{:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1327}],
+    :xt/iid #bytes "0714f95c1b6851785c86c123be2cbaa2"}
+   {:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 556}],
+    :xt/iid #bytes "072050e6b895800ab0d439b45c3a4556"}
+   {:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 816}],
+    :xt/iid #bytes "072d5c923dceec155e11580b6153a3a3"}]
+  [{:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 979}],
+    :xt/iid #bytes "0741418020febb026bd2b9abbc3e11b9"}]
+  [{:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 179}],
+    :xt/iid #bytes "079b6f3220e03c3ce2fa74830e4a364c"}
+   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 947}],
+    :xt/iid #bytes "07a1af3ea67e0c85afd9f40f2edce046"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 136}],
+    :xt/iid #bytes "07b04b25f563483782bedfae4ac65d46"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 447}],
+    :xt/iid #bytes "07ba6fc791d6d1b4a2f6addeec72c973"}]
+  [{:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1300}],
+    :xt/iid #bytes "07d2e5a94a9404665fddf4cc651d34ad"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 318}],
+    :xt/iid #bytes "07e1672e79caad486aa14eb4f9b7cc49"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 68}],
+    :xt/iid #bytes "081d5b18d56d2d0a3864303b79e94511"}
+   {:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 768}],
+    :xt/iid #bytes "0830a3bc6111c4b0188e894d8e0f605c"}
+   {:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1456}],
+    :xt/iid #bytes "08690304431344ea3b8e87622ad92324"}
+   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 761}],
+    :xt/iid #bytes "0877d33b3ccaf249d539bde2ff7f1b02"}
+   {:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1157}],
+    :xt/iid #bytes "089813bea950e6fac18d957c83c91846"}
    {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 419}],
+    :xt/iid #bytes "08d2b357054853321ffdb148ceb10caf"}
+   {:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 487}],
+    :xt/iid #bytes "08d6c1a46f7f6c694b770e72782da9fe"}
+   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 427}],
+    :xt/iid #bytes "08e4e441a456cc34bae06349dd60d5fd"}]
+  [{:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 956}],
+    :xt/iid #bytes "0917be528bc84ced9fa3eabdae270b19"}
+   {:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 497}],
+    :xt/iid #bytes "0919fa0aa96e55d46fab64b1e42895f9"}
+   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1272}],
+    :xt/iid #bytes "09279d20ea04e356f5bfa6b038befc74"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
+    :op #xt/tagged [:put #:xt{:id 51}],
+    :xt/iid #bytes "0941953eebf260e5296755e93382fed6"}
+   {:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1195}],
+    :xt/iid #bytes "09516961e3590ae9d9d02b371ba51e14"}
+   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1363}],
+    :xt/iid #bytes "096c8a860a287a0dc631b41751a6a33b"}
+   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1560}],
+    :xt/iid #bytes "09749f40266037ec1e9590931d94186c"}
+   {:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 858}],
+    :xt/iid #bytes "09ff8069f9dce453adf58a879562e166"}]
+  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1349}],
+    :xt/iid #bytes "0acca092e99855742f71f8cc0cc300ce"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 146}],
+    :xt/iid #bytes "0afa67ec22e0c723ba955bf8f9841d7e"}]
+  [{:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 514}],
+    :xt/iid #bytes "0b79b0a87766cad8aca8232d938f8c30"}
+   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1365}],
+    :xt/iid #bytes "0b82286dca05246c2737a7439b17a026"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 890}],
+    :xt/iid #bytes "0bb2d1ed1c2ad5447dfa15d27b3e917f"}
+   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1235}],
+    :xt/iid #bytes "0bc5e5b8740341988af1e66e0b2460e6"}
+   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 478}],
+    :xt/iid #bytes "0bcb62acf330e279053fbd18c2dd716c"}
+   {:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1319}],
+    :xt/iid #bytes "0beb02848776942624c9de59a5ba8ce7"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 722}],
+    :xt/iid #bytes "0bee0a3eee613197a1e001c48bbf5af4"}]
+  [{:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 749}],
+    :xt/iid #bytes "0c0df299a6be10ea75d38a63f18c3335"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 135}],
+    :xt/iid #bytes "0c37cb2407eba7b368e441aca963ae57"}
+   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1308}],
+    :xt/iid #bytes "0cb148c257063b1a6a0e1cceaa44d946"}
+   {:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1231}],
+    :xt/iid #bytes "0cbd4e673045d3e63f935cc1dc1dc3a3"}
    {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
-  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 657}],
-    :xt/iid #bytes "0f271c841527ac213a9da933f3c0c682"}
-   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 115}],
-    :xt/iid #bytes "0f3c1d4100d19cdcb62825362f0d5497"}
-   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 700}],
-    :xt/iid #bytes "0f77b6d577c0d878fc07ce558d82de42"}
-   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1357}],
-    :xt/iid #bytes "0f7c64ef41f15322e57d9962d2902740"}
-   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 805}],
-    :xt/iid #bytes "0f7d37d9e44b9cf75a4e335073592745"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 210}],
-    :xt/iid #bytes "0f8bab29aa01e10860942f5b5a0b347b"}
-   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 522}],
-    :xt/iid #bytes "0f8fbea0119d2661211241fbbd23a8c7"}
-   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 417}],
-    :xt/iid #bytes "0f97f3f68271564778a57aa781be1f1e"}]
+    :op #xt/tagged [:put #:xt{:id 518}],
+    :xt/iid #bytes "0cfcffa728c2582a4be065fc008ce9c8"}]
+  [{:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1173}],
+    :xt/iid #bytes "0d045d018d1da366cf9e52bb8263d160"}
+   {:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 965}],
+    :xt/iid #bytes "0d73554a96e896b6561cbdde07950960"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 103}],
+    :xt/iid #bytes "0de886ef47f37c39172042278e44a607"}
+   {:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1051}],
+    :xt/iid #bytes "0df406fffa4ec7756de7156ef3cb6e58"}]
+  [{:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 599}],
+    :xt/iid #bytes "0e0a21a75bbbc7674523941795b5d488"}
+   {:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1287}],
+    :xt/iid #bytes "0e4ede2735da87fe1e78b078baf9d15d"}
+   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1061}],
+    :xt/iid #bytes "0e52b2a14edd20b8f3fc4133689c23a8"}
+   {:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1144}],
+    :xt/iid #bytes "0e576653382413d3b9c477776fb4b312"}
+   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 634}],
+    :xt/iid #bytes "0e62b3337f67912c0d7620014dc998f0"}
+   {:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 687}],
+    :xt/iid #bytes "0e81aae7ae5c8da67cf9a9e4c538dea3"}
+   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1540}],
+    :xt/iid #bytes "0ecd85ec50ae50d5c354864e5a6dfd32"}
+   {:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 527}],
+    :xt/iid #bytes "0eec88498770ad276bb0a930f456c6b0"}]
   [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p01-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p01-b182.arrow.edn
@@ -5,1090 +5,480 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
-  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 801}],
-    :xt/iid #bytes "1f28d294a675dc659642c498bcd1004c"}
-   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 646}],
-    :xt/iid #bytes "1f2bc0d731f0c81b3ce722ead374a9e5"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 225}],
-    :xt/iid #bytes "1f7c09b24714846bfbd0caeb497c2f32"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 194}],
-    :xt/iid #bytes "1f842c59e0c183a0e91c8a6ff852398e"}
-   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 832}],
-    :xt/iid #bytes "1f8dbb509f00a7c2094fd6961e331c8e"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 796}],
-    :xt/iid #bytes "1f9f8a859468a973f7e7a3bf854d9c80"}
-   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1373}],
-    :xt/iid #bytes "1fb783bae2571a341f802b4e6bff3a46"}
-   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 193}],
-    :xt/iid #bytes "1ffaaf1f04a26686b05630f8a6685645"}]
+ ([{:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 604}],
+    :xt/iid #bytes "100afcbbfb8d2577e76a1ef7ad4e6d4f"}
+   {:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1530}],
+    :xt/iid #bytes "10f28cc7f475bf4916c14d5f7febeca3"}]
+  [{:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 653}],
+    :xt/iid #bytes "112a9b116e67af5726ff48f690f682d7"}
+   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1416}],
+    :xt/iid #bytes "11bc05c812843ca0777eae8843ff901c"}
+   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 997}],
+    :xt/iid #bytes "11cae0149d92be685c3188ae6562edca"}
+   {:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 434}],
+    :xt/iid #bytes "11d35b86e570d2697398309175ea7a87"}
+   {:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 568}],
+    :xt/iid #bytes "11ee2d38fcd400f90c695a8aa1b077ce"}]
+  [{:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 259}],
+    :xt/iid #bytes "12041210809829867b98fcd15df56585"}
+   {:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1039}],
+    :xt/iid #bytes "12077e7cfcf2b800cce358376daf0394"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 200}],
+    :xt/iid #bytes "121e7f6730608b06a81418e44afd5ab1"}
+   {:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 443}],
+    :xt/iid #bytes "121f00ced97b4850e336b9b996bdd256"}
+   {:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 671}],
+    :xt/iid #bytes "1227c918eec2c29507e7d27e56ecfd57"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 25}],
+    :xt/iid #bytes "12515b3f6b5257f248295339da43c53a"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 807}],
+    :xt/iid #bytes "1262f1f17552d2f36d85b2e37ab89449"}]
+  [{:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 175}],
+    :xt/iid #bytes "12b4423405608303504234d703a14309"}]
+  [{:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1014}],
+    :xt/iid #bytes "12fb15a07e907db35bd734fe18136eb2"}
+   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1317}],
+    :xt/iid #bytes "12fbd3fdf28895c53cf20864a08a5dfd"}]
+  [{:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1437}],
+    :xt/iid #bytes "1310eed9fceb10824c951ab6dc42749b"}
+   {:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1129}],
+    :xt/iid #bytes "132391045d3701acaf79c9141f743647"}
+   {:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 977}],
+    :xt/iid #bytes "1346f0c6074d20f19ba2e8f0f9c36426"}
+   {:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1450}],
+    :xt/iid #bytes "135b5c34ac1a8129025cbe9942bdcfac"}
+   {:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1293}],
+    :xt/iid #bytes "1363f680c193fa4a2fc1b4dee014f945"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 151}],
+    :xt/iid #bytes "13aec04d511522b53d63ae07bc39c011"}
+   {:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 535}],
+    :xt/iid #bytes "13c73d20616257def8ed6eb8b8e0efa0"}
+   {:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 603}],
+    :xt/iid #bytes "13e4dc20e16aff8e79a9e7048093f298"}]
+  [{:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 75}],
+    :xt/iid #bytes "144e903a76aa339ca510bc1bd4d93618"}
+   {:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1550}],
+    :xt/iid #bytes "145dd636851f47ff75acc6084c32b871"}
+   {:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1227}],
+    :xt/iid #bytes "14dae612d51ae0a31add2f32a9aa1aa5"}]
+  [{:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1359}],
+    :xt/iid #bytes "1503c75578e3f2984cc6e13a199d18a3"}
+   {:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 620}],
+    :xt/iid #bytes "152876b65e2bc7a9193e7423f2353980"}
+   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 267}],
+    :xt/iid #bytes "1531b1ae93bfc79761b0c2b6632be5f0"}
+   {:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 780}],
+    :xt/iid #bytes "156dde03324d48890d06bcdfc78efdba"}
+   {:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 580}],
+    :xt/iid #bytes "159c826485a80ab9462e17cabae64d64"}
+   {:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1196}],
+    :xt/iid #bytes "15dba04e1197d283062356b6f9d9336b"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 59}],
+    :xt/iid #bytes "15dbfa13ae9b4203a520fa0caa33b47b"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 241}],
+    :xt/iid #bytes "15f238624b21033900c5f8897a3ffc8e"}]
+  [{:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 187}],
+    :xt/iid #bytes "162991d14c2b05049e243724aa5d01c6"}
+   {:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 887}],
+    :xt/iid #bytes "163eaae1c97db71f595448c8f04937b9"}]
+  [{:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1214}],
+    :xt/iid #bytes "164d84b7b5463b846c40a5d023708858"}
+   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 667}],
+    :xt/iid #bytes "16613ac6249834e835d0fc7b47901b0a"}
+   {:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1132}],
+    :xt/iid #bytes "16658c680e7054d3c0892f1a3937f691"}
+   {:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 782}],
+    :xt/iid #bytes "166d00587df0063868a1561e04042bb2"}
+   {:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 365}],
+    :xt/iid #bytes "167a8c48ebaa8493033bd6c49987be9a"}
+   {:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 963}],
+    :xt/iid #bytes "167ee8fbd4ed57536ec39c6688a8d42e"}]
+  [{:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1481}],
+    :xt/iid #bytes "16bf8c327c336807364f6935cda0215c"}]
+  [{:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 849}],
+    :xt/iid #bytes "16c230b378daaf49f4bebcefd96fa58d"}
+   {:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 489}],
+    :xt/iid #bytes "16eba33273ccd789e15ec70915ad71d2"}]
+  [{:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 531}],
+    :xt/iid #bytes "170eb32564ddfb824479633e4c7cfa4a"}
+   {:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1104}],
+    :xt/iid #bytes "170f6341a87c1078bbaed715b3f47844"}
+   {:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1551}],
+    :xt/iid #bytes "17235ccf8c2fe868cb2de1f6f7e774b5"}]
+  [{:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 483}],
+    :xt/iid #bytes "1760fc6b2e1d1e02901ca5d9b20f26ce"}
+   {:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1180}],
+    :xt/iid #bytes "17642da9b5c0df7bc6d0ef9619bcede1"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 353}],
+    :xt/iid #bytes "17664b2d63ac35e2c26e7f7762a3bf52"}
+   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1470}],
+    :xt/iid #bytes "17679de93a68d52b72f5ee9b89b01ef1"}]
+  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 931}],
+    :xt/iid #bytes "1796e6a52fced17027f7d414f68d2ba9"}]
+  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1444}],
+    :xt/iid #bytes "17d97e1c69dc7fec1661538b4f5dcfa5"}
+   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 633}],
+    :xt/iid #bytes "17e9eec02d17408d3041bad1f9b7931f"}]
+  [{:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 632}],
+    :xt/iid #bytes "184703b7cbbb32af82dfd53802b74ca8"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 348}],
+    :xt/iid #bytes "186835a76246498a35c0b5dc51f34b14"}
+   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 629}],
+    :xt/iid #bytes "18a06086f14847a334cd65f9a60fa5cf"}
+   {:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 915}],
+    :xt/iid #bytes "18ecb000537797b1daa4f6a10e272f91"}
+   {:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1222}],
+    :xt/iid #bytes "18ff1d1d45c9524d54d7c91336092d6c"}]
+  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1453}],
+    :xt/iid #bytes "1901a671c21de9d97755d423917dbcc6"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1391}],
+    :xt/iid #bytes "192a3a738b82547ad1eaa0f7d9c6151e"}
+   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 950}],
+    :xt/iid #bytes "19e7ac2c692b839a5ad235ac0685749a"}
+   {:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 905}],
+    :xt/iid #bytes "19ed993452ff4f53ec20b5ca0ae3d2db"}]
+  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1275}],
+    :xt/iid #bytes "1a2dcf1a63a9c7c398830656964d73c0"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 64}],
+    :xt/iid #bytes "1a91deb3742283487d66c3b500f6effd"}
+   {:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 424}],
+    :xt/iid #bytes "1a9db013c23698996c24054e4689bd2a"}
+   {:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 886}],
+    :xt/iid #bytes "1abd4d367b7a6ecc058d3e99d8dd68eb"}
+   {:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 957}],
+    :xt/iid #bytes "1ad84b07b398bfec0ab338c5b86f8fff"}]
+  [{:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 400}],
+    :xt/iid #bytes "1b1b79a35aeafbc06592176f573e0042"}
+   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 996}],
+    :xt/iid #bytes "1b3362617d3c9ec7d01c4c7ce710501b"}]
+  [{:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 940}],
+    :xt/iid #bytes "1b6a3c3a3a40c08e378333ec8f222e26"}]
+  [{:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 220}],
+    :xt/iid #bytes "1b880f6f4cdedd6cf9f73029ee7d3f66"}]
+  [{:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 567}],
+    :xt/iid #bytes "1bc22c3a1bac2dc20a49b193be83cdda"}
+   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 357}],
+    :xt/iid #bytes "1bce0514332a7a1a9bec4d79a2786c1f"}
+   {:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 455}],
+    :xt/iid #bytes "1bdd3ca9d412dd197128b6d27dac0a6b"}
+   {:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 481}],
+    :xt/iid #bytes "1be3beb77971f6707dd9954195e3821e"}
+   {:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1198}],
+    :xt/iid #bytes "1bef9c5c29b6ab7742a1d3355f4edae7"}]
+  [{:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 792}],
+    :xt/iid #bytes "1c41e437efd6fa2e26849444df9af15b"}
+   {:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1283}],
+    :xt/iid #bytes "1c62a74ebf86a04fec9f8efa9eb8063f"}
+   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1346}],
+    :xt/iid #bytes "1c764b2a0eed5c3e892177bc82fae24a"}
+   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 456}],
+    :xt/iid #bytes "1c874f41a08af02077529343929f1b78"}
+   {:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 691}],
+    :xt/iid #bytes "1cee94064481db1e5a97ed30c46e5f69"}
+   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1234}],
+    :xt/iid #bytes "1cfcf3ac9623707875f79ce39e0838ec"}]
+  [{:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 837}],
+    :xt/iid #bytes "1d54b18af8342d34b31f3592a417be23"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 153}],
+    :xt/iid #bytes "1d9736d725f5f7f72340540fbf47d995"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 334}],
+    :xt/iid #bytes "1dd81fb449fc93bfe3313f5945bf14d8"}
+   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 430}],
+    :xt/iid #bytes "1dda28be91aa26e1e5e90397516e57ac"}]
+  [{:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 354}],
+    :xt/iid #bytes "1e1b4142f9fe433d893437424841088d"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 83}],
+    :xt/iid #bytes "1e944f8d9bb459f3ffd8eb690d6d762f"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 247}],
+    :xt/iid #bytes "1eafb972eacca6bbdff95c2f3a6b644b"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 706}],
+    :xt/iid #bytes "1edd9445dd34269666a5e76238325894"}]
   [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p02-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p02-b182.arrow.edn
@@ -5,470 +5,490 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
-  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1001}],
-    :xt/iid #bytes "2f21f6830b2ace2ab7e7dbe6f6f5d46b"}
-   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1433}],
-    :xt/iid #bytes "2f98aef582397d47d52a6b4ba824e72e"}
-   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 772}],
-    :xt/iid #bytes "2fc60f109d758e6ccf480198a63a87b6"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 616}],
-    :xt/iid #bytes "2fc85799270eba996d79f179833472d4"}]
+ ([{:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1175}],
+    :xt/iid #bytes "202f9773b628551a922824f2210df5ef"}]
+  [{:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 826}],
+    :xt/iid #bytes "206d831580f8ca6236edc2224696dd8b"}
+   {:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1077}],
+    :xt/iid #bytes "2071d4ab15dbcb6da0ef6426698e57b3"}
+   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 867}],
+    :xt/iid #bytes "20730e47902b11e398d8201d9682802d"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 352}],
+    :xt/iid #bytes "2077439c0f82ecd2ceb7a6c39b768a38"}]
+  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1370}],
+    :xt/iid #bytes "2083f926462b3008bbd2dcbc84a188b2"}
+   {:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1081}],
+    :xt/iid #bytes "20858012cf0e1046887c9fd83130893d"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 95}],
+    :xt/iid #bytes "209404c84136b9b10bfbab855bd67ad6"}
+   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1100}],
+    :xt/iid #bytes "20a748343837165ee3b9e4854b5fba09"}]
+  [{:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 610}],
+    :xt/iid #bytes "20cad4f90b9891e72ef921786f99973c"}
+   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 647}],
+    :xt/iid #bytes "20cadea2bbc68c50f2f5f7895177dd96"}]
+  [{:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1522}],
+    :xt/iid #bytes "212311257d144bab3c4d3487f99cf73d"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 158}],
+    :xt/iid #bytes "213041d1406e2cd4c17da9ff44f4266c"}
+   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 461}],
+    :xt/iid #bytes "21a706fa6186126cf2a6efcc2a65dad2"}]
+  [{:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 465}],
+    :xt/iid #bytes "2229a8ff78688b5d05e15ce9c93932a8"}
+   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1541}],
+    :xt/iid #bytes "223887588f5b339a2880937113eeae4b"}
+   {:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 554}],
+    :xt/iid #bytes "223b4e041cb2687eb4628778cef843fd"}
+   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1462}],
+    :xt/iid #bytes "223bb47418dd4a07d781e2d04bd18686"}]
+  [{:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 989}],
+    :xt/iid #bytes "228783ab2dbdf6ba14b040d556eba4f9"}]
+  [{:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 205}],
+    :xt/iid #bytes "22ccb18777bdfb478ce0ffddee69477d"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 113}],
+    :xt/iid #bytes "22e39313ce5ffdde631491b53c651e95"}
+   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 457}],
+    :xt/iid #bytes "22eb6570812f64897590261a6c14b06d"}
+   {:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1461}],
+    :xt/iid #bytes "22ec0aafd20821acb64d6da177821e56"}]
+  [{:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1192}],
+    :xt/iid #bytes "2306f6280718cfdc8138f2dac142908a"}
+   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 838}],
+    :xt/iid #bytes "23132d20365a6c72390d96705d32e058"}
+   {:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 651}],
+    :xt/iid #bytes "235f86ba0cac692e01652c39ab0c0f40"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 54}],
+    :xt/iid #bytes "2372ee1a61a6a8030cf533e9a01670a3"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 809}],
+    :xt/iid #bytes "2391929a9974a20e7db35edb78ba4cc0"}
+   {:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 932}],
+    :xt/iid #bytes "23976149812481e1948b9ea3f827781a"}]
+  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1271}],
+    :xt/iid #bytes "241991994fc11c54b9ed0dc44d4eb504"}
+   {:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 553}],
+    :xt/iid #bytes "245c61d1fd330b5f3420e30865978277"}
+   {:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 790}],
+    :xt/iid #bytes "2471556afe66422661571f8e1002bf88"}
+   {:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 376}],
+    :xt/iid #bytes "24834573b46c64c14e8e12b64330ba30"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 251}],
+    :xt/iid #bytes "24996cb395e558634605430f6d5d0e53"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1395}],
+    :xt/iid #bytes "24c23da2922bebf255d276cf92e389c7"}
+   {:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 552}],
+    :xt/iid #bytes "24d2cc9db1eacb383cb0a7c95fbb035f"}
+   {:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1043}],
+    :xt/iid #bytes "24f9fa339e4fc797ab4ea43b68b581d9"}]
+  [{:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1514}],
+    :xt/iid #bytes "2535aecc693d7e734298ed0f5224a59f"}
+   {:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 852}],
+    :xt/iid #bytes "2538c26296a6d801b00822a29b1b508f"}
+   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 745}],
+    :xt/iid #bytes "2582202769516f41cc3b826e3dc27a13"}
+   {:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 715}],
+    :xt/iid #bytes "25b9fb266efba9259be4148737665a37"}]
+  [{:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1042}],
+    :xt/iid #bytes "2619264358dd5188adbd47279e13d227"}
+   {:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1183}],
+    :xt/iid #bytes "2629f8cda88b6c68d3c4fbfedfedbefb"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 726}],
+    :xt/iid #bytes "263300987c12d04952035b0ec3a51857"}
+   {:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1507}],
+    :xt/iid #bytes "266b11642e6d84cc6194295c4364c04f"}
+   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 590}],
+    :xt/iid #bytes "268951dcef68d89cfe057860d1932674"}
+   {:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 432}],
+    :xt/iid #bytes "26a40ccf9005c87d3c204bb1324757ed"}
+   {:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 754}],
+    :xt/iid #bytes "26e9b135cf244b0b29a623c652c4ee56"}]
+  [{:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 881}],
+    :xt/iid #bytes "277791652e7692f8cb7ae46a4881688c"}
+   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1512}],
+    :xt/iid #bytes "279f313c2c016483047f1fc0d2684769"}
+   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1067}],
+    :xt/iid #bytes "27c96a98ff6a5b0c1116c88df14f6449"}]
+  [{:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 272}],
+    :xt/iid #bytes "284d4650e9335b60c101d28ac362c7c0"}
+   {:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 737}],
+    :xt/iid #bytes "285382fd7ed9a7f0a1d321fcd7602152"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 133}],
+    :xt/iid #bytes "28c5f03785396f16c83e30f375547173"}
+   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1062}],
+    :xt/iid #bytes "28d54128f01db5e65896ee871231c777"}]
+  [{:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 639}],
+    :xt/iid #bytes "2901270900c7adbd5819726aea931aba"}
+   {:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 853}],
+    :xt/iid #bytes "29339c43e6ed948f99bcbd27bff0c468"}]
+  [{:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1329}],
+    :xt/iid #bytes "294d0aad126eace83f376ad78ff2d106"}
+   {:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1041}],
+    :xt/iid #bytes "29642b6ad6550fd8557470e9dfb03f55"}]
+  [{:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1216}],
+    :xt/iid #bytes "298b03752c7c5eb220d401d829dad210"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 123}],
+    :xt/iid #bytes "29ad5232524010a141649064c04b577b"}
+   {:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 490}],
+    :xt/iid #bytes "29af7bb60feccf5b5095dc5b043d608e"}
+   {:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 440}],
+    :xt/iid #bytes "29b26d263599d9d09708f72720587d5d"}]
+  [{:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 803}],
+    :xt/iid #bytes "29d634a5c2d3c4c0e04bb990945aef6b"}
+   {:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 435}],
+    :xt/iid #bytes "29ded64f8fee1492a466acca72be8615"}]
+  [{:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 242}],
+    :xt/iid #bytes "2a19694c308373113ea6e209baeefaf5"}
+   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1497}],
+    :xt/iid #bytes "2a292e1c0adaba19bb9004b967993d00"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 184}],
+    :xt/iid #bytes "2a4a26457d59d6ac4ef727533b6294cc"}
+   {:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 679}],
+    :xt/iid #bytes "2a8be7e1600c4dc18194ba3f4a842fbf"}
+   {:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 420}],
+    :xt/iid #bytes "2adafd3da744bcf5467845ab755d211f"}
+   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1469}],
+    :xt/iid #bytes "2adde2081ee7ae2c9a0bd0160e98322c"}]
+  [{:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 985}],
+    :xt/iid #bytes "2b0f3153ab6e38b162193e10d6e1f143"}
+   {:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 491}],
+    :xt/iid #bytes "2b12feaa9cd82ed48acba13daea3fc24"}
+   {:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1458}],
+    :xt/iid #bytes "2b4a3f289019b217c0cc7c10e0c33cc7"}
+   {:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 638}],
+    :xt/iid #bytes "2b55a5f925f6ae6f7e9178e40d8700dd"}
+   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1358}],
+    :xt/iid #bytes "2b76bcbfb46424f3d39e5afe1b5b6895"}
+   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1372}],
+    :xt/iid #bytes "2ba5f0746e4faca5366fe8f1c5715eef"}
+   {:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 389}],
+    :xt/iid #bytes "2bad149c85071b2be11a2a67e2af1e58"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 111}],
+    :xt/iid #bytes "2bd41b51f30dabd381a01eed5682f3ee"}]
+  [{:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1305}],
+    :xt/iid #bytes "2c0639c8736f3923a0b009c239fbc41a"}
+   {:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 710}],
+    :xt/iid #bytes "2c16943dec2dcefec30747b83edb34c3"}
+   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 703}],
+    :xt/iid #bytes "2c2e3284d0f481b2c3353d3c172daf8b"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1390}],
+    :xt/iid #bytes "2cba200a36c867b0c649c531e02bec11"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 300}],
+    :xt/iid #bytes "2cc48a05198a7714e01b281084390a2d"}
+   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1417}],
+    :xt/iid #bytes "2cdf00d4573af48c8e2482abc6006b73"}]
+  [{:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1473}],
+    :xt/iid #bytes "2d8e1ce882ddaf3e7ebf7c6e27b79852"}
+   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1352}],
+    :xt/iid #bytes "2dabdec8bd8edb4fefbf63271ab90b8b"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 31}],
+    :xt/iid #bytes "2dca677a31b76bdf622f2ce61e99f2cd"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 96}],
+    :xt/iid #bytes "2ddc6b5533a1a717b2554c5aaa3cc531"}
+   {:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1499}],
+    :xt/iid #bytes "2ddd70bc5cf8f9737f220ab0cdaa3ead"}
+   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1519}],
+    :xt/iid #bytes "2ded5217f5d60c95fa171d67e5d65ed1"}]
+  [{:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 233}],
+    :xt/iid #bytes "2e25cc8beae4edc208499bbb57a0a0ff"}
+   {:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 879}],
+    :xt/iid #bytes "2e7558613707426074d9bf31b043912b"}
+   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 898}],
+    :xt/iid #bytes "2e7cb17d934624cfdc306911ad7faebd"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 892}],
+    :xt/iid #bytes "2ec6991dc91d636765adc26abbe51f73"}
+   {:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 538}],
+    :xt/iid #bytes "2ee574768e4cd290956af6879dd20b2e"}]
   [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p03-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p03-b182.arrow.edn
@@ -5,485 +5,440 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 362}],
+    :xt/iid #bytes "3022d624c0bc8ff8d7da774ccc7b9858"}
+   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1122}],
+    :xt/iid #bytes "3025eecaa85ddfa1a048537c4dfe42ae"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 49}],
+    :xt/iid #bytes "30386ebe265797353770689774b25634"}
+   {:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1250}],
+    :xt/iid #bytes "303d32ade624dec7f099a69a7f295436"}
+   {:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 964}],
+    :xt/iid #bytes "305a1f922923eee8e1c2e2aadf667d8b"}
+   {:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 395}],
+    :xt/iid #bytes "306b41bc873028f8e5b0642580fb4521"}]
+  [{:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1008}],
+    :xt/iid #bytes "31237e0541dd67f058898a49ff8f5304"}
+   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1172}],
+    :xt/iid #bytes "3182c550d4a76c8e6284073d1a7d5ed4"}
+   {:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1200}],
+    :xt/iid #bytes "31aaee1e5d2de111004f327658f7ef56"}
+   {:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 918}],
+    :xt/iid #bytes "31ea51eec93e48c1b666803ccc563cf7"}
+   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 666}],
+    :xt/iid #bytes "31f416a5e09f0c0a82a28f56feefdfba"}]
+  [{:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 129}],
+    :xt/iid #bytes "32034ebe719debc23cec170dc1142a00"}
+   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
-  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1348}],
-    :xt/iid #bytes "3f0e911ea69b94badc72b8c792e958b6"}
-   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 101}],
-    :xt/iid #bytes "3f55a8856f62675df100abe83c001b8e"}
-   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1019}],
-    :xt/iid #bytes "3f5ff5a590ee02f54b178a94779d4594"}
-   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1563}],
-    :xt/iid #bytes "3fabc1487ce905138fa2c6c3cf87c270"}
-   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1099}],
-    :xt/iid #bytes "3fd43267bb19a16957264c2486e6c22f"}]
+    :op #xt/tagged [:put #:xt{:id 1350}],
+    :xt/iid #bytes "321812ae29db928468701955144ab815"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 709}],
+    :xt/iid #bytes "3266bffa236ed5b3c3b3127f5ce8fe84"}
+   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1521}],
+    :xt/iid #bytes "32787e5739d5df518757d8a2d7fc4240"}
+   {:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 398}],
+    :xt/iid #bytes "32981be2d8883ebc7c548aafe6b666f9"}
+   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 798}],
+    :xt/iid #bytes "32cac6e038b3d5e1d2bf46c976969aae"}
+   {:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 504}],
+    :xt/iid #bytes "32e4677e77b59d16234fe7b3a15affd7"}
+   {:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1407}],
+    :xt/iid #bytes "32f45f8fc4c842c1d53d80fe9dc1dc7c"}]
+  [{:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1244}],
+    :xt/iid #bytes "3327472864cf37cae05678b33b3aa89d"}
+   {:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 379}],
+    :xt/iid #bytes "332e02ea44f791f2334e44bf431d6bd4"}
+   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 356}],
+    :xt/iid #bytes "333a3ff42f59cf8a01cfa64dfc838671"}
+   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1338}],
+    :xt/iid #bytes "3350c0f1d1b01d90e3bdd160f1a2530f"}
+   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 969}],
+    :xt/iid #bytes "33610a9a431a6777ba16376c5f6802cc"}
+   {:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 601}],
+    :xt/iid #bytes "336cbb0d875d8fefa872c154853fbf5a"}
+   {:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 862}],
+    :xt/iid #bytes "33a115d85a12ace28c33f42d0ef645c4"}]
+  [{:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 507}],
+    :xt/iid #bytes "34074814979fb71e1b17fbc926451eeb"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 240}],
+    :xt/iid #bytes "3435f6271391eb222b8e0c7662951144"}
+   {:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 917}],
+    :xt/iid #bytes "345de83518023372a89ec95ffb6be404"}
+   {:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1446}],
+    :xt/iid #bytes "34c0c0570b61ab1173374e95ac97f0da"}]
+  [{:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1161}],
+    :xt/iid #bytes "3628b631044bb1fba492995180b75b4d"}
+   {:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 492}],
+    :xt/iid #bytes "366f31cfe0fe34b925deac1cff579e9a"}
+   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1054}],
+    :xt/iid #bytes "36e48849438bce7f2d0246f681729da2"}]
+  [{:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 558}],
+    :xt/iid #bytes "372e0648cddeacc2665a833bd4d12d94"}
+   {:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 933}],
+    :xt/iid #bytes "3737b14b8c0266d05b108af2694a5b9c"}
+   {:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1155}],
+    :xt/iid #bytes "3744cf7899fb29a8ba8f7b076b2f5daf"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 704}],
+    :xt/iid #bytes "379eb9237c7b941dcb08c66a3c73d4e1"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 119}],
+    :xt/iid #bytes "37ad872190ba8744ca6272255b750bdc"}
+   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 824}],
+    :xt/iid #bytes "37b68bfaf71b1ab5090580d0d9d9d66c"}
+   {:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1002}],
+    :xt/iid #bytes "37b957092aba851289334b71abf3e13f"}]
+  [{:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 439}],
+    :xt/iid #bytes "385d8c524478f9ff13ef582b3728ed64"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 201}],
+    :xt/iid #bytes "38b85365d40ef4e3f2af832dc0f6a663"}
+   {:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 689}],
+    :xt/iid #bytes "38c9612f6639c083e244311a3f904625"}]
+  [{:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1171}],
+    :xt/iid #bytes "390ac960a3a1d5451c5443026bc4cc23"}
+   {:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 874}],
+    :xt/iid #bytes "394b7af3d8dfec33c9274f82e16abdc7"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 211}],
+    :xt/iid #bytes "394cbd71dbe4725b3f5ece063089eb1b"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 6}],
+    :xt/iid #bytes "396ee89382efc154e95d7875976cce37"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 102}],
+    :xt/iid #bytes "3984fdccba95acf4bdb471008298fb62"}]
+  [{:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1089}],
+    :xt/iid #bytes "3a5da6ec72365b3e6f6f4dfb7bd1ec6a"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 92}],
+    :xt/iid #bytes "3a7a519c88e96892da480ac4ed1f3a02"}
+   {:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 764}],
+    :xt/iid #bytes "3a7d59619dffad1047bb947c70b2f071"}
+   {:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 847}],
+    :xt/iid #bytes "3aa0dbce506902df984bac4b91bda86f"}
+   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1442}],
+    :xt/iid #bytes "3afd9923868afee2a90ac55a51eee428"}]
+  [{:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 236}],
+    :xt/iid #bytes "3b13a011fb4a72dbebacc8d65310ff05"}
+   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 262}],
+    :xt/iid #bytes "3b2b355dd3ea4da95442e5b0b8ee9721"}]
+  [{:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 339}],
+    :xt/iid #bytes "3b8574e691a90541c7f16605c6ceeae1"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 199}],
+    :xt/iid #bytes "3b87699e1f1e12221b432e9dc17c19fa"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 320}],
+    :xt/iid #bytes "3b8a91a71b4815da789b9f43a47b0da0"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 445}],
+    :xt/iid #bytes "3b9e76139a41541bfbe5a9d78188d6c0"}
+   {:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1110}],
+    :xt/iid #bytes "3ba2bfdc28ffeeb81354288358e49de0"}
+   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 274}],
+    :xt/iid #bytes "3bb262bad78be2bc8d3bf713821c1c47"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 39}],
+    :xt/iid #bytes "3bb36f9329c2d524ea6ef142ea9a939f"}
+   {:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1323}],
+    :xt/iid #bytes "3bbc9d5a707e3a7df5f612967e18a373"}]
+  [{:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 962}],
+    :xt/iid #bytes "3bf595580fef8c685c195fb5c1bfd831"}
+   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 475}],
+    :xt/iid #bytes "3bf899b22275a1dcc109ef7d5facd6b3"}]
+  [{:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1440}],
+    :xt/iid #bytes "3c37f011a9c290e773db7d96c39bfb10"}
+   {:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1048}],
+    :xt/iid #bytes "3c809656dbb37f07590663d3a173dcab"}
+   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1298}],
+    :xt/iid #bytes "3cda655ac8f0c91bfe4fc5cf5fbe2765"}]
+  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 458}],
+    :xt/iid #bytes "3d095902c9ed049160e738d450fcf7d4"}
+   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1280}],
+    :xt/iid #bytes "3d0c5eeb8f18b5b5cb4c7a16a2774ca2"}
+   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 520}],
+    :xt/iid #bytes "3d105c650862a6525d76981f8fb6d4f1"}
+   {:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 907}],
+    :xt/iid #bytes "3d26fa78215f52935861889f579a6c39"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 298}],
+    :xt/iid #bytes "3d33c8839a8252d947e423b9a30f6a42"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 21}],
+    :xt/iid #bytes "3d3d6dea887cefc1e7a2ca3e91f4e9c8"}]
+  [{:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 106}],
+    :xt/iid #bytes "3d64d83184ec106ded63a751ce9aec32"}]
+  [{:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 190}],
+    :xt/iid #bytes "3d9013c8f39e7aa32e7e79b0a0fc1997"}
+   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1261}],
+    :xt/iid #bytes "3d9a7d206d59d1a2a1de2be537422a5e"}
+   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1212}],
+    :xt/iid #bytes "3db4c3c445b1dfb2777c806d2da1ee53"}]
+  [{:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 405}],
+    :xt/iid #bytes "3ddce117a8c205f5fd859a607dcdb05a"}
+   {:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 788}],
+    :xt/iid #bytes "3dfd61638dee7db0dc619b2116f0d4ed"}]
+  [{:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1050}],
+    :xt/iid #bytes "3e0d152db0699204aebf953d45b03dc9"}
+   {:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1131}],
+    :xt/iid #bytes "3e52bea4481f9868fcdccea4927872e6"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 156}],
+    :xt/iid #bytes "3e948e7bcf61bb3623fec86638b9f1fb"}
+   {:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1083}],
+    :xt/iid #bytes "3ec69b854dfa9e9c7df1da1c54c5ca6a"}
+   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 760}],
+    :xt/iid #bytes "3ec9829484223d87b374bc8904e5040c"}
+   {:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 820}],
+    :xt/iid #bytes "3ef97bf1a7bb70c13d254724ce997cf4"}]
   [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p10-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p10-b182.arrow.edn
@@ -5,490 +5,430 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
+    :op #xt/tagged [:put #:xt{:id 648}],
+    :xt/iid #bytes "40222420ca7aa65eb661de755db40239"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 23}],
+    :xt/iid #bytes "403219726e2d258e28b3efd310b19613"}
+   {:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1548}],
+    :xt/iid #bytes "404f0b424afa3b6a0f96530819720a12"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 315}],
+    :xt/iid #bytes "40c649f68755420ec7d3b982fa77131f"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 284}],
+    :xt/iid #bytes "40d8e2558d6aa134d5c236aaae1dae24"}]
+  [{:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 968}],
+    :xt/iid #bytes "41a93fe908b8c939603a084f360b7f77"}
+   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 750}],
+    :xt/iid #bytes "41d13b3b4b49d6be3fc2a7a90e1c6c48"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 2}],
+    :xt/iid #bytes "420fce314175df402adbeae3cfbbb856"}
+   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 698}],
+    :xt/iid #bytes "422da4692ddddd1c613b93ceddf36f0b"}
+   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 925}],
+    :xt/iid #bytes "4261ecf79169314174d0bc40a317b3da"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 40}],
+    :xt/iid #bytes "42695feb6140635f5462836bd2c8f17f"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 185}],
+    :xt/iid #bytes "42bd5212f6e7dd0db68869dfa0034870"}]
+  [{:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 392}],
+    :xt/iid #bytes "4319f3203c52e94f9cd2d55bdc6b1a57"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 90}],
+    :xt/iid #bytes "435c5cfc548fdefea5946d18ffc5f666"}
+   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 799}],
+    :xt/iid #bytes "435e7b740cbffe36e3f8d99b05da26d9"}
+   {:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 436}],
+    :xt/iid #bytes "43caa786a93a2c016c69071b61d77e96"}
+   {:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 605}],
+    :xt/iid #bytes "43ef552746ccb5cc46fc2e1c30618f3e"}]
+  [{:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1225}],
+    :xt/iid #bytes "44192742f402e45e124e968946d7462e"}
+   {:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1546}],
+    :xt/iid #bytes "446c64175a89504ab81797b67345c5f0"}]
+  [{:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 829}],
+    :xt/iid #bytes "455b674698aa9879464a48e05c5eed5d"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 203}],
+    :xt/iid #bytes "45b09127f2425b5ec41915ee6057b859"}]
+  [{:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 329}],
+    :xt/iid #bytes "463324d8c6e8b7957a4d688f589d060a"}
+   {:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1330}],
+    :xt/iid #bytes "46397fcec413188067d703c2795868b1"}
+   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 336}],
+    :xt/iid #bytes "465e616d21e05f4ad00dc6c5f542c414"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 165}],
+    :xt/iid #bytes "4688cfba00431876631eedbcc7469577"}
    {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
+    :op #xt/tagged [:put #:xt{:id 276}],
+    :xt/iid #bytes "46bf53a692426c42ebcd55166bd55589"}]
+  [{:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 944}],
+    :xt/iid #bytes "47030834345fab9e652735ae1eec85b2"}
+   {:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1387}],
+    :xt/iid #bytes "4752e9834f801be1c203fcb09fc18d8f"}
+   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1281}],
+    :xt/iid #bytes "4783468c906dc4cbc5be2dd4d8481812"}
+   {:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1218}],
+    :xt/iid #bytes "4783e948b3eecabd69098da29df1b849"}
+   {:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1160}],
+    :xt/iid #bytes "47901386a46a309e8f7a58d776d5b151"}
+   {:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1351}],
+    :xt/iid #bytes "47b02735926c4c21e5c868afb26f886d"}
+   {:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 678}],
+    :xt/iid #bytes "47f94f49d3b1895a102005c901e365e2"}]
+  [{:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 94}],
+    :xt/iid #bytes "4814d067f3f8a679248078648ef4e41b"}]
+  [{:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1003}],
+    :xt/iid #bytes "484949301a19e8b552618de3ca32b136"}
+   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 825}],
+    :xt/iid #bytes "485a47fb56a2bbc92dc0342f3f7d6aba"}
+   {:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 937}],
+    :xt/iid #bytes "485ed5fd087fe3b3c5ab07e72fdf5a43"}]
+  [{:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 412}],
+    :xt/iid #bytes "4881948f6493423b6f873950d4ab23f1"}
+   {:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1445}],
+    :xt/iid #bytes "4892d76bad36c6f95b3fef8af34503b0"}
+   {:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 597}],
+    :xt/iid #bytes "489340f2d054d212de8a8efa5f965d91"}]
+  [{:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 260}],
+    :xt/iid #bytes "48d5921deeb3d8e69024a2c3ea11f0bd"}
+   {:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1264}],
+    :xt/iid #bytes "48d8e86d202087dd62507a8ad6a861ac"}
+   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 594}],
+    :xt/iid #bytes "48ea67ed89baddf8e9a8a581755f3524"}]
+  [{:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 188}],
+    :xt/iid #bytes "492666daf1bb208aa96f4c9326030fcb"}]
+  [{:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 283}],
+    :xt/iid #bytes "496e01d77d8fafb07fa1fa40ecb57e3b"}]
+  [{:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 955}],
+    :xt/iid #bytes "49853d794df29c0c5cc52159b961bef5"}
+   {:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 557}],
+    :xt/iid #bytes "498c7e58ce641670525e2026d7519c7e"}
+   {:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 688}],
+    :xt/iid #bytes "49950d367a7c1e19a1fd6dafe928d912"}
+   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1556}],
+    :xt/iid #bytes "49967c4f6e8a2b20efb6818c7966c633"}
+   {:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 397}],
+    :xt/iid #bytes "49a612e5c77e92f21a04cd506048d201"}
+   {:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 623}],
+    :xt/iid #bytes "49b2ecc8ba67968d146c891b475089b5"}
+   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 561}],
+    :xt/iid #bytes "49b7378595e981fc54a70545fd2805b1"}]
+  [{:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1515}],
+    :xt/iid #bytes "49dc604a36fb2a324ac4f6457c8e8762"}]
+  [{:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 207}],
+    :xt/iid #bytes "4ae45a44d53d8f7ce92b700d67db2ab7"}]
+  [{:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 770}],
+    :xt/iid #bytes "4b0cd19026208a0f557c1b19677590ad"}
+   {:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 766}],
+    :xt/iid #bytes "4b2cea2a4dc31b0b7bdc0e6d46af524c"}
    {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 297}],
+    :xt/iid #bytes "4b3273a103b59b1fa74064c7341b874a"}
+   {:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1478}],
+    :xt/iid #bytes "4b5e67e4ab46ed426a8f6cede9a65b6a"}
+   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
+    :op #xt/tagged [:put #:xt{:id 1237}],
+    :xt/iid #bytes "4b87344e4d8a50002d1aded05fd398dd"}
    {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
-  [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 631}],
-    :xt/iid #bytes "4f020d2f8b51b0c02559c37738d4b40c"}
-   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 278}],
-    :xt/iid #bytes "4f9bd804ec0ed439b27c73bdae53a690"}
-   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 294}],
-    :xt/iid #bytes "4fbcaf020aecbcadea412e186ee1b486"}
-   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 122}],
-    :xt/iid #bytes "4ff1c8846489147ba13afa2e760ac54f"}]
+    :op #xt/tagged [:put #:xt{:id 279}],
+    :xt/iid #bytes "4bcb1c2cf33853525d97e6a355a03d53"}]
+  [{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 8}],
+    :xt/iid #bytes "4c1dc1f491eb4e4e3e5e34a36df4fd84"}]
+  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1368}],
+    :xt/iid #bytes "4c7014120ed8128361a6b49f1a9330ea"}
+   {:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 380}],
+    :xt/iid #bytes "4c78ac06bb228d9e4844029f45591a11"}]
+  [{:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 331}],
+    :xt/iid #bytes "4c868f1fd3fa6671225e51568bf73be6"}
+   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1236}],
+    :xt/iid #bytes "4c91d1050b783741d17a517f1eb968cf"}
+   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 751}],
+    :xt/iid #bytes "4c98ca651fd1bbb0908c121c0e59a2a1"}
+   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 993}],
+    :xt/iid #bytes "4c9e0f6298977a635f994b4b127eb223"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1}],
+    :xt/iid #bytes "4cd9b7672d7fbee8fb51fb1e049f6903"}
+   {:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 823}],
+    :xt/iid #bytes "4cee63f69325e9636d25cb5a61919ef1"}
+   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1124}],
+    :xt/iid #bytes "4cf8d3329b7ef10b292f13ac2d50c200"}
+   {:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 510}],
+    :xt/iid #bytes "4cff160e64247db2d274db632bc50f9c"}]
+  [{:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 191}],
+    :xt/iid #bytes "4d16fdb13bbc641dfdd6e3274d69daa9"}
+   {:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1026}],
+    :xt/iid #bytes "4d1a64d36ddda1832adec174f982db1e"}
+   {:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 480}],
+    :xt/iid #bytes "4d1d12a5fe76cf17ea918594fa95e4d7"}
+   {:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 930}],
+    :xt/iid #bytes "4d3cecf65b04017e6223ac7d19f55c07"}
+   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1463}],
+    :xt/iid #bytes "4db752c43a3d414741a1f4015fdca465"}
+   {:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 598}],
+    :xt/iid #bytes "4db9a886949a7b18a31c373c9026c113"}]
+  [{:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 525}],
+    :xt/iid #bytes "4e030508df6dc244ee5c0377c0fa9051"}
+   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1559}],
+    :xt/iid #bytes "4e2d04c8e0f5658db48ec229c23cd1c2"}
+   {:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 488}],
+    :xt/iid #bytes "4e7e4056a708f7030d05e2099a263b43"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 322}],
+    :xt/iid #bytes "4e87c935e7c6d2cfc321b9b29ed61f1a"}
+   {:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1109}],
+    :xt/iid #bytes "4ea02f80851aef5b3b89c714bb60790c"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 893}],
+    :xt/iid #bytes "4ea0755c114f61b32ad4e353e73781ad"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1394}],
+    :xt/iid #bytes "4ee616dc7b9c02c9b9874eab7a058f23"}]
   [{:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p11-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p11-b182.arrow.edn
@@ -5,385 +5,420 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 848}],
+    :xt/iid #bytes "501c71a482a4c07e95acc3e35b6b4cf2"}
+   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1277}],
+    :xt/iid #bytes "5030159c89741211d735bd88144053a5"}
+   {:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 394}],
+    :xt/iid #bytes "50526f18ac2803b7328d2d03c1792bdf"}
+   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 910}],
+    :xt/iid #bytes "506172ffd001e98d3adb5d249fc7dd6b"}
+   {:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1230}],
+    :xt/iid #bytes "50b76db07fe75c776046e5cf8c076332"}
+   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1493}],
+    :xt/iid #bytes "50b77d8e66e4222bf40556f635b538cf"}
+   {:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1094}],
+    :xt/iid #bytes "50e1bebf6819b16f0f398727c04df9d9"}
+   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 773}],
+    :xt/iid #bytes "50e8d314a9fd998d8b28c2749f675a1a"}]
+  [{:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 645}],
+    :xt/iid #bytes "5135b5be89800da2b572bee4895f795a"}
+   {:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 532}],
+    :xt/iid #bytes "51598c8dc435ede1ed10284dcbf7eac3"}
+   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1542}],
+    :xt/iid #bytes "51b9c1b2d7e1599384776a490d2785dd"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 228}],
+    :xt/iid #bytes "51d24967a0eee28228e3e3dabb1fed8f"}]
+  [{:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 563}],
+    :xt/iid #bytes "52c5de7d0873a3e2470a9a60c227ef2e"}
+   {:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1159}],
+    :xt/iid #bytes "52dbf9187e17ad10ef6469a395dea1dd"}]
+  [{:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 740}],
+    :xt/iid #bytes "531ac4bb2da2e44fb2eac301b684f196"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 171}],
+    :xt/iid #bytes "537ac777da79e0b495e126d4792b73d7"}
+   {:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 984}],
+    :xt/iid #bytes "537b9add1589d26e7261cb3810d07932"}
+   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 406}],
+    :xt/iid #bytes "537ed1967c0ccdfa9971c7cde00136a1"}
+   {:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1428}],
+    :xt/iid #bytes "53c7bdfbdd16b290cab46968578540b9"}
+   {:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 372}],
+    :xt/iid #bytes "53cc29f9ab57ca2e65dde6503b0abe53"}
+   {:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1133}],
+    :xt/iid #bytes "53e8f35973d42c431998fd3d25eca4b7"}]
+  [{:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 425}],
+    :xt/iid #bytes "5405c8a9dc9ddcebfc1c9fdbf481ab8c"}
+   {:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1532}],
+    :xt/iid #bytes "542d1ccdda7bfece61d22166a02ee820"}
+   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 896}],
+    :xt/iid #bytes "5483a35c0af3da1fe5251ca86ec5875c"}
+   {:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 966}],
+    :xt/iid #bytes "54950626f8ac0dcb805d0d7e6164388a"}
+   {:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1426}],
+    :xt/iid #bytes "54d83964b626ce68856b8a491e04900b"}
+   {:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1128}],
+    :xt/iid #bytes "54ec52da84050c86009c5d2e235db837"}
+   {:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 813}],
+    :xt/iid #bytes "54f5e7c7a71fd4c6f7cc0df3445e41c6"}]
+  [{:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 871}],
+    :xt/iid #bytes "552058523b000209038aa1a935ea0819"}
+   {:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1113}],
+    :xt/iid #bytes "5521120dc91d344bb740fb36ab828560"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 288}],
+    :xt/iid #bytes "552c773456b6d26215274a11c3b8877a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 52}],
+    :xt/iid #bytes "55bfc78e47207dc5125af00a5f52d66c"}]
+  [{:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1402}],
+    :xt/iid #bytes "560eb275e2f5331ea55d712f222dfee4"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 139}],
+    :xt/iid #bytes "56438668c41161b90a2e54d04d7c548a"}
+   {:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 752}],
+    :xt/iid #bytes "565ece949d9a20f529ce87ef63b9b42b"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 121}],
+    :xt/iid #bytes "56631378e6c99834a66b8a87243eb6b6"}
+   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1021}],
+    :xt/iid #bytes "56843e733dbb9615049c7002e9d0683e"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 178}],
+    :xt/iid #bytes "56867341bf1bde4f3979ad563be4b6fc"}
+   {:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 902}],
+    :xt/iid #bytes "56897c443e1685b28ded0c32bf089710"}
+   {:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
-  [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1451}],
-    :xt/iid #bytes "5f018fd6d4b9eb3e5d58b03835bcb321"}
-   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1303}],
-    :xt/iid #bytes "5f1782c93e418e84565cc540d918a8cd"}
-   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 618}],
-    :xt/iid #bytes "5f8bb7150aaee01241078faeb34e4dbf"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 741}],
-    :xt/iid #bytes "5fcadb63c6e215a5c5ce627f5076679b"}
-   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 326}],
-    :xt/iid #bytes "5fd8c70a677654122ec0005ef04cf930"}]
+    :op #xt/tagged [:put #:xt{:id 1454}],
+    :xt/iid #bytes "56a4a3f2b5ecddd3736b12f52ee1ef88"}]
+  [{:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 374}],
+    :xt/iid #bytes "57049942ff3848aaedf2ae7495110726"}
+   {:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 496}],
+    :xt/iid #bytes "571a88ff05f21217ed296e133879fdf7"}
+   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1324}],
+    :xt/iid #bytes "571c9f31cd98e558ce3c381580f96a7d"}
+   {:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 364}],
+    :xt/iid #bytes "5761f0ca45541fcb053f6ea40a51d85a"}
+   {:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1078}],
+    :xt/iid #bytes "577153846210cd622448fa71293f087a"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 32}],
+    :xt/iid #bytes "579a6e6b342a11b9c01fffd40edb24ad"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 313}],
+    :xt/iid #bytes "57a7b3f57475fb1da77d804447beffe6"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 446}],
+    :xt/iid #bytes "57f4b946317bd6164b6f0732fd7f2b62"}]
+  [{:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1460}],
+    :xt/iid #bytes "584d8e5cd114dfbd74d9807a45b71577"}
+   {:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 578}],
+    :xt/iid #bytes "58871807fd4f75c7611879d5870d780c"}
+   {:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 451}],
+    :xt/iid #bytes "5888758023a576352a8ca1b8124e2d3b"}
+   {:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1156}],
+    :xt/iid #bytes "5896a71dcb637196623a318b97abb140"}
+   {:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 452}],
+    :xt/iid #bytes "58b1511372b6f8a114257bb8c3929d68"}]
+  [{:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 621}],
+    :xt/iid #bytes "591e5d19f970ce07767cc273b2fa9834"}
+   {:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 857}],
+    :xt/iid #bytes "59c1df9d2df13f64f51427de8b885fc8"}
+   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1068}],
+    :xt/iid #bytes "59d23a0a1445e26ca1ee1ffcdf877ec2"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 11}],
+    :xt/iid #bytes "59db9aafb533427b96d89789885dea4b"}
+   {:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1153}],
+    :xt/iid #bytes "59f437f9ae4f715c10bf5d833ba09eb8"}]
+  [{:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 382}],
+    :xt/iid #bytes "5a0a91139ab680056b334c3b47d76fc1"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 7}],
+    :xt/iid #bytes "5a39f9a9c7598d32872c704ba30a672f"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1208}],
+    :xt/iid #bytes "5aa450727b7b30f9c5bbcf1ab35def24"}
+   {:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1475}],
+    :xt/iid #bytes "5ae03f076202757aa4ebfd1491c2942a"}]
+  [{:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 363}],
+    :xt/iid #bytes "5bb136cd532ad7fc665afd9122f1dd9c"}
+   {:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 880}],
+    :xt/iid #bytes "5bbb607251a9fab8d9c99bbb6a903c89"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1207}],
+    :xt/iid #bytes "5bc86897b9e4ad8dd855bb3ddb0a25b0"}
+   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1400}],
+    :xt/iid #bytes "5bffb928414c36f1cf3f992cdbb5a910"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 60}],
+    :xt/iid #bytes "5c3d22b88bfd17e8eeb4fe669fbb033b"}
+   {:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 929}],
+    :xt/iid #bytes "5c71467ecdf097c02d04d9c19fe4cb1a"}
+   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 562}],
+    :xt/iid #bytes "5c9c90b87e6212e528322610a4be8d1c"}]
+  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 576}],
+    :xt/iid #bytes "5d3cb1ba7183842a0ad37b855ed26607"}
+   {:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 716}],
+    :xt/iid #bytes "5d68886e0db65c298c6b6b9f8f42d43f"}
+   {:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 846}],
+    :xt/iid #bytes "5d75a8963505f7ae903ca9f6bcb9e90a"}
+   {:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 421}],
+    :xt/iid #bytes "5da82c952ba1706c2df8f7c60f4f9431"}
+   {:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1242}],
+    :xt/iid #bytes "5da9e213a257694f9a0d535071cf1340"}
+   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1516}],
+    :xt/iid #bytes "5db63c7e966d166ca6c4e90fd7aa542e"}]
+  [{:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 385}],
+    :xt/iid #bytes "5e11e8c2103098519bb75c1be90cbb17"}
+   {:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 784}],
+    :xt/iid #bytes "5e4d344ae378a0825e703521271a29c7"}
+   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 992}],
+    :xt/iid #bytes "5e5b37826ef6c76b0de6f31fd9d90a6e"}
+   {:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 655}],
+    :xt/iid #bytes "5e991e0ddad3bcdf65f7b15825dcee5b"}
+   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1309}],
+    :xt/iid #bytes "5ea4e25d868a06d0be450b741f7dcc61"}
+   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1069}],
+    :xt/iid #bytes "5eb022beb9dc3b07d65af680e4e67ebe"}
+   {:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 680}],
+    :xt/iid #bytes "5eca39d5c12aa1aba099b1d5cba1aa8a"}]
   [{:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p12-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p12-b182.arrow.edn
@@ -5,770 +5,495 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
+    :op #xt/tagged [:put #:xt{:id 533}],
+    :xt/iid #bytes "6006439e6a4bc5d90e2f289eccc70d5a"}
+   {:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 453}],
+    :xt/iid #bytes "600f440034c740822a8f1f92043e4512"}
+   {:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 732}],
+    :xt/iid #bytes "6027546bab40cf0a016586a191a5a387"}
+   {:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 642}],
+    :xt/iid #bytes "602d23cfde4e3a8d823a171d3fd2c26c"}
+   {:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1547}],
+    :xt/iid #bytes "608104a935e34630896281cdab273543"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 444}],
+    :xt/iid #bytes "608140d56e0a18407c6dc197418e7545"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 301}],
+    :xt/iid #bytes "60bf8aedc9e0139c0672f14a7e63bba6"}
+   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 835}],
+    :xt/iid #bytes "60f168b716d2538928f9c9940f03c026"}]
+  [{:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 317}],
+    :xt/iid #bytes "6160ed777981a09ef72c4b769da6ca23"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 333}],
+    :xt/iid #bytes "616d1bac5b1f7f434d6c0a2ee5fe3da9"}
+   {:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 693}],
+    :xt/iid #bytes "61bc18ba999048ee76debfd4cae1ea96"}
+   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 830}],
+    :xt/iid #bytes "61c50a422e40aca268fcb5066462bb16"}
+   {:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 935}],
+    :xt/iid #bytes "61f913ffe99961268860c8ab4770b1c3"}]
+  [{:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 986}],
+    :xt/iid #bytes "6236bc6976e6729275ac4f8bd045627a"}
+   {:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1044}],
+    :xt/iid #bytes "6247cba854b1831184fe5f1270e582f5"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 316}],
+    :xt/iid #bytes "628926b0e1d424a4c8c7c8de3390e7a7"}
+   {:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1366}],
+    :xt/iid #bytes "628fa1a141c69ea45f11d56613806015"}
+   {:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 882}],
+    :xt/iid #bytes "62c8ab318c2329509597753815bcdfc1"}
+   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 355}],
+    :xt/iid #bytes "62e736178a161c4ef21d1f6464598dd0"}]
+  [{:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 304}],
+    :xt/iid #bytes "63065ba681a3e5e21b32b06405efbf2b"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 195}],
+    :xt/iid #bytes "631f7ac51f82df51f0d75dd29939850e"}
+   {:xt/system-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 486}],
+    :xt/iid #bytes "636245b9345b35a3a8e83f3101eff063"}
+   {:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 859}],
+    :xt/iid #bytes "6378ac6249e165f5484f7e3d787e774e"}
+   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1337}],
+    :xt/iid #bytes "63c8225ec4c22621d6d03d1967fdcac4"}
+   {:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 903}],
+    :xt/iid #bytes "63d0f36929ec7cb6bc297f5d49777742"}]
+  [{:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 77}],
+    :xt/iid #bytes "64537eb8352ec264b1b29855d5fca2f1"}
+   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 699}],
+    :xt/iid #bytes "645e6862f209e43c17b44fde86887893"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 24}],
+    :xt/iid #bytes "64b0cf833d08d23b08185c18bb7a0ef2"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 168}],
+    :xt/iid #bytes "64c3762140bc7f68a621713980713f86"}
+   {:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1420}],
+    :xt/iid #bytes "64ef0ecc8102fb88a7e2f964bffc87ce"}]
+  [{:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 403}],
+    :xt/iid #bytes "65346aea0c1af23d419e60b7abdf30c6"}
+   {:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 548}],
+    :xt/iid #bytes "657c4d5fd60ecff3e9c227de1a2c5030"}
+   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 664}],
+    :xt/iid #bytes "65d53e3f56b49e0d4a4f3742f3847e90"}]
+  [{:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 408}],
+    :xt/iid #bytes "6601cf81fa0ec225d224620a8038ce2f"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 232}],
+    :xt/iid #bytes "664b74ffc0f8d86e7a96bccb3f8d772a"}
+   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1301}],
+    :xt/iid #bytes "665f5fe38f4605683a469e1c38316b1a"}
+   {:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 730}],
+    :xt/iid #bytes "6675d564c86214cc17c78a57a1113160"}
+   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1121}],
+    :xt/iid #bytes "66a0a7a1a00d7e73ba1785d707c2752e"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 239}],
+    :xt/iid #bytes "66ab375a0c928ef9d38d7c4157746680"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 63}],
+    :xt/iid #bytes "670e0adab66b3c8d8bd8d537191476bc"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 174}],
+    :xt/iid #bytes "671a4e7ac7d9bc8c6cdc8ca5e5ff97ad"}
    {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1013}],
+    :xt/iid #bytes "6732e78eab6c85a717389785c6ae4100"}
+   {:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 524}],
+    :xt/iid #bytes "67349f0bdcbbcd2ee0a2028b1525c41c"}
+   {:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 696}],
+    :xt/iid #bytes "676350721000ba7785d236cf3e5019c8"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 155}],
+    :xt/iid #bytes "67635c6c72af39c3b856a7c8a43cb422"}
+   {:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1527}],
+    :xt/iid #bytes "6775513c964650f08cc7a2b5a6fa774f"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 88}],
+    :xt/iid #bytes "67dab271891b30891ba13f6a6dc89ac7"}]
+  [{:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 934}],
+    :xt/iid #bytes "682be373604e915849b575e75757251c"}
+   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1314}],
+    :xt/iid #bytes "683c195f694ba7aaf7cdbbaf3cf2d4fa"}
+   {:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 423}],
+    :xt/iid #bytes "68432f5d7e1f8a46862f216459b1a55c"}
+   {:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1448}],
+    :xt/iid #bytes "6869a1ecba7fb0007836258025b35480"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 44}],
+    :xt/iid #bytes "686f14ba273969e58b4852ce75c6a473"}
+   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 758}],
+    :xt/iid #bytes "68bc2bfda96723a7218c4dd8cb6a48c3"}
+   {:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 889}],
+    :xt/iid #bytes "68d07050c64afb8fd3dfedd8e4927536"}]
+  [{:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 593}],
+    :xt/iid #bytes "698b78433d7268bd8ab610527e6db722"}
+   {:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
+    :op #xt/tagged [:put #:xt{:id 844}],
+    :xt/iid #bytes "6990b860deec19a9db5b84aac0038512"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 213}],
+    :xt/iid #bytes "69b6db1996f88790dea98c0f26b58ce7"}
+   {:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1248}],
+    :xt/iid #bytes "69b7808e0186b92ba051c1830563a3cb"}]
+  [{:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1509}],
+    :xt/iid #bytes "6a0c8469c402149c478b938004343976"}
+   {:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 108}],
+    :xt/iid #bytes "6a1aa9b3dda959ebdc1c325c1395e9db"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 142}],
+    :xt/iid #bytes "6a3044e68acfd26a3500e54ed89d8d3b"}
+   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1020}],
+    :xt/iid #bytes "6a9a0a38a823eab7770578660e9fdfec"}
+   {:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1528}],
+    :xt/iid #bytes "6aa4d3746ebfdcdc900a4f5e8b52fa35"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1412}],
+    :xt/iid #bytes "6ad7bb85b693dfafe4a746fd0bfa7452"}]
+  [{:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1219}],
+    :xt/iid #bytes "6b222c1a2e26dda9f4cdc217c14ceef9"}
+   {:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 850}],
+    :xt/iid #bytes "6b516724372570f2c5b51164fa4b87ae"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 150}],
+    :xt/iid #bytes "6b5b1c7d42ed17ef00426336041b774e"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 12}],
+    :xt/iid #bytes "6b61d14d319dc99b14d637f659dd15f4"}
+   {:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1150}],
+    :xt/iid #bytes "6bbbc7ece478ee6ce6629713d6f3a788"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 37}],
+    :xt/iid #bytes "6bca30b2206d363296b9d8640e8183ea"}
+   {:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1384}],
+    :xt/iid #bytes "6bd2c7ba960bb8a95182519fd4efd512"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 69}],
+    :xt/iid #bytes "6c01e72f796effaabfe0f9a088eea7cb"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 132}],
+    :xt/iid #bytes "6c11d1d9d6189c77215258e45dfe1e84"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 182}],
+    :xt/iid #bytes "6c1cf16dd9fd2128e49f7b3b5cbd4ca9"}
+   {:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1508}],
+    :xt/iid #bytes "6c213577ae253d011b102e13a3eef934"}]
+  [{:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1149}],
+    :xt/iid #bytes "6c40209843f309f91dad1041f6220cf5"}
+   {:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 669}],
+    :xt/iid #bytes "6c48b78a81245a8f3514287c23a3d26e"}
+   {:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 463}],
+    :xt/iid #bytes "6c4f27d2fda3e6a6eedf9c94c0674ed0"}
+   {:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1254}],
+    :xt/iid #bytes "6c69f1957eeb03a6a461e9d530ec9366"}
+   {:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 756}],
+    :xt/iid #bytes "6c7a0d2696cc305ddc978246c45f1cbd"}]
+  [{:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 384}],
+    :xt/iid #bytes "6ca4e00614e81073425d212ab2f70616"}]
+  [{:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1181}],
+    :xt/iid #bytes "6d17985c8cc1d87df94391c47fe533bf"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 332}],
+    :xt/iid #bytes "6d29fd85e233a04712a34a13a94e7c61"}
+   {:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 864}],
+    :xt/iid #bytes "6d364536fa0e73c59cc806754980f70d"}
+   {:xt/system-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 906}],
+    :xt/iid #bytes "6d3d09c3b2ef19bddde2404db2fbc254"}]
+  [{:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1302}],
+    :xt/iid #bytes "6d51cee5f2bb7c0fb8952148f28128b2"}
    {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
-  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1447}],
-    :xt/iid #bytes "6f01a71d0fa3c0d55b5d2742eb94abc4"}
-   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1016}],
-    :xt/iid #bytes "6f1c3b957386a3314880882014eca673"}
-   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 431}],
-    :xt/iid #bytes "6f2b95357f74a93253049f13c4a3f9e4"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 256}],
-    :xt/iid #bytes "6f419d0997e5718e2027bc637dbafae3"}
-   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 104}],
-    :xt/iid #bytes "6f504fa06f683c66ef115cecb1530643"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 840}],
-    :xt/iid #bytes "6fd6ad9b01d6103d1008372e94e81131"}
-   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 404}],
-    :xt/iid #bytes "6fdb9dcfaef2d10ea97210a5144530ad"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 951}],
-    :xt/iid #bytes "6fefbc1d73bc613b22bbce31d62db461"}]
+    :op #xt/tagged [:put #:xt{:id 402}],
+    :xt/iid #bytes "6d5cde261c8cb3a43ed42f6f73c1e2b8"}
+   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 617}],
+    :xt/iid #bytes "6d6905a25d3408d339eccf394887bfbb"}
+   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 908}],
+    :xt/iid #bytes "6d7e572b44a1f3dcfc8f2370756934d6"}]
+  [{:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1510}],
+    :xt/iid #bytes "6dd6dfd279ac6d1fca07637df1a89477"}
+   {:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 516}],
+    :xt/iid #bytes "6dd940ca157f019abe8d51df7f8aa313"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 189}],
+    :xt/iid #bytes "6dfe4a17ead7eda309a27032c8e4834d"}]
+  [{:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1485}],
+    :xt/iid #bytes "6e3147e5613d9c05218a917aabfab7e0"}
+   {:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 720}],
+    :xt/iid #bytes "6e33e0e8898f27ddf79cec8d9e007219"}
+   {:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1176}],
+    :xt/iid #bytes "6e72faf9a547bc1585571a5fa5b4f9ca"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 4}],
+    :xt/iid #bytes "6ed5045938d710d075142228a0a53aed"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 806}],
+    :xt/iid #bytes "6ee85278fc66b4ba09cb1efb6ecde219"}]
   [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p13-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p13-b182.arrow.edn
@@ -5,490 +5,535 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
+    :op #xt/tagged [:put #:xt{:id 872}],
+    :xt/iid #bytes "70167d050b7b3ff0c1ead1bab1dfd2f2"}
    {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
+    :op #xt/tagged [:put #:xt{:id 1058}],
+    :xt/iid #bytes "703942c87a6bf0869bf2ee23839c06e5"}]
+  [{:xt/system-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1353}],
+    :xt/iid #bytes "70532d5b8b4368296d9802ed933579c2"}
+   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 337}],
+    :xt/iid #bytes "705bc958047bc9336fd80460114c069d"}]
+  [{:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1505}],
+    :xt/iid #bytes "7080da6fceb591e5778afd46974c6c2f"}
+   {:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 676}],
+    :xt/iid #bytes "709d09e8c8c91937bcdf8e16173e8506"}
+   {:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 786}],
+    :xt/iid #bytes "70bea1e1fef46fd418aa799804f603f5"}]
+  [{:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1135}],
+    :xt/iid #bytes "70d50483f8b75c5c2c1831070832322b"}
+   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 415}],
+    :xt/iid #bytes "70dfa5a5ebdad27d07b6592700f1a97f"}]
+  [{:xt/system-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1449}],
+    :xt/iid #bytes "7127e1c9f7f4d2886be4752920ae858b"}
+   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1379}],
+    :xt/iid #bytes "71284f2ced6aa80574d3b1506734b09a"}]
+  [{:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1211}],
+    :xt/iid #bytes "71506750e162831a6c1a3d2b9b85b8a1"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 448}],
+    :xt/iid #bytes "7176d63cfa5755d6a95fca2b08322c05"}]
+  [{:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 619}],
+    :xt/iid #bytes "718f34db3e393e15a7529ba80a1fcf44"}
+   {:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1052}],
+    :xt/iid #bytes "71b3f3727d363d42c8d2de4b3c04e455"}]
+  [{:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 841}],
+    :xt/iid #bytes "71c726f53b6d117a4cf1db5162d2dce4"}
+   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1328}],
+    :xt/iid #bytes "71d93b9ec89788010b613871412eeba3"}
+   {:xt/system-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 967}],
+    :xt/iid #bytes "71db8d6154c6d5e331e0e8a63113239f"}
+   {:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 787}],
+    :xt/iid #bytes "71f44d138b8f5bec2169a6ef6d49d6a5"}]
+  [{:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 818}],
+    :xt/iid #bytes "7221a760ce88a04770f8f6b1d6cf7315"}
+   {:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 464}],
+    :xt/iid #bytes "7244cbb7a275a81641f4db80c949130c"}
+   {:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 652}],
+    :xt/iid #bytes "725e0fbf04e3ff3a3e5e5df61ef93da7"}
+   {:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 719}],
+    :xt/iid #bytes "72867f2fa76d9d4a5ae26e3a71028e2a"}
+   {:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1075}],
+    :xt/iid #bytes "72dd08cda327dff65718579f7eb3a1bf"}
+   {:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1501}],
+    :xt/iid #bytes "72fc514be0a1911f4693da5d40c6d3af"}]
+  [{:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1375}],
+    :xt/iid #bytes "731c9527e5653b31f23ca6b4a3800ed0"}
+   {:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1252}],
+    :xt/iid #bytes "7323389f356960a035ff0a903541cf8d"}
+   {:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 958}],
+    :xt/iid #bytes "7334e0dc07a26bd20ae3888118cd078b"}
+   {:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1080}],
+    :xt/iid #bytes "73364f9bcb4597d9116db92b1b6fcdcf"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 217}],
+    :xt/iid #bytes "733cf7e2dfc2eab15388b92e900eb7d6"}
+   {:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 938}],
+    :xt/iid #bytes "7385526b6e5f7c2d2ae225cfd66e7cd2"}
+   {:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 677}],
+    :xt/iid #bytes "73d5a58a640f071b23da3a8a6177caed"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 10}],
+    :xt/iid #bytes "73f6128db300f3751f2e509545be996d"}]
+  [{:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 105}],
+    :xt/iid #bytes "742c9aaaffbbcf91b2abb64c169a75a2"}
+   {:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1197}],
+    :xt/iid #bytes "7431cea748e438510e89f401d89b2307"}
+   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 519}],
+    :xt/iid #bytes "7449d5ea558f4368f298ed517841751b"}
+   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 264}],
+    :xt/iid #bytes "744cc63ddfb14649c4de3a4856fe084f"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 204}],
+    :xt/iid #bytes "7467fbb0f016b9c9d166b23dc1cebff5"}
+   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1142}],
+    :xt/iid #bytes "74921b661bd59d9b5523323de5760107"}
+   {:xt/system-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 449}],
+    :xt/iid #bytes "74a1da0e0a4e146d10e3e40495030c9a"}
+   {:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 718}],
+    :xt/iid #bytes "74dd37f983138181aff8002651984308"}]
+  [{:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 987}],
+    :xt/iid #bytes "754788184e412b7b44c2bb69ace6e756"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 197}],
+    :xt/iid #bytes "7558ad61d00500504a38cc300abe05ba"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 57}],
+    :xt/iid #bytes "7558b0662ec1340ef98bb0efbe70ec6f"}
+   {:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 845}],
+    :xt/iid #bytes "759d76b66454a93bfd59c8a2dc74b038"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 727}],
+    :xt/iid #bytes "75b4314225afe40d30f63031972be5ad"}
+   {:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 426}],
+    :xt/iid #bytes "75f127af00d99ac26209d0f0747438ff"}]
+  [{:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1177}],
+    :xt/iid #bytes "76682978de217388c80d3dd3b7582a4a"}
+   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 635}],
+    :xt/iid #bytes "7672ffece1d683de1971be1b4b07243e"}
    {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
-  [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1273}],
-    :xt/iid #bytes "7f4aff4b0f0d86abe683f77a34a5e1ce"}
-   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 183}],
-    :xt/iid #bytes "7f5feac1519ae69b30304afdd5c90612"}
-   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1055}],
-    :xt/iid #bytes "7f6a49f3ad12b9e0069d98017c66e63c"}
-   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1187}],
-    :xt/iid #bytes "7f9dae20e39cca2eaecaba4d285b02a6"}]
+    :op #xt/tagged [:put #:xt{:id 1190}],
+    :xt/iid #bytes "769f1c5319142593cb939b6096006f04"}
+   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 948}],
+    :xt/iid #bytes "76c9d6bd57ad6842d84680f1dd8efc80"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 17}],
+    :xt/iid #bytes "76cc8d5592a3146e196656440de9b5ad"}
+   {:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1531}],
+    :xt/iid #bytes "76d46c5bbdc88e80a196e80b6429535a"}
+   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1378}],
+    :xt/iid #bytes "76f2ae325e3ce32a878cf350f0c7d81c"}]
+  [{:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 437}],
+    :xt/iid #bytes "770c0ba1af7a39304cb3dec9f0e43e81"}
+   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 899}],
+    :xt/iid #bytes "771092568a2c83d5ece8daf370d19aa5"}]
+  [{:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 145}],
+    :xt/iid #bytes "777f8343a5f9263eb40a82a151327576"}]
+  [{:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1380}],
+    :xt/iid #bytes "778bac64184cb9aac60abc394330f689"}
+   {:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 277}],
+    :xt/iid #bytes "77a51cbe19fc3568904cfc39937e7982"}
+   {:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1147}],
+    :xt/iid #bytes "77a9ff3eaa93c8ab15f13f894bff486f"}
+   {:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 396}],
+    :xt/iid #bytes "77b2d5e712ea307e65d8bc8c24b84a0c"}]
+  [{:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1045}],
+    :xt/iid #bytes "77d78e79d05c2a1dc4a429a2d7dbedbb"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 249}],
+    :xt/iid #bytes "77f81c1dd9e797d0f07b0737ba531049"}]
+  [{:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 226}],
+    :xt/iid #bytes "780f83f7991e70659a63fbaea3c156a9"}
+   {:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1117}],
+    :xt/iid #bytes "7810a89b072916f708965c84a30eeb93"}
+   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 800}],
+    :xt/iid #bytes "781b665b49f3a5a7fe007c1e07f7cd4a"}
+   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1443}],
+    :xt/iid #bytes "78431d0bdc59c550ea11c1acecca689c"}
+   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 923}],
+    :xt/iid #bytes "784c3d4c0600c84274de7b10b48279b8"}
+   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1495}],
+    :xt/iid #bytes "78c3f403d1fa11bd0911642584bb6812"}
+   {:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1489}],
+    :xt/iid #bytes "78dc07cf9aa90dd9064807f4ae452551"}]
+  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 574}],
+    :xt/iid #bytes "7906b88a9c05d25ff8f531dda905d859"}
+   {:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1506}],
+    :xt/iid #bytes "7917017cd277f7fc99ddf62d53139c50"}
+   {:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1086}],
+    :xt/iid #bytes "79355cae7f0bc4b322e4924fb4203638"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 162}],
+    :xt/iid #bytes "7946c195fde566c2a79b7a2448912920"}
+   {:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1151}],
+    :xt/iid #bytes "79541411763b3bd9fa828743ca76249f"}
+   {:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1247}],
+    :xt/iid #bytes "79db30954d1f466442274ca844358d03"}
+   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1554}],
+    :xt/iid #bytes "79f3bbc3b55f1fb8d1f1be329d04d962"}]
+  [{:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1018}],
+    :xt/iid #bytes "7a22cc2cdc876361b240f36351a74563"}
+   {:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 842}],
+    :xt/iid #bytes "7a345dbc8207c6b7fb8a947c994842ac"}
+   {:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 854}],
+    :xt/iid #bytes "7a3b80490054a07aec644a3eff364727"}
+   {:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 860}],
+    :xt/iid #bytes "7a46c06c9b7d1d0af6e2137a19928176"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1411}],
+    :xt/iid #bytes "7aa97567f72adb20ea6bb229948c0012"}
+   {:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 369}],
+    :xt/iid #bytes "7ace13fc4cf9e6aed523f660be0bc895"}
+   {:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 656}],
+    :xt/iid #bytes "7ae9669166b614c9f2fe07e6b86e5233"}]
+  [{:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1145}],
+    :xt/iid #bytes "7b723565b03839392a7b0a628ba3b380"}
+   {:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 391}],
+    :xt/iid #bytes "7bd1c224fb28704a51e5de0b8e096bc3"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 38}],
+    :xt/iid #bytes "7bda31aaf7d09a81ae2c7548e2ab415b"}
+   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1060}],
+    :xt/iid #bytes "7be33a2d000df27c8c36b8f7bac75a11"}
+   {:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 974}],
+    :xt/iid #bytes "7bf1400f5eba818d77b6edc53f58e117"}
+   {:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1178}],
+    :xt/iid #bytes "7bf156d209401a30cddff1daaa5336d2"}
+   {:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 878}],
+    :xt/iid #bytes "7bf9f983104792130db82b4ef9b323fc"}]
+  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 924}],
+    :xt/iid #bytes "7c0c0f44335fb7477058ebf76910c339"}
+   {:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1486}],
+    :xt/iid #bytes "7c39556cd9a7d1a379c9b0bb6f92b333"}
+   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1518}],
+    :xt/iid #bytes "7cc0ea28b02b256be4099fca078768d5"}]
+  [{:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1017}],
+    :xt/iid #bytes "7d2c22a43687997fb9681ea711ff3fb5"}
+   {:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 973}],
+    :xt/iid #bytes "7d84ee28f3672b52fdb6da526fc6d451"}
+   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1467}],
+    :xt/iid #bytes "7da984bc3b461d77a8b0e10957f7a3c4"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 16}],
+    :xt/iid #bytes "7daa2b32ed44f20a09e879c26e1e4985"}
+   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1342}],
+    :xt/iid #bytes "7db7c4d18ae2ff98d18c8425328b3173"}
+   {:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 468}],
+    :xt/iid #bytes "7dd5f52aa21653940a076e6aa0320be7"}
+   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 414}],
+    :xt/iid #bytes "7dfeb11b35b179970aad43bbd9b328dc"}]
+  [{:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1141}],
+    :xt/iid #bytes "7e1b16264a073158abe14e0845f2dad7"}
+   {:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 295}],
+    :xt/iid #bytes "7ecf4eb8dc61da84af44e967db717fdb"}
+   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1325}],
+    :xt/iid #bytes "7edd0ba7960642d918751942bb814e60"}
+   {:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1543}],
+    :xt/iid #bytes "7ee774b87a1fb4e36a39b21177b396c0"}]
   [{:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p20-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p20-b182.arrow.edn
@@ -5,850 +5,465 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 325}],
+    :xt/iid #bytes "800a29ad887af0f35e3e5633c6806484"}
+   {:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1425}],
+    :xt/iid #bytes "803d5ef35af86e88da18b1c209529551"}
+   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1561}],
+    :xt/iid #bytes "804be72cdb0aaba25c940a39d0bc1619"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 53}],
+    :xt/iid #bytes "804cc105695138a4694e8c04082026ba"}
+   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1167}],
+    :xt/iid #bytes "8097924dbed9c6ab777bc557f485a848"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 43}],
+    :xt/iid #bytes "80ab568943b1ebb988b70a6096cf261a"}
+   {:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
+    :op #xt/tagged [:put #:xt{:id 381}],
+    :xt/iid #bytes "80d23f470a73bf8ccd8cd2d9dcad9e19"}]
+  [{:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 668}],
+    :xt/iid #bytes "812110c9464108bcfb7b7cfbf44d5dec"}
+   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 560}],
+    :xt/iid #bytes "814cd3099783496b39947082ba91d871"}
+   {:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 731}],
+    :xt/iid #bytes "8172156d63912a21b61d76d0b720108b"}]
+  [{:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 441}],
+    :xt/iid #bytes "8229455080f46f622ae870194790fedc"}
+   {:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1403}],
+    :xt/iid #bytes "829cafb726cfe02f002c3d6d4862f055"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 287}],
+    :xt/iid #bytes "82c5cb4b05baf4efd1c403a1cd9d22c4"}]
+  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 311}],
+    :xt/iid #bytes "830b83c7a399b7850da90a39c2d4053c"}
+   {:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1228}],
+    :xt/iid #bytes "831c1e2e269ad99806755021e6481506"}]
+  [{:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 290}],
+    :xt/iid #bytes "8363d0d3d43cf2981e7b731dca4d66fb"}
+   {:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 235}],
+    :xt/iid #bytes "8367fa42508c88bdc3877351c936b567"}]
+  [{:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 221}],
+    :xt/iid #bytes "83866dcd3a70a05808796e799661c779"}
+   {:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 975}],
+    :xt/iid #bytes "8391f1364411ce50c88bf09acbc9ffc4"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 167}],
+    :xt/iid #bytes "8398334cacd2d9f1710f2b99b65218be"}
+   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1012}],
+    :xt/iid #bytes "83af55ac0937f0df532b84ec755127fd"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 126}],
+    :xt/iid #bytes "83af9257bdf5c6cfc569da5be7e4b734"}
+   {:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1427}],
+    :xt/iid #bytes "83ba6e28bd53f694494586037d1b8319"}]
+  [{:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1199}],
+    :xt/iid #bytes "83df44e10c3d6c48addf6342c6557a7c"}]
+  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1191}],
+    :xt/iid #bytes "8449e4dc7cc8cb9cd08b32dd0c1fbe6e"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 114}],
+    :xt/iid #bytes "84522f4d4e183ac2828b82bd696e9265"}
+   {:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 536}],
+    :xt/iid #bytes "845efee28fccb97892245c962e9397cb"}
+   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1066}],
+    :xt/iid #bytes "849e58da16f338b0312f5353742c6bb4"}
+   {:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1524}],
+    :xt/iid #bytes "84af0f04aa93e32c0e38ed69eab08a63"}
+   {:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1202}],
+    :xt/iid #bytes "84b0feb45d99a8e9a561d688e96fad1c"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 198}],
+    :xt/iid #bytes "84f4f1a388eec75229cdf8ac8b51c3d7"}]
   [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 695}],
+    :xt/iid #bytes "853e3a1432eab73720812e9a90eaeb8a"}
+   {:xt/system-from #xt/zdt "2020-03-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 498}],
+    :xt/iid #bytes "8588e7f07d4a51d09a48a96a24ef8b1c"}
+   {:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
+    :op #xt/tagged [:put #:xt{:id 588}],
+    :xt/iid #bytes "859697b8124006a66c0d06f454682b65"}
    {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 836}],
+    :xt/iid #bytes "85a1b7efb4f3ea4de0596a5b05fbda3d"}
+   {:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1184}],
+    :xt/iid #bytes "85cc79daf0ad1fbfc580b94559385cd3"}
+   {:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 916}],
+    :xt/iid #bytes "85d7f7dd8adec1bebe1529da05e170a0"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 230}],
+    :xt/iid #bytes "85ec98e63faed30758221e8141c0d759"}
+   {:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 988}],
+    :xt/iid #bytes "85ed7490e69db3886e661881e7ef4ddf"}]
+  [{:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1162}],
+    :xt/iid #bytes "865043e140e2dbf99ba31f433a5e2862"}
+   {:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1221}],
+    :xt/iid #bytes "866d567522a0eb819870e2d1560c8cc4"}
+   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 763}],
+    :xt/iid #bytes "867d7e01f596f559e2056f5005b9e019"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 41}],
+    :xt/iid #bytes "86892071bcc8b4406f09ae8947c74a56"}
+   {:xt/system-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 407}],
+    :xt/iid #bytes "86c532555d67c47fd793ecd666951da1"}
+   {:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 681}],
+    :xt/iid #bytes "86d488b421d359acf11b6d781e574855"}]
+  [{:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 650}],
+    :xt/iid #bytes "872e3048ec41f00ccd640862913c76f5"}
+   {:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 602}],
+    :xt/iid #bytes "87731d88f7bf55a3d7ef21b9af67a02f"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 85}],
+    :xt/iid #bytes "877946904fe9387e22e244c8bb4d82ef"}
+   {:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 469}],
+    :xt/iid #bytes "8796f072cb4553a575599bfef8a3cd7e"}
+   {:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 735}],
+    :xt/iid #bytes "87e432805966670029302623c03a9b7b"}]
+  [{:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 900}],
+    :xt/iid #bytes "8809e3d5c2098edee4fb55b6129afed0"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 224}],
+    :xt/iid #bytes "885af4669ce5530d25df24f75cd047f6"}
+   {:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1090}],
+    :xt/iid #bytes "88699338f6a7fcc8d9121bf9fe75676c"}
+   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 897}],
+    :xt/iid #bytes "8873db68f6cb9d981308c251308b0a9d"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 157}],
+    :xt/iid #bytes "88ae227fc15633b8677b223e6ffec1ef"}
+   {:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1220}],
+    :xt/iid #bytes "88f43d7982fa56956893cfb0b826b9da"}
+   {:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1005}],
+    :xt/iid #bytes "88f79e8dc4fdb2245f63ea63741dcda7"}]
+  [{:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1107}],
+    :xt/iid #bytes "89aa429eb9e1080036ff17298f7bdb86"}
+   {:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 815}],
+    :xt/iid #bytes "89cf5f0ed6b92e06868a9832a09498c1"}]
+  [{:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 238}],
+    :xt/iid #bytes "8ad61a12edc3cd20bf45a476c786fb11"}
+   {:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1106}],
+    :xt/iid #bytes "8ae085bb506d3c42d9117bdc4be7d544"}
+   {:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 600}],
+    :xt/iid #bytes "8aed1ff18761fa231265d7d643987ee9"}
+   {:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 438}],
+    :xt/iid #bytes "8af0bea47e728fb36c815efab63e2d07"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 169}],
+    :xt/iid #bytes "8af2999e4c4cd0ab116832091f382fec"}]
+  [{:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1558}],
+    :xt/iid #bytes "8b2683498fd3b9eadf5e6ae141944818"}]
+  [{:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 692}],
-    :xt/iid #bytes "8f24cd3c5939f254076c253a5a27033c"}
-   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 477}],
-    :xt/iid #bytes "8f307a477f8346af405114441f9577ab"}
-   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 257}],
-    :xt/iid #bytes "8f37b88a663b808ef2333bdf2436b81c"}
-   {:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 459}],
-    :xt/iid #bytes "8f4d8283710d746fcabb90166826a738"}
-   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1064}],
-    :xt/iid #bytes "8f6b9e2c0063576577efbfede3fbc8d2"}
-   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 952}],
-    :xt/iid #bytes "8fc4eadfca2e1270f86b121c56519377"}
-   {:xt/system-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-20T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 839}],
-    :xt/iid #bytes "8fe57fc6ce7ad1908ee945fc6cc2efed"}]
+    :op #xt/tagged [:put #:xt{:id 476}],
+    :xt/iid #bytes "8b475299fd2b2dfb8c9d74b1bd222445"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 894}],
+    :xt/iid #bytes "8b4a50c84d1bc3c5fe2890ecc5fe4905"}
+   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1377}],
+    :xt/iid #bytes "8b578746f4acd153a275c1908a0118ff"}
+   {:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1282}],
+    :xt/iid #bytes "8b59667c8e47e9e6cd1f5a41ec03f003"}
+   {:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1318}],
+    :xt/iid #bytes "8b5f8000ababa1e8a2ebe62fb7eb68c1"}]
+  [{:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 759}],
+    :xt/iid #bytes "8bbbc2676e071bf75ad8a57cc7090a10"}]
+  [{:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1253}],
+    :xt/iid #bytes "8bc7acbfee30d3c95cd80a0b73f78a2f"}
+   {:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1233}],
+    :xt/iid #bytes "8be62e4f4d6938ad7b37e44f1f8cac73"}
+   {:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1423}],
+    :xt/iid #bytes "8bf2748ed899e8616a582dc075499313"}]
+  [{:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1295}],
+    :xt/iid #bytes "8c0a92f8c0e1918106288c9c781bbffc"}
+   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1464}],
+    :xt/iid #bytes "8ca9a7e3f489ba4a842aa432873d3c7f"}]
+  [{:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1310}],
+    :xt/iid #bytes "8d1c7148c5358f46f35ac16662e86b42"}]
+  [{:xt/system-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1154}],
+    :xt/iid #bytes "8d47eda297542c6133576857180a3a1d"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 97}],
+    :xt/iid #bytes "8d4bda2aa4cf8296739a3956ce45133b"}
+   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1434}],
+    :xt/iid #bytes "8d5d28f682ec5511910d0cb09dc28a7d"}
+   {:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1116}],
+    :xt/iid #bytes "8d7d119fd4ef9ffc1389fbb14f3352eb"}]
+  [{:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1074}],
+    :xt/iid #bytes "8d971334a5a4a8a4008d970401ab2991"}
+   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1396}],
+    :xt/iid #bytes "8d9aa9f717acb521ab1874174d33dcdc"}
+   {:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1102}],
+    :xt/iid #bytes "8db6927d8f5d121f458e8df534d49277"}
+   {:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1256}],
+    :xt/iid #bytes "8dbb60f3c077742724a74f53c5e3c194"}]
+  [{:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1049}],
+    :xt/iid #bytes "8dc5cd4709e7f77a474dbb78c5ff24cf"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 79}],
+    :xt/iid #bytes "8dd55d760ea46ce16aeab2723874dece"}]
+  [{:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 110}],
+    :xt/iid #bytes "8e13b292504ef3283f9ae7dcb423d751"}
+   {:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1266}],
+    :xt/iid #bytes "8e23fe4c260d46131c7a27d9fd5dcad8"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 134}],
+    :xt/iid #bytes "8e24182ef5d10a199df39946b2525597"}
+   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1123}],
+    :xt/iid #bytes "8efbeec0877c4c0711fd1b6923df9483"}]
   [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p21-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p21-b182.arrow.edn
@@ -5,220 +5,525 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 625}],
+    :xt/iid #bytes "901e247776559db1b38351cc48860fc4"}
+   {:xt/system-from #xt/zdt "2020-09-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1562}],
+    :xt/iid #bytes "9034d544cd133cbad4b705fbd51acc36"}]
+  [{:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 976}],
+    :xt/iid #bytes "905c7673a182ee3d6740e44b3ef571eb"}
+   {:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 78}],
+    :xt/iid #bytes "9067f5b998a440876cb13881025e605b"}
+   {:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 980}],
+    :xt/iid #bytes "906982e7d636ec7c737283fbb6865d97"}]
+  [{:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 587}],
+    :xt/iid #bytes "90aacb8f0d764fcd865cdff9e73da150"}]
+  [{:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 572}],
+    :xt/iid #bytes "90c33ddbb688e6b69da5eeb37f6f3887"}
+   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1297}],
+    :xt/iid #bytes "90c841d17bc0f165e1112cfc02a8fd40"}
+   {:xt/system-from #xt/zdt "2020-01-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 137}],
+    :xt/iid #bytes "90c9a4ae9dc74c6b11257b3a1ae1b440"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 344}],
+    :xt/iid #bytes "90cb420d6f3244b22f3f5c9b7fa77af1"}
+   {:xt/system-from #xt/zdt "2020-06-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 936}],
+    :xt/iid #bytes "90f24db1418596ea161dc19c4df4f242"}]
+  [{:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 265}],
+    :xt/iid #bytes "912258de80c24497ed89b1fd886f6c8d"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 118}],
+    :xt/iid #bytes "915113c4275987ec9668610783758a0d"}
+   {:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1226}],
+    :xt/iid #bytes "9171dca7b4c819b8238de7bb1d696f39"}
+   {:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 462}],
+    :xt/iid #bytes "918b6293b2fa3a37dcedfe5b3cf09d22"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 124}],
+    :xt/iid #bytes "91a6929e58fd2e866b09892981c062cd"}]
+  [{:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1027}],
+    :xt/iid #bytes "921b55d7817cab792eb544973228be79"}
+   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 258}],
+    :xt/iid #bytes "924760091604846850b078b7f32d81d1"}
+   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1315}],
+    :xt/iid #bytes "925dc36023b77749391da9e1cfb79258"}
+   {:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1073}],
+    :xt/iid #bytes "925fb64e4b029ad4c1814f6b76127e06"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 70}],
+    :xt/iid #bytes "92bdf28dd517ce00aa3481ccf179f787"}
+   {:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 152}],
+    :xt/iid #bytes "92fdbe74fb7517c030fc3827f77b06e1"}]
+  [{:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1238}],
+    :xt/iid #bytes "9302a13b6d63f90478d19c15ddc6f0cf"}
+   {:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 484}],
+    :xt/iid #bytes "932be9a97cb8519ff7b25c5a94936422"}
+   {:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 586}],
+    :xt/iid #bytes "9351edcc68355aeb4cc2273e2b6b1082"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 34}],
+    :xt/iid #bytes "936475308fb0784a6a8f8aec1b819ef5"}
+   {:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 884}],
+    :xt/iid #bytes "9369c3f17ebeafa51ce76a51b21e6a8b"}
+   {:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 537}],
+    :xt/iid #bytes "93ab625c85e0117d96e747e7b6cb4831"}
+   {:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1249}],
+    :xt/iid #bytes "93c3a33bf86bc5dcb897fc40a6b76f09"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 218}],
+    :xt/iid #bytes "93e0c386af56717c4a5c4179bad812ce"}]
+  [{:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1119}],
+    :xt/iid #bytes "9422235d9b3190242cec27fabd4615f0"}
+   {:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 493}],
+    :xt/iid #bytes "9450520be6cd51269c58157b1f7a2192"}
+   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1517}],
+    :xt/iid #bytes "946ba2b54766aebb512c08f8dbc4690e"}
+   {:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 542}],
+    :xt/iid #bytes "94885b1c940412d07072686b9285edaa"}
+   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1138}],
+    :xt/iid #bytes "9497a282e4e76b377193060769e6cc8e"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 254}],
+    :xt/iid #bytes "94f7fdd99238fc3782f4a739fa4d33f0"}]
+  [{:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1321}],
+    :xt/iid #bytes "950155f2f433cd6a5d2c328b9266fc93"}
+   {:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 612}],
+    :xt/iid #bytes "952b30206f4fa5333a076308fd3e152e"}
+   {:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1076}],
+    :xt/iid #bytes "953579fa3bba372705569728cd26d60d"}
+   {:xt/system-from #xt/zdt "2020-05-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-27T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
-  [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 883}],
+    :xt/iid #bytes "9589c1fa91ca9624a1ce583e01652db0"}
+   {:xt/system-from #xt/zdt "2020-02-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 697}],
-    :xt/iid #bytes "9f190998428209b3dada81fdd01f7285"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 314}],
+    :xt/iid #bytes "9596858c57e0b8d8616e1d1d220c1e96"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 870}],
-    :xt/iid #bytes "9f3a4e49e57ea3bcc1b5c380242803ca"}]
+    :op #xt/tagged [:put #:xt{:id 307}],
+    :xt/iid #bytes "95e393708259538f4aec0ee9c87bec3d"}]
+  [{:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1193}],
+    :xt/iid #bytes "960be47f606ed8f11bf83750f7f83af4"}
+   {:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 622}],
+    :xt/iid #bytes "960d8176f47eb03fc88a7187fcbde9c0"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 98}],
+    :xt/iid #bytes "962e5cf22c85ffad72a6cf254b2e43fc"}]
+  [{:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1057}],
+    :xt/iid #bytes "964d2fdf433479a5e9b24b9dc560c887"}
+   {:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 613}],
+    :xt/iid #bytes "96640026a4426b3f31c8faac3c691752"}
+   {:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 275}],
+    :xt/iid #bytes "9671d7e86139b807fa027d423de676d4"}
+   {:xt/system-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 624}],
+    :xt/iid #bytes "9674a02fa7f10d465b044f0dd97c61d5"}]
+  [{:xt/system-from #xt/zdt "2020-06-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 998}],
+    :xt/iid #bytes "96810d92662e4cc1adcffbe3e795c96b"}
+   {:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1333}],
+    :xt/iid #bytes "968326f8f611b63ec00402757154defb"}
+   {:xt/system-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 202}],
+    :xt/iid #bytes "9699131767e76d78bcf41a819dcbcaf9"}
+   {:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1079}],
+    :xt/iid #bytes "96a2e5d03bee885f71bc083c882a417a"}]
+  [{:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 393}],
+    :xt/iid #bytes "96d10f2161cfbd2b058021591719b1b3"}
+   {:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1289}],
+    :xt/iid #bytes "96e1124565e24634e6d47e2370e5a520"}]
+  [{:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 833}],
+    :xt/iid #bytes "971d7cd3d9dd8f45f73df9143b934ed0"}
+   {:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1267}],
+    :xt/iid #bytes "972219268ca754a96d1bcb3f82ecb3ac"}
+   {:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 682}],
+    :xt/iid #bytes "973092d67c53d14147eafcd0453bd267"}
+   {:xt/system-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 762}],
+    :xt/iid #bytes "9787299149959b12161d7d9ba0d9a02b"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 808}],
+    :xt/iid #bytes "979ae284e76765bfbfea6dd27efdac92"}
+   {:xt/system-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 422}],
+    :xt/iid #bytes "97af2f69b47d2dc2d3fbcd3cf72d8b05"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1209}],
+    :xt/iid #bytes "97ba6aa99a5fa12fef38fbb43c0a88d5"}
+   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 774}],
+    :xt/iid #bytes "97bd539874c066712d617431ff1253c2"}]
+  [{:xt/system-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1545}],
+    :xt/iid #bytes "98197ef6c8633881f1f941f3034ff81a"}
+   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 994}],
+    :xt/iid #bytes "982cdd931b5e3ebe4f9b0226b47b0bc0"}
+   {:xt/system-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 107}],
+    :xt/iid #bytes "985e418869572f5ce4f637235b6b0337"}
+   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1336}],
+    :xt/iid #bytes "988baa53f1c4fb44f4dbcdef0b9f04d5"}
+   {:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 528}],
+    :xt/iid #bytes "98b52ad453a3f2ac9e1acd8b5486b9e9"}
+   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 912}],
+    :xt/iid #bytes "98e48acb280ba6fad4a468559dafdb7d"}
+   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 665}],
+    :xt/iid #bytes "98f181aea5d380d2fd6790a11f93ff92"}]
+  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 928}],
+    :xt/iid #bytes "990f1e2b92e826476a3ce5a2a0257537"}
+   {:xt/system-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1549}],
+    :xt/iid #bytes "994490cc9c4b0a6e4d39122c60a5bdc1"}
+   {:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 401}],
+    :xt/iid #bytes "994d44aa22e97b07c7ce68afe33aee17"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 166}],
+    :xt/iid #bytes "9960924a9d56a89513754721cf61fe7f"}
+   {:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 714}],
+    :xt/iid #bytes "9976acb756194856dab9216db9e47721"}
+   {:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1040}],
+    :xt/iid #bytes "99965102b7acaf7b4e2db1e84c8180cd"}
+   {:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 450}],
+    :xt/iid #bytes "99e7235f9fb06410499cb78f8f954615"}]
+  [{:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 503}],
+    :xt/iid #bytes "9a1aa7f4dad145e60b52fbf855711a27"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 125}],
+    :xt/iid #bytes "9a377ce780d8b60af7b81a17a7bd11ea"}
+   {:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 3}],
+    :xt/iid #bytes "9a83c6cb1126d93de4a30715b28f1f4b"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1393}],
+    :xt/iid #bytes "9aadcf0279ec8ac533fb47844b645c2a"}
+   {:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 208}],
+    :xt/iid #bytes "9aba48a24ee4a53f3650adc255a75f06"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 342}],
+    :xt/iid #bytes "9ae03d90a477a3619cb9a9227a899c05"}]
+  [{:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 502}],
+    :xt/iid #bytes "9b423ae665568d2b726a858007f0f5f4"}
+   {:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 375}],
+    :xt/iid #bytes "9b9230d99360484e11804744fc3cd833"}
+   {:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1285}],
+    :xt/iid #bytes "9b99767817ca6e9f0c0ea9aaf3ce9f4b"}
+   {:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1291}],
+    :xt/iid #bytes "9bab2fd02d33b725ca76f94b09ae313f"}]
+  [{:xt/system-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 460}],
+    :xt/iid #bytes "9c1d01c3a71b8f26af17f69bf86ba351"}
+   {:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 571}],
+    :xt/iid #bytes "9c35d52ace5ea45a12645ceefec31e0d"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 73}],
+    :xt/iid #bytes "9c3fc047d8c4b96ee089439f5cb3130e"}
+   {:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 181}],
+    :xt/iid #bytes "9ccf4bfd5b62038f8f8bb39dcb6e6674"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 285}],
+    :xt/iid #bytes "9cd84006fa93af519dd957a2257ebc8a"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 128}],
+    :xt/iid #bytes "9cf5d67d71c2b3ec1c50ccdc4b5ead7e"}]
+  [{:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 637}],
+    :xt/iid #bytes "9d4a3753d474612e60e9f23913043423"}
+   {:xt/system-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 378}],
+    :xt/iid #bytes "9d8582da7355a018dedeff22a1941300"}
+   {:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 702}],
+    :xt/iid #bytes "9d929ac7af446ac507a856f666de807f"}]
+  [{:xt/system-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 209}],
+    :xt/iid #bytes "9e073579d00b40a59651e9f931c4735b"}
+   {:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 757}],
+    :xt/iid #bytes "9e553c6a8843de3ca2f9946a020e616d"}
+   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1164}],
+    :xt/iid #bytes "9e83ee3b1f8efeee0f40fbe0bb83d31b"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 291}],
+    :xt/iid #bytes "9eac1fbc4b5d453942a38df7a82127e5"}
+   {:xt/system-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 36}],
+    :xt/iid #bytes "9eb020a42fdb35a1ad33cdd263ebe72e"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 159}],
+    :xt/iid #bytes "9ee66bc6ae0f94512a67c902945a544f"}
+   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1382}],
+    :xt/iid #bytes "9eff0b9a11a86dce9332134040e8fb68"}]
   [{:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p22-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p22-b182.arrow.edn
@@ -5,570 +5,470 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 717}],
+    :xt/iid #bytes "a08727ac2600c3724a65ad28ad52f23e"}
+   {:xt/system-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 690}],
+    :xt/iid #bytes "a0cb0db3cc32b86b6038766acca3c98b"}
+   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1213}],
+    :xt/iid #bytes "a0cbdf08ebb9aa43a0718f75d1411d91"}]
+  [{:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 753}],
+    :xt/iid #bytes "a13a58e67b7036bc9c5d201415c29d7d"}
+   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1263}],
+    :xt/iid #bytes "a15dfb8158c69e546dca959b32782c2e"}
+   {:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 530}],
+    :xt/iid #bytes "a17ff30a055461636f40721156dad785"}]
+  [{:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 387}],
+    :xt/iid #bytes "a215a70114030c1c2b1bea5237cca6bb"}
+   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1306}],
+    :xt/iid #bytes "a217340d8ddfe62424267cf5d11e9506"}]
+  [{:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1385}],
+    :xt/iid #bytes "a24661d1d967c6a1552db79bc6b443ad"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 350}],
+    :xt/iid #bytes "a24e14008c41eafa1b9d86ddfe18eb12"}
+   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1398}],
+    :xt/iid #bytes "a24ef88a59074bc9cf22654c346164c3"}
+   {:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 819}],
+    :xt/iid #bytes "a2785b2867c2b7782692b5e321b89bcd"}]
+  [{:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 513}],
+    :xt/iid #bytes "a2e4093fcd6665b64733dd626f9a16b8"}
+   {:xt/system-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 261}],
+    :xt/iid #bytes "a2eccba01e87c2d3993514279c3af28c"}
+   {:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1286}],
+    :xt/iid #bytes "a2f4ec56efb3a814cb9d88c912f28170"}]
+  [{:xt/system-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 234}],
+    :xt/iid #bytes "a32f317d64f7617fb43c01f72d7db735"}
+   {:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1000}],
+    :xt/iid #bytes "a3346d18105ef801c3598fec426dcc5d"}
+   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1439}],
+    :xt/iid #bytes "a360f7de992625c294c7282379a9d703"}
+   {:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1269}],
+    :xt/iid #bytes "a3694651e49a021785ccad1a3f42244e"}
+   {:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 990}],
+    :xt/iid #bytes "a3d50e10f80745d141c5c8cc5ca827e2"}]
+  [{:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1251}],
+    :xt/iid #bytes "a407c53851cbae68d7db684db56108bd"}
+   {:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 606}],
+    :xt/iid #bytes "a40fd2f5fe7b8b120faa3159700e4360"}
+   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 577}],
+    :xt/iid #bytes "a42903d1a59cfd0fe5afe0d9dd419950"}]
+  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 299}],
+    :xt/iid #bytes "a45bf7e0122b3deaa89ee5c388bc8421"}
+   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1139}],
+    :xt/iid #bytes "a47062881429b128274c8bdce80f2af4"}]
+  [{:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1010}],
+    :xt/iid #bytes "a4816f21f132216d27db0e2760f9bf15"}
+   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1065}],
+    :xt/iid #bytes "a49d63d06ddec9016167cd9cebcd21c0"}]
+  [{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 0}],
+    :xt/iid #bytes "a4e167a76a05add8a8654c169b07b044"}
+   {:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1479}],
+    :xt/iid #bytes "a4fc63eb666313974a1d15ad511633df"}]
+  [{:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1279}],
+    :xt/iid #bytes "a50c92fd039c2df6f433bec65078a39a"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1205}],
+    :xt/iid #bytes "a51809c4ad2dea42ae40e787890094e4"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 147}],
+    :xt/iid #bytes "a52893cff688be57b307c71cffad45ff"}]
+  [{:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 945}],
+    :xt/iid #bytes "a57bb5fa2df628602403e7af6bbc1411"}
+   {:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1203}],
+    :xt/iid #bytes "a57efacb02fb6b7286b64c3c1c04feb6"}]
+  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 81}],
+    :xt/iid #bytes "a583b18a6c8b71ae73b3ae47d28ebaac"}
+   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 748}],
+    :xt/iid #bytes "a5865b6c0aa571798d5e1b4707ace0d1"}
+   {:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1487}],
+    :xt/iid #bytes "a586eb6138484c2785449b2b8c577683"}]
+  [{:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 349}],
+    :xt/iid #bytes "a5d307b96b2b4bd640801787928d33a1"}]
+  [{:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 67}],
+    :xt/iid #bytes "a645347a70687fec1f582b9174e4db1e"}
+   {:xt/system-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1158}],
+    :xt/iid #bytes "a65ec105846fa82d533b801cec57c357"}
+   {:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1374}],
+    :xt/iid #bytes "a67c85751c4879ac78a82aa48caecc17"}
+   {:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 767}],
+    :xt/iid #bytes "a6d23d1be770bb3c2040d52d76709829"}]
+  [{:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 779}],
+    :xt/iid #bytes "a71078ef348a3d6c349359c7c12728f1"}
+   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1432}],
+    :xt/iid #bytes "a712855b82acbdd73f1f09ade44c0b77"}
+   {:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1276}],
+    :xt/iid #bytes "a724fd3dcc2a16f00fee4f293098656f"}
+   {:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1091}],
+    :xt/iid #bytes "a73a196108327c96d69e80c7b7c03a00"}]
+  [{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 22}],
+    :xt/iid #bytes "a7919bcf8cf010310d8db3715e822f38"}
+   {:xt/system-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 755}],
+    :xt/iid #bytes "a7a3dedcdb63e70755d8d9cd8eccdd4a"}
+   {:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1369}],
+    :xt/iid #bytes "a7bfaede2108c9cb88300e4f58a0bbda"}]
+  [{:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 812}],
+    :xt/iid #bytes "a7d5dc072a67e71d285b13b5b1d0a7ea"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 811}],
+    :xt/iid #bytes "a7d5f9e0b573a57b77decf4bf2616068"}
+   {:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 791}],
+    :xt/iid #bytes "a7e71e89e924c602f1bef7630a79bd86"}]
+  [{:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 87}],
+    :xt/iid #bytes "a83024535c683323ac80577163978db5"}
+   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1494}],
+    :xt/iid #bytes "a899a35cc9e439bc980af33e3bb7ef3f"}
+   {:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 546}],
+    :xt/iid #bytes "a8e0b048e645cb1af371a1c46c318bd2"}]
+  [{:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1354}],
+    :xt/iid #bytes "a91ab56e12d98477068ce58aa28ca125"}
+   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1344}],
+    :xt/iid #bytes "a94de982c2fdf9d6d02663e23882afb6"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 45}],
+    :xt/iid #bytes "a9af7ab51deeff728949714184eca5a0"}
+   {:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1536}],
+    :xt/iid #bytes "a9d247ea776c77ead0c065604767d08b"}]
+  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1037}],
+    :xt/iid #bytes "aa06de0d4778d109ff076f36f16980d9"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 127}],
+    :xt/iid #bytes "aa4400e859fb24dd120cf66e24690c44"}
+   {:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 982}],
+    :xt/iid #bytes "aa720e882ae76340e66b40a8b5eddb7a"}
+   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 954}],
+    :xt/iid #bytes "aa7329b06ff7b08bb5371e4564bc3be1"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 292}],
+    :xt/iid #bytes "aa96051eba0190666442c9e13663dd8b"}
+   {:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 500}],
+    :xt/iid #bytes "aa9c86944e06907c4dbf560d8fc3bb0b"}
+   {:xt/system-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 351}],
+    :xt/iid #bytes "aac67940459fe9f1d74ea620f0eb6539"}
+   {:xt/system-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 705}],
+    :xt/iid #bytes "aae60dc7bb7ace3b06e2d99604ba6cea"}]
+  [{:xt/system-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 180}],
+    :xt/iid #bytes "ab5787efa8d3b74d9912631c24636310"}
+   {:xt/system-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1072}],
+    :xt/iid #bytes "ab5f710d4134ab277b531a92e70a956f"}
+   {:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 863}],
+    :xt/iid #bytes "abcd086e5caf765678b9c3fae2d1427c"}
+   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 869}],
+    :xt/iid #bytes "abed18a468a580b8da1253276afd382e"}]
+  [{:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 649}],
+    :xt/iid #bytes "ac032ffcefc03131f3311993f314d7e4"}
+   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1262}],
+    :xt/iid #bytes "ac4e92bf41bff0d10e4a342a32a3e93d"}
+   {:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 822}],
+    :xt/iid #bytes "aca7d1a77d4e0ee3a901f87962ec1c1a"}
+   {:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 728}],
+    :xt/iid #bytes "acb357383f2744c6351c29daaa95f33e"}]
+  [{:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 885}],
+    :xt/iid #bytes "ad75c9b167aa780c4fb810661838763f"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 65}],
+    :xt/iid #bytes "ad9add29dd4346f511eb32c895ba0147"}
+   {:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1085}],
+    :xt/iid #bytes "ada70e9aeea5454c5ea572c34c90bd9b"}
+   {:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1483}],
+    :xt/iid #bytes "add8ac43b55b51efdf1742f375ef59d8"}]
+  [{:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 62}],
+    :xt/iid #bytes "ae405c49da388a35175c7ff40d12abe7"}
+   {:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 508}],
+    :xt/iid #bytes "ae788347c539a30db8cea79875585e8d"}
+   {:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1290}],
+    :xt/iid #bytes "ae92ea06538e84081916a24ab0a3e652"}
+   {:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 360}],
+    :xt/iid #bytes "aee97d8cbd834162daa98a77b4d5d45b"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 309}],
+    :xt/iid #bytes "aeef4815c98f43631ce3e7fa79c88d5a"}
+   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1186}],
+    :xt/iid #bytes "aefee6147213a99198d041a06da049fa"}]
+  [{:xt/system-from #xt/zdt "2020-07-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-28T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1246}],
+    :xt/iid #bytes "af1c35f8d635369c22aeb87860e9c022"}
+   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1259}],
+    :xt/iid #bytes "af22d33143ca9c13eb2689a2a9145eb0"}
+   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 831}],
+    :xt/iid #bytes "af2c66373327ec99c2c4299da4f2c2fc"}]
+  [{:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1424}],
+    :xt/iid #bytes "af6573f511c1ce322ac3e13dbf6d79dc"}]
+  [{:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1223}],
+    :xt/iid #bytes "af83a33722c4a030ffd878b9f5d25084"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
-  [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 306}],
-    :xt/iid #bytes "afc3cdeee571c128916c52d1558087c2"}
-   {:xt/system-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 995}],
-    :xt/iid #bytes "afc647e72f60d69a1e88e0b6d4b90533"}
-   {:xt/system-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 901}],
-    :xt/iid #bytes "afd1d482feabf634e7013b513d1638db"}
-   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 231}],
-    :xt/iid #bytes "afd576bf445c295bbe00bd81faeabdc6"}]
+    :op #xt/tagged [:put #:xt{:id 308}],
+    :xt/iid #bytes "af8b1f927602f6510a2e32f8870dddf2"}
+   {:xt/system-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 810}],
+    :xt/iid #bytes "af92d5b4c6062a24cec7a54265400be8"}]
   [{:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p23-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p23-b182.arrow.edn
@@ -5,660 +5,510 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 543}],
+    :xt/iid #bytes "b03fd594a74b18c2c9e5b47ba54c6764"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 252}],
+    :xt/iid #bytes "b04edac037b8f0c58aa6e3cba929be7b"}
+   {:xt/system-from #xt/zdt "2020-02-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-08T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
+    :op #xt/tagged [:put #:xt{:id 229}],
+    :xt/iid #bytes "b056163d4500a9b7c567ea0e880ca843"}
+   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1023}],
+    :xt/iid #bytes "b0d76bfc2f21f849d4220eacb83aee20"}
+   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1163}],
+    :xt/iid #bytes "b0dbe49ead4e373e085ffb690880acc5"}]
+  [{:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 541}],
+    :xt/iid #bytes "b16dad523dfa19463a754a7de31dc904"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 29}],
+    :xt/iid #bytes "b189386f76e9ca2de95a8cfb6e964c69"}
+   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1381}],
+    :xt/iid #bytes "b1b21162b8c55fc74a3a80f52c51cc92"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 323}],
+    :xt/iid #bytes "b1ddb0175d32e2d8deaf8db0acd68081"}
+   {:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1500}],
+    :xt/iid #bytes "b1fc09dcb5928d91bd36d2bcb6250bc6"}
+   {:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 244}],
+    :xt/iid #bytes "b1fec1d08d3466c41015367662f792f5"}]
+  [{:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 367}],
+    :xt/iid #bytes "b21bf2e871caf485affa8bf8257ab7b0"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 170}],
+    :xt/iid #bytes "b25ba4fb6402b26347311bb21f7ea5c9"}
+   {:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 371}],
+    :xt/iid #bytes "b2850224fee939d9a34db0ed0a048909"}]
+  [{:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 494}],
+    :xt/iid #bytes "b3005854db99127e345c7ec06d40dad7"}
+   {:xt/system-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1004}],
+    :xt/iid #bytes "b30f9215ea97a47838d74c7ade092e30"}
+   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1492}],
+    :xt/iid #bytes "b33986d09e595b38015ae0b7e945f17d"}
+   {:xt/system-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 654}],
+    :xt/iid #bytes "b33e78adf0904307bcd4a7f6c62504d9"}
+   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1401}],
+    :xt/iid #bytes "b35985fea2bfed2033fe41be809e9e56"}
+   {:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1477}],
+    :xt/iid #bytes "b35f5f5c6adc4117f889ee3cee3fde69"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 293}],
+    :xt/iid #bytes "b38a063cbd17de5fee53028cb28cb6c9"}
+   {:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 373}],
+    :xt/iid #bytes "b3d4b6b25eb711b06bd251b6aa27063b"}]
+  [{:xt/system-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 112}],
+    :xt/iid #bytes "b45eae64b013c9768f8e2bd2f4942811"}
+   {:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 793}],
+    :xt/iid #bytes "b4769920960722b58165eee43df17237"}
+   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1296}],
+    :xt/iid #bytes "b4c6f4aa29afa49fa274ae288676757c"}
+   {:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 943}],
+    :xt/iid #bytes "b4dcb1074f602362c1f0d0c8bd77e8f4"}]
+  [{:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 684}],
+    :xt/iid #bytes "b54f5659862cb83cdd897b5d912e5e46"}
+   {:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 370}],
+    :xt/iid #bytes "b575edc9ba6f2b65bb8879029b210b36"}
+   {:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1185}],
+    :xt/iid #bytes "b57f4ac25f4bac538315ad3d21636701"}
+   {:xt/system-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1194}],
+    :xt/iid #bytes "b58b8c0361d0df67c759f1703cb5cec9"}
+   {:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 517}],
+    :xt/iid #bytes "b5b030435852dcb452011d2024127ef7"}]
+  [{:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 775}],
+    :xt/iid #bytes "b6080303815b4c1267b465881a148813"}
+   {:xt/system-from #xt/zdt "2020-06-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 999}],
+    :xt/iid #bytes "b6085134d55fc33c5fa83f9a1814a151"}
+   {:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 544}],
+    :xt/iid #bytes "b612e17d4b633b648bf338631c1fdff4"}
+   {:xt/system-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 789}],
+    :xt/iid #bytes "b627c76af0ccd00b72f08403a928bbda"}]
+  [{:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 138}],
+    :xt/iid #bytes "b6650f6f12948b660e22dc6ac2cd9c47"}
+   {:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1046}],
+    :xt/iid #bytes "b66fb65c915fd71deb32727d5dc6df0c"}]
+  [{:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1313}],
+    :xt/iid #bytes "b695017ebf29d3ae1e01fc9229be354a"}
+   {:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 368}],
+    :xt/iid #bytes "b697203f7a62cf99032204ab908c03ee"}
+   {:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1490}],
+    :xt/iid #bytes "b69cffbb2e6a1394122c6725e8c72413"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 99}],
+    :xt/iid #bytes "b69e060cf32e96bdbfe841366924c30a"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 192}],
+    :xt/iid #bytes "b69fb20bf81ad4015c4eda4adb1fd86c"}
+   {:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 116}],
+    :xt/iid #bytes "b6bf043b51896c2c4963042d726dfcf2"}]
+  [{:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 670}],
+    :xt/iid #bytes "b6eae9e6340c4920c00b67e11ab38769"}]
+  [{:xt/system-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1504}],
+    :xt/iid #bytes "b7101dcb778e078e4b22d0baddf96cf0"}
+   {:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 466}],
+    :xt/iid #bytes "b735cdb86891b96f46826eb00fdc6331"}
+   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1143}],
+    :xt/iid #bytes "b76c2ae40023ce7de3ede52644cc53ad"}
+   {:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 550}],
+    :xt/iid #bytes "b78739f27410bcdefb01731e40b142f6"}
+   {:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 581}],
+    :xt/iid #bytes "b7b326928d55095d6e149ae536cdae10"}]
+  [{:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 163}],
+    :xt/iid #bytes "b824f57e338ef055db4b9af16d4a3982"}
+   {:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 959}],
+    :xt/iid #bytes "b8447a0d40caccc587e73a4a6d944625"}
+   {:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 814}],
+    :xt/iid #bytes "b880aacecdef54ddb068786c213a03cb"}
+   {:xt/system-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 888}],
+    :xt/iid #bytes "b8a8f2ed046ef3de2bd7b30867233e06"}
+   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1465}],
+    :xt/iid #bytes "b8b78998d3e8f050201cc67288f64a3f"}
+   {:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1092}],
+    :xt/iid #bytes "b8d17e2d2e9b69d4fa3059c3403e9a81"}
+   {:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 9}],
+    :xt/iid #bytes "b8fa730e0f65ce7934c7424579ca827f"}]
+  [{:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1503}],
+    :xt/iid #bytes "b917c8765697d662af06020483753aa1"}
    {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 746}],
+    :xt/iid #bytes "b91b9642f9183004c38ec4af6ce737d9"}
+   {:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
+    :op #xt/tagged [:put #:xt{:id 685}],
+    :xt/iid #bytes "b93e86471af43d20a751f4860e723fd1"}]
   [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
+    :op #xt/tagged [:put #:xt{:id 248}],
+    :xt/iid #bytes "b95e782e3641975f92a07964af9880fa"}
+   {:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 661}],
+    :xt/iid #bytes "b9704ad0122ae5caf916551b0111195d"}]
+  [{:xt/system-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 245}],
+    :xt/iid #bytes "b987787c691234eb44fc769d508ef673"}
+   {:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 529}],
+    :xt/iid #bytes "b9a964c6edb486713c4d4afdaec0033b"}]
+  [{:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1210}],
+    :xt/iid #bytes "b9c20db0400f9aebda42fff4973579fb"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 255}],
+    :xt/iid #bytes "b9e613a4af1a9cdfa1c1c294888aaf8b"}
+   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 328}],
+    :xt/iid #bytes "b9f134d4acdcdc122d70a47d3c0cd770"}
    {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
-  [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 246}],
-    :xt/iid #bytes "bf2d9a40a80deb8d35529f8847d9a366"}
-   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1035}],
-    :xt/iid #bytes "bf8be50f4afd970fba086bca6f31ded2"}
-   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1438}],
-    :xt/iid #bytes "bf8e9711488645f8f4cd3a5933a2dfa5"}
-   {:xt/system-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 747}],
-    :xt/iid #bytes "bfa73f51bffd9cc13ed3c8488755df12"}
-   {:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 663}],
-    :xt/iid #bytes "bfb8444a5f5b0aba6daae226efb36d6a"}]
+    :op #xt/tagged [:put #:xt{:id 1034}],
+    :xt/iid #bytes "b9f2706e50ce24602aad5732a5808f0f"}]
+  [{:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 271}],
+    :xt/iid #bytes "ba4a5c6bb1e49fa84d4bb75fb918f0bf"}
+   {:xt/system-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 289}],
+    :xt/iid #bytes "ba9b299b96d610b78b388db8c0c4ec2a"}
+   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1347}],
+    :xt/iid #bytes "baabe377517ab8ff69ac106359fabd38"}
+   {:xt/system-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 694}],
+    :xt/iid #bytes "baae5e64c4947fddbc91480463491200"}]
+  [{:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1555}],
+    :xt/iid #bytes "bb52238908a3dd451e7b16d3468bbba0"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 15}],
+    :xt/iid #bytes "bb5853ce561874ca6065792937eeb75a"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1204}],
+    :xt/iid #bytes "bb839acb244dc9962d71ae203d5a9d22"}
+   {:xt/system-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1215}],
+    :xt/iid #bytes "bba322a30dbe27dc6b9cf73b7ac63853"}
+   {:xt/system-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 675}],
+    :xt/iid #bytes "bbb00d800bbed8b0f33491780fbceb3f"}]
+  [{:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 641}],
+    :xt/iid #bytes "bc3704d593a6dc2aba23d65345ff5cc1"}
+   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 802}],
+    :xt/iid #bytes "bc5b3f7e81d90273a2b164209d95a4f7"}
+   {:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 584}],
+    :xt/iid #bytes "bcd439697aa49f7f0610ac15a813ffb0"}
+   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1125}],
+    :xt/iid #bytes "bce257e12e788c235089b3f54e3c4833"}]
+  [{:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 472}],
+    :xt/iid #bytes "bd0a22785e44d5d697d63a5f68af1cb1"}
+   {:xt/system-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 61}],
+    :xt/iid #bytes "bd2bb4f353d275b5f2d72c6161f93212"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 160}],
+    :xt/iid #bytes "bd2c01f21be7e3728ac775872fb96d55"}
+   {:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1537}],
+    :xt/iid #bytes "bd2f220f80117d2189eafcb8375abee3"}]
+  [{:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 909}],
+    :xt/iid #bytes "bd4ee4bfd974fe58b3dd0a38b4c8f237"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 20}],
+    :xt/iid #bytes "bd53318aa9171e466caa9f6df1f33d97"}
+   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1397}],
+    :xt/iid #bytes "bd70b526d507ad9615ee065391bc6178"}]
+  [{:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 971}],
+    :xt/iid #bytes "bd80ac6dbfb77eb7202db9a9d785281e"}
+   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1316}],
+    :xt/iid #bytes "bda5bf6cb034ae1a1956446114f1e252"}]
+  [{:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 615}],
+    :xt/iid #bytes "bde83a7359a35b81f150446c2748a6a1"}]
+  [{:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1311}],
+    :xt/iid #bytes "be0304319ef2d6b9969ed8f22b15511f"}
+   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 743}],
+    :xt/iid #bytes "be07cb97aaecff6a3e38ad2e74a0b915"}
+   {:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 673}],
+    :xt/iid #bytes "be16c9b58b35f3d2be936166cf4eeba6"}
+   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 827}],
+    :xt/iid #bytes "be1d09d3ee2f2321a8b5550507ae7444"}
+   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1468}],
+    :xt/iid #bytes "be3bbc58d3b137fe2532f337a831416d"}]
+  [{:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1360}],
+    :xt/iid #bytes "be481fd8097184219c5a88b17fdcfa9b"}
+   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 630}],
+    :xt/iid #bytes "be4ffd24496211dfaaedf76154addedf"}]
+  [{:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 46}],
+    :xt/iid #bytes "becd6a989137bb79bb006bad23d15a11"}
+   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 920}],
+    :xt/iid #bytes "bedf6ccccb42e05bf8cc0bfa2646d17a"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 140}],
+    :xt/iid #bytes "beead92ba9b9e28de24f6cb1580dbb95"}]
   [{:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p30-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p30-b182.arrow.edn
@@ -5,640 +5,395 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1118}],
+    :xt/iid #bytes "c01de328fb266bc76af51881801da40c"}
+   {:xt/system-from #xt/zdt "2020-02-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-11T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 250}],
+    :xt/iid #bytes "c06e7c69b19b8e6513b0347a1f854267"}
+   {:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 566}],
+    :xt/iid #bytes "c071573cb669f27552064703e4f2623a"}
+   {:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
+    :op #xt/tagged [:put #:xt{:id 1112}],
+    :xt/iid #bytes "c0cb655d3671888a66310e5edfad417a"}]
+  [{:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1525}],
+    :xt/iid #bytes "c100785ce24586ed6323d972e671ed47"}
+   {:xt/system-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1082}],
+    :xt/iid #bytes "c10bfcf4ad5856f6ea6e23182be81395"}
+   {:xt/system-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 551}],
+    :xt/iid #bytes "c11f6a546ad5e5490cf61a79e267c7b5"}
+   {:xt/system-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 614}],
+    :xt/iid #bytes "c12a4adc39554a01cfb2f4b92a6fbcd8"}
+   {:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 93}],
+    :xt/iid #bytes "c15f2b10a61e54d7013d207a73422c2a"}
+   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1436}],
+    :xt/iid #bytes "c1fd92fba995351e416bf36fd5e0ab45"}]
+  [{:xt/system-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 495}],
+    :xt/iid #bytes "c2531412c0d9ec323d47372765797238"}
+   {:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 960}],
+    :xt/iid #bytes "c2b97fd8d6677def5922bd30931511df"}]
+  [{:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1096}],
+    :xt/iid #bytes "c328a24753f5bba97775f87dffc02668"}
+   {:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 506}],
+    :xt/iid #bytes "c3d65d6722dd965d1524e195c93b07ca"}]
+  [{:xt/system-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1376}],
+    :xt/iid #bytes "c407f42a4aaf9721a6f582bc79a1e848"}
    {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 868}],
+    :xt/iid #bytes "c4222f6ef3cb1d6d80410c45dbe90c04"}]
+  [{:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1415}],
+    :xt/iid #bytes "c44f5f818283d5d1eaf9ab7e9d464941"}
+   {:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
-  [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1188}],
-    :xt/iid #bytes "cf1450e0d21f35a5c87201d150b69c03"}
-   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 565}],
-    :xt/iid #bytes "cf4645a5175a66ebdee259d016bf56db"}
-   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 340}],
-    :xt/iid #bytes "cf571a2db2d81c5936df4e7af8b97b35"}
-   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 282}],
-    :xt/iid #bytes "cf958d8816d82489cd60fc8612676916"}
-   {:xt/system-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-25T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 866}],
-    :xt/iid #bytes "cfabf11db427431e113ccce2d848403e"}
-   {:xt/system-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-19T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1383}],
-    :xt/iid #bytes "cfb48f27f3fde91af9cb6a2161cb3ff2"}]
+    :op #xt/tagged [:put #:xt{:id 1189}],
+    :xt/iid #bytes "c454f4d569be65b381a481c4103f2c07"}]
+  [{:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 640}],
+    :xt/iid #bytes "c488e43ddb5bc74004780c18a85963bd"}
+   {:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 470}],
+    :xt/iid #bytes "c49bf28414e3f1da8e39619079a81aee"}
+   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1355}],
+    :xt/iid #bytes "c4ae3f94fc9634bb588133ff779d0e27"}]
+  [{:xt/system-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 428}],
+    :xt/iid #bytes "c4cc9a0763831b05820c6177cfba9654"}
+   {:xt/system-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 953}],
+    :xt/iid #bytes "c4e67e6664c6299908f7165adc2ff486"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 56}],
+    :xt/iid #bytes "c4f949cd305536893d65d29dceacd4a6"}]
+  [{:xt/system-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1284}],
+    :xt/iid #bytes "c53917d1861182f4530fabba2f0ff58a"}
+   {:xt/system-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1520}],
+    :xt/iid #bytes "c54cd120ff430563837348cba6e7cb7b"}
+   {:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 611}],
+    :xt/iid #bytes "c587497dad64e1777db3d56925d77a45"}
+   {:xt/system-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 589}],
+    :xt/iid #bytes "c5a52f52af8623b88fc104b1813f1d2d"}
+   {:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 410}],
+    :xt/iid #bytes "c5c5ea28b27d81898c571a88382405e6"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 172}],
+    :xt/iid #bytes "c5d70d88672185c14210002a57ed20c4"}
+   {:xt/system-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1326}],
+    :xt/iid #bytes "c5e91590450eec7ffb5a03a2240aea31"}]
+  [{:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1056}],
+    :xt/iid #bytes "c6010fbf34f9668a22d990c95d1e2fa3"}
+   {:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 26}],
+    :xt/iid #bytes "c640ffaf23b6ed414321946cdc7e342a"}
+   {:xt/system-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 467}],
+    :xt/iid #bytes "c67481d53afd3b683b9059a3ac6be7e3"}
+   {:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1011}],
+    :xt/iid #bytes "c6815df8420ffbcb80127d288d70899e"}
+   {:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 921}],
+    :xt/iid #bytes "c6efa157ec2645594b9fee164a47753b"}
+   {:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 865}],
+    :xt/iid #bytes "c6f6c7b5ef5ab0cc41ce73ad58937c97"}]
+  [{:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 855}],
+    :xt/iid #bytes "c719c33a111b9b3c39e09c0ee6ebf07c"}
+   {:xt/system-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 55}],
+    :xt/iid #bytes "c779d8aec84d2c121b1e1da36bf877ae"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1409}],
+    :xt/iid #bytes "c7824c61918490b922c019c2efa5bd0f"}
+   {:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1009}],
+    :xt/iid #bytes "c78823b69ac506f37ec494f9952b623b"}]
+  [{:xt/system-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 701}],
+    :xt/iid #bytes "c82bac33a1947011082bd04dadd08b8b"}
+   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 595}],
+    :xt/iid #bytes "c8c4ab8b87707035ab439094842df548"}
+   {:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 927}],
+    :xt/iid #bytes "c8f74955cd99a75656cb4ff8cd8544d4"}]
+  [{:xt/system-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 273}],
+    :xt/iid #bytes "c98952fa5f8c57414da743a155562cf7"}
+   {:xt/system-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 66}],
+    :xt/iid #bytes "c9fd3eccf817a69d14d5e12461210824"}]
+  [{:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1093}],
+    :xt/iid #bytes "ca1f23447023f906d74eff8cac133cd5"}
+   {:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1322}],
+    :xt/iid #bytes "ca80aff827af9b969dac4fbcc5b59ebe"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 86}],
+    :xt/iid #bytes "cabdc6bbb70a8b4285a17a60708d2f2f"}
+   {:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1108}],
+    :xt/iid #bytes "cac86d0649183cf4f4d496f71a579557"}]
+  [{:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 569}],
+    :xt/iid #bytes "cb00a196c7c66edb80ca38f9f1c0893a"}
+   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1471}],
+    :xt/iid #bytes "cb1c744caf9f6536fd4ddf755284e2e5"}
+   {:xt/system-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 644}],
+    :xt/iid #bytes "cb1fadb9cd56fc400cedf8bf1fdeb2e0"}]
+  [{:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 131}],
+    :xt/iid #bytes "cb4a8665e4039d234f6731996f58cff8"}
+   {:xt/system-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 161}],
+    :xt/iid #bytes "cb779086bd0f8cbd6febdf7f8a1e99cc"}]
+  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 80}],
+    :xt/iid #bytes "cb8ba6674d75559bd92148f6a2951fc4"}
+   {:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1484}],
+    :xt/iid #bytes "cb8e26b328d937ca2c961d40a82f28f6"}
+   {:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 416}],
+    :xt/iid #bytes "cb96947163d263dd6202d400873a0b0e"}
+   {:xt/system-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 771}],
+    :xt/iid #bytes "cba8015057d39c67e85af79c44272dc4"}]
+  [{:xt/system-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1217}],
+    :xt/iid #bytes "cbca0311f02bf4a1f12ecfa8239522d0"}
+   {:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1268}],
+    :xt/iid #bytes "cbcd956fdfaf97345ccfa3135e4b3494"}
+   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1364}],
+    :xt/iid #bytes "cbed176d27e44fd9803662691dd5aa37"}]
+  [{:xt/system-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 972}],
+    :xt/iid #bytes "cc1aa391666ba816fab1afebc0666c97"}
+   {:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 512}],
+    :xt/iid #bytes "cc384704239b17bf39c473f9282bd0af"}
+   {:xt/system-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 390}],
+    :xt/iid #bytes "cc455aadcaefd61b6feb78e13676303c"}
+   {:xt/system-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1105}],
+    :xt/iid #bytes "ccc84347f4bf33a244c6edb5c518399b"}
+   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 214}],
+    :xt/iid #bytes "ccf6803c91ea729115fc4279385ae922"}]
+  [{:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 303}],
+    :xt/iid #bytes "cd1f1290f870cfa3a819d64de6a83216"}
+   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 592}],
+    :xt/iid #bytes "cd4dceb84c2fc686632cf39e85de49ae"}
+   {:xt/system-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 856}],
+    :xt/iid #bytes "cd5d3bd1702ecf00f06defbdf4898f1a"}
+   {:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 482}],
+    :xt/iid #bytes "cd76effee842013ba2382d4f29138bd7"}
+   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1098}],
+    :xt/iid #bytes "cd9d92ee12534ce7e1369643813dcdea"}
+   {:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 939}],
+    :xt/iid #bytes "cda30a803175d8d8d0940cc29f0738b6"}
+   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1299}],
+    :xt/iid #bytes "cdd1e0aa920e91aa09d1d1c5f43bb3db"}]
+  [{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 27}],
+    :xt/iid #bytes "ce4aee1536e25ca13b34a2b730be0b8e"}
+   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1169}],
+    :xt/iid #bytes "cec74ddfc15430df08407492b9cea7b0"}
+   {:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1084}],
+    :xt/iid #bytes "cee947cafcb41d1f8b0f13bde8e59874"}]
   [{:xt/system-from #xt/zdt "2020-07-18T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-07-18T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p31-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p31-b182.arrow.edn
@@ -5,535 +5,455 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 154}],
+    :xt/iid #bytes "d019fb00045604c3f731eed3d31e7236"}
+   {:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 511}],
+    :xt/iid #bytes "d03482d8f47a9431f0837d627916983c"}
+   {:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1331}],
+    :xt/iid #bytes "d05baa9770a4bd49c0d87f6fcf167f0e"}
+   {:xt/system-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1201}],
+    :xt/iid #bytes "d067a4a2353bcc0344db8dbe27d86674"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 144}],
+    :xt/iid #bytes "d07dcc42f0b412ada671f1de2523e58a"}
+   {:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 48}],
+    :xt/iid #bytes "d0f3b88e076ef7282e86aa8bacc4a34a"}]
+  [{:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 658}],
+    :xt/iid #bytes "d1143da230bf7726315eec0307227100"}
+   {:xt/system-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1435}],
+    :xt/iid #bytes "d1230bae90bb0a792e992affa35fbb5c"}
+   {:xt/system-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 660}],
+    :xt/iid #bytes "d169ef0ae2b68a04c4524d57b2f94905"}
+   {:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 409}],
+    :xt/iid #bytes "d1774c643b3195d04e97f4cea573f097"}
+   {:xt/system-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 186}],
+    :xt/iid #bytes "d1a8fcabc030522d2f5755bdcb9cc0b0"}
+   {:xt/system-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 120}],
+    :xt/iid #bytes "d1e7d7ac3f9835fc051f04b926c2059d"}]
+  [{:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 413}],
+    :xt/iid #bytes "d215be82a2ee12542ffcca5897e714df"}
+   {:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1028}],
+    :xt/iid #bytes "d24a49238eb94e96d3c42569806b7992"}
+   {:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1482}],
+    :xt/iid #bytes "d250e9a30d21741d340bfefe583badfe"}
+   {:xt/system-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 828}],
+    :xt/iid #bytes "d25d4bb9635ac51cc09c1f2991c1da0a"}
+   {:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 913}],
+    :xt/iid #bytes "d282a2de932275bc57ea37a2d6da99ca"}
+   {:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1491}],
+    :xt/iid #bytes "d2c8d5328a64c53c0fe1d9f096e6e6bd"}
+   {:xt/system-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1304}],
+    :xt/iid #bytes "d2fe658dee0d1d0cc999e5529a605b1f"}]
+  [{:xt/system-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 296}],
+    :xt/iid #bytes "d33f75ddd9871ad72606381f111874c9"}
+   {:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1345}],
+    :xt/iid #bytes "d38435ce6dc2deab50176e3494246d41"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 345}],
+    :xt/iid #bytes "d3a037e2077aa958dbf55b25fcb4726b"}
+   {:xt/system-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 509}],
+    :xt/iid #bytes "d3d1c6b0b8c419353dbab7158506921a"}]
+  [{:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1134}],
+    :xt/iid #bytes "d40f9efdc53f8254693264e5cd09caef"}
+   {:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 876}],
+    :xt/iid #bytes "d415cdf1dbe9a653ec181d2b8543da43"}
+   {:xt/system-from #xt/zdt "2020-08-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1288}],
+    :xt/iid #bytes "d43a445887ca62b989147dd1b427c2e3"}
+   {:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
+    :op #xt/tagged [:put #:xt{:id 547}],
+    :xt/iid #bytes "d4e989bda4c14099043b26c838d057ea"}
+   {:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1476}],
+    :xt/iid #bytes "d4fe1e984b0d12f881f75d9acf7ada95"}]
+  [{:xt/system-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 501}],
+    :xt/iid #bytes "d502a8bcdf6aacd8583262397070df49"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 149}],
+    :xt/iid #bytes "d5042580a076c3d537032d05858163c3"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 177}],
+    :xt/iid #bytes "d53cdcbf204ee78f00449edc52d38df6"}
+   {:xt/system-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 570}],
+    :xt/iid #bytes "d5f16f4e7a2c8db702891e1c708ecf3f"}]
+  [{:xt/system-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 643}],
+    :xt/iid #bytes "d61f03822f2fed747d675b17c04fe743"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 35}],
+    :xt/iid #bytes "d62f6a60f0023075899057b2269dee60"}
+   {:xt/system-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 596}],
+    :xt/iid #bytes "d63de56fb35800598286fedf72241b3c"}
+   {:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 738}],
+    :xt/iid #bytes "d6d928f2b6ed8213a30070232c09e740"}
+   {:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 540}],
+    :xt/iid #bytes "d6f4873ea974aebbc76c9711b18f914f"}
+   {:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1529}],
+    :xt/iid #bytes "d6f854291a5b62075a891366907dc9c0"}]
+  [{:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1371}],
+    :xt/iid #bytes "d70a0edd79815fa087ba036cfa5537ab"}
+   {:xt/system-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1472}],
+    :xt/iid #bytes "d74418a3893e92f6f7e75e552979f441"}
+   {:xt/system-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 564}],
+    :xt/iid #bytes "d74730c4be7a95cee46acaa7fca51b9b"}
+   {:xt/system-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 683}],
+    :xt/iid #bytes "d75a2e41871c8eb236c02897b5e69e08"}
+   {:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 583}],
+    :xt/iid #bytes "d7c56137ca862456cd83d3b0356fb6f9"}
+   {:xt/system-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 377}],
+    :xt/iid #bytes "d7cf450e4e0f3674c3b16e04ccc2fa5b"}
+   {:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 143}],
+    :xt/iid #bytes "d7f9d3b9763d2f94c1e09a336600afe6"}]
+  [{:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 713}],
+    :xt/iid #bytes "d83695deb0698e8f7d77031d6fbd525d"}
+   {:xt/system-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 411}],
+    :xt/iid #bytes "d8ae3f4f6b239bf530e282e2400d3dcf"}
+   {:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1229}],
+    :xt/iid #bytes "d8b1861060bae869a30f40be0597a988"}
+   {:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1243}],
+    :xt/iid #bytes "d8e63a33e21d7570c96d76937332673b"}
+   {:xt/system-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1392}],
+    :xt/iid #bytes "d8e787847aa7261ea160f9d7b9fd129b"}]
+  [{:xt/system-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 526}],
+    :xt/iid #bytes "d9386163628673f0da0accae29a276e7"}
+   {:xt/system-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 173}],
+    :xt/iid #bytes "d9f45d278397c5420b1c144944c8e3a3"}]
+  [{:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 388}],
+    :xt/iid #bytes "da706a0e0a0913f0c1325339a0af3123"}
+   {:xt/system-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 783}],
+    :xt/iid #bytes "daa434e8e0c093c17dafb218ab1ca451"}
+   {:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1334}],
+    :xt/iid #bytes "dab24678de02074144374bd83d9240da"}
+   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 949}],
+    :xt/iid #bytes "dad3ea40cdcad389b3e01bcdae7a1095"}]
+  [{:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 711}],
+    :xt/iid #bytes "db3516156d4e1e3369a368e8cef4a13b"}
+   {:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 875}],
+    :xt/iid #bytes "db367fd089072c62dd2927e3361e56ff"}
+   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 341}],
+    :xt/iid #bytes "dbe5414720eccb345e777b3b272a4c7d"}]
+  [{:xt/system-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1343}],
+    :xt/iid #bytes "dc031a66bbb79a8b4cdd926879bb8618"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 89}],
+    :xt/iid #bytes "dc20d5ea7f5d101b60ee3966f5dd6b5b"}
+   {:xt/system-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 302}],
+    :xt/iid #bytes "dc3966257e13385b1daa7ce5bf3e25af"}]
+  [{:xt/system-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1111}],
+    :xt/iid #bytes "dc7010669d835861436fae4fabd20d7e"}]
+  [{:xt/system-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 418}],
+    :xt/iid #bytes "dc83a6d8062b13624fba06a8b7ee5b66"}
+   {:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 981}],
+    :xt/iid #bytes "dc8be01a7a9b90f2d93d8e9e7c0c5f5f"}
+   {:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1535}],
+    :xt/iid #bytes "dc97f31dc43a83996087b082bf7bde78"}
+   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 744}],
+    :xt/iid #bytes "dcb52a07d5743f79b4b8f299132dc308"}
+   {:xt/system-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 164}],
+    :xt/iid #bytes "dcbf558b250273262558a0ad69d3ae10"}
+   {:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1007}],
+    :xt/iid #bytes "dcbfaf869ee5dc0ec95bac212d9a9f5e"}]
+  [{:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1137}],
+    :xt/iid #bytes "dcda3757603a66089409d718c10f8964"}
+   {:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 765}],
+    :xt/iid #bytes "dcdf79d371f4a1614c9dccd482677fb9"}
+   {:xt/system-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 386}],
+    :xt/iid #bytes "dcfe83f89f01bf7858bac6f03be1c14a"}]
+  [{:xt/system-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 117}],
+    :xt/iid #bytes "dd0a655ef9a2eafc43fa2cde97ae0716"}
+   {:xt/system-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 607}],
+    :xt/iid #bytes "dd403eefe9e87cba438fcd83ca225cb1"}
+   {:xt/system-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1136}],
+    :xt/iid #bytes "dd4defe91c1642764b0c16a65a0c87ea"}
+   {:xt/system-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 895}],
+    :xt/iid #bytes "dd58c4e3823da502d099588524ec17e2"}
+   {:xt/system-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 399}],
+    :xt/iid #bytes "dd5bfa7db6d104e157973ef63d0ac3cb"}
+   {:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1038}],
+    :xt/iid #bytes "dd5f27847bd1c6553030e6892c3cda2e"}
+   {:xt/system-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 804}],
+    :xt/iid #bytes "ddc49dc5dc0baff33bf007a0a714103a"}
    {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
-  [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 873}],
-    :xt/iid #bytes "df059f21ebd10966a909e7c082ca9342"}
-   {:xt/system-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1307}],
-    :xt/iid #bytes "df39b9999d600d484e17e71e7501e188"}
-   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1170}],
-    :xt/iid #bytes "df3a9230e9df77eb4080e679dfee3886"}
-   {:xt/system-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-07-30T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1260}],
-    :xt/iid #bytes "df64121ebe9dcb156dffc0ae67efe41b"}
-   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1070}],
-    :xt/iid #bytes "dfaac2fbe9018c486ea71404d474ea6e"}]
+    :op #xt/tagged [:put #:xt{:id 1258}],
+    :xt/iid #bytes "ddf3ada42cd3ece118e40d7553a72765"}]
+  [{:xt/system-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 366}],
+    :xt/iid #bytes "de057c7061fd92dad090c7fb9d831476"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 222}],
+    :xt/iid #bytes "de1f13731b6cadd4df036bfd1e7f6811"}]
+  [{:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1389}],
+    :xt/iid #bytes "de42b6ed35cbe1d88e01613409437c90"}]
+  [{:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 521}],
+    :xt/iid #bytes "de8095a4abbca3a35df3b5d0cf55d8f9"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 14}],
+    :xt/iid #bytes "dea15cd27308f2b675436b404b243f44"}]
+  [{:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1526}],
+    :xt/iid #bytes "dec409d6d307ec508273c382de9b2a87"}
+   {:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1332}],
+    :xt/iid #bytes "ded87671e7aa8547c4eb58d5529052d9"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 723}],
+    :xt/iid #bytes "dee6de4c42687bd07e60bc6ecd4a4cfc"}
+   {:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 13}],
+    :xt/iid #bytes "deecac0ba6fed8f8f873548fd32533b3"}]
   [{:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p32-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p32-b182.arrow.edn
@@ -5,640 +5,445 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
+    :op #xt/tagged [:put #:xt{:id 1340}],
+    :xt/iid #bytes "e032b2fb8dba589ebb19295cbad95c38"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1413}],
+    :xt/iid #bytes "e04047bc794fc3ebb2aca388189176ee"}
+   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1030}],
+    :xt/iid #bytes "e059e27c0b0511f08c995ac04d04240b"}
+   {:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 72}],
+    :xt/iid #bytes "e0c1668acbe0c084692aa0842c6d5518"}
+   {:xt/system-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1140}],
+    :xt/iid #bytes "e0e76e3cac7a90e387ff71b1a918f55e"}
+   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1419}],
+    :xt/iid #bytes "e0fea6ddad64fe6bd57dd3b20b7b6dfd"}]
+  [{:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1241}],
+    :xt/iid #bytes "e1099f860a9cfb3a779bdde46b7140ac"}
+   {:xt/system-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1356}],
+    :xt/iid #bytes "e137085ee491c9abbfb2ae90c0381782"}
+   {:xt/system-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1274}],
+    :xt/iid #bytes "e18aafb3253261773b0859a7dfd815ab"}
+   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1101}],
+    :xt/iid #bytes "e1e093f556de5ca0062492d7ab98e728"}]
+  [{:xt/system-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 721}],
+    :xt/iid #bytes "e2370a7cfb720aa5acfefb651f60d8c5"}
    {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1339}],
+    :xt/iid #bytes "e254184a247cf64c96fb9c0499f9ed68"}
+   {:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1115}],
+    :xt/iid #bytes "e263686fe38f48aba6021d6027fa47f1"}
+   {:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1406}],
+    :xt/iid #bytes "e2751ffa054c751d80ab185ef4ca329b"}
+   {:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
+    :op #xt/tagged [:put #:xt{:id 1179}],
+    :xt/iid #bytes "e2cc2683708e67f0e6fd1d88196a8dcc"}
+   {:xt/system-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 555}],
+    :xt/iid #bytes "e2fd48103712fba06ffd4789b75efa7d"}]
+  [{:xt/system-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1174}],
+    :xt/iid #bytes "e32cc262b5e4882844aa0294fb0df0bb"}
+   {:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1459}],
+    :xt/iid #bytes "e3309fa880f84189f46336c185c34bae"}
+   {:xt/system-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1312}],
+    :xt/iid #bytes "e375d448e5aaa930af0753a50993b000"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 343}],
+    :xt/iid #bytes "e3c8005c1ec50b1fbda9808230b85fb0"}]
+  [{:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1130}],
+    :xt/iid #bytes "e4395b37a8257c514e1b3cd5042d13b3"}
+   {:xt/system-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 33}],
+    :xt/iid #bytes "e43bceaba7c58321578be22540fdcb2c"}]
+  [{:xt/system-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1320}],
+    :xt/iid #bytes "e459b39d57f6a3a514518260a63ba3bb"}
+   {:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 777}],
+    :xt/iid #bytes "e45c67ffb16d0c87f2e1886afc6c5ba6"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 18}],
+    :xt/iid #bytes "e4737972dfe5dd09cdbaeb9f26705a26"}]
+  [{:xt/system-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 582}],
+    :xt/iid #bytes "e48a3b8492619cc562c70e6276b1b3fa"}
    {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
-  [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 926}],
-    :xt/iid #bytes "ef1b540e6b2adbf0de50ba5fb177d32a"}
-   {:xt/system-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-08-12T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1341}],
-    :xt/iid #bytes "ef46b7c597e3d5fb200fbd48f689ef70"}
-   {:xt/system-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-06-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 946}],
-    :xt/iid #bytes "ef50a9fc39c4920d38efe88eabc638c3"}
-   {:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 1511}],
-    :xt/iid #bytes "ef9b353c028f1b46b8a8252afc5c4178"}
-   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 227}],
-    :xt/iid #bytes "efd0bd717fcc079b4c108858f3f88a5c"}
-   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 627}],
-    :xt/iid #bytes "efda0f67b55c29558a78f26ee22b63b5"}
-   {:xt/system-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-09T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 591}],
-    :xt/iid #bytes "eff716f9521fba5d0fd223de95304f84"}]
+    :op #xt/tagged [:put #:xt{:id 626}],
+    :xt/iid #bytes "e4992e080eddf69d86ffcde8e4beecc9"}]
+  [{:xt/system-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 662}],
+    :xt/iid #bytes "e4c395d8e7a2cf0779d465b51e5f58ac"}
+   {:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1087}],
+    :xt/iid #bytes "e4e24feaad7d17ac9ceec72a67801aa2"}]
+  [{:xt/system-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 545}],
+    :xt/iid #bytes "e53c5aae29a001e40daae166f7bcdb95"}
+   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 268}],
+    :xt/iid #bytes "e571a824dc991c72f2f8eb72711f5976"}
+   {:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 471}],
+    :xt/iid #bytes "e597b9f0e0afa385c677c7dea7d561b9"}
+   {:xt/system-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 961}],
+    :xt/iid #bytes "e5a03e0cdb5d900af07881fa010da2d2"}
+   {:xt/system-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 196}],
+    :xt/iid #bytes "e5a38a98e655f39b93df265605baeb01"}
+   {:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 608}],
+    :xt/iid #bytes "e5d4a6b1c8507248a846866dd71f533d"}]
+  [{:xt/system-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 74}],
+    :xt/iid #bytes "e610c13bcb2a0469fb4da6f6d3946fe9"}
+   {:xt/system-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 672}],
+    :xt/iid #bytes "e63773fb84b44f6b2cc946b62fdd0906"}
+   {:xt/system-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 914}],
+    :xt/iid #bytes "e6727bd79ca7f1f7a8ed577fe19c9909"}
+   {:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 736}],
+    :xt/iid #bytes "e67a420810558dcc1e901e7e4b682df6"}
+   {:xt/system-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 851}],
+    :xt/iid #bytes "e69292b5daa255e4c485fcc3b7d91f4b"}
+   {:xt/system-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 84}],
+    :xt/iid #bytes "e6c7ae92cdcca49e2ca68f0798f65ac4"}
+   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 327}],
+    :xt/iid #bytes "e6e6fffa7db4b2d026f46bffc2368460"}
+   {:xt/system-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 130}],
+    :xt/iid #bytes "e6fa3ad2cf43fa9dcd16d2067874909e"}]
+  [{:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 266}],
+    :xt/iid #bytes "e739803d39aa6cf54430c631b6e681a1"}
+   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 479}],
+    :xt/iid #bytes "e76c2326a20cf63aca7a9b8d905f9e73"}
+   {:xt/system-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 739}],
+    :xt/iid #bytes "e79390794a005f906a5825bb4e58f9e7"}
+   {:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1388}],
+    :xt/iid #bytes "e7aa467ff7d2603b54786ad0b88f1a1d"}
+   {:xt/system-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1114}],
+    :xt/iid #bytes "e7af728016bbb232aea49d5ae014c4d5"}
+   {:xt/system-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1059}],
+    :xt/iid #bytes "e7bd9f61a89aced68ea2c6133660cc31"}
+   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1166}],
+    :xt/iid #bytes "e7bfb1c9dce18edc3656219404d2478c"}
+   {:xt/system-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 534}],
+    :xt/iid #bytes "e7e350138f070863de1cb4922d65a2da"}]
+  [{:xt/system-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1278}],
+    :xt/iid #bytes "e808af43fdf54c90ef7104e911bad6cf"}
+   {:xt/system-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 523}],
+    :xt/iid #bytes "e8162dbd25e441ad111e9d643fa1c7c2"}
+   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 795}],
+    :xt/iid #bytes "e82df4876b7e54841a7ec7ca18686203"}
+   {:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1404}],
+    :xt/iid #bytes "e88c0b9236640cbaf666dcbcd0b28461"}
+   {:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1032}],
+    :xt/iid #bytes "e89d0ba24302d8de650efa7ff158b4a6"}
+   {:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1029}],
+    :xt/iid #bytes "e8a049f1186fc4e64ef952372ed5bb86"}
+   {:xt/system-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1466}],
+    :xt/iid #bytes "e8b2a0f890bf369848264e58a475ce4d"}]
+  [{:xt/system-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1182}],
+    :xt/iid #bytes "e901c808d294e6e0c348fbb40931f22f"}
+   {:xt/system-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 310}],
+    :xt/iid #bytes "e905188e0e8ba439ef73874557207c3e"}
+   {:xt/system-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 609}],
+    :xt/iid #bytes "e90fba10241986d6b048cacebce95d49"}
+   {:xt/system-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1399}],
+    :xt/iid #bytes "e94e9e0abd7663188066c2c90119b006"}
+   {:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1024}],
+    :xt/iid #bytes "e9ae62fcab9bcf5f87353fc642ed2d41"}
+   {:xt/system-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 817}],
+    :xt/iid #bytes "e9f0220f414de38223010377818f40ab"}]
+  [{:xt/system-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 911}],
+    :xt/iid #bytes "ea28fea65a2536e49c8993834d396b8d"}]
+  [{:xt/system-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 769}],
+    :xt/iid #bytes "eb0c008d1b6a4e0f137736a8533b7812"}
+   {:xt/system-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1088}],
+    :xt/iid #bytes "eb1e4129314aa5ffbfb3508a1b0f148c"}
+   {:xt/system-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1097}],
+    :xt/iid #bytes "eb27beda39cfd5f8da3afce4347b40d9"}
+   {:xt/system-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 42}],
+    :xt/iid #bytes "ebc35dc1b8e2602b72beb8d8e5bcdb2b"}
+   {:xt/system-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 991}],
+    :xt/iid #bytes "ebc561621992718d5ed89b4e83fca32c"}
+   {:xt/system-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1063}],
+    :xt/iid #bytes "ebcb2049f066632c3d7b2c355e029f0a"}]
+  [{:xt/system-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1474}],
+    :xt/iid #bytes "ec018b2afa1bfc758e87e1fd2a84dda4"}
+   {:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 346}],
+    :xt/iid #bytes "ec354fb331777f9b941cb9d740706b01"}
+   {:xt/system-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 834}],
+    :xt/iid #bytes "ec40857e2207fde746327c59bd2bc06e"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1410}],
+    :xt/iid #bytes "ec4f7060cd456777fcdd8ac0d1cfe471"}
+   {:xt/system-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1405}],
+    :xt/iid #bytes "ec630f0481f3758091aeec242305895d"}
+   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1361}],
+    :xt/iid #bytes "ec6b51aaf78930a40f804d1bd7f54861"}]
+  [{:xt/system-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1480}],
+    :xt/iid #bytes "ed18038019a62a738047c4a842671a56"}
+   {:xt/system-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1408}],
+    :xt/iid #bytes "ed2db5d94792bdcf0ec37b0bad3372bc"}
+   {:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 778}],
+    :xt/iid #bytes "ed3f85bb07e2aec29991080cff9e262f"}
+   {:xt/system-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 324}],
+    :xt/iid #bytes "ed9136d30ebe56124221f25b7ac56820"}
+   {:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1502}],
+    :xt/iid #bytes "ed9408668b3fd58a9866838bf05af096"}
+   {:xt/system-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 433}],
+    :xt/iid #bytes "eda010faad5673847724822d9ee49202"}
+   {:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1127}],
+    :xt/iid #bytes "edf7fc70e521fba5bca32e68f7a5de61"}]
+  [{:xt/system-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 281}],
+    :xt/iid #bytes "ee2dbc499288d102c7e25780a7c7bfc8"}
+   {:xt/system-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-18T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1006}],
+    :xt/iid #bytes "ee4e5a3c82e2cbb10b04fe550d0dec75"}
+   {:xt/system-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 539}],
+    :xt/iid #bytes "ee9db4e85f07bf98243ffbbea532dedb"}]
   [{:xt/system-from #xt/zdt "2020-06-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-06-04T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p33-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/data/l03-rc-p33-b182.arrow.edn
@@ -5,520 +5,475 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :i64}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :i64}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
- ([{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+ ([{:xt/system-from #xt/zdt "2020-06-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-24T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1047}],
+    :xt/iid #bytes "f0006b31914d22b8acb097d28092bd72"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 330}],
+    :xt/iid #bytes "f000f5bc8203bade6103bc4d80c755b2"}
+   {:xt/system-from #xt/zdt "2020-07-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-15T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1168}],
+    :xt/iid #bytes "f0d1f95dad8ef9f3a99d84a2c087c4c5"}
+   {:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 941}],
+    :xt/iid #bytes "f0f13d56e470df7f7d1de8752453e6a2"}]
+  [{:xt/system-from #xt/zdt "2020-06-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-25T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
+    :op #xt/tagged [:put #:xt{:id 1053}],
+    :xt/iid #bytes "f10524027d8faee1887f870ffadd7534"}
+   {:xt/system-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1265}],
+    :xt/iid #bytes "f1882dd3f81dac26dcbce3e10983579e"}
+   {:xt/system-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1523}],
+    :xt/iid #bytes "f18bc76b55cfd68596420cb9d210478a"}
+   {:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1431}],
+    :xt/iid #bytes "f1b7e92f416a5458fb486de25b90637e"}
+   {:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1255}],
+    :xt/iid #bytes "f1bfeba094103d7b110f6ae4a4a14c24"}
+   {:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 776}],
+    :xt/iid #bytes "f1c118ff0c888dad409139ea3464c3d1"}
+   {:xt/system-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-30T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 176}],
+    :xt/iid #bytes "f1f01511fefd6be8fd810df3181d9b48"}]
+  [{:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 219}],
+    :xt/iid #bytes "f200da3feee30b64b0a6c4b50d8cd3ff"}
+   {:xt/system-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 216}],
+    :xt/iid #bytes "f20e6a9337ad7b00cf1f8829edbd4dda"}
+   {:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1422}],
+    :xt/iid #bytes "f22cf744667ecdbebbb5b16026e9f013"}
+   {:xt/system-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 253}],
+    :xt/iid #bytes "f22e28ee35070af1141edd8923b47e78"}]
+  [{:xt/system-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 91}],
+    :xt/iid #bytes "f248279170ccbdb67c8d066e379edecb"}
+   {:xt/system-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 361}],
+    :xt/iid #bytes "f263eeff7d3c590245cea81b528bc9d0"}]
+  [{:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1146}],
+    :xt/iid #bytes "f295c77d09fd48cf159f7a1ac690434e"}
+   {:xt/system-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1126}],
+    :xt/iid #bytes "f2a440378c50af26a30d677053033af8"}
+   {:xt/system-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 223}],
+    :xt/iid #bytes "f2a9d6ef03880e8bff0969735d8a2737"}]
+  [{:xt/system-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-22T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1031}],
+    :xt/iid #bytes "f30377604f899ba7460cacb6770a883c"}
+   {:xt/system-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1362}],
+    :xt/iid #bytes "f30be5b0b9970aa60d8caccb262fd7f9"}
+   {:xt/system-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-15T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 628}],
+    :xt/iid #bytes "f320854101207655a62e71a9514c81b3"}
+   {:xt/system-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 821}],
+    :xt/iid #bytes "f32d079825fc9e7de7deafbeb1ffd496"}
+   {:xt/system-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-08T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1498}],
+    :xt/iid #bytes "f3b8e7ff45037e83b658edc7a5e54b0b"}
+   {:xt/system-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1025}],
+    :xt/iid #bytes "f3cb55a22977c1dd195633a0eed304dd"}]
+  [{:xt/system-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1429}],
+    :xt/iid #bytes "f4026070bc8dc82f99b055ec82af3eed"}
+   {:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1534}],
+    :xt/iid #bytes "f4039cf4021dd491d6c5b6b9bde24db8"}
+   {:xt/system-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1095}],
+    :xt/iid #bytes "f4627d75c2688f5ea07abc765d28822e"}
+   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1418}],
+    :xt/iid #bytes "f46a03bf7921ca24c18d9576269060ba"}
+   {:xt/system-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 454}],
+    :xt/iid #bytes "f4d7adf88ece397a121abc45d74abfb0"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 724}],
+    :xt/iid #bytes "f4e376b4bff204d910068d4c7d2befa6"}
+   {:xt/system-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 983}],
+    :xt/iid #bytes "f4f1ef4153984a463d5e9df57575915f"}]
+  [{:xt/system-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1513}],
+    :xt/iid #bytes "f506af2f6295532c102aa00c8caaa170"}
+   {:xt/system-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1335}],
+    :xt/iid #bytes "f5352beda276f51f91cdd313415579e3"}
+   {:xt/system-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 942}],
+    :xt/iid #bytes "f56c0d6b112281c441df021e380f4747"}
+   {:xt/system-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 269}],
+    :xt/iid #bytes "f5724543a3f194df2a97ca0d4ec25121"}
+   {:xt/system-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-02T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 733}],
+    :xt/iid #bytes "f58a9c96ea4299d5f9021f10daf21a2a"}
+   {:xt/system-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-13T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1533}],
+    :xt/iid #bytes "f5ceede563a350d71874c13b60ab2e87"}
+   {:xt/system-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-10T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 781}],
+    :xt/iid #bytes "f5f41cf1a94dc2302f8df3c1c100ca2e"}]
+  [{:xt/system-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1539}],
+    :xt/iid #bytes "f62ef8a9725e3a488f3894830d153a56"}
+   {:xt/system-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-12T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 978}],
+    :xt/iid #bytes "f6387c9fee44bb13319167dac1b75715"}
+   {:xt/system-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 474}],
+    :xt/iid #bytes "f68c75093ab4b6e3cd6e9e5598801a94"}
+   {:xt/system-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1224}],
+    :xt/iid #bytes "f69ffa8f3c0affd2fc365866056bd73d"}]
+  [{:xt/system-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 347}],
+    :xt/iid #bytes "f7058a287d349060bed509f10cf18edb"}
+   {:xt/system-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 286}],
+    :xt/iid #bytes "f73e30473dae9aabd8c9c3f256fe028a"}
+   {:xt/system-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-28T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1071}],
+    :xt/iid #bytes "f751c85474814cdd299eeb319ab7a44a"}
+   {:xt/system-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-31T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1452}],
+    :xt/iid #bytes "f75ad965487edd9d0b10511aa94c572e"}
+   {:xt/system-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 515}],
+    :xt/iid #bytes "f7ad6127d217caa174a5fcae80acd634"}
+   {:xt/system-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1457}],
+    :xt/iid #bytes "f7f27d8460995685652657b60bb9762a"}
+   {:xt/system-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 877}],
+    :xt/iid #bytes "f7f8580728ab6523ae32a4c516eda16f"}]
+  [{:xt/system-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 843}],
+    :xt/iid #bytes "f8265282ea0fe344b9a66d806f4117c8"}
+   {:xt/system-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-21T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 485}],
+    :xt/iid #bytes "f884e42658a5467179a67e0407f99e06"}
+   {:xt/system-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 321}],
+    :xt/iid #bytes "f890b399e656a357c415555371e1f20d"}
+   {:xt/system-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 338}],
+    :xt/iid #bytes "f893d255cd0099f56980b1cd0fdc4fd0"}
+   {:xt/system-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-05T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1294}],
+    :xt/iid #bytes "f894acc5a963360157d04720cae38971"}
+   {:xt/system-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-27T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1245}],
+    :xt/iid #bytes "f8a2498739d1245a825f7f5c5012a278"}
+   {:xt/system-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 861}],
+    :xt/iid #bytes "f8a4746fb474de0d472dff2a885b5eb8"}
+   {:xt/system-from #xt/zdt "2020-03-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 499}],
+    :xt/iid #bytes "f8d4ecc936be1a8b581037943c3ca5b6"}]
+  [{:xt/system-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1421}],
+    :xt/iid #bytes "f919dbc8ec04dbe6c14bf2408c552013"}
+   {:xt/system-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-05-01T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 725}],
+    :xt/iid #bytes "f92f68d8792e507ffd288edd19dca64f"}
+   {:xt/system-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1022}],
+    :xt/iid #bytes "f939c179178a0a272346b9c977bca501"}
+   {:xt/system-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 473}],
+    :xt/iid #bytes "f972632ebad2f019d9a4b26485e0e365"}
+   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1552}],
+    :xt/iid #bytes "f98841a3bd1929bcabcf2e4f8586d2ee"}
+   {:xt/system-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-20T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1386}],
+    :xt/iid #bytes "f9b44a447db5e92c5ad65a50ee563acd"}
+   {:xt/system-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-19T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1015}],
+    :xt/iid #bytes "f9cbfeefc90e4bf8401b224da5193438"}]
+  [{:xt/system-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-11T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1148}],
+    :xt/iid #bytes "fa03b53805fe1ce5394359c77bc91aba"}
+   {:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 19}],
+    :xt/iid #bytes "fa5128f99a20e220451b1733612fe886"}
+   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1557}],
+    :xt/iid #bytes "fa8aeba984ababfcd8d4e08317532fa8"}
    {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 358}],
+    :xt/iid #bytes "fab546cdb543e03b6bb65d62e1e137a2"}
+   {:xt/system-from #xt/zdt "2020-07-21T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-21T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
+    :op #xt/tagged [:put #:xt{:id 1206}],
+    :xt/iid #bytes "fac5ddf5defdc0c25cffefef7fc412f4"}
+   {:xt/system-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 712}],
+    :xt/iid #bytes "faf9f86ec4325c3d77afdb4bf049abbf"}]
+  [{:xt/system-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-03T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 922}],
+    :xt/iid #bytes "fb0be7dc7ab02633c26f36f769728fc0"}
+   {:xt/system-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-02-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 335}],
+    :xt/iid #bytes "fb0c8b11c380f1a08516f8a835fba137"}
+   {:xt/system-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-06T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1488}],
+    :xt/iid #bytes "fb1cf0756f40594e62f1b3e3bf0d8401"}
+   {:xt/system-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1232}],
+    :xt/iid #bytes "fb1fbd089d89b030a28d4768af84d5e8"}
+   {:xt/system-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1257}],
+    :xt/iid #bytes "fb5b10fbaea7ac3fd1fe578afeca840e"}
+   {:xt/system-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-03-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 442}],
+    :xt/iid #bytes "fbe3f7033ca7952bacfbc503d989189f"}]
+  [{:xt/system-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-06-23T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1036}],
+    :xt/iid #bytes "fc7ad71e87d3723d1fb5fb14d3d495ad"}
    {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
-  [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 82}],
-    :xt/iid #bytes "ff179d959fb904655facfbb2227f19ae"}
-   {:xt/system-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-04-06T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 573}],
-    :xt/iid #bytes "ff30b675c675d627670d435d640b7bf8"}
-   {:xt/system-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-05T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 212}],
-    :xt/iid #bytes "ff5ea82b2a5b66aab57bf1ca184d4a70"}
-   {:xt/system-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-13T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 797}],
-    :xt/iid #bytes "ff8ea96466984f77ed007ccaf22a40bd"}
-   {:xt/system-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-05-04T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 742}],
-    :xt/iid #bytes "ff9dbd6cf4bf23ecaf476b58bb418d75"}
-   {:xt/system-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-from #xt/zdt "2020-02-29T00:00Z[UTC]",
-    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
-    :op #xt/tagged [:put #:xt{:id 359}],
-    :xt/iid #bytes "ffdd1b66e26b899493deadfcbe51987e"}]
+    :op #xt/tagged [:put #:xt{:id 575}],
+    :xt/iid #bytes "fca16bd8e96c9c9ec0a8accaea1cdccc"}
+   {:xt/system-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1367}],
+    :xt/iid #bytes "fca887397ffc87d2b0f8413d25f632e1"}
+   {:xt/system-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1553}],
+    :xt/iid #bytes "fcdafa948764d36c282eadefc398429a"}
+   {:xt/system-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-17T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 100}],
+    :xt/iid #bytes "fcef3963f5be4e78da91c2db9be92ca8"}]
+  [{:xt/system-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-24T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 141}],
+    :xt/iid #bytes "fd12e21baf2a9117d1e61563441ed752"}
+   {:xt/system-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-09-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1496}],
+    :xt/iid #bytes "fd17c378bd28a140f80018f9cea5c407"}
+   {:xt/system-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-14T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1165}],
+    :xt/iid #bytes "fd2f47ad3644a41258f68a609ee27339"}
+   {:xt/system-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 148}],
+    :xt/iid #bytes "fdb3c00260701898ce89921ad20dbf84"}
+   {:xt/system-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-26T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1239}],
+    :xt/iid #bytes "fddbd8c441cee2f2d3f38beeb97c52b8"}
+   {:xt/system-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-29T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1441}],
+    :xt/iid #bytes "fdea27fe9c4b7f8e18055158dd8e7964"}]
+  [{:xt/system-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-01-09T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 50}],
+    :xt/iid #bytes "fe308246ceb760a0442106fc0b7c65bb"}
+   {:xt/system-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-07-07T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1120}],
+    :xt/iid #bytes "fe4a7256332b1a2863b463573c473270"}
+   {:xt/system-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-08-25T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 1414}],
+    :xt/iid #bytes "fea164f30cf303875e58f0250c1d725d"}
+   {:xt/system-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-from #xt/zdt "2020-04-16T00:00Z[UTC]",
+    :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",
+    :op #xt/tagged [:put #:xt{:id 636}],
+    :xt/iid #bytes "febd6f076b5a138cc961823feb30cf81"}]
   [{:xt/system-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-14T00:00Z[UTC]",
     :xt/valid-to #xt/zdt "+294247-01-10T04:00:54.775807Z[UTC]",

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p0-b11f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p0-b11f.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p0-b13f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p0-b13f.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p0-b162.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p0-b162.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p0-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p0-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p0-b1a4.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p0-b1a4.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p1-b11f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p1-b11f.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p1-b13f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p1-b13f.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p1-b162.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p1-b162.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p1-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p1-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p1-b1a4.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p1-b1a4.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p2-b11f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p2-b11f.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p2-b13f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p2-b13f.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p2-b162.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p2-b162.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p2-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p2-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p2-b1a4.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p2-b1a4.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p3-b11f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p3-b11f.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p3-b13f.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p3-b13f.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p3-b162.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p3-b162.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p3-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p3-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p3-b1a4.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l02-rc-p3-b1a4.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p00-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p00-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p01-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p01-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p02-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p02-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p03-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p03-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p10-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p10-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p11-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p11-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p12-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p12-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p13-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p13-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p20-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p20-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p21-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p21-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p22-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p22-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p23-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p23-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p30-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p30-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p31-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p31-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p32-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p32-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p33-b182.arrow.edn
+++ b/src/test/resources/xtdb/compactor-test/test-l2+-compaction/meta/l03-rc-p33-b182.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/public$device_info/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/public$device_info/data/l00-rc-b00.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :utf8}
-                 {"api_version" :utf8}
-                 {"manufacturer" :utf8}
-                 {"model" :utf8}
-                 {"os_name" :utf8}]}]}),
+                 {"_id" :utf8,
+                  "api_version" :utf8,
+                  "manufacturer" :utf8,
+                  "model" :utf8,
+                  "os_name" :utf8}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/public$device_info/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/public$device_info/meta/l00-rc-b00.arrow.edn
@@ -1,21 +1,21 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/public$device_readings/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/public$device_readings/data/l00-rc-b00.arrow.edn
@@ -5,24 +5,24 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"cpu_avg_15min" :f64}
-                 {"device_id" :utf8}
-                 {"rssi" :f64}
-                 {"cpu_avg_5min" :f64}
-                 {"battery_status" :utf8}
-                 {"ssid" :utf8}
-                 {"time" :instant}
-                 {"battery_level" :f64}
-                 {"bssid" :utf8}
-                 {"battery_temperature" :f64}
-                 {"cpu_avg_1min" :f64}
-                 {"_id" :utf8}
-                 {"mem_free" :f64}
-                 {"mem_used" :f64}]}]}),
+                 {"cpu_avg_1min" :f64,
+                  "cpu_avg_15min" :f64,
+                  "device_id" :utf8,
+                  "battery_level" :f64,
+                  "mem_used" :f64,
+                  "battery_status" :utf8,
+                  "mem_free" :f64,
+                  "time" :instant,
+                  "ssid" :utf8,
+                  "rssi" :f64,
+                  "_id" :utf8,
+                  "cpu_avg_5min" :f64,
+                  "battery_temperature" :f64,
+                  "bssid" :utf8}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/public$device_readings/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/public$device_readings/meta/l00-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/arrow/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$foo/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$foo/data/l00-rc-b00.arrow.edn
@@ -5,13 +5,11 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"bar" :i64}
-                 {"toto" [:? :utf8]}]}]}),
+                 {"_id" :i64, "bar" :i64, "toto" [:? :utf8]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-05T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "-290308-12-21T19:59:05.224192Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$foo/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$foo/meta/l00-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$hello/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$hello/data/l00-rc-b00.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put" [:struct {"_id" :uuid} {"a" :i64}]}]}),
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put" [:struct {"_id" :uuid, "a" :i64}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$hello/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$hello/meta/l00-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$world/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$world/data/l00-rc-b00.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put" [:struct {"_id" :uuid} {"b" :i64}]}]}),
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put" [:struct {"_id" :uuid, "b" :i64}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "-290308-12-21T19:59:05.224192Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$world/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/public$world/meta/l00-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/arrow/v06_e01/tables/public$xt_docs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/arrow/v06_e01/tables/public$xt_docs/data/l00-rc-b00.arrow.edn
@@ -5,18 +5,18 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" [:union :utf8 :i64 :keyword]}
-                 {"list" [:? :list [:union :f64 :utf8 :instant :bool]]}
-                 {"struct"
+                 {"_id" [:union :utf8 :i64 :keyword],
+                  "list" [:? :list [:union :f64 :utf8 :instant :bool]],
+                  "struct"
                   [:?
                    :struct
-                   {"a" [:union :i64 :bool]}
-                   {"b" [:? :utf8]}
-                   {"c" [:? :utf8]}]}]}]}),
+                   {"a" [:union :i64 :bool],
+                    "b" [:? :utf8],
+                    "c" [:? :utf8]}]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/arrow/v06_e01/tables/public$xt_docs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/arrow/v06_e01/tables/public$xt_docs/meta/l00-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"list" [:? :i32]}
-                     {"struct" [:? :list :i32]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "list" [:? :i32],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/arrow/v06_e01/tables/xt$txs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/arrow/v06_e01/tables/xt$txs/data/l00-rc-b00.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/arrow/v06_e01/tables/xt$txs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/arrow/v06_e01/tables/xt$txs/meta/l00-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/tables/public$xt_docs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/tables/public$xt_docs/blocks/b00.binpb.edn
@@ -4,7 +4,7 @@
   "list"
   #xt/field {"list" [:? :list [:union :f64 :utf8 :instant :bool]]},
   "struct"
-  #xt/field {"struct" [:? :struct {"a" [:union :i64 :bool]} {"b" [:? :utf8]} {"c" [:? :utf8]}]}},
+  #xt/field {"struct" [:? :struct {"a" [:union :i64 :bool], "b" [:? :utf8], "c" [:? :utf8]}]}},
  :hlls
  {"_id" [-1707429676 6.01764709272061],
   "list" [-791736731 3.004403133222472],

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/arrow/v06/tables/public$table/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/arrow/v06/tables/public$table/data/l00-rc-b00.arrow.edn
@@ -5,14 +5,14 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"foo" :i64}
-                 {"bar" :utf8}
-                 {"baz" [:union :i64 :f64]}]}]}),
+                 {"_id" :i64,
+                  "foo" :i64,
+                  "bar" :utf8,
+                  "baz" [:union :i64 :f64]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/arrow/v06/tables/public$table/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/arrow/v06/tables/public$table/meta/l00-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/arrow/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/arrow/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/arrow/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/arrow/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/data/l00-rc-b00.arrow.edn
@@ -5,14 +5,14 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :utf8}
-                 {"a" [:? :i64]}
-                 {"b" [:? :i64]}
-                 {"c" [:? :i64]}]}]}),
+                 {"_id" :utf8,
+                  "a" [:? :i64],
+                  "b" [:? :i64],
+                  "c" [:? :i64]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/data/l00-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/data/l00-rc-b01.arrow.edn
@@ -4,7 +4,7 @@
              {"_valid_from" :instant}
              {"_valid_to" :instant}
              {"op"
-              [:union {"delete" [:? :null]} {"erase" [:? :null]}]}),
+              [:union {"delete" [:? :null], "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/data/l00-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/data/l00-rc-b02.arrow.edn
@@ -4,7 +4,7 @@
              {"_valid_from" :instant}
              {"_valid_to" :instant}
              {"op"
-              [:union {"delete" [:? :null]} {"erase" [:? :null]}]}),
+              [:union {"delete" [:? :null], "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "-290308-12-21T19:59:05.224192Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/data/l00-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/data/l00-rc-b03.arrow.edn
@@ -4,7 +4,7 @@
              {"_valid_from" :instant}
              {"_valid_to" :instant}
              {"op"
-              [:union {"delete" [:? :null]} {"erase" [:? :null]}]}),
+              [:union {"delete" [:? :null], "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "-290308-12-21T19:59:05.224192Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/meta/l00-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "numbers"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/meta/l00-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/meta/l00-rc-b01.arrow.edn
@@ -1,21 +1,21 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/meta/l00-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/meta/l00-rc-b02.arrow.edn
@@ -1,21 +1,21 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/meta/l00-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/public$docs/meta/l00-rc-b03.arrow.edn
@@ -1,21 +1,21 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/data/l00-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/data/l00-rc-b01.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/data/l00-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/data/l00-rc-b02.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/data/l00-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/data/l00-rc-b03.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-04T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-04T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b01.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b01.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b02.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b02.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b03.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/copes-with-missing-put/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b03.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/arrow/objects/v06/tables/public$xt_docs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/arrow/objects/v06/tables/public$xt_docs/data/l00-rc-b00.arrow.edn
@@ -5,22 +5,21 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" [:union :utf8 :keyword :i64]}
-                 {"list" [:? :list [:union :f64 :utf8 :instant :bool]]}
-                 {"struct"
+                 {"_id" [:union :utf8 :keyword :i64],
+                  "list" [:? :list [:union :f64 :utf8 :instant :bool]],
+                  "struct"
                   [:?
                    :struct
-                   {"a" [:union :i64 :bool]}
-                   {"b"
+                   {"a" [:union :i64 :bool],
+                    "b"
                     [:union
                      :utf8
                      [:struct
-                      {"c" [:? :utf8]}
-                      {"d" [:? :utf8]}]]}]}]}]}),
+                      {"c" [:? :utf8], "d" [:? :utf8]}]]}]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/arrow/objects/v06/tables/public$xt_docs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/arrow/objects/v06/tables/public$xt_docs/meta/l00-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"list" [:? :i32]}
-                     {"struct" [:? :list :i32]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "list" [:? :i32],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/arrow/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/arrow/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-02T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-02T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/tables/public$xt_docs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/tables/public$xt_docs/blocks/b00.binpb.edn
@@ -4,7 +4,7 @@
   "list"
   #xt/field {"list" [:? :list [:union :f64 :utf8 :instant :bool]]},
   "struct"
-  #xt/field {"struct" [:? :struct {"a" [:union :i64 :bool]} {"b" [:union :utf8 [:struct {"c" [:? :utf8]} {"d" [:? :utf8]}]]}]}},
+  #xt/field {"struct" [:? :struct {"a" [:union :i64 :bool], "b" [:union :utf8 [:struct {"c" [:? :utf8], "d" [:? :utf8]}]]}]}},
  :hlls
  {"_id" [-1707429676 6.01764709272061],
   "list" [-791736731 3.004403133222472],

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/arrow/objects/v06/tables/public$xt_docs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/arrow/objects/v06/tables/public$xt_docs/data/l00-rc-b00.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put" [:struct {"_id" :utf8} {"month" [:? :utf8]}]}]}),
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put" [:struct {"_id" :utf8, "month" [:? :utf8]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-04-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/arrow/objects/v06/tables/public$xt_docs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/arrow/objects/v06/tables/public$xt_docs/meta/l00-rc-b00.arrow.edn
@@ -1,21 +1,21 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/arrow/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/arrow/objects/v06/tables/xt$txs/data/l00-rc-b00.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-03T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-03T00:00Z[UTC]",

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/arrow/objects/v06/tables/xt$txs/meta/l00-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/metadata-test/duration/public$xt_docs/data/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/duration/public$xt_docs/data/l01-rc-b00.arrow.edn
@@ -6,11 +6,9 @@
              {"op"
               [:union
                {"put"
-                [:struct
-                 {"_id" :utf8}
-                 {"duration" [:duration :micro]}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+                [:struct {"_id" :utf8, "duration" [:duration :micro]}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/metadata-test/duration/public$xt_docs/meta/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/duration/public$xt_docs/meta/l01-rc-b00.arrow.edn
@@ -1,23 +1,23 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"durations"
-                      [:? :struct {"min" :f64} {"max" :f64}]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "durations"
+                      [:? :struct {"min" :f64, "max" :f64}]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/metadata-test/duration/xt$txs/data/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/duration/xt$txs/data/l01-rc-b00.arrow.edn
@@ -7,13 +7,13 @@
               [:union
                {"put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/metadata-test/duration/xt$txs/meta/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/duration/xt$txs/meta/l01-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/metadata-test/set/public$xt_docs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/set/public$xt_docs/data/l00-rc-b00.arrow.edn
@@ -5,10 +5,10 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
-                [:struct {"_id" :utf8} {"colours" [:set :utf8]}]}]}),
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
+                [:struct {"_id" :utf8, "colours" [:set :utf8]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/metadata-test/set/public$xt_docs/data/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/set/public$xt_docs/data/l01-rc-b00.arrow.edn
@@ -5,9 +5,9 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"put" [:struct {"_id" :utf8} {"colours" [:set :utf8]}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+               {"put" [:struct {"_id" :utf8, "colours" [:set :utf8]}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/metadata-test/set/public$xt_docs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/set/public$xt_docs/meta/l00-rc-b00.arrow.edn
@@ -1,22 +1,22 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"set" [:? :i32]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "set" [:? :i32]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/metadata-test/set/public$xt_docs/meta/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/set/public$xt_docs/meta/l01-rc-b00.arrow.edn
@@ -1,22 +1,22 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"set" [:? :i32]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "root-col?" :bool,
+                      "count" :i64,
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "set" [:? :i32]}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/metadata-test/set/xt$txs/data/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/set/xt$txs/data/l00-rc-b00.arrow.edn
@@ -5,15 +5,15 @@
              {"_valid_to" :instant}
              {"op"
               [:union
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}
-               {"put"
+               {"delete" [:? :null],
+                "erase" [:? :null],
+                "put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/metadata-test/set/xt$txs/data/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/set/xt$txs/data/l01-rc-b00.arrow.edn
@@ -7,13 +7,13 @@
               [:union
                {"put"
                 [:struct
-                 {"_id" :i64}
-                 {"system_time" :instant}
-                 {"committed" :bool}
-                 {"user_metadata" [:? :struct]}
-                 {"error" [:? :transit]}]}
-               {"delete" [:? :null]}
-               {"erase" [:? :null]}]}),
+                 {"_id" :i64,
+                  "system_time" :instant,
+                  "committed" :bool,
+                  "user_metadata" [:? :struct],
+                  "error" [:? :transit]}],
+                "delete" [:? :null],
+                "erase" [:? :null]}]}),
  :batches
  ([{:xt/system-from #xt/zdt "2020-01-01T00:00Z[UTC]",
     :xt/valid-from #xt/zdt "2020-01-01T00:00Z[UTC]",

--- a/src/test/resources/xtdb/metadata-test/set/xt$txs/meta/l00-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/set/xt$txs/meta/l00-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/metadata-test/set/xt$txs/meta/l01-rc-b00.arrow.edn
+++ b/src/test/resources/xtdb/metadata-test/set/xt$txs/meta/l01-rc-b00.arrow.edn
@@ -1,25 +1,25 @@
 {:schema
  #xt/schema ({"nodes"
               [:union
-               {"nil" [:? :null]}
-               {"branch-iid" [:list [:? :i32]]}
-               {"leaf"
+               {"nil" [:? :null],
+                "branch-iid" [:list [:? :i32]],
+                "leaf"
                 [:struct
-                 {"data-page-idx" :i32}
-                 {"columns"
+                 {"data-page-idx" :i32,
+                  "columns"
                   [:list
                    {"col"
                     [:struct
-                     {"col-name" :utf8}
-                     {"root-col?" :bool}
-                     {"count" :i64}
-                     {"bytes" [:? :struct {"bloom" [:? :varbinary]}]}
-                     {"date-times"
-                      [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"numbers" [:? :struct {"min" :f64} {"max" :f64}]}
-                     {"bool" [:? :bool]}
-                     {"struct" [:? :list :i32]}
-                     {"transit" [:? :bool]}]}]}]}]}),
+                     {"col-name" :utf8,
+                      "transit" [:? :bool],
+                      "count" :i64,
+                      "bool" [:? :bool],
+                      "bytes" [:? :struct {"bloom" [:? :varbinary]}],
+                      "numbers" [:? :struct {"min" :f64, "max" :f64}],
+                      "date-times"
+                      [:? :struct {"min" :f64, "max" :f64}],
+                      "struct" [:? :list :i32],
+                      "root-col?" :bool}]}]}]}]}),
  :batches
  ([{:nodes
     #xt/tagged [:leaf

--- a/src/test/resources/xtdb/tx-log-test/can-write-opts.arrow.edn
+++ b/src/test/resources/xtdb/tx-log-test/can-write-opts.arrow.edn
@@ -3,7 +3,7 @@
               [:list
                [:union
                 {"sql"
-                 [:struct {"query" :utf8} {"args" [:? :varbinary]}]}]]}
+                 [:struct {"query" :utf8, "args" [:? :varbinary]}]}]]}
              {"system-time" [:? :instant]}
              {"default-tz" :utf8}
              {"user" [:? :utf8]}

--- a/src/test/resources/xtdb/tx-log-test/can-write-sql.arrow.edn
+++ b/src/test/resources/xtdb/tx-log-test/can-write-sql.arrow.edn
@@ -3,7 +3,7 @@
               [:list
                [:union
                 {"sql"
-                 [:struct {"query" :utf8} {"args" [:? :varbinary]}]}]]}
+                 [:struct {"query" :utf8, "args" [:? :varbinary]}]}]]}
              {"system-time" [:? :instant]}
              {"default-tz" :utf8}
              {"user" [:? :utf8]}

--- a/src/test/resources/xtdb/tx-log-test/can-write-tx.arrow.edn
+++ b/src/test/resources/xtdb/tx-log-test/can-write-tx.arrow.edn
@@ -4,36 +4,36 @@
                [:union
                 {"put-docs"
                  [:struct
-                  {"iids" [:list [:fixed-size-binary 16]]}
-                  {"documents"
+                  {"iids" [:list [:fixed-size-binary 16]],
+                   "documents"
                    [:union
                     {"public/device_info"
                      [:list
                       [:struct
-                       {"_id" :utf8}
-                       {"api_version" :utf8}
-                       {"manufacturer" :utf8}
-                       {"model" :utf8}
-                       {"os_name" :utf8}]]}
-                    {"public/device_readings"
+                       {"_id" :utf8,
+                        "api_version" :utf8,
+                        "manufacturer" :utf8,
+                        "model" :utf8,
+                        "os_name" :utf8}]],
+                     "public/device_readings"
                      [:list
                       [:struct
-                       {"cpu_avg_15min" :f64}
-                       {"device_id" :utf8}
-                       {"rssi" :f64}
-                       {"cpu_avg_5min" :f64}
-                       {"battery_status" :utf8}
-                       {"ssid" :utf8}
-                       {"time" :instant}
-                       {"battery_level" :f64}
-                       {"bssid" :utf8}
-                       {"battery_temperature" :f64}
-                       {"cpu_avg_1min" :f64}
-                       {"_id" :utf8}
-                       {"mem_free" :f64}
-                       {"mem_used" :f64}]]}]}
-                  {"_valid_from" [:? :instant]}
-                  {"_valid_to" [:? :instant]}]}]]}
+                       {"cpu_avg_1min" :f64,
+                        "cpu_avg_15min" :f64,
+                        "device_id" :utf8,
+                        "battery_level" :f64,
+                        "mem_used" :f64,
+                        "battery_status" :utf8,
+                        "mem_free" :f64,
+                        "time" :instant,
+                        "ssid" :utf8,
+                        "rssi" :f64,
+                        "_id" :utf8,
+                        "cpu_avg_5min" :f64,
+                        "battery_temperature" :f64,
+                        "bssid" :utf8}]]}],
+                   "_valid_from" [:? :instant],
+                   "_valid_to" [:? :instant]}]}]]}
              {"system-time" [:? :instant]}
              {"default-tz" :utf8}
              {"user" [:? :utf8]}

--- a/src/test/resources/xtdb/tx-log-test/docs-with-different-keys.arrow.edn
+++ b/src/test/resources/xtdb/tx-log-test/docs-with-different-keys.arrow.edn
@@ -4,19 +4,19 @@
                [:union
                 {"put-docs"
                  [:struct
-                  {"iids" [:list [:fixed-size-binary 16]]}
-                  {"documents"
+                  {"iids" [:list [:fixed-size-binary 16]],
+                   "documents"
                    [:union
                     {"public/foo"
                      [:list
                       [:struct
-                       {"_id" [:union :keyword :utf8]}
-                       {"a" [:? :i64]}
-                       {"b" [:? :i64]}]]}
-                    {"public/bar"
-                     [:list [:struct {"_id" :i64} {"c" :i64}]]}]}
-                  {"_valid_from" [:? :instant]}
-                  {"_valid_to" [:? :instant]}]}]]}
+                       {"_id" [:union :keyword :utf8],
+                        "a" [:? :i64],
+                        "b" [:? :i64]}]],
+                     "public/bar"
+                     [:list [:struct {"_id" :i64, "c" :i64}]]}],
+                   "_valid_from" [:? :instant],
+                   "_valid_to" [:? :instant]}]}]]}
              {"system-time" [:? :instant]}
              {"default-tz" :utf8}
              {"user" [:? :utf8]}

--- a/src/test/resources/xtdb/tx-log-test/tx-metadata.arrow.edn
+++ b/src/test/resources/xtdb/tx-log-test/tx-metadata.arrow.edn
@@ -3,16 +3,16 @@
               [:list
                [:union
                 {"sql"
-                 [:struct {"query" :utf8} {"args" [:? :varbinary]}]}]]}
+                 [:struct {"query" :utf8, "args" [:? :varbinary]}]}]]}
              {"system-time" [:? :instant]}
              {"default-tz" :utf8}
              {"user" [:? :utf8]}
              {"user-metadata"
               [:?
                :struct
-               {"source" :utf8}
-               {"tags" [:list :utf8]}
-               {"correlation_id" :utf8}]}),
+               {"source" :utf8,
+                "tags" [:list :utf8],
+                "correlation_id" :utf8}]}),
  :data
  [{:user-metadata
    {:source "mobile-app",

--- a/src/testFixtures/clojure/xtdb/test_generators.clj
+++ b/src/testFixtures/clojure/xtdb/test_generators.clj
@@ -256,12 +256,12 @@
                     #xt.arrow/type :instant instant-gen
                     #xt.arrow/type [:date :day] local-date-gen
                     #xt.arrow/type [:time-local :nano] local-time-gen
-                    #xt.arrow/type :list (gen/vector (vec-type->value-generator (first (.getChildren vec-type))) 0 10)
-                    #xt.arrow/type :set (gen/set (vec-type->value-generator (first (.getChildren vec-type))) {:min-elements 0 :max-elements 10})
-                    #xt.arrow/type :union (gen/one-of (map vec-type->value-generator (.getChildren vec-type)))
-                    #xt.arrow/type :struct (gen/let [entries (apply gen/tuple (map (fn [^Field child-field]
-                                                                                     (gen/let [v (vec-type->value-generator child-field)]
-                                                                                       (when v [(keyword (.getName child-field)) v])))
+                    #xt.arrow/type :list (gen/vector (vec-type->value-generator (.firstChildOrNull vec-type)) 0 10)
+                    #xt.arrow/type :set (gen/set (vec-type->value-generator (.firstChildOrNull vec-type)) {:min-elements 0 :max-elements 10})
+                    #xt.arrow/type :union (gen/one-of (map vec-type->value-generator (vals (.getChildren vec-type))))
+                    #xt.arrow/type :struct (gen/let [entries (apply gen/tuple (map (fn [[child-name child-type]]
+                                                                                     (gen/let [v (vec-type->value-generator child-type)]
+                                                                                       (when v [(keyword child-name) v])))
                                                                                    (.getChildren vec-type)))]
                                              (->> (filter some? entries)
                                                   (into {})))


### PR DESCRIPTION
follows on (partially supersedes) #5003 

In the EE, we required the ordering of legs within a union to be consistent between compile-time and run-time - the previous col-types reflected this by using a map of types, but the newer VectorTypes leaned more on Arrow's `Field`, which imposes an ordering.

This PR moves VectorTypes slightly back towards col-types by making the children a map from field-name -> VectorType, and updates the helpers/reader-macros accordingly.