### PR TITLE
feat: Handling cursoring within cmd-exec-query.

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -1327,7 +1327,8 @@
       Future$State/FAILED (throw (.exceptionNow task)))))
 
 (defn cmd-exec-query [{:keys [conn-state !closing? query-error-counter] :as conn}
-                      {:keys [limit statement-type query ^IResultCursor cursor pg-cols] :as _portal}]
+                      {:keys [limit statement-type query ^IResultCursor cursor pg-cols portal-name pending-rows]
+                       :as _portal}]
   ;; Create an implicit transaction if one hasn't already been started
   (let [transaction (get-in @conn-state [:transaction])]
     (when (:failed transaction)
@@ -1338,6 +1339,7 @@
 
   (try
     (let [!n-rows-out (volatile! 0)
+          !pending (volatile! [])
           {session-params :parameters, :as session} (:session @conn-state)
           fallback (fallback-type session)
           serialize-row (fn [^RelationReader rel idx]
@@ -1355,7 +1357,15 @@
       (run-cancellable-query!
        conn
        (fn []
-         (while (and (or (nil? limit) (< @!n-rows-out limit))
+         ;; Send any pending rows from previous Execute
+         (when (not-empty pending-rows)
+           (let [[to-send to-keep] (split-at (or limit (count pending-rows)) pending-rows)] 
+             (run! send-row! to-send)
+             (vreset! !pending (vec to-keep))))
+
+         ;; If no pending rows left to process, continue with cursor
+         (while (and (empty? @!pending)
+                     (or (nil? limit) (< @!n-rows-out limit))
                      (.tryAdvance cursor
                                   (fn [^RelationReader rel]
                                     (log/trace "advancing cursor with rel count" (.getRowCount rel))
@@ -1364,11 +1374,23 @@
 
                                       @!closing? (log/trace "query result stream stopping (conn closing)")
 
-                                      :else (dotimes [idx (cond-> (.getRowCount rel) 
-                                                            limit (min (- limit @!n-rows-out)))]
-                                              (send-row! (serialize-row rel idx))))))))))
+                                      :else (let [row-count (.getRowCount rel)
+                                                  num-to-send (cond-> row-count
+                                                                limit (min (- limit @!n-rows-out)))]
+                                              ;; Send rows up to limit 
+                                              (dotimes [idx num-to-send] 
+                                                (send-row! (serialize-row rel idx)))
+                                              ;; Buffer any remaining rows for next Execute 
+                                              (dotimes [idx (- row-count num-to-send)] 
+                                                (vswap! !pending conj (serialize-row rel (+ num-to-send idx))))))))))))
 
-      (pgio/cmd-write-msg conn pgio/msg-command-complete {:command (str (statement-head query) " " @!n-rows-out)}))
+      ;; Save any pending rows back to portal
+      (when portal-name
+        (swap! conn-state assoc-in [:portals portal-name :pending-rows] @!pending))
+
+      (if (= @!n-rows-out limit)
+        (pgio/cmd-write-msg conn pgio/msg-portal-suspended)
+        (pgio/cmd-write-msg conn pgio/msg-command-complete {:command (str (statement-head query) " " @!n-rows-out)})))
 
     (catch Interrupted e (throw e))
     (catch InterruptedException e (throw e))
@@ -1488,7 +1510,8 @@
   (let [portal (or (get-in @conn-state [:portals portal-name])
                    (throw (pgio/err-protocol-violation "no such portal")))]
     (execute-portal conn (cond-> portal
-                           (not (zero? limit)) (assoc :limit limit)))))
+                           (not (zero? limit)) (assoc :limit limit)
+                           :always (assoc :portal-name portal-name)))))
 
 (defmethod handle-msg* :msg-simple-query [{:keys [conn-state] :as conn} {:keys [query]}]
   (swap! conn-state assoc :protocol :simple)

--- a/src/test/clojure/xtdb/pgwire_protocol_test.clj
+++ b/src/test/clojure/xtdb/pgwire_protocol_test.clj
@@ -391,3 +391,45 @@
                   [:msg-command-complete {:command "SELECT 3"}]
                   [:msg-ready {:status :transaction}]]
                  @!in-msgs))))))
+
+;; When result-size = limit, we require one extra Execute round-trip to discover the cursor is exhausted.
+;; We could avoid this by augmenting cursors with a 'hasMore' check, but accepting this for now.
+(deftest test-cursor-row-count-equals-limit-5131
+  (let [{:keys [!in-msgs] :as frontend} (->recording-frontend)
+        portal-name "cursor-test"
+        stmt-name "cursor-stmt"]
+    (with-open [conn (->conn frontend {"user" "xtdb" "database" "xtdb"})]
+      (reset! !in-msgs [])
+      (pgwire/handle-msg conn {:msg-name :msg-simple-query
+                               :query "INSERT INTO bar RECORDS {_id: 1}, {_id: 2}"})
+
+      (t/testing "First Execute: row count = limit, returns portal-suspended"
+        (reset! !in-msgs [])
+        (pgwire/handle-msg conn {:msg-name :msg-simple-query :query "BEGIN"})
+        (pgwire/handle-msg conn {:msg-name :msg-parse :stmt-name stmt-name
+                                 :query "SELECT _id FROM bar ORDER BY _id" :param-oids []})
+        (pgwire/handle-msg conn {:msg-name :msg-bind
+                                 :portal-name portal-name :stmt-name stmt-name
+                                 :arg-format [] :args [] :result-format nil})
+        (pgwire/handle-msg conn {:msg-name :msg-execute :portal-name portal-name :limit 2})
+        (pgwire/handle-msg conn {:msg-name :msg-sync})
+
+        (t/is (= [[:msg-command-complete {:command "BEGIN"}]
+                  [:msg-ready {:status :transaction}]
+                  [:msg-parse-complete]
+                  [:msg-bind-complete]
+                  [:msg-data-row {:vals ["1"]}]
+                  [:msg-data-row {:vals ["2"]}]
+                  [:msg-portal-suspended]
+                  [:msg-ready {:status :transaction}]]
+                 @!in-msgs)))
+
+      (t/testing "Second Execute: cursor exhausted, returns command-complete (not portal-suspended)"
+        (reset! !in-msgs [])
+        (pgwire/handle-msg conn {:msg-name :msg-execute :portal-name portal-name :limit 2})
+        (pgwire/handle-msg conn {:msg-name :msg-sync})
+        (pgwire/handle-msg conn {:msg-name :msg-terminate})
+
+        (t/is (= [[:msg-command-complete {:command "SELECT 2"}]
+                  [:msg-ready {:status :transaction}]]
+                 @!in-msgs))))))

--- a/src/test/clojure/xtdb/pgwire_protocol_test.clj
+++ b/src/test/clojure/xtdb/pgwire_protocol_test.clj
@@ -344,3 +344,50 @@
                                        :detail nil}}]
                 [:msg-ready {:status :idle}]]
                (test "SELECT 1 one; BEGIN"))))))
+
+(deftest test-cursor-protocol-messages-5131
+  (let [{:keys [!in-msgs] :as frontend} (->recording-frontend)
+        portal-name "cursor-test"
+        stmt-name "cursor-stmt"]
+    (with-open [conn (->conn frontend {"user" "xtdb" "database" "xtdb"})]
+      (reset! !in-msgs [])
+      (pgwire/handle-msg conn {:msg-name :msg-simple-query
+                               :query "INSERT INTO foo RECORDS {_id: 1}, {_id: 2}, {_id: 3}"})
+
+      (t/testing "Execute with limit returns portal-suspended"
+        (reset! !in-msgs [])
+        (pgwire/handle-msg conn {:msg-name :msg-simple-query
+                                 :query "BEGIN"})
+        (pgwire/handle-msg conn {:msg-name :msg-parse :stmt-name stmt-name
+                                 :query "SELECT _id FROM foo ORDER BY _id" :param-oids []})
+        (pgwire/handle-msg conn {:msg-name :msg-bind
+                                 :portal-name portal-name :stmt-name stmt-name
+                                 :arg-format [] :args [] :result-format nil})
+        (pgwire/handle-msg conn {:msg-name :msg-describe :describe-type :portal :describe-name portal-name})
+        (pgwire/handle-msg conn {:msg-name :msg-execute :portal-name portal-name :limit 2})
+        (pgwire/handle-msg conn {:msg-name :msg-sync})
+
+        (t/is (= [[:msg-command-complete {:command "BEGIN"}]
+                  [:msg-ready {:status :transaction}]
+                  [:msg-parse-complete]
+                  [:msg-bind-complete]
+                  [:msg-row-description {:columns [{:column-name "_id"
+                                                    :table-oid 0 :column-attribute-number 0
+                                                    :column-oid 20 :typlen 8
+                                                    :type-modifier -1 :result-format :text}]}]
+                  [:msg-data-row {:vals ["1"]}]
+                  [:msg-data-row {:vals ["2"]}]
+                  [:msg-portal-suspended]
+                  [:msg-ready {:status :transaction}]]
+                 @!in-msgs)))
+
+      (t/testing "Subsequent Execute returns remaining rows and command-complete"
+        (reset! !in-msgs [])
+        (pgwire/handle-msg conn {:msg-name :msg-execute :portal-name portal-name :limit 2})
+        (pgwire/handle-msg conn {:msg-name :msg-sync})
+        (pgwire/handle-msg conn {:msg-name :msg-terminate})
+
+        (t/is (= [[:msg-data-row {:vals ["3"]}]
+                  [:msg-command-complete {:command "SELECT 3"}]
+                  [:msg-ready {:status :transaction}]]
+                 @!in-msgs))))))

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -3074,7 +3074,7 @@ ORDER BY 1,2;")
     (with-open [conn (pgjdbc-conn)]
       (let [total-rows 10000]
         (doseq [batch (partition-all 1000 (range total-rows))]
-          (xt/submit-tx conn (mapv (fn [n] [:put-docs :foo {:xt/id n}]) batch)))))
+          (xt/execute-tx conn (mapv (fn [n] [:put-docs :foo {:xt/id n}]) batch)))))
 
     (with-open [conn (pgjdbc-conn)]
       ;; pgjdbc requires autocommit=false for cursor mode
@@ -3087,6 +3087,36 @@ ORDER BY 1,2;")
                          (recur (conj rows (.getLong rs 1)))
                          rows))]
             (t/is (= 10000 (count rows)))))))))
+
+(t/deftest test-cursor-fetch-sizes
+  (with-open [conn (pgjdbc-conn)]
+    (xt/execute-tx conn (mapv (fn [n] [:put-docs :cursor-test {:xt/id n}]) (range 200))))
+
+  (letfn [(count-rows [fetch-size]
+            (with-open [conn (pgjdbc-conn)]
+              (.setAutoCommit conn false)
+              (let [stmt (doto (.prepareStatement conn "SELECT * FROM cursor_test")
+                           (.setFetchSize fetch-size))]
+                (with-open [rs (.executeQuery stmt)]
+                  (loop [n 0]
+                    (if (.next rs)
+                      (recur (inc n))
+                      n))))))]
+    
+    (t/testing "fetch size = 1"
+      (t/is (= 200 (count-rows 1))))
+    
+    (t/testing "fetch size = row count (one full batch)"
+      (t/is (= 200 (count-rows 200)))) 
+
+    (t/testing "fetch size is exact divisor (two full batches)"
+      (t/is (= 200 (count-rows 100))))
+
+    (t/testing "fetch size is not exact divisor"
+      (t/is (= 200 (count-rows 75))))
+
+    (t/testing "fetch size larger than row count"
+      (t/is (= 200 (count-rows 500))))))
 
 (comment
   (user/set-log-level! 'xtdb.pgwire :trace))


### PR DESCRIPTION
Resolves #5131
Github actions: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Apgwire-cursoring-5131

### Background

Metabase uses cursors when exporting query results. In this mode, the client repeatedly issues Execute calls with a row limit until the server signals completion. Prior to this change, XTDB would stop sending rows once limit was reached, but failed to:
- correctly signal that the portal was suspended
- preserve any remaining rows already read from relations.

As a result, clients such as Metabase would silently miss rows during export, typically observing only the first 500 rows even though the full result set was available.

### What this changes

- Implements the correct pgwire message flow when an `Execute` reaches its limit but more rows remain:
  - Sends `PortalSuspended` instead of `CommandComplete`
- Buffers any leftover rows from partially-consumed relations when a limit is applied
- Persists buffered rows on the portal so they can be returned on subsequent Execute calls

This brings XTDB’s cursor / portal behavior in line with pgwire expectations and fixes incremental fetch semantics. Metabase exports now return all rows (or correctly respect metabase export limits):
- Tested this by exporting a table with 100,000 rows - previously we'd only return the first 500, now we return everything. 

### Tests

Adds a regression test covering cursor-based fetching with setFetchSize on JDBC to pgwire_test, ensuring that all rows are returned across multiple fetches.