### PR TITLE
Use sorted-sets in trie-catalog state lists, fix #5140

### DIFF
--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -189,6 +189,15 @@
            (partitions ["l00-rc-b00"] ["l00-rc-b01"] ["l00-rc-b02"]
                        ["l01-r20200101-b01"] ["l01-r20200102-b01"]))))
 
+(t/deftest issues-with-garbage-being-unordered-5140
+  (t/is (= [2 1 0]
+           (->> (-> (apply-msgs ["l00-rc-b00" 10] ["l00-rc-b01" 10] ["l00-rc-b02" 10] ["l00-rc-b03" 10]
+                                ["l01-rc-b00" 10] ["l01-rc-b01" 20] ["l01-rc-b02" 10] ["l01-rc-b03" 20]
+                                ["l02-rc-p0-b01" 10] ["l02-rc-p1-b01" 10] ["l02-rc-p2-b01" 10] ["l02-rc-p3-b01" 10])
+                    :tries
+                    (get-in [[1 nil []] :garbage]))
+                (map :block-idx)))))
+
 (t/deftest test-l0-l1-tries
   (t/is (= #{} (curr-tries)))
 


### PR DESCRIPTION
This adds sorted sets at the bottom of the trie catalog to assure the `live`, `nascent` and `garbage` sets are always sorted descending by block index. The scenario from the test case which shows that things might become garbage in different order is as follows:
- File size target is 20.
- Ignoring recency in the following as it's not relevant.
- L0-00 size 10, L0-01 size 10, L0-02 size 10, L0-03 size 10 arrive
- L1-00 size 10, L1-01 size 20, L1-02 size 10, L0-03 size 20 get compacted.
- After this the L1 live list contains [03, 01] and the garbage list contains [02 00]
- When now L1-01 gets superseded we can not just insert at the front of the L1 garbage list as this would violate the descending by block index invariant.

Using sorted-sets might be a bit overkill as one could likely always check the beginning of the lists and insert at the appropriate location, but sorted sets seemed like an easy option to get something correct working.