### PR TITLE
Relational operators use vec-types rather than Arrow fields

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -2178,7 +2178,7 @@
 
               {:keys [return-type !projection-fn]} (emit-projection expr {:param-types (->param-types args)
                                                                           :var-types var-types})]
-          (util/with-close-on-catch [out-vec (Vector/open allocator (types/->field return-type col-name))]
+          (util/with-close-on-catch [out-vec (Vector/open allocator (str col-name) return-type)]
             (try
               (@!projection-fn in-rel schema args out-vec)
               (catch ArithmeticException e

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -2167,7 +2167,8 @@
                             :return-type)]
 
     (reify ProjectionSpec
-      (getField [_] (types/->field widest-out-type col-name))
+      (getToName [_] (str col-name))
+      (getType [_] widest-out-type)
 
       (project [_ allocator in-rel schema args]
         (let [var-types (->> in-rel

--- a/core/src/main/clojure/xtdb/expression/list.clj
+++ b/core/src/main/clojure/xtdb/expression/list.clj
@@ -11,9 +11,9 @@
   (-> (fn [expr opts]
         (let [expr (expr/prepare-expr expr)
               {:keys [return-type continue] :as emitted-expr} (expr/codegen-expr expr opts)
-              field (types/unnest-field (types/->field return-type))
+              el-type (->> return-type (keep types/unnest-type) (apply types/merge-types))
               lvr-sym (gensym 'lvr)]
-          {:field field
+          {:vec-type el-type
            :->list-expr (eval `(fn [~(-> expr/schema-sym (expr/with-tag IPersistentMap))
                                     ~(-> expr/args-sym (expr/with-tag RelationReader))]
                                  (let [~@(expr/batch-bindings emitted-expr)]

--- a/core/src/main/clojure/xtdb/expression/map.clj
+++ b/core/src/main/clojure/xtdb/expression/map.clj
@@ -51,15 +51,15 @@
        pg-class-schema-hack
        params)))
 
-(defn ->theta-comparator [build-rel probe-rel theta-expr params {:keys [build-fields probe-fields param-types]}]
-  (let [var-types (update-vals (merge build-fields probe-fields) types/->type)
+(defn ->theta-comparator [build-rel probe-rel theta-expr params {:keys [build-vec-types probe-vec-types param-types]}]
+  (let [var-types (merge build-vec-types probe-vec-types)
         f (build-comparator (->> (expr/form->expr theta-expr {:var-types var-types, :param-types param-types})
                                  (expr/prepare-expr)
                                  (ewalk/postwalk-expr (fn [{:keys [op] :as expr}]
                                                         (cond-> expr
                                                           (= op :variable)
                                                           (into (let [{:keys [variable]} expr]
-                                                                  (if (contains? probe-fields variable)
+                                                                  (if (contains? probe-vec-types variable)
                                                                     {:rel right-rel, :idx right-idx}
                                                                     {:rel left-rel, :idx left-idx})))))))
                             {:var-types var-types, :param-types param-types})]

--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -124,23 +124,23 @@
   (fn [ra-expr opts]
     (:op ra-expr)))
 
-(defn- ensure-types
-  "Ensures :types is present alongside :fields. During migration, derives :types from :fields if missing."
-  [{:keys [fields types] :as emitted}]
+(defn- ensure-vec-types
+  "Ensures :vec-types is present alongside :fields. During migration, derives :vec-types from :fields if missing."
+  [{:keys [fields vec-types] :as emitted}]
   (cond-> emitted
-    (and fields (not types))
-    (assoc :types (update-vals fields #(VectorType/fromField ^Field %)))))
+    (and fields (not vec-types))
+    (assoc :vec-types (update-vals fields #(VectorType/fromField ^Field %)))))
 
 (defn- ensure-fields
-  "Ensures :fields is present alongside :types. During migration, derives :fields from :types if missing."
-  [{:keys [fields types] :as emitted}]
+  "Ensures :fields is present alongside :vec-types. During migration, derives :fields from :vec-types if missing."
+  [{:keys [fields vec-types] :as emitted}]
   (cond-> emitted
-    (and types (not fields))
-    (assoc :fields (into {} (map (fn [[k ^VectorType v]] [k (.toField v (str k))])) types))))
+    (and vec-types (not fields))
+    (assoc :fields (into {} (map (fn [[k ^VectorType v]] [k (.toField v (str k))])) vec-types))))
 
 (defn unary-expr {:style/indent 1} [{->inner-cursor :->cursor, :as inner-rel} f]
-  (-> (f (ensure-types inner-rel))
-      (ensure-types)
+  (-> (f (ensure-vec-types inner-rel))
+      (ensure-vec-types)
       (ensure-fields)
       (update :->cursor (fn [->cursor]
                           (fn [opts]
@@ -148,8 +148,8 @@
                               (->cursor opts inner)))))))
 
 (defn binary-expr {:style/indent 2} [{->left-cursor :->cursor, :as left} {->right-cursor :->cursor, :as right} f]
-  (-> (f (ensure-types left) (ensure-types right))
-      (ensure-types)
+  (-> (f (ensure-vec-types left) (ensure-vec-types right))
+      (ensure-vec-types)
       (ensure-fields)
       (update :->cursor (fn [->cursor]
                           (fn [opts]

--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -124,7 +124,7 @@
   (fn [ra-expr opts]
     (:op ra-expr)))
 
-(defn- ensure-vec-types
+(defn ensure-vec-types
   "Ensures :vec-types is present alongside :fields. During migration, derives :vec-types from :fields if missing."
   [{:keys [fields vec-types] :as emitted}]
   (cond-> emitted

--- a/core/src/main/clojure/xtdb/operator/apply.clj
+++ b/core/src/main/clojure/xtdb/operator/apply.clj
@@ -71,9 +71,7 @@
            :explain {:columns (pr-str columns)}
            :vec-types out-vec-types
 
-           :->cursor (let [out-dep-vec-types (-> out-dep-vec-types
-                                                 (update-keys str)
-                                                 (update-vals types/->type))
+           :->cursor (let [out-dep-vec-types (update-keys out-dep-vec-types str)
                            mode-strat (->mode-strategy mode mark-join-projection out-dep-vec-types)
                            open-dependent-cursor
                            (if (= mode :mark-join)

--- a/core/src/main/clojure/xtdb/operator/apply.clj
+++ b/core/src/main/clojure/xtdb/operator/apply.clj
@@ -3,11 +3,9 @@
             [xtdb.error :as err]
             [xtdb.expression :as expr]
             [xtdb.logical-plan :as lp]
-            [xtdb.rewrite :refer [zmatch]]
             [xtdb.types :as types]
             [xtdb.vector.reader :as vr])
-  (:import (java.util.function Consumer)
-           (xtdb ICursor)
+  (:import (xtdb ICursor)
            (xtdb.arrow RelationReader)
            (xtdb.operator.apply ApplyCursor ApplyMode$AntiJoin ApplyMode$CrossJoin ApplyMode$LeftJoin ApplyMode$MarkJoin ApplyMode$SemiJoin ApplyMode$SingleJoin DependentCursorFactory)))
 
@@ -22,17 +20,17 @@
          :independent-relation ::lp/ra-expression
          :dependent-relation ::lp/ra-expression))
 
-(defn ->mode-strategy [mode mark-join-projection dependent-fields]
+(defn ->mode-strategy [mode mark-join-projection dependent-vec-types]
   (case mode
     :mark-join
     (let [[col-name _expr] (first mark-join-projection)]
       (ApplyMode$MarkJoin. (str col-name)))
 
-    :cross-join (ApplyMode$CrossJoin. dependent-fields)
-    :left-outer-join (ApplyMode$LeftJoin. dependent-fields)
+    :cross-join (ApplyMode$CrossJoin. dependent-vec-types)
+    :left-outer-join (ApplyMode$LeftJoin. dependent-vec-types)
     :semi-join ApplyMode$SemiJoin/INSTANCE
     :anti-join ApplyMode$AntiJoin/INSTANCE
-    :single-join (ApplyMode$SingleJoin. dependent-fields)))
+    :single-join (ApplyMode$SingleJoin. dependent-vec-types)))
 
 (defmethod lp/emit-expr :apply [{:keys [opts independent-relation dependent-relation]} args]
   (let [{:keys [mode columns mark-join-projection]} opts]
@@ -40,77 +38,75 @@
 
     (lp/unary-expr (lp/emit-expr independent-relation args)
       (fn [{indep-vec-types :vec-types, :as indep-rel}]
-        (let [independent-fields (into {} (map (fn [[k v]] [k (types/->field v k)])) indep-vec-types)
-              {:keys [param-types] :as dependent-args} (-> args
-                                                          (update :param-types
-                                                                  (fnil into {})
-                                                                  (map (fn [[ik dk]]
-                                                                         (if-let [vec-type (get indep-vec-types ik)]
-                                                                           [dk vec-type]
-                                                                           (throw (err/incorrect :xtdb.apply/missing-column
-                                                                                                 (str "Column missing from independent relation: " ik)
-                                                                                                 {:column ik})))))
-                                                                  columns))
-            {dep-vec-types :vec-types, ->dependent-cursor :->cursor, :as dep-rel} (lp/emit-expr dependent-relation dependent-args)
-            dependent-fields (into {} (map (fn [[k v]] [k (types/->field v k)])) dep-vec-types)
-            out-dependent-fields (case mode
-                                   :mark-join
-                                   (let [[col-name _expr] (first mark-join-projection)]
-                                     {col-name (types/->field [:? :bool] col-name)})
+        (let [{:keys [param-types] :as dependent-args} (-> args
+                                                           (update :param-types
+                                                                   (fnil into {})
+                                                                   (map (fn [[ik dk]]
+                                                                          (if-let [vec-type (get indep-vec-types ik)]
+                                                                            [dk vec-type]
+                                                                            (throw (err/incorrect :xtdb.apply/missing-column
+                                                                                                  (str "Column missing from independent relation: " ik)
+                                                                                                  {:column ik})))))
+                                                                   columns))
+              {dep-vec-types :vec-types, ->dependent-cursor :->cursor, :as dep-rel} (lp/emit-expr dependent-relation dependent-args)
+              out-dep-vec-types (case mode
+                                  :mark-join
+                                  (let [[col-name _expr] (first mark-join-projection)]
+                                    {col-name #xt/type [:? :bool]})
 
-                                   :cross-join dependent-fields
+                                  :cross-join dep-vec-types
 
-                                   (:left-outer-join :single-join) (types/with-nullable-fields dependent-fields)
+                                  (:left-outer-join :single-join) (types/with-nullable-types dep-vec-types)
 
-                                   (:semi-join :anti-join) {})
-            out-fields (merge-with types/merge-fields independent-fields out-dependent-fields)]
-          (let [out-vec-types (update-vals out-fields types/->type)]
-            {:op (case mode
-                   :mark-join :apply-mark-join
-                   :cross-join :apply-cross-join
-                   :left-outer-join :apply-left-join
-                   :semi-join :apply-semi-join
-                   :anti-join :apply-anti-join
-                   :single-join :apply-single-join)
-             :children [indep-rel dep-rel]
-             :explain {:columns (pr-str columns)}
-             :vec-types out-vec-types
+                                  (:semi-join :anti-join) {})
+              out-vec-types (merge-with types/merge-types indep-vec-types out-dep-vec-types)]
+          {:op (case mode
+                 :mark-join :apply-mark-join
+                 :cross-join :apply-cross-join
+                 :left-outer-join :apply-left-join
+                 :semi-join :apply-semi-join
+                 :anti-join :apply-anti-join
+                 :single-join :apply-single-join)
+           :children [indep-rel dep-rel]
+           :explain {:columns (pr-str columns)}
+           :vec-types out-vec-types
 
-             :->cursor (let [out-dep-fields (for [[col-name field] out-dependent-fields]
-                                              (types/field-with-name field (str col-name)))
-                             mode-strat (->mode-strategy mode mark-join-projection out-dep-fields)
-                             open-dependent-cursor
-                             (if (= mode :mark-join)
-                               (let [[_col-name form] (first mark-join-projection)
-                                     input-types {:var-types dep-vec-types
-                                                  :param-types param-types}
-                                     projection-spec (expr/->expression-projection-spec "_expr" (expr/form->expr form input-types) input-types)]
-                                 (fn [{:keys [allocator args explain-analyze? tracer query-span] :as query-opts}]
-                                   (let [^ICursor dep-cursor (->dependent-cursor query-opts)]
-                                     (cond-> (reify ICursor
-                                               (getCursorType [_] "apply-mark-join")
-                                               (getChildCursors [_] [dep-cursor])
+           :->cursor (let [out-dep-vec-types (-> out-dep-vec-types
+                                                 (update-keys str)
+                                                 (update-vals types/->type))
+                           mode-strat (->mode-strategy mode mark-join-projection out-dep-vec-types)
+                           open-dependent-cursor
+                           (if (= mode :mark-join)
+                             (let [[_col-name form] (first mark-join-projection)
+                                   input-types {:var-types dep-vec-types
+                                                :param-types param-types}
+                                   projection-spec (expr/->expression-projection-spec "_expr" (expr/form->expr form input-types) input-types)]
+                               (fn [{:keys [allocator args explain-analyze? tracer query-span] :as query-opts}]
+                                 (let [^ICursor dep-cursor (->dependent-cursor query-opts)]
+                                   (cond-> (reify ICursor
+                                             (getCursorType [_] "apply-mark-join")
+                                             (getChildCursors [_] [dep-cursor])
 
-                                               (tryAdvance [_ c]
-                                                 (.tryAdvance dep-cursor (fn [in-rel]
-                                                                           (with-open [match-vec (.project projection-spec allocator in-rel {} args)]
-                                                                             (.accept c (vr/rel-reader [match-vec]))))))
+                                             (tryAdvance [_ c]
+                                               (.tryAdvance dep-cursor (fn [in-rel]
+                                                                         (with-open [match-vec (.project projection-spec allocator in-rel {} args)]
+                                                                           (.accept c (vr/rel-reader [match-vec]))))))
 
-                                               (close [_] (.close dep-cursor)))
-                                       (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))))
-                               ->dependent-cursor)]
+                                             (close [_] (.close dep-cursor)))
+                                     (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))))
+                             ->dependent-cursor)]
 
-                         (fn [{:keys [allocator explain-analyze? tracer query-span] :as query-opts} independent-cursor]
-                           (cond-> (ApplyCursor. allocator mode-strat independent-cursor out-dep-fields
-                                                 (reify DependentCursorFactory
-                                                   (open [_this in-rel idx]
-                                                     (open-dependent-cursor (-> query-opts
-                                                                                (update :args
-                                                                                        (fn [^RelationReader args]
-                                                                                          (RelationReader/from (concat args
-                                                                                                                       (for [[ik dk] columns]
-                                                                                                                         (-> (.vectorForOrNull in-rel (str ik))
-                                                                                                                             (.select (int-array [idx]))
-                                                                                                                             (.withName (str dk)))))
-                                                                                                               1))))))))
-                             (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))}))))))
+                       (fn [{:keys [allocator explain-analyze? tracer query-span] :as query-opts} independent-cursor]
+                         (cond-> (ApplyCursor. allocator mode-strat independent-cursor out-dep-vec-types
+                                               (reify DependentCursorFactory
+                                                 (open [_this in-rel idx]
+                                                   (open-dependent-cursor (-> query-opts
+                                                                              (update :args
+                                                                                      (fn [^RelationReader args]
+                                                                                        (RelationReader/from (concat args
+                                                                                                                     (for [[ik dk] columns]
+                                                                                                                       (-> (.vectorForOrNull in-rel (str ik))
+                                                                                                                           (.select (int-array [idx]))
+                                                                                                                           (.withName (str dk)))))
+                                                                                                             1))))))))
+                           (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))})))))

--- a/core/src/main/clojure/xtdb/operator/apply.clj
+++ b/core/src/main/clojure/xtdb/operator/apply.clj
@@ -51,7 +51,7 @@
                                                                                                  (str "Column missing from independent relation: " ik)
                                                                                                  {:column ik})))))
                                                                   columns))
-            {dep-vec-types :vec-types, ->dependent-cursor :->cursor, :as dep-rel} (lp/ensure-vec-types (lp/emit-expr dependent-relation dependent-args))
+            {dep-vec-types :vec-types, ->dependent-cursor :->cursor, :as dep-rel} (lp/emit-expr dependent-relation dependent-args)
             dependent-fields (into {} (map (fn [[k v]] [k (types/->field v k)])) dep-vec-types)
             out-dependent-fields (case mode
                                    :mark-join
@@ -75,43 +75,42 @@
              :children [indep-rel dep-rel]
              :explain {:columns (pr-str columns)}
              :vec-types out-vec-types
-             :fields out-fields
 
-           :->cursor (let [out-dep-fields (for [[col-name field] out-dependent-fields]
-                                            (types/field-with-name field (str col-name)))
-                           mode-strat (->mode-strategy mode mark-join-projection out-dep-fields)
-                           open-dependent-cursor
-                           (if (= mode :mark-join)
-                             (let [[_col-name form] (first mark-join-projection)
-                                   input-types {:var-types dep-vec-types
-                                                :param-types param-types}
-                                   projection-spec (expr/->expression-projection-spec "_expr" (expr/form->expr form input-types) input-types)]
-                               (fn [{:keys [allocator args explain-analyze? tracer query-span] :as query-opts}]
-                                 (let [^ICursor dep-cursor (->dependent-cursor query-opts)]
-                                   (cond-> (reify ICursor
-                                             (getCursorType [_] "apply-mark-join")
-                                             (getChildCursors [_] [dep-cursor])
+             :->cursor (let [out-dep-fields (for [[col-name field] out-dependent-fields]
+                                              (types/field-with-name field (str col-name)))
+                             mode-strat (->mode-strategy mode mark-join-projection out-dep-fields)
+                             open-dependent-cursor
+                             (if (= mode :mark-join)
+                               (let [[_col-name form] (first mark-join-projection)
+                                     input-types {:var-types dep-vec-types
+                                                  :param-types param-types}
+                                     projection-spec (expr/->expression-projection-spec "_expr" (expr/form->expr form input-types) input-types)]
+                                 (fn [{:keys [allocator args explain-analyze? tracer query-span] :as query-opts}]
+                                   (let [^ICursor dep-cursor (->dependent-cursor query-opts)]
+                                     (cond-> (reify ICursor
+                                               (getCursorType [_] "apply-mark-join")
+                                               (getChildCursors [_] [dep-cursor])
 
-                                             (tryAdvance [_ c]
-                                               (.tryAdvance dep-cursor (fn [in-rel]
-                                                                         (with-open [match-vec (.project projection-spec allocator in-rel {} args)]
-                                                                           (.accept c (vr/rel-reader [match-vec]))))))
+                                               (tryAdvance [_ c]
+                                                 (.tryAdvance dep-cursor (fn [in-rel]
+                                                                           (with-open [match-vec (.project projection-spec allocator in-rel {} args)]
+                                                                             (.accept c (vr/rel-reader [match-vec]))))))
 
-                                             (close [_] (.close dep-cursor)))
-                                     (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))))
-                             ->dependent-cursor)]
+                                               (close [_] (.close dep-cursor)))
+                                       (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))))
+                               ->dependent-cursor)]
 
-                       (fn [{:keys [allocator explain-analyze? tracer query-span] :as query-opts} independent-cursor]
-                         (cond-> (ApplyCursor. allocator mode-strat independent-cursor out-dep-fields
-                                               (reify DependentCursorFactory
-                                                 (open [_this in-rel idx]
-                                                   (open-dependent-cursor (-> query-opts
-                                                                              (update :args
-                                                                                      (fn [^RelationReader args]
-                                                                                        (RelationReader/from (concat args
-                                                                                                                     (for [[ik dk] columns]
-                                                                                                                       (-> (.vectorForOrNull in-rel (str ik))
-                                                                                                                           (.select (int-array [idx]))
-                                                                                                                           (.withName (str dk)))))
-                                                                                                             1))))))))
-                           (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))}))))))
+                         (fn [{:keys [allocator explain-analyze? tracer query-span] :as query-opts} independent-cursor]
+                           (cond-> (ApplyCursor. allocator mode-strat independent-cursor out-dep-fields
+                                                 (reify DependentCursorFactory
+                                                   (open [_this in-rel idx]
+                                                     (open-dependent-cursor (-> query-opts
+                                                                                (update :args
+                                                                                        (fn [^RelationReader args]
+                                                                                          (RelationReader/from (concat args
+                                                                                                                       (for [[ik dk] columns]
+                                                                                                                         (-> (.vectorForOrNull in-rel (str ik))
+                                                                                                                             (.select (int-array [idx]))
+                                                                                                                             (.withName (str dk)))))
+                                                                                                               1))))))))
+                             (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))}))))))

--- a/core/src/main/clojure/xtdb/operator/apply.clj
+++ b/core/src/main/clojure/xtdb/operator/apply.clj
@@ -62,17 +62,18 @@
 
                                    (:semi-join :anti-join) {})
             out-fields (merge-with types/merge-fields independent-fields out-dependent-fields)]
-          {:op (case mode
-                 :mark-join :apply-mark-join
-                 :cross-join :apply-cross-join
-                 :left-outer-join :apply-left-join
-                 :semi-join :apply-semi-join
-                 :anti-join :apply-anti-join
-                 :single-join :apply-single-join)
-           :children [indep-rel dep-rel]
-           :explain {:columns (pr-str columns)}
-           :fields out-fields
-           :vec-types (update-vals out-fields types/->type)
+          (let [out-vec-types (update-vals out-fields types/->type)]
+            {:op (case mode
+                   :mark-join :apply-mark-join
+                   :cross-join :apply-cross-join
+                   :left-outer-join :apply-left-join
+                   :semi-join :apply-semi-join
+                   :anti-join :apply-anti-join
+                   :single-join :apply-single-join)
+             :children [indep-rel dep-rel]
+             :explain {:columns (pr-str columns)}
+             :vec-types out-vec-types
+             :fields out-fields
 
            :->cursor (let [out-dep-fields (for [[col-name field] out-dependent-fields]
                                             (types/field-with-name field (str col-name)))
@@ -111,4 +112,4 @@
                                                                                                                            (.select (int-array [idx]))
                                                                                                                            (.withName (str dk)))))
                                                                                                              1))))))))
-                           (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))})))))
+                           (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))}))))))

--- a/core/src/main/clojure/xtdb/operator/arrow.clj
+++ b/core/src/main/clojure/xtdb/operator/arrow.clj
@@ -48,7 +48,6 @@
     {:op :arrow
      :children []
      :vec-types (update-vals fields #(VectorType/fromField ^Field %))
-     :fields fields
      :->cursor (fn [{:keys [^BufferAllocator allocator explain-analyze? tracer query-span]}]
                  (util/with-close-on-catch [loader (path->loader allocator path)
                                             rel (Relation. allocator (.getSchema loader))]

--- a/core/src/main/clojure/xtdb/operator/arrow.clj
+++ b/core/src/main/clojure/xtdb/operator/arrow.clj
@@ -7,7 +7,7 @@
            (java.nio.file CopyOption Files Path)
            (org.apache.arrow.memory BufferAllocator RootAllocator)
            org.apache.arrow.vector.types.pojo.Field
-           (xtdb.arrow Relation Relation$ILoader)
+           (xtdb.arrow Relation Relation$ILoader VectorType)
            xtdb.ICursor))
 
 (defmethod lp/ra-expr :arrow [_]
@@ -41,17 +41,19 @@
 
 ;; HACK: not ideal that we have to open the file in the emitter just to get the fields?
 (defn- path->cursor [^Path path on-close-fn]
-  {:op :arrow
-   :children []
-   :fields (with-open [al (RootAllocator.)
-                       loader (path->loader al path)]
-             (->> (.getFields (.getSchema loader))
-                  (into {} (map (juxt #(symbol (.getName ^Field %)) identity)))))
-   :->cursor (fn [{:keys [^BufferAllocator allocator explain-analyze? tracer query-span]}]
-               (util/with-close-on-catch [loader (path->loader allocator path)
-                                          rel (Relation. allocator (.getSchema loader))]
-                 (cond-> (ArrowCursor. rel loader on-close-fn)
-                   (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))})
+  (let [fields (with-open [al (RootAllocator.)
+                           loader (path->loader al path)]
+                 (->> (.getFields (.getSchema loader))
+                      (into {} (map (juxt #(symbol (.getName ^Field %)) identity)))))]
+    {:op :arrow
+     :children []
+     :vec-types (update-vals fields #(VectorType/fromField ^Field %))
+     :fields fields
+     :->cursor (fn [{:keys [^BufferAllocator allocator explain-analyze? tracer query-span]}]
+                 (util/with-close-on-catch [loader (path->loader allocator path)
+                                            rel (Relation. allocator (.getSchema loader))]
+                   (cond-> (ArrowCursor. rel loader on-close-fn)
+                     (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span))))}))
 
 (defmethod lp/emit-expr :arrow [{:keys [^URL url]} _args]
   ;; TODO: should we make it possible to disable local files?

--- a/core/src/main/clojure/xtdb/operator/distinct.clj
+++ b/core/src/main/clojure/xtdb/operator/distinct.clj
@@ -75,10 +75,11 @@
 
 (defmethod lp/emit-expr :distinct [{:keys [_opts relation]} args]
   (lp/unary-expr (lp/emit-expr relation args)
-                 (fn [{inner-fields :fields :as inner-rel}]
+                 (fn [{inner-fields :fields, inner-vec-types :vec-types :as inner-rel}]
                    {:op :distinct
                     :children [inner-rel]
                     :fields inner-fields
+                    :vec-types inner-vec-types
                     :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                                 (cond-> (DistinctCursor. allocator in-cursor
                                                          (->relation-map allocator

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -403,7 +403,6 @@
                                                   (let [[to-column agg-form] (first agg)]
                                                     [(str to-column) (pr-str agg-form)]))))}
                :vec-types out-vec-types
-               :fields out-fields
 
              :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                          (cond-> (util/with-close-on-catch [agg-specs (LinkedList.)]

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -13,9 +13,8 @@
            (java.util ArrayList LinkedList List Spliterator)
            (java.util.stream IntStream IntStream$Builder)
            (org.apache.arrow.memory BufferAllocator)
-           (org.apache.arrow.vector.types.pojo Field)
            (xtdb ICursor)
-           (xtdb.arrow RelationReader Vector VectorReader VectorWriter)
+           (xtdb.arrow RelationReader Vector VectorReader VectorType VectorWriter)
            (xtdb.arrow.agg AggregateSpec AggregateSpec$Factory Average Count GroupMapper GroupMapper$Mapper GroupMapper$Null RowCount StdDevPop StdDevSamp Sum VariancePop VarianceSamp)
            (xtdb.expression.map RelationMapBuilder)
            xtdb.operator.distinct.DistinctRelationMap
@@ -41,17 +40,17 @@
 
 (set! *unchecked-math* :warn-on-boxed)
 
-(defn ->group-mapper [^BufferAllocator allocator, group-fields]
-  (if-let [group-col-names (not-empty (set (keys group-fields)))]
+(defn ->group-mapper [^BufferAllocator allocator, group-vec-types]
+  (if-let [group-col-names (not-empty (set (keys group-vec-types)))]
     (GroupMapper$Mapper. allocator
-                         (distinct/->relation-map allocator {:build-fields group-fields
+                         (distinct/->relation-map allocator {:build-vec-types group-vec-types
                                                              :build-key-col-names (vec group-col-names)
                                                              :nil-keys-equal? true}))
     (GroupMapper$Null. allocator)))
 
 (defmulti ^AggregateSpec$Factory ->aggregate-factory
   #_{:clj-kondo/ignore [:unused-binding]}
-  (fn [{:keys [f from-name from-field to-name zero-row?]}]
+  (fn [{:keys [f from-name from-type to-name zero-row?]}]
     (expr/normalise-fn-name f)))
 
 (defmethod ->aggregate-factory :row_count [{:keys [to-name zero-row?]}]
@@ -104,7 +103,7 @@
       (getType [_] to-type)
 
       (build [this al]
-        (let [out-vec (Vector/open al (.getField this))]
+        (let [out-vec (Vector/open al (.getColName this) (.getType this))]
           (reify
             AggregateSpec
             (aggregate [_ in-rel group-mapping]
@@ -124,11 +123,11 @@
             Closeable
             (close [_] (.close out-vec))))))))
 
-(defmethod ->aggregate-factory :sum [{:keys [from-name from-field to-name zero-row?]}]
-  (Sum. (str from-name) (str to-name) (Sum/outType (types/->type (or from-field :null))) zero-row?))
+(defmethod ->aggregate-factory :sum [{:keys [from-name from-type to-name zero-row?]}]
+  (Sum. (str from-name) (str to-name) (Sum/outType from-type) zero-row?))
 
-(defmethod ->aggregate-factory :avg [{:keys [from-name from-field to-name zero-row?]}]
-  (Average. (str from-name) (types/->type (or from-field :null)) (str to-name) zero-row?))
+(defmethod ->aggregate-factory :avg [{:keys [from-name from-type to-name zero-row?]}]
+  (Average. (str from-name) from-type (str to-name) zero-row?))
 
 (defmethod ->aggregate-factory :var_pop [{:keys [from-name to-name zero-row?]}]
   (VariancePop. (str from-name) (str to-name) zero-row?))
@@ -155,13 +154,13 @@
 
 (defn- min-max-factory
   "compare-kw: update the accumulated value if `(compare-kw el acc)`"
-  [compare-kw {:keys [from-name from-field] :as agg-opts}]
+  [compare-kw {:keys [from-name from-type] :as agg-opts}]
 
-  (let [to-arrow-type (LeastUpperBound/of [(types/->type from-field)])
+  (let [to-arrow-type (LeastUpperBound/of [from-type])
         to-type (or (some-> to-arrow-type types/->type)
                     (throw (err/incorrect :xtdb.group-by/incomparable-min-max-types
                                           "Incomparable types in min/max aggregate"
-                                          {:from-field from-field})))]
+                                          {:from-type from-type})))]
     (assert-supported-min-max-type to-type)
 
     (reducing-agg-factory (into agg-opts
@@ -182,7 +181,7 @@
 (defmethod ->aggregate-factory :max_all [agg-opts] (min-max-factory :> agg-opts))
 (defmethod ->aggregate-factory :max_distinct [agg-opts] (min-max-factory :> agg-opts))
 
-(defn- wrap-distinct [^AggregateSpec$Factory agg-factory, from-name, ^Field from-field]
+(defn- wrap-distinct [^AggregateSpec$Factory agg-factory, from-name, ^VectorType from-type]
   (reify AggregateSpec$Factory
     (getColName [_] (.getColName agg-factory))
     (getType [_] (.getType agg-factory))
@@ -199,7 +198,7 @@
               (dotimes [idx (.getValueCount in-vec)]
                 (let [group-idx (.getInt group-mapping idx)]
                   (while (<= (.size rel-maps) group-idx)
-                    (.add rel-maps (distinct/->relation-map al {:build-fields {from-name from-field}
+                    (.add rel-maps (distinct/->relation-map al {:build-vec-types {from-name from-type}
                                                                 :build-key-col-names [from-name]})))
                   (let [^DistinctRelationMap rel-map (nth rel-maps group-idx)]
                     (while (<= (.size builders) group-idx)
@@ -224,29 +223,29 @@
             (util/close agg-spec)
             (util/close rel-maps)))))))
 
-(defmethod ->aggregate-factory :count_distinct [{:keys [from-name from-field] :as agg-opts}]
+(defmethod ->aggregate-factory :count_distinct [{:keys [from-name from-type] :as agg-opts}]
   (-> (->aggregate-factory (assoc agg-opts :f :count))
-      (wrap-distinct from-name from-field)))
+      (wrap-distinct from-name from-type)))
 
 (defmethod ->aggregate-factory :count_all [agg-opts]
   (->aggregate-factory (assoc agg-opts :f :count)))
 
-(defmethod ->aggregate-factory :sum_distinct [{:keys [from-name from-field] :as agg-opts}]
+(defmethod ->aggregate-factory :sum_distinct [{:keys [from-name from-type] :as agg-opts}]
   (-> (->aggregate-factory (assoc agg-opts :f :sum))
-      (wrap-distinct from-name from-field)))
+      (wrap-distinct from-name from-type)))
 
 (defmethod ->aggregate-factory :sum_all [agg-opts]
   (->aggregate-factory (assoc agg-opts :f :sum)))
 
-(defmethod ->aggregate-factory :avg_distinct [{:keys [from-name from-field] :as agg-opts}]
+(defmethod ->aggregate-factory :avg_distinct [{:keys [from-name from-type] :as agg-opts}]
   (-> (->aggregate-factory (assoc agg-opts :f :avg))
-      (wrap-distinct from-name from-field)))
+      (wrap-distinct from-name from-type)))
 
 (defmethod ->aggregate-factory :avg_all [agg-opts]
   (->aggregate-factory (assoc agg-opts :f :avg)))
 
 (deftype ArrayAggAggregateSpec [^BufferAllocator allocator
-                                from-name ^Field to-field
+                                from-name to-name ^VectorType to-type
                                 ^VectorWriter acc-col
                                 ^:unsynchronized-mutable ^long base-idx
                                 ^List group-idxmaps
@@ -267,7 +266,7 @@
       (set! (.base-idx this) (+ base-idx row-count))))
 
   (openFinishedVector [_]
-    (util/with-close-on-catch [out-vec (Vector/open allocator to-field)]
+    (util/with-close-on-catch [out-vec (Vector/open allocator to-name to-type)]
       (let [el-writer (.getListElements out-vec)
             row-copier (.rowCopier acc-col el-writer)]
         (doseq [^IntStream$Builder isb group-idxmaps]
@@ -289,33 +288,31 @@
   (close [_]
     (util/close acc-col)))
 
-(defmethod ->aggregate-factory :array_agg [{:keys [from-name from-field to-name zero-row?]}]
-  (let [from-type (types/->type from-field)
-        to-type (cond-> (types/->type [:list from-type])
+(defmethod ->aggregate-factory :array_agg [{:keys [from-name from-type to-name zero-row?]}]
+  (let [to-type (cond-> (types/->type [:list from-type])
                   zero-row? types/->nullable-type)]
     (reify AggregateSpec$Factory
       (getColName [_] (str to-name))
       (getType [_] to-type)
 
       (build [this al]
-        (util/with-close-on-catch [acc-col (Vector/open al (types/->field from-type "$data$"))]
-          (ArrayAggAggregateSpec. al from-name (.getField this) acc-col
+        (util/with-close-on-catch [acc-col (Vector/open al "$data$" from-type)]
+          (ArrayAggAggregateSpec. al from-name (.getColName this) (.getType this) acc-col
                                   0 (ArrayList.) (if zero-row? :null :empty-rel)))))))
 
-(defmethod ->aggregate-factory :array_agg_distinct [{:keys [from-name from-field] :as agg-opts}]
+(defmethod ->aggregate-factory :array_agg_distinct [{:keys [from-name from-type] :as agg-opts}]
   (-> (->aggregate-factory (assoc agg-opts :f :array_agg))
-      (wrap-distinct from-name from-field)))
+      (wrap-distinct from-name from-type)))
 
-(defmethod ->aggregate-factory :vec_agg [{:keys [from-name from-field to-name zero-row?]}]
-  (let [from-type (types/->type from-field)
-        to-type (types/->type [:list from-type])]
+(defmethod ->aggregate-factory :vec_agg [{:keys [from-name from-type to-name zero-row?]}]
+  (let [to-type (types/->type [:list from-type])]
     (reify AggregateSpec$Factory
       (getColName [_] (str to-name))
       (getType [_] to-type)
 
       (build [this al]
-        (util/with-close-on-catch [acc-col (Vector/open al (types/->field from-type "$data$"))]
-          (ArrayAggAggregateSpec. al from-name (.getField this) acc-col
+        (util/with-close-on-catch [acc-col (Vector/open al "$data$" from-type)]
+          (ArrayAggAggregateSpec. al from-name (.getColName this) (.getType this) acc-col
                                   0 (ArrayList.) (if zero-row? :empty-vec :empty-rel)))))))
 
 (defn- bool-agg-factory [step-f-kw {:keys [from-name] :as agg-opts}]
@@ -374,8 +371,7 @@
         group-cols (mapv second group-cols)]
     (lp/unary-expr (lp/emit-expr relation args)
       (fn [{:keys [vec-types], :as inner-rel}]
-        (let [fields (into {} (map (fn [[k v]] [k (types/->field v k)])) vec-types)
-              agg-factories (for [[_ agg] aggs]
+        (let [agg-factories (for [[_ agg] aggs]
                               (let [[to-column agg-form] (first agg)]
                                 (->aggregate-factory (into {:to-name to-column
                                                             :zero-row? (empty? group-cols)}
@@ -385,32 +381,31 @@
 
                                                              [:unary agg-opts]
                                                              (let [{:keys [f from-column]} agg-opts
-                                                                   from-field (get fields from-column types/null-field)]
+                                                                   from-type (get vec-types from-column VectorType/NULL)]
                                                                {:f f
                                                                 :from-name from-column
-                                                                :from-field from-field}))))))]
-          (let [out-fields (into (->> group-cols
-                                     (into {} (map (juxt identity fields))))
-                                (->> agg-factories
-                                     (into {} (map (comp (juxt #(symbol (.getName ^Field %)) identity)
-                                                         #(.getField ^AggregateSpec$Factory %))))))]
-            (let [out-vec-types (update-vals out-fields types/->type)]
-              {:op :group-by
-               :children [inner-rel]
-               :explain {:group-by (mapv str group-cols)
-                         :aggregates (->> aggs
-                                          (mapv (fn [[_ agg]]
-                                                  (let [[to-column agg-form] (first agg)]
-                                                    [(str to-column) (pr-str agg-form)]))))}
-               :vec-types out-vec-types
+                                                                :from-type from-type}))))))
+              out-vec-types (into (->> group-cols
+                                         (into {} (map (juxt identity vec-types))))
+                                    (->> agg-factories
+                                         (into {} (map (juxt #(symbol (.getColName ^AggregateSpec$Factory %))
+                                                             #(.getType ^AggregateSpec$Factory %))))))]
+          {:op :group-by
+           :children [inner-rel]
+           :explain {:group-by (mapv str group-cols)
+                     :aggregates (->> aggs
+                                      (mapv (fn [[_ agg]]
+                                              (let [[to-column agg-form] (first agg)]
+                                                [(str to-column) (pr-str agg-form)]))))}
+           :vec-types out-vec-types
 
-             :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
-                         (cond-> (util/with-close-on-catch [agg-specs (LinkedList.)]
-                                   (doseq [^AggregateSpec$Factory factory agg-factories]
-                                     (.add agg-specs (.build factory allocator)))
+           :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
+                       (cond-> (util/with-close-on-catch [agg-specs (LinkedList.)]
+                                 (doseq [^AggregateSpec$Factory factory agg-factories]
+                                   (.add agg-specs (.build factory allocator)))
 
-                                   (GroupByCursor. allocator in-cursor
-                                                   (->group-mapper allocator (select-keys fields group-cols))
-                                                   (vec agg-specs)
-                                                   false))
-                           (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))))))
+                                 (GroupByCursor. allocator in-cursor
+                                                 (->group-mapper allocator (select-keys vec-types group-cols))
+                                                 (vec agg-specs)
+                                                 false))
+                         (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))))

--- a/core/src/main/clojure/xtdb/operator/let.clj
+++ b/core/src/main/clojure/xtdb/operator/let.clj
@@ -2,6 +2,7 @@
   (:require [clojure.spec.alpha :as s]
             [xtdb.error :as err]
             [xtdb.logical-plan :as lp]
+            [xtdb.types :as types]
             [xtdb.util :as util])
   (:import [xtdb ICursor ICursor$Factory]
            [xtdb.operator LetCursorFactory]))
@@ -15,11 +16,11 @@
 
 (defmethod lp/emit-expr :let [{[binding bound-rel] :binding, :keys [relation]} emit-opts]
   (let [{->bound-cursor :->cursor, :as emitted-bound-rel} (lp/ensure-vec-types (lp/emit-expr bound-rel emit-opts))
-        {->body-cursor :->cursor, :as emitted-body-rel} (lp/ensure-vec-types (lp/emit-expr relation (assoc-in emit-opts [:let-bindings binding] emitted-bound-rel)))]
+        {->body-cursor :->cursor, body-vec-types :vec-types, :as emitted-body-rel} (lp/ensure-vec-types (lp/emit-expr relation (assoc-in emit-opts [:let-bindings binding] emitted-bound-rel)))]
     {:op :let
      :children [emitted-bound-rel emitted-body-rel]
-     :vec-types (:vec-types emitted-body-rel)
-     :fields (:fields emitted-body-rel)
+     :vec-types body-vec-types
+     :fields (into {} (map (fn [[k v]] [k (types/->field v k)])) body-vec-types)
      :stats (:stats emitted-body-rel)
      :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span] :as opts}]
                  (cond-> (util/with-close-on-catch [bound-cursor (->bound-cursor opts)
@@ -37,18 +38,18 @@
          :opts (s/keys :req-un [::col-names])))
 
 (defmethod lp/emit-expr :relation [{:keys [relation]} emit-opts]
-  (let [{:keys [vec-types fields stats]} (or (get-in emit-opts [:let-bindings relation])
-                                              (let [available (set (keys (:let-bindings emit-opts)))]
-                                                (throw (err/fault ::missing-relation
-                                                                  (format "Can't find relation '%s', available %s"
-                                                                          relation available)
-                                                                  {:relation relation
-                                                                   :available available}))))]
+  (let [{:keys [vec-types stats]} (or (get-in emit-opts [:let-bindings relation])
+                                       (let [available (set (keys (:let-bindings emit-opts)))]
+                                         (throw (err/fault ::missing-relation
+                                                           (format "Can't find relation '%s', available %s"
+                                                                   relation available)
+                                                           {:relation relation
+                                                            :available available}))))]
 
     {:op :relation
      :children []
      :vec-types vec-types
-     :fields fields
+     :fields (into {} (map (fn [[k v]] [k (types/->field v k)])) vec-types)
      :stats stats
      :->cursor (fn [{:keys [explain-analyze? tracer query-span] :as opts}]
                  (let [^ICursor$Factory cursor-factory (or (get-in opts [:let-bindings relation])

--- a/core/src/main/clojure/xtdb/operator/let.clj
+++ b/core/src/main/clojure/xtdb/operator/let.clj
@@ -15,12 +15,11 @@
          :relation ::lp/ra-expression))
 
 (defmethod lp/emit-expr :let [{[binding bound-rel] :binding, :keys [relation]} emit-opts]
-  (let [{->bound-cursor :->cursor, :as emitted-bound-rel} (lp/ensure-vec-types (lp/emit-expr bound-rel emit-opts))
-        {->body-cursor :->cursor, body-vec-types :vec-types, :as emitted-body-rel} (lp/ensure-vec-types (lp/emit-expr relation (assoc-in emit-opts [:let-bindings binding] emitted-bound-rel)))]
+  (let [{->bound-cursor :->cursor, :as emitted-bound-rel} (lp/emit-expr bound-rel emit-opts)
+        {->body-cursor :->cursor, body-vec-types :vec-types, :as emitted-body-rel} (lp/emit-expr relation (assoc-in emit-opts [:let-bindings binding] emitted-bound-rel))]
     {:op :let
      :children [emitted-bound-rel emitted-body-rel]
      :vec-types body-vec-types
-     :fields (into {} (map (fn [[k v]] [k (types/->field v k)])) body-vec-types)
      :stats (:stats emitted-body-rel)
      :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span] :as opts}]
                  (cond-> (util/with-close-on-catch [bound-cursor (->bound-cursor opts)
@@ -49,7 +48,6 @@
     {:op :relation
      :children []
      :vec-types vec-types
-     :fields (into {} (map (fn [[k v]] [k (types/->field v k)])) vec-types)
      :stats stats
      :->cursor (fn [{:keys [explain-analyze? tracer query-span] :as opts}]
                  (let [^ICursor$Factory cursor-factory (or (get-in opts [:let-bindings relation])

--- a/core/src/main/clojure/xtdb/operator/list.clj
+++ b/core/src/main/clojure/xtdb/operator/list.clj
@@ -55,10 +55,11 @@
         expr (expr/form->expr v input-types) 
         {:keys [field ->list-expr]} (expr-list/compile-list-expr expr input-types)
         named-field (types/field-with-name field (str out-col))
-        fields {(symbol (.getName named-field)) named-field}]
+        fields {(symbol (.getName named-field)) named-field}
+        vec-types (update-vals (restrict-cols fields list-expr) types/->type)]
     {:op :list
      :children []
-     :fields (restrict-cols fields list-expr)
+     :vec-types vec-types
      :->cursor (fn [{:keys [allocator ^RelationReader args explain-analyze? tracer query-span]}]
                  (cond-> (ListCursor. allocator (->list-expr schema args) named-field
                                       *batch-size* 0)

--- a/core/src/main/clojure/xtdb/operator/order_by.clj
+++ b/core/src/main/clojure/xtdb/operator/order_by.clj
@@ -267,11 +267,12 @@
 (defmethod lp/emit-expr :order-by [{:keys [opts relation]} args]
   (let [{:keys [order-specs]} opts]
     (lp/unary-expr (lp/emit-expr relation args)
-      (fn [{:keys [fields], :as rel}]
+      (fn [{:keys [fields vec-types], :as rel}]
         {:op :order-by
          :children [rel]
          :explain {:order-specs (pr-str order-specs)}
          :fields fields
+         :vec-types vec-types
          :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                      (cond-> (OrderByCursor. allocator in-cursor (rename-fields fields) order-specs false nil nil nil nil)
                        (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))}))))

--- a/core/src/main/clojure/xtdb/operator/order_by.clj
+++ b/core/src/main/clojure/xtdb/operator/order_by.clj
@@ -273,7 +273,6 @@
            :children [rel]
            :explain {:order-specs (pr-str order-specs)}
            :vec-types vec-types
-           :fields fields
            :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                        (cond-> (OrderByCursor. allocator in-cursor (rename-fields fields) order-specs false nil nil nil nil)
                          (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))))

--- a/core/src/main/clojure/xtdb/operator/patch.clj
+++ b/core/src/main/clojure/xtdb/operator/patch.clj
@@ -43,7 +43,6 @@
          :explain {:valid-from (pr-str valid-from)
                    :valid-to (pr-str valid-to)}
          :vec-types out-vec-types
-         :fields out-fields
          :->cursor (fn [{:keys [^BufferAllocator allocator current-time explain-analyze? tracer query-span] :as qopts} inner]
                      (let [valid-from (time/instant->micros (->instant (or valid-from [:literal current-time]) qopts))
                            valid-to (or (some-> valid-to (->instant qopts) time/instant->micros) Long/MAX_VALUE)]

--- a/core/src/main/clojure/xtdb/operator/patch.clj
+++ b/core/src/main/clojure/xtdb/operator/patch.clj
@@ -5,8 +5,8 @@
             [xtdb.logical-plan :as lp]
             [xtdb.time :as time]
             [xtdb.types :as types])
-  (:import org.apache.arrow.memory.BufferAllocator
-           org.apache.arrow.vector.types.pojo.Schema
+  (:import java.util.Map
+           org.apache.arrow.memory.BufferAllocator
            (xtdb ICursor)
            [xtdb.arrow Relation RelationReader]
            xtdb.operator.PatchGapsCursor))
@@ -34,10 +34,9 @@
 
 (defmethod lp/emit-expr :patch-gaps [{:keys [relation], {:keys [valid-from valid-to]} :opts} opts]
   (lp/unary-expr (lp/emit-expr relation opts)
-    (fn [{inner-vec-types :vec-types :as inner-rel}]
+    (fn [{inner-vec-types :vec-types, :as inner-rel}]
       (let [out-vec-types (-> inner-vec-types
-                              (update 'doc types/->nullable-type))
-            out-fields (into {} (map (fn [[k v]] [k (types/->field v k)])) out-vec-types)]
+                              (update 'doc types/->nullable-type))]
         {:op :patch-gaps
          :children [inner-rel]
          :explain {:valid-from (pr-str valid-from)
@@ -52,9 +51,7 @@
                                                {:valid-from (time/micros->instant valid-from)
                                                 :valid-to (time/micros->instant valid-to)}))
                          (cond-> (PatchGapsCursor. inner
-                                                   (Relation. allocator
-                                                              (Schema. (for [[nm field] out-fields]
-                                                                         (types/field-with-name field (str nm)))))
+                                                   (Relation. allocator ^Map (update-keys out-vec-types str))
                                                    valid-from
                                                    valid-to)
                            (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))))}))))

--- a/core/src/main/clojure/xtdb/operator/project.clj
+++ b/core/src/main/clojure/xtdb/operator/project.clj
@@ -54,7 +54,7 @@
 (defmethod lp/emit-expr :project [{:keys [relation], {:keys [projections append-columns?]} :opts} {:keys [param-types] :as args}]
   (let [emitted-child-relation (lp/emit-expr relation args)]
     (lp/unary-expr emitted-child-relation
-      (fn [{inner-fields :fields, inner-vec-types :vec-types :as inner-rel}]
+      (fn [{inner-vec-types :vec-types :as inner-rel}]
         (let [projection-specs (concat (when append-columns?
                                          (for [[col-name col-type] inner-vec-types]
                                            (->identity-projection-spec col-name col-type)))
@@ -89,8 +89,8 @@
              :children [inner-rel]
              :explain {:project (pr-str (into [] (map second) projections))
                        :append? (boolean append-columns?)}
-             :fields (into {} (map (fn [[k ^VectorType v]] [k (.toField v (str k))])) out-vec-types)
              :vec-types out-vec-types
+             :fields (into {} (map (fn [[k v]] [k (types/->field v k)])) out-vec-types)
              :stats (:stats emitted-child-relation)
              :->cursor (fn [{:keys [explain-analyze? tracer query-span] :as opts} in-cursor]
                          (cond-> (->project-cursor opts in-cursor projection-specs)

--- a/core/src/main/clojure/xtdb/operator/project.clj
+++ b/core/src/main/clojure/xtdb/operator/project.clj
@@ -90,7 +90,6 @@
              :explain {:project (pr-str (into [] (map second) projections))
                        :append? (boolean append-columns?)}
              :vec-types out-vec-types
-             :fields (into {} (map (fn [[k v]] [k (types/->field v k)])) out-vec-types)
              :stats (:stats emitted-child-relation)
              :->cursor (fn [{:keys [explain-analyze? tracer query-span] :as opts} in-cursor]
                          (cond-> (->project-cursor opts in-cursor projection-specs)

--- a/core/src/main/clojure/xtdb/operator/rename.clj
+++ b/core/src/main/clojure/xtdb/operator/rename.clj
@@ -2,7 +2,6 @@
   (:require [clojure.set :as set]
             [clojure.spec.alpha :as s]
             [xtdb.logical-plan :as lp]
-            [xtdb.types :as types]
             [xtdb.util :as util]
             [xtdb.vector.reader :as vr])
   (:import (java.util LinkedList Map)
@@ -46,8 +45,7 @@
                               (into {}))
         col-name-reverse-mapping (set/map-invert col-name-mapping)
         out-vec-types (->> inner-vec-types
-                           (into {} (map (fn [[k v]] [(col-name-mapping k) v]))))
-        out-fields (into {} (map (fn [[k v]] [k (types/->field v k)])) out-vec-types)]
+                           (into {} (map (fn [[k v]] [(col-name-mapping k) v])))) ]
     {:op :rename
      :children [emitted-child-relation]
      :explain {:prefix (some-> prefix str), :columns (some-> columns pr-str)}

--- a/core/src/main/clojure/xtdb/operator/rename.clj
+++ b/core/src/main/clojure/xtdb/operator/rename.clj
@@ -38,7 +38,7 @@
     (util/try-close in-cursor)))
 
 (defmethod lp/emit-expr :rename [{:keys [columns relation prefix]} args]
-  (let [{->inner-cursor :->cursor, inner-vec-types :vec-types, :as emitted-child-relation} (lp/ensure-vec-types (lp/emit-expr relation args))
+  (let [{->inner-cursor :->cursor, inner-vec-types :vec-types, :as emitted-child-relation} (lp/emit-expr relation args)
         col-name-mapping (->> (for [old-name (set (keys inner-vec-types))]
                                 [old-name
                                  (cond-> (get columns old-name old-name)
@@ -52,7 +52,6 @@
      :children [emitted-child-relation]
      :explain {:prefix (some-> prefix str), :columns (some-> columns pr-str)}
      :vec-types out-vec-types
-     :fields out-fields
      :stats (:stats emitted-child-relation)
      :->cursor (fn [{:keys [explain-analyze? tracer query-span] :as opts}]
                  (let [opts (-> opts

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -243,6 +243,7 @@
                    :predicates (mapv pr-str (vals selects))}
 
          :fields fields
+         :types (update-vals fields types/->type)
          :stats {:row-count row-count}
          :->cursor (fn [{:keys [allocator, snaps, snapshot-token, schema, args pushdown-blooms pushdown-iids explain-analyze? tracer query-span] :as opts}]
                      (let [^Snapshot snapshot (get snaps db-name)

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -242,7 +242,6 @@
                    :columns (vec col-names)
                    :predicates (mapv pr-str (vals selects))}
 
-         :fields fields
          :vec-types (->> fields (into {} (keep (fn [[k v]] (when v [k (types/->type v)])))))
          :stats {:row-count row-count}
          :->cursor (fn [{:keys [allocator, snaps, snapshot-token, schema, args pushdown-blooms pushdown-iids explain-analyze? tracer query-span] :as opts}]

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -221,7 +221,7 @@
 
             col-preds (->> (for [[col-name select-form] selects]
                              ;; for temporal preds, we may not need to re-apply these if they can be represented as a temporal range.
-                             (let [input-types {:var-types (update-vals fields types/->type)
+                             (let [input-types {:var-types (->> fields (into {} (keep (fn [[k v]] (when v [k (types/->type v)])))))
                                                 :param-types param-types}]
                                (MapEntry/create col-name
                                                 (expr/->expression-selection-spec (expr/form->expr select-form input-types)
@@ -243,7 +243,7 @@
                    :predicates (mapv pr-str (vals selects))}
 
          :fields fields
-         :vec-types (update-vals fields types/->type)
+         :vec-types (->> fields (into {} (keep (fn [[k v]] (when v [k (types/->type v)])))))
          :stats {:row-count row-count}
          :->cursor (fn [{:keys [allocator, snaps, snapshot-token, schema, args pushdown-blooms pushdown-iids explain-analyze? tracer query-span] :as opts}]
                      (let [^Snapshot snapshot (get snaps db-name)

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -243,7 +243,7 @@
                    :predicates (mapv pr-str (vals selects))}
 
          :fields fields
-         :types (update-vals fields types/->type)
+         :vec-types (update-vals fields types/->type)
          :stats {:row-count row-count}
          :->cursor (fn [{:keys [allocator, snaps, snapshot-token, schema, args pushdown-blooms pushdown-iids explain-analyze? tracer query-span] :as opts}]
                      (let [^Snapshot snapshot (get snaps db-name)

--- a/core/src/main/clojure/xtdb/operator/select.clj
+++ b/core/src/main/clojure/xtdb/operator/select.clj
@@ -2,8 +2,7 @@
   (:require [clojure.spec.alpha :as s]
             [xtdb.coalesce :as coalesce]
             [xtdb.expression :as expr]
-            [xtdb.logical-plan :as lp]
-            [xtdb.types :as types])
+            [xtdb.logical-plan :as lp])
   (:import (xtdb ICursor)
            (xtdb.operator SelectCursor)))
 
@@ -26,7 +25,7 @@
           {:op :select
            :stats inner-stats
            :children [inner-rel]
-           :explain  {:predicate (pr-str predicate)}
+           :explain {:predicate (pr-str predicate)}
            :vec-types inner-vec-types
            :->cursor (fn [{:keys [allocator args schema explain-analyze? tracer query-span]} in-cursor]
                        (cond-> (-> (SelectCursor. allocator in-cursor selector schema args)

--- a/core/src/main/clojure/xtdb/operator/select.clj
+++ b/core/src/main/clojure/xtdb/operator/select.clj
@@ -28,7 +28,6 @@
            :children [inner-rel]
            :explain  {:predicate (pr-str predicate)}
            :vec-types inner-vec-types
-           :fields (into {} (map (fn [[k v]] [k (types/->field v k)])) inner-vec-types)
            :->cursor (fn [{:keys [allocator args schema explain-analyze? tracer query-span]} in-cursor]
                        (cond-> (-> (SelectCursor. allocator in-cursor selector schema args)
                                    (coalesce/->coalescing-cursor allocator))

--- a/core/src/main/clojure/xtdb/operator/set.clj
+++ b/core/src/main/clojure/xtdb/operator/set.clj
@@ -72,7 +72,6 @@
                       {:op :union-all
                        :children [left-rel right-rel]
                        :vec-types out-vec-types
-                       :fields (into {} (map (fn [[k v]] [k (types/->field v k)])) out-vec-types)
                        :->cursor (fn [{:keys [explain-analyze? tracer query-span]} left-cursor right-cursor]
                                    (cond-> (UnionAllCursor. left-cursor right-cursor)
                                      (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))}))))
@@ -132,7 +131,6 @@
                       {:op :intersect
                        :children [left-rel right-rel]
                        :vec-types out-vec-types
-                       :fields (into {} (map (fn [[k v]] [k (types/->field v k)])) out-vec-types)
                        :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} left-cursor right-cursor]
                                    (let [build-side (join/->build-side allocator
                                                                        {:fields left-fields
@@ -155,7 +153,6 @@
                       {:op :difference
                        :children [left-rel right-rel]
                        :vec-types out-vec-types
-                       :fields (into {} (map (fn [[k v]] [k (types/->field v k)])) out-vec-types)
                        :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} left-cursor right-cursor]
                                    (let [build-side (join/->build-side allocator
                                                                        {:fields left-fields

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -1,5 +1,6 @@
 (ns xtdb.operator.table
   (:require [clojure.spec.alpha :as s]
+            [clojure.tools.logging :as log]
             [xtdb.error :as err]
             [xtdb.expression :as expr]
             [xtdb.expression.list :as expr-list]
@@ -7,12 +8,11 @@
             [xtdb.rewrite :refer [zmatch]]
             [xtdb.types :as types]
             [xtdb.util :as util]
-            [xtdb.vector.reader :as vr]
-            [xtdb.vector.writer :as vw])
+            [xtdb.vector.reader :as vr])
   (:import clojure.lang.MapEntry
            (java.util HashMap HashSet List Set)
            (org.apache.arrow.memory BufferAllocator)
-           (org.apache.arrow.vector.types.pojo ArrowType$Union Field Schema)
+           (org.apache.arrow.vector.types.pojo ArrowType$Union)
            (xtdb ICursor)
            (xtdb.arrow ListExpression Relation RelationReader RelationWriter Vector VectorType VectorWriter)))
 
@@ -45,13 +45,13 @@
   (close [_]
     (util/close out-rel)))
 
-(defn- restrict-cols [fields {:keys [explicit-col-names]}]
-  (cond-> fields
-    explicit-col-names (-> (->> (merge (zipmap explicit-col-names (repeat types/null-field))))
+(defn- restrict-cols [vec-types {:keys [explicit-col-names]}]
+  (cond-> vec-types
+    explicit-col-names (-> (->> (merge (zipmap explicit-col-names (repeat #xt/type :null))))
                            (select-keys explicit-col-names))))
 
 (defn- emit-rows-table [rows table-expr {:keys [param-types schema] :as opts}]
-  (let [field-sets (HashMap.)
+  (let [type-sets (HashMap.)
         out-rows (->> rows
                       (mapv (fn [[row-tag row-arg]]
                               (case row-tag
@@ -64,9 +64,9 @@
                                              ks (into #{} (map symbol) (keys children))]
 
                                          (doseq [[child-name ^VectorType child-type] children
-                                                 :let [^Set field-set (.computeIfAbsent field-sets (symbol child-name)
-                                                                                        (fn [_] (HashSet.)))]]
-                                           (.add field-set (.toField child-type child-name)))
+                                                 :let [^Set type-set (.computeIfAbsent type-sets (symbol child-name)
+                                                                                       (fn [_] (HashSet.)))]]
+                                           (.add type-set child-type))
 
                                          {:ks ks
                                           :write-row! (fn write-param-row! [{:keys [^RelationReader args]}, ^RelationWriter out-rel]
@@ -80,18 +80,18 @@
                                                                            expr (try
                                                                                   (expr/form->expr v (assoc opts :param-types param-types))
                                                                                   (catch Exception e
-                                                                                    (clojure.tools.logging/warn "fail" {:expr v, :param-types param-types})
+                                                                                    (log/warn "fail" {:expr v, :param-types param-types})
                                                                                     (throw e)))
-                                                                           ^Set field-set (.computeIfAbsent field-sets k (fn [_] (HashSet.)))]
+                                                                           ^Set type-set (.computeIfAbsent type-sets k (fn [_] (HashSet.)))]
                                                                        (case (:op expr)
                                                                          :literal (do
-                                                                                    (.add field-set (types/->field (types/value->vec-type v)))
+                                                                                    (.add type-set (types/value->vec-type v))
                                                                                     (MapEntry/create k (fn write-literal! [_ ^VectorWriter out-col]
                                                                                                          (.writeObject out-col v))))
 
                                                                          :param (let [{:keys [param]} expr
-                                                                                        ^VectorType param-type (get param-types param)]
-                                                                                  (.add field-set (.toField param-type (str param)))
+                                                                                      ^VectorType param-type (get param-types param)]
+                                                                                  (.add type-set param-type)
                                                                                   (MapEntry/create k (fn write-param! [{:keys [^RelationReader args]} ^VectorWriter out-col]
                                                                                                        (.writeObject out-col
                                                                                                                      (-> (.vectorForOrNull args (str param))
@@ -102,7 +102,7 @@
                                                                          (let [input-types (assoc opts :param-types param-types)
                                                                                expr (expr/form->expr v input-types)
                                                                                projection-spec (expr/->expression-projection-spec "_scalar" expr input-types)]
-                                                                           (.add field-set (.getField projection-spec))
+                                                                           (.add type-set (.getType projection-spec))
                                                                            (MapEntry/create k (fn write-expr! [{:keys [allocator args]} ^VectorWriter out-col]
                                                                                                 (util/with-open [out-vec (.project projection-spec allocator (vr/rel-reader [] 1) schema args)]
                                                                                                   (.writeObject out-col (.getObject out-vec 0))))))))))))]
@@ -116,67 +116,58 @@
         key-freqs (->> (into [] (mapcat :ks) out-rows)
                        (frequencies))
         row-count (count out-rows)
-        fields (-> field-sets
-                   (->> (into {} (map (juxt key (fn [[k ^Set !v-types]]
-                                                  (when-not (= row-count (get key-freqs (symbol k)))
-                                                    (.add !v-types types/null-field))
-                                                  (-> (apply types/merge-fields !v-types)
-                                                      (types/field-with-name (str k))))))))
-                   (restrict-cols table-expr))]
-
-    (let [vec-types (update-vals fields types/->type)]
-      {:vec-types vec-types
-       :fields fields
-       :row-count row-count
-       :->out-rel (fn [{:keys [^BufferAllocator allocator] :as opts}]
-                    (let [row-count (count rows)]
-                      (when (pos? row-count)
-                        (util/with-close-on-catch [out-rel (Relation. allocator (Schema. (or (vals fields) [])))]
-                          (doseq [{:keys [write-row!]} out-rows]
-                            (write-row! opts out-rel))
-
-                          out-rel))))})))
-
-(defn- emit-col-table [col-spec table-expr {:keys [param-types schema] :as opts}]
-  (let [[out-col v] (first col-spec)
-        expr (expr/form->expr v opts)
-        input-types opts
-        {:keys [field ->list-expr]} (expr-list/compile-list-expr expr input-types)
-        named-field (types/field-with-name field (str out-col))]
-    (let [out-fields (-> {(symbol (.getName named-field)) named-field}
-                         (restrict-cols table-expr))
-          out-vec-types (update-vals out-fields types/->type)]
-      {:vec-types out-vec-types
-       :fields out-fields
-       :->out-rel (fn [{:keys [^BufferAllocator allocator, ^RelationReader args]}]
-                    (util/with-close-on-catch [out-vec (Vector/open allocator named-field)]
-                      (let [^ListExpression list-expr (->list-expr schema args)]
-                        (when list-expr
-                          (.writeTo list-expr out-vec 0 (.getSize list-expr)))
-                        (Relation. allocator ^List (vector out-vec) (.getValueCount out-vec)))))})))
-
-(defn- emit-arg-table [param table-expr {:keys [param-types]}]
-  (let [fields (-> (into {} (for [^VectorType leg-type (or (get param-types param)
-                                                               (throw (err/incorrect :unknown-table "Table refers to unknown param"
-                                                                                     {:param param, :params (set (keys param-types))})))
-                                  :when (not= #xt.arrow/type :null (.getArrowType leg-type))
-                                  :when (or (= #xt.arrow/type :list (.getArrowType leg-type))
-                                            (throw (err/incorrect :illegal-param-type "Table param must be of type struct list"
-                                                                  {:param param})))
-                                  :let [el-type (first (vals (.getChildren leg-type)))]
-                                  ^VectorType el-leg-type el-type
-                                  :when (or (= #xt.arrow/type :struct (.getArrowType el-leg-type))
-                                            (= #xt.arrow/type :null (.getArrowType el-leg-type))
-                                            (throw (err/incorrect :illegal-param-type "Table param must be of type struct list"
-                                                                  {:param param})))
-                                  [child-name ^VectorType child-type] (.getChildren el-leg-type)]
-                              (MapEntry/create (symbol child-name) (.toField child-type child-name))))
-
-                   (restrict-cols table-expr))
-          vec-types (update-vals fields types/->type)]
+        vec-types (-> type-sets
+                      (->> (into {} (map (juxt key (fn [[k ^Set !v-types]]
+                                                     (when-not (= row-count (get key-freqs (symbol k)))
+                                                       (.add !v-types #xt/type :null))
+                                                     (apply types/merge-types !v-types))))))
+                      (restrict-cols table-expr))]
 
     {:vec-types vec-types
-     :fields fields
+     :row-count row-count
+     :->out-rel (fn [{:keys [^BufferAllocator allocator] :as opts}]
+                  (let [row-count (count rows)]
+                    (when (pos? row-count)
+                      (util/with-close-on-catch [out-rel (Relation. allocator ^java.util.Map (update-keys vec-types str))]
+                        (doseq [{:keys [write-row!]} out-rows]
+                          (write-row! opts out-rel))
+
+                        out-rel))))}))
+
+(defn- emit-col-table [col-spec table-expr {:keys [schema] :as input-types}]
+  (let [[out-col v] (first col-spec)
+        expr (expr/form->expr v input-types)
+        {:keys [vec-type ->list-expr]} (expr-list/compile-list-expr expr input-types)
+        out-vec-types (-> {out-col vec-type}
+                          (restrict-cols table-expr))
+        out-type (get out-vec-types out-col)]
+    {:vec-types out-vec-types
+     :->out-rel (fn [{:keys [^BufferAllocator allocator, ^RelationReader args]}]
+                  (util/with-close-on-catch [out-vec (Vector/open allocator (str out-col) out-type)]
+                    (let [^ListExpression list-expr (->list-expr schema args)]
+                      (when list-expr
+                        (.writeTo list-expr out-vec 0 (.getSize list-expr)))
+                      (Relation. allocator ^List (vector out-vec) (.getValueCount out-vec)))))}))
+
+(defn- emit-arg-table [param table-expr {:keys [param-types]}]
+  (let [vec-types (-> (into {} (for [^VectorType leg-type (or (get param-types param)
+                                                               (throw (err/incorrect :unknown-table "Table refers to unknown param"
+                                                                                     {:param param, :params (set (keys param-types))})))
+                                     :when (not= #xt.arrow/type :null (.getArrowType leg-type))
+                                     :when (or (= #xt.arrow/type :list (.getArrowType leg-type))
+                                               (throw (err/incorrect :illegal-param-type "Table param must be of type struct list"
+                                                                     {:param param})))
+                                     :let [el-type (first (vals (.getChildren leg-type)))]
+                                     ^VectorType el-leg-type el-type
+                                     :when (or (= #xt.arrow/type :struct (.getArrowType el-leg-type))
+                                               (= #xt.arrow/type :null (.getArrowType el-leg-type))
+                                               (throw (err/incorrect :illegal-param-type "Table param must be of type struct list"
+                                                                     {:param param})))
+                                     [child-name ^VectorType child-type] (.getChildren el-leg-type)]
+                                 (MapEntry/create (symbol child-name) child-type)))
+                      (restrict-cols table-expr))]
+
+    {:vec-types vec-types
      :->out-rel (fn [{:keys [^BufferAllocator allocator, ^RelationReader args]}]
                   (let [vec-rdr (.vectorForOrNull args (str (symbol param)))
                         list-rdr (cond-> vec-rdr
@@ -187,20 +178,20 @@
 
                     (Relation. allocator
                                ^List (vec (for [k (some-> el-struct-rdr .getKeyNames)
-                                                :when (contains? fields (symbol k))]
+                                                :when (contains? vec-types (symbol k))]
                                             (.openSlice (.vectorFor el-struct-rdr k) allocator)))
                                (.getValueCount el-rdr))))}))
 
 (defmethod lp/emit-expr :table [{:keys [table] :as table-expr} opts]
-  (let [{:keys [fields vec-types ->out-rel row-count]} (zmatch table
-                                                               [:rows rows] (emit-rows-table rows table-expr opts)
-                                                               [:column col] (emit-col-table col table-expr opts)
-                                                               [:param param] (emit-arg-table param table-expr opts))]
+  (let [{:keys [vec-types ->out-rel row-count]} (zmatch table
+                                                  [:rows rows] (emit-rows-table rows table-expr opts)
+                                                  [:column col] (emit-col-table col table-expr opts)
+                                                  [:param param] (emit-arg-table param table-expr opts))]
 
-    {:op       :table
+    {:op :table
      :children []
      :vec-types vec-types
-     :stats    (when row-count {:row-count row-count})
+     :stats (when row-count {:row-count row-count})
      :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span] :as opts}]
                  (cond-> (TableCursor. allocator (->out-rel opts))
                    (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))}))

--- a/core/src/main/clojure/xtdb/operator/table.clj
+++ b/core/src/main/clojure/xtdb/operator/table.clj
@@ -200,7 +200,6 @@
     {:op       :table
      :children []
      :vec-types vec-types
-     :fields   fields
      :stats    (when row-count {:row-count row-count})
      :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span] :as opts}]
                  (cond-> (TableCursor. allocator (->out-rel opts))

--- a/core/src/main/clojure/xtdb/operator/top.clj
+++ b/core/src/main/clojure/xtdb/operator/top.clj
@@ -61,13 +61,14 @@
 
 (defmethod lp/emit-expr :top [{:keys [relation], {[skip-tag skip-arg] :skip, [limit-tag limit-arg] :limit} :top} args]
   (lp/unary-expr (lp/emit-expr relation args)
-    (fn [{fields :fields :as inner-rel}]
+    (fn [{fields :fields, vec-types :vec-types :as inner-rel}]
       {:op :top
        :children [inner-rel]
        :explain (->> {:skip (some-> skip-arg pr-str),
                       :limit (some-> limit-arg pr-str)}
                      (into {} (filter val)))
        :fields fields
+       :vec-types vec-types
        :->cursor (fn [{:keys [args explain-analyze? tracer query-span]} in-cursor]
                    (cond-> (TopCursor. in-cursor
                                        (case skip-tag

--- a/core/src/main/clojure/xtdb/operator/top.clj
+++ b/core/src/main/clojure/xtdb/operator/top.clj
@@ -69,7 +69,6 @@
                       :limit (some-> limit-arg pr-str)}
                      (into {} (filter val)))
        :vec-types vec-types
-       :fields (into {} (map (fn [[k v]] [k (types/->field v k)])) vec-types)
        :->cursor (fn [{:keys [args explain-analyze? tracer query-span]} in-cursor]
                    (cond-> (TopCursor. in-cursor
                                        (case skip-tag

--- a/core/src/main/clojure/xtdb/operator/unnest.clj
+++ b/core/src/main/clojure/xtdb/operator/unnest.clj
@@ -114,7 +114,6 @@
                                    :to to-col
                                    :ordinality ordinality-column}
                          :vec-types out-vec-types
-                         :fields out-fields
                          :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                                     (cond-> (UnnestCursor. allocator in-cursor
                                                            (str from-col) (types/field-with-name unnest-field (str to-col))

--- a/core/src/main/clojure/xtdb/operator/unnest.clj
+++ b/core/src/main/clojure/xtdb/operator/unnest.clj
@@ -98,23 +98,25 @@
 (defmethod lp/emit-expr :unnest [{:keys [columns relation], {:keys [ordinality-column]} :opts}, op-args]
   (let [[to-col from-col] (first columns)]
     (lp/unary-expr (lp/emit-expr relation op-args)
-                   (fn [{:keys [fields] :as inner-rel}]
-                     (let [unnest-field (->> (get fields from-col)
+                   (fn [{:keys [vec-types] :as inner-rel}]
+                     (let [fields (into {} (map (fn [[k v]] [k (types/->field v k)])) vec-types)
+                           unnest-field (->> (get fields from-col)
                                              types/flatten-union-field
                                              (keep types/unnest-field)
                                              (apply types/merge-fields))
                            out-fields (-> fields
                                           (assoc to-col (types/field-with-name unnest-field (str to-col)))
                                           (cond-> ordinality-column (assoc ordinality-column (types/->field :i32 ordinality-column))))]
-                       {:op :unnest
-                        :children [inner-rel]
-                        :explain {:from from-col
-                                  :to to-col
-                                  :ordinality ordinality-column}
-                        :fields out-fields
-                        :vec-types (update-vals out-fields types/->type)
-                        :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
+                       (let [out-vec-types (update-vals out-fields types/->type)]
+                        {:op :unnest
+                         :children [inner-rel]
+                         :explain {:from from-col
+                                   :to to-col
+                                   :ordinality ordinality-column}
+                         :vec-types out-vec-types
+                         :fields out-fields
+                         :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                                     (cond-> (UnnestCursor. allocator in-cursor
                                                            (str from-col) (types/field-with-name unnest-field (str to-col))
                                                            (some-> ordinality-column str))
-                                      (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))))
+                                      (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))}))))))

--- a/core/src/main/clojure/xtdb/operator/window.clj
+++ b/core/src/main/clojure/xtdb/operator/window.clj
@@ -137,8 +137,9 @@
   (let [{:keys [projections windows]} specs
         [_window-name {:keys [partition-cols order-specs]}] (first windows)]
     (lp/unary-expr (lp/emit-expr relation args)
-      (fn [{:keys [fields] :as inner-rel}]
-        (let [window-fn-factories (vec (for [p projections]
+      (fn [{:keys [vec-types] :as inner-rel}]
+        (let [fields (into {} (map (fn [[k v]] [k (types/->field v k)])) vec-types)
+              window-fn-factories (vec (for [p projections]
                                          ;; ignoring window-name for now
                                          (let [[to-column {:keys [_window-name window-agg]}] (first p)]
                                            (->window-fn-factory (into {:to-name to-column
@@ -153,25 +154,26 @@
                                    (->> window-fn-factories
                                         (into {} (map (juxt #(.getToColumnName ^IWindowFnSpecFactory %)
                                                             #(.getToColumnField ^IWindowFnSpecFactory %)))))))]
-          {:op :window
-           :children [inner-rel]
-           :explain {:partition-by (vec partition-cols)
-                     :order-by (pr-str order-specs)
-                     :window-functions (->> projections
-                                           (mapv (fn [p]
-                                                   (let [[to-column {:keys [window-agg]}] (first p)]
-                                                     [to-column (pr-str window-agg)]))))}
-           :fields out-fields
-           :vec-types (update-vals out-fields types/->type)
+          (let [out-vec-types (update-vals out-fields types/->type)]
+            {:op :window
+             :children [inner-rel]
+             :explain {:partition-by (vec partition-cols)
+                       :order-by (pr-str order-specs)
+                       :window-functions (->> projections
+                                             (mapv (fn [p]
+                                                     (let [[to-column {:keys [window-agg]}] (first p)]
+                                                       [to-column (pr-str window-agg)]))))}
+             :vec-types out-vec-types
+             :fields out-fields
 
-           :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
-                       (cond-> (util/with-close-on-catch [window-fn-specs (LinkedList.)]
-                                 (doseq [^IWindowFnSpecFactory factory window-fn-factories]
-                                   (.add window-fn-specs (.build factory allocator)))
+             :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
+                         (cond-> (util/with-close-on-catch [window-fn-specs (LinkedList.)]
+                                   (doseq [^IWindowFnSpecFactory factory window-fn-factories]
+                                     (.add window-fn-specs (.build factory allocator)))
 
-                                 (WindowFnCursor. allocator in-cursor (order-by/rename-fields fields)
-                                                  (group-by/->group-mapper allocator (select-keys fields partition-cols))
-                                                  order-specs
-                                                  (vec window-fn-specs)
-                                                  false))
-                         (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))))
+                                   (WindowFnCursor. allocator in-cursor (order-by/rename-fields fields)
+                                                    (group-by/->group-mapper allocator (select-keys fields partition-cols))
+                                                    order-specs
+                                                    (vec window-fn-specs)
+                                                    false))
+                           (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))}))))))

--- a/core/src/main/clojure/xtdb/operator/window.clj
+++ b/core/src/main/clojure/xtdb/operator/window.clj
@@ -164,7 +164,6 @@
                                                      (let [[to-column {:keys [window-agg]}] (first p)]
                                                        [to-column (pr-str window-agg)]))))}
              :vec-types out-vec-types
-             :fields out-fields
 
              :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                          (cond-> (util/with-close-on-catch [window-fn-specs (LinkedList.)]

--- a/core/src/main/clojure/xtdb/operator/window.clj
+++ b/core/src/main/clojure/xtdb/operator/window.clj
@@ -162,6 +162,7 @@
                                                    (let [[to-column {:keys [window-agg]}] (first p)]
                                                      [to-column (pr-str window-agg)]))))}
            :fields out-fields
+           :vec-types (update-vals out-fields types/->type)
 
            :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
                        (cond-> (util/with-close-on-catch [window-fn-specs (LinkedList.)]

--- a/core/src/main/clojure/xtdb/operator/window.clj
+++ b/core/src/main/clojure/xtdb/operator/window.clj
@@ -12,9 +12,8 @@
   (:import (clojure.lang IPersistentMap)
            (com.carrotsearch.hppc LongLongHashMap LongLongMap)
            (java.io Closeable)
-           (java.util LinkedList List Spliterator)
+           (java.util LinkedList List Map Spliterator)
            (org.apache.arrow.memory BufferAllocator)
-           (org.apache.arrow.vector.types.pojo Field)
            (xtdb ICursor)
            (xtdb.arrow IntVector LongVector RelationReader Relation)
            (xtdb.arrow.agg GroupMapper)))
@@ -64,7 +63,7 @@
 #_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
 (definterface IWindowFnSpecFactory
   (^clojure.lang.Symbol getToColumnName [])
-  (^org.apache.arrow.vector.types.pojo.Field getToColumnField [])
+  (^xtdb.arrow.VectorType getToColumnType [])
   (^xtdb.operator.window.IWindowFnSpec build [^org.apache.arrow.memory.BufferAllocator allocator]))
 
 #_{:clj-kondo/ignore [:unused-binding]}
@@ -75,7 +74,7 @@
 (defmethod ->window-fn-factory :row_number [{:keys [to-name]}]
   (reify IWindowFnSpecFactory
     (getToColumnName [_] to-name)
-    (getToColumnField [_] (types/->field :i64))
+    (getToColumnType [_] #xt/type :i64)
 
     (build [_ al]
       (let [out-vec (LongVector. al (str to-name) false)
@@ -94,7 +93,7 @@
 
 (deftype WindowFnCursor [^BufferAllocator allocator
                          ^ICursor in-cursor
-                         ^IPersistentMap static-fields
+                         static-vec-types
                          ^GroupMapper group-mapper
                          order-specs
                          ^List window-specs
@@ -110,7 +109,7 @@
 
        (let [window-groups (gensym "window-groups")]
          ;; TODO we likely want to do some retaining here instead of copying
-         (util/with-open [out-rel (Relation. allocator ^List static-fields)
+         (util/with-open [out-rel (Relation. allocator ^Map (update-keys static-vec-types str))
                           group-mapping (IntVector/open allocator (str window-groups) false)]
 
            (.forEachRemaining in-cursor (fn [^RelationReader in-rel]
@@ -138,41 +137,39 @@
         [_window-name {:keys [partition-cols order-specs]}] (first windows)]
     (lp/unary-expr (lp/emit-expr relation args)
       (fn [{:keys [vec-types] :as inner-rel}]
-        (let [fields (into {} (map (fn [[k v]] [k (types/->field v k)])) vec-types)
-              window-fn-factories (vec (for [p projections]
+        (let [window-fn-factories (vec (for [p projections]
                                          ;; ignoring window-name for now
                                          (let [[to-column {:keys [_window-name window-agg]}] (first p)]
                                            (->window-fn-factory (into {:to-name to-column
                                                                        :zero-row? (empty? partition-cols)}
                                                                       (zmatch window-agg
-                                                                        [:nullary agg-opts]
-                                                                        (select-keys agg-opts [:f])
+                                                                              [:nullary agg-opts]
+                                                                              (select-keys agg-opts [:f])
 
-                                                                        [:unary _agg-opts]
-                                                                        (throw (UnsupportedOperationException.))))))))
-              out-fields (-> (into fields
-                                   (->> window-fn-factories
-                                        (into {} (map (juxt #(.getToColumnName ^IWindowFnSpecFactory %)
-                                                            #(.getToColumnField ^IWindowFnSpecFactory %)))))))]
-          (let [out-vec-types (update-vals out-fields types/->type)]
-            {:op :window
-             :children [inner-rel]
-             :explain {:partition-by (vec partition-cols)
-                       :order-by (pr-str order-specs)
-                       :window-functions (->> projections
-                                             (mapv (fn [p]
-                                                     (let [[to-column {:keys [window-agg]}] (first p)]
-                                                       [to-column (pr-str window-agg)]))))}
-             :vec-types out-vec-types
+                                                                              [:unary _agg-opts]
+                                                                              (throw (UnsupportedOperationException.))))))))
+              out-vec-types (into vec-types
+                                  (->> window-fn-factories
+                                       (into {} (map (juxt #(.getToColumnName ^IWindowFnSpecFactory %)
+                                                           #(.getToColumnType ^IWindowFnSpecFactory %))))))]
+          {:op :window
+           :children [inner-rel]
+           :explain {:partition-by (vec partition-cols)
+                     :order-by (pr-str order-specs)
+                     :window-functions (->> projections
+                                            (mapv (fn [p]
+                                                    (let [[to-column {:keys [window-agg]}] (first p)]
+                                                      [to-column (pr-str window-agg)]))))}
+           :vec-types out-vec-types
 
-             :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
-                         (cond-> (util/with-close-on-catch [window-fn-specs (LinkedList.)]
-                                   (doseq [^IWindowFnSpecFactory factory window-fn-factories]
-                                     (.add window-fn-specs (.build factory allocator)))
+           :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]} in-cursor]
+                       (cond-> (util/with-close-on-catch [window-fn-specs (LinkedList.)]
+                                 (doseq [^IWindowFnSpecFactory factory window-fn-factories]
+                                   (.add window-fn-specs (.build factory allocator)))
 
-                                   (WindowFnCursor. allocator in-cursor (order-by/rename-fields fields)
-                                                    (group-by/->group-mapper allocator (select-keys fields partition-cols))
-                                                    order-specs
-                                                    (vec window-fn-specs)
-                                                    false))
-                           (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))}))))))
+                                 (WindowFnCursor. allocator in-cursor vec-types
+                                                  (group-by/->group-mapper allocator (select-keys vec-types partition-cols))
+                                                  order-specs
+                                                  (vec window-fn-specs)
+                                                  false))
+                         (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer query-span)))})))))

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -194,7 +194,7 @@
 (defn- emit-query [{:keys [conformed-plan scan-cols col-names ^Cache emit-cache, explain-analyze?]},
                    scan-emitter, ^Database$Catalog db-cat, snaps
                    param-types, {:keys [default-tz]}]
-  (.get emit-cache {:scan-fields (scan/scan-fields db-cat snaps scan-cols)
+  (.get emit-cache {:scan-vec-types (scan/scan-vec-types db-cat snaps scan-cols)
 
                     ;; this one is just to reset the cache for up-to-date stats
                     ;; probably over-zealous
@@ -205,10 +205,10 @@
                     :param-types param-types
                     :explain-analyze? explain-analyze?}
 
-        (fn [{:keys [scan-fields param-types default-tz]}]
+        (fn [{:keys [scan-vec-types param-types default-tz]}]
           (binding [expr/*default-tz* default-tz]
             (-> (lp/emit-expr conformed-plan
-                              {:scan-fields scan-fields
+                              {:scan-vec-types scan-vec-types
                                :default-tz default-tz
                                :param-types param-types
                                :db-cat db-cat

--- a/core/src/main/clojure/xtdb/types.clj
+++ b/core/src/main/clojure/xtdb/types.clj
@@ -81,6 +81,11 @@
    "_system_from" (->field :instant "_system_from"), "_system_to" (->field [:? :instant] "_system_to")
    "_valid_from" (->field :instant "_valid_from"), "_valid_to" (->field [:? :instant] "_valid_to")})
 
+(def temporal-vec-types
+  {"_iid" (st/->type :iid)
+   "_system_from" (st/->type :instant), "_system_to" (st/->type [:? :instant])
+   "_valid_from" (st/->type :instant), "_valid_to" (st/->type [:? :instant])})
+
 (defn temporal-col-name? [col-name]
   (contains? temporal-fields (str col-name)))
 

--- a/core/src/main/clojure/xtdb/vector/reader.clj
+++ b/core/src/main/clojure/xtdb/vector/reader.clj
@@ -16,7 +16,7 @@
    (RelationReader/from cols row-count)))
 
 (defn- ->absent-col [col-name allocator row-count]
-  (doto (Vector/open allocator (st/->field {col-name [:? :null]}))
+  (doto (Vector/open allocator (str col-name) (st/->type [:? :null]))
     (.ensureCapacity row-count)))
 
 (defn- available-col-names [^xtdb.arrow.RelationReader rel]

--- a/core/src/main/kotlin/xtdb/IResultCursor.kt
+++ b/core/src/main/kotlin/xtdb/IResultCursor.kt
@@ -1,12 +1,13 @@
 package xtdb
 
 import io.micrometer.core.instrument.Counter
-import org.apache.arrow.vector.types.pojo.Field
 import xtdb.arrow.RelationReader
+import xtdb.arrow.VectorType
 import java.util.function.Consumer
+import java.util.SequencedMap
 
 interface IResultCursor : ICursor {
-    val resultFields: List<Field>
+    val resultTypes: SequencedMap<String, VectorType>
 
     class ErrorTrackingCursor(
         private val inner: IResultCursor,

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -36,9 +36,10 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         override fun executeQuery(): QueryResult {
             val sql = this.sql ?: error("SQL query not set")
             val cursor = node.openSqlQuery(sql)
+            val schema = Schema(cursor.resultTypes.map { (name, type) -> type.toField(name) })
 
             return QueryResult(-1, object : ArrowReader(node.allocator) {
-                override fun readSchema() = Schema(cursor.resultFields)
+                override fun readSchema() = schema
 
                 override fun loadNextBatch(): Boolean =
                     cursor.tryAdvance { inRel ->

--- a/core/src/main/kotlin/xtdb/arrow/agg/AggregateSpec.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/AggregateSpec.kt
@@ -4,11 +4,13 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.pojo.Field
 import xtdb.arrow.RelationReader
 import xtdb.arrow.Vector
-import xtdb.arrow.VectorReader
+import xtdb.arrow.VectorType
 
 interface AggregateSpec : AutoCloseable {
     interface Factory {
-        val field: Field
+        val colName: String
+        val type: VectorType
+        val field: Field get() = type.toField(colName)
         fun build(al: BufferAllocator): AggregateSpec
     }
 

--- a/core/src/main/kotlin/xtdb/arrow/agg/AggregateSpec.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/AggregateSpec.kt
@@ -10,7 +10,6 @@ interface AggregateSpec : AutoCloseable {
     interface Factory {
         val colName: String
         val type: VectorType
-        val field: Field get() = type.toField(colName)
         fun build(al: BufferAllocator): AggregateSpec
     }
 

--- a/core/src/main/kotlin/xtdb/arrow/agg/Average.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/Average.kt
@@ -2,15 +2,13 @@ package xtdb.arrow.agg
 
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.pojo.ArrowType
-import org.apache.arrow.vector.types.pojo.Field
 import xtdb.arrow.*
 import xtdb.arrow.Vector.Companion.openVector
 import xtdb.arrow.VectorType.Companion.F64
 import xtdb.arrow.VectorType.Companion.maybe
-import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.util.closeOnCatch
 
-class Average(val fromName: FieldName, fromType: VectorType, toName: FieldName, val hasZeroRow: Boolean) : AggregateSpec.Factory {
+class Average(val fromName: FieldName, fromType: VectorType, override val colName: FieldName, val hasZeroRow: Boolean) : AggregateSpec.Factory {
 
     private val sumOutType = Sum.outType(fromType).let { when(it.arrowType) {
         is ArrowType.Int, is ArrowType.FloatingPoint, is ArrowType.Decimal, is ArrowType.Null -> F64
@@ -18,7 +16,7 @@ class Average(val fromName: FieldName, fromType: VectorType, toName: FieldName, 
         else -> throw IllegalArgumentException("Cannot compute AVERAGE over type $fromType")
     } }
 
-    override val field: Field = toName ofType maybe(sumOutType)
+    override val type: VectorType = maybe(sumOutType)
 
     override fun build(al: BufferAllocator) = object : AggregateSpec {
         private val sumAgg = Sum(fromName, "sum", sumOutType, hasZeroRow).build(al)

--- a/core/src/main/kotlin/xtdb/arrow/agg/Average.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/Average.kt
@@ -28,7 +28,7 @@ class Average(val fromName: FieldName, fromType: VectorType, override val colNam
         }
 
         override fun openFinishedVector(): Vector =
-            al.openVector(field).closeOnCatch { outVec ->
+            al.openVector(colName, type).closeOnCatch { outVec ->
                 sumAgg.openFinishedVector().use { sumVec ->
                     countAgg.openFinishedVector().use { countVec ->
                         sumVec.divideInto(countVec, outVec)

--- a/core/src/main/kotlin/xtdb/arrow/agg/Count.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/Count.kt
@@ -1,20 +1,19 @@
 package xtdb.arrow.agg
 
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.types.pojo.Field
 import xtdb.arrow.FieldName
 import xtdb.arrow.RelationReader
 import xtdb.arrow.Vector
 import xtdb.arrow.Vector.Companion.openVector
+import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.I64
-import xtdb.arrow.VectorType.Companion.ofType
 
 class Count(
     private val fromColName: FieldName,
-    outColName: FieldName,
+    override val colName: FieldName,
     private val hasZeroRow: Boolean
 ) : AggregateSpec.Factory {
-    override val field: Field = outColName ofType I64
+    override val type: VectorType = I64
 
     override fun build(al: BufferAllocator): AggregateSpec {
         val outVec = al.openVector(field)

--- a/core/src/main/kotlin/xtdb/arrow/agg/Count.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/Count.kt
@@ -16,7 +16,7 @@ class Count(
     override val type: VectorType = I64
 
     override fun build(al: BufferAllocator): AggregateSpec {
-        val outVec = al.openVector(field)
+        val outVec = al.openVector(colName, type)
         return object : AggregateSpec {
 
             override fun aggregate(inRel: RelationReader, groupMapping: GroupMapping) {

--- a/core/src/main/kotlin/xtdb/arrow/agg/RowCount.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/RowCount.kt
@@ -12,7 +12,7 @@ class RowCount(override val colName: FieldName, val hasZeroRow: Boolean) : Aggre
     override val type: VectorType = I64
 
     override fun build(al: BufferAllocator): AggregateSpec {
-        val outVec = al.openVector(field)
+        val outVec = al.openVector(colName, type)
         return object : AggregateSpec {
 
             override fun aggregate(inRel: RelationReader, groupMapping: GroupMapping) {

--- a/core/src/main/kotlin/xtdb/arrow/agg/RowCount.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/RowCount.kt
@@ -1,16 +1,15 @@
 package xtdb.arrow.agg
 
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.types.pojo.Field
 import xtdb.arrow.FieldName
 import xtdb.arrow.RelationReader
 import xtdb.arrow.Vector
 import xtdb.arrow.Vector.Companion.openVector
+import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.I64
-import xtdb.arrow.VectorType.Companion.ofType
 
-class RowCount(outColName: FieldName, val hasZeroRow: Boolean) : AggregateSpec.Factory {
-    override val field: Field = outColName ofType I64
+class RowCount(override val colName: FieldName, val hasZeroRow: Boolean) : AggregateSpec.Factory {
+    override val type: VectorType = I64
 
     override fun build(al: BufferAllocator): AggregateSpec {
         val outVec = al.openVector(field)

--- a/core/src/main/kotlin/xtdb/arrow/agg/StdDev.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/StdDev.kt
@@ -17,7 +17,7 @@ sealed class StdDev(override val colName: FieldName, private val varianceFactory
             varianceAgg.aggregate(inRel, groupMapping)
 
         override fun openFinishedVector(): Vector =
-            DoubleVector(al, field.name, nullable = true).closeOnCatch { outVec ->
+            DoubleVector(al, colName, nullable = true).closeOnCatch { outVec ->
                 varianceAgg.openFinishedVector().use { it.sqrtInto(outVec) }
             }
 

--- a/core/src/main/kotlin/xtdb/arrow/agg/StdDev.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/StdDev.kt
@@ -1,16 +1,14 @@
 package xtdb.arrow.agg
 
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.types.pojo.Field
 import xtdb.arrow.*
 import xtdb.arrow.VectorType.Companion.F64
 import xtdb.arrow.VectorType.Companion.maybe
-import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.util.closeOnCatch
 
-sealed class StdDev(toName: FieldName, private val varianceFactory: AggregateSpec.Factory) : AggregateSpec.Factory {
+sealed class StdDev(override val colName: FieldName, private val varianceFactory: AggregateSpec.Factory) : AggregateSpec.Factory {
 
-    override val field: Field = toName ofType maybe(F64)
+    override val type: VectorType = maybe(F64)
 
     override fun build(al: BufferAllocator) = object : AggregateSpec {
         private val varianceAgg = varianceFactory.build(al)

--- a/core/src/main/kotlin/xtdb/arrow/agg/Sum.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/Sum.kt
@@ -20,7 +20,7 @@ class Sum(
     }
 
     override fun build(al: BufferAllocator) = object : AggregateSpec {
-        private val outVec = al.openVector(field)
+        private val outVec = al.openVector(colName, type)
 
         override fun aggregate(inRel: RelationReader, groupMapping: GroupMapping) {
             val inVec = inRel.vectorForOrNull(fromName) ?: return

--- a/core/src/main/kotlin/xtdb/arrow/agg/Sum.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/Sum.kt
@@ -2,19 +2,15 @@ package xtdb.arrow.agg
 
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.pojo.ArrowType
-import org.apache.arrow.vector.types.pojo.Field
 import xtdb.arrow.*
 import xtdb.arrow.Vector.Companion.openVector
 import xtdb.arrow.VectorType.Companion.maybe
-import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.error.Incorrect
 import xtdb.types.leastUpperBound
 
 class Sum(
-    val fromName: FieldName, toName: FieldName, toType: VectorType, val hasZeroRow: Boolean
+    val fromName: FieldName, override val colName: FieldName, override val type: VectorType, val hasZeroRow: Boolean
 ) : AggregateSpec.Factory {
-
-    override val field: Field = toName ofType toType
 
     companion object {
         @JvmStatic

--- a/core/src/main/kotlin/xtdb/arrow/agg/Variance.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/Variance.kt
@@ -38,7 +38,7 @@ sealed class Variance(
         }
 
         override fun openFinishedVector(): Vector {
-            val outVec = al.openVector(field) as DoubleVector
+            val outVec = al.openVector(colName, type) as DoubleVector
 
             sumxAgg.openFinishedVector().use { sumxVec ->
                 sumx2Agg.openFinishedVector().use { sumx2Vec ->

--- a/core/src/main/kotlin/xtdb/arrow/agg/Variance.kt
+++ b/core/src/main/kotlin/xtdb/arrow/agg/Variance.kt
@@ -3,24 +3,22 @@ package xtdb.arrow.agg
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.types.FloatingPointPrecision
 import org.apache.arrow.vector.types.pojo.ArrowType
-import org.apache.arrow.vector.types.pojo.Field
 import xtdb.arrow.*
 import xtdb.arrow.Vector.Companion.openVector
 import xtdb.arrow.VectorType.Companion.F64
 import xtdb.arrow.VectorType.Companion.maybe
-import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.util.closeOnCatch
 import kotlin.math.max
 
 sealed class Variance(
     val fromName: FieldName,
-    toName: FieldName,
+    override val colName: FieldName,
     val hasZeroRow: Boolean,
     private val isSample: Boolean
 ) : AggregateSpec.Factory {
 
     private val f64Type = ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
-    override val field: Field = toName.ofType(maybe(f64Type))
+    override val type: VectorType = maybe(f64Type)
 
     override fun build(al: BufferAllocator) = object : AggregateSpec {
         private val sumxAgg = Sum(fromName, "sumx", F64, hasZeroRow).build(al)

--- a/core/src/main/kotlin/xtdb/operator/ProjectionSpec.kt
+++ b/core/src/main/kotlin/xtdb/operator/ProjectionSpec.kt
@@ -6,13 +6,15 @@ import xtdb.arrow.LongVector
 import xtdb.arrow.RelationAsStructReader
 import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorReader
-import xtdb.trie.ColumnName
+import xtdb.arrow.FieldName
 import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.util.closeOnCatch
 
 interface ProjectionSpec {
-    val field: Field
+    val toName: FieldName
+    val type: VectorType
+    val field: Field get() = type.toField(toName)
 
     /**
      * @param args a single-row indirect relation containing the args for this invocation - maybe a view over a bigger arg relation.
@@ -24,50 +26,50 @@ interface ProjectionSpec {
         args: RelationReader
     ): VectorReader
 
-    class Identity(override val field: Field) : ProjectionSpec {
+    class Identity(override val toName: FieldName, override val type: VectorType) : ProjectionSpec {
         override fun project(
             allocator: BufferAllocator, inRel: RelationReader, schema: Map<String, Any>, args: RelationReader
-        ): VectorReader = inRel[field.name]
+        ): VectorReader = inRel[toName]
     }
 
-    class RowNumber(colName: ColumnName) : ProjectionSpec {
-        override val field = colName ofType VectorType.I64
+    class RowNumber(override val toName: FieldName) : ProjectionSpec {
+        override val type: VectorType = VectorType.I64
 
         private var rowNum = 1L
 
         override fun project(
             allocator: BufferAllocator, inRel: RelationReader, schema: Map<String, Any>, args: RelationReader
         ) =
-            LongVector(allocator, field.name, false).closeOnCatch { rowNumVec ->
+            LongVector(allocator, toName, false).closeOnCatch { rowNumVec ->
                 repeat(inRel.rowCount) { rowNumVec.writeLong(rowNum++) }
                 rowNumVec
             }
     }
 
     // only returns the row number within the batch - see #4131
-    class LocalRowNumber(colName: ColumnName) : ProjectionSpec {
-        override val field = colName ofType VectorType.I64
+    class LocalRowNumber(override val toName: FieldName) : ProjectionSpec {
+        override val type: VectorType = VectorType.I64
 
         override fun project(
             allocator: BufferAllocator, inRel: RelationReader, schema: Map<String, Any>, args: RelationReader
         ): VectorReader =
-            LongVector(allocator, field.name, false).closeOnCatch { rowNumVec ->
+            LongVector(allocator, toName, false).closeOnCatch { rowNumVec ->
                 var rowNum = 1L
                 repeat(inRel.rowCount) { rowNumVec.writeLong(rowNum++) }
                 rowNumVec
             }
     }
 
-    class Star(override val field: Field) : ProjectionSpec {
+    class Star(override val toName: FieldName, override val type: VectorType) : ProjectionSpec {
         override fun project(
             allocator: BufferAllocator, inRel: RelationReader, schema: Map<String, Any>, args: RelationReader
-        ) = RelationAsStructReader(field.name, inRel).openSlice(allocator)
+        ) = RelationAsStructReader(toName, inRel).openSlice(allocator)
     }
 
-    class Rename(private val fromName: ColumnName, override val field: Field) : ProjectionSpec {
+    class Rename(private val fromName: FieldName, override val toName: FieldName, override val type: VectorType) : ProjectionSpec {
         override fun project(
             allocator: BufferAllocator, inRel: RelationReader, schema: Map<String, Any>, args: RelationReader
         ) =
-            inRel.vectorFor(fromName).withName(field.name)
+            inRel.vectorFor(fromName).withName(toName)
     }
 }

--- a/core/src/main/kotlin/xtdb/operator/distinct/DistinctRelationMap.kt
+++ b/core/src/main/kotlin/xtdb/operator/distinct/DistinctRelationMap.kt
@@ -1,11 +1,11 @@
 package xtdb.operator.distinct
 
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.arrow.IntVector
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorReader
+import xtdb.arrow.VectorTypes
 import xtdb.expression.map.IndexHasher.Companion.hasher
 import xtdb.expression.map.RelationMapBuilder
 import xtdb.trie.MutableMemoryHashTrie
@@ -13,7 +13,7 @@ import java.util.function.IntBinaryOperator
 
 class DistinctRelationMap(
     val allocator: BufferAllocator,
-    val schema: Schema,
+    val vecTypes: VectorTypes,
     val keyColumnNames: List<String>,
     private val storeFullBuildRel: Boolean,
     private val comparatorFactory: ComparatorFactory,
@@ -24,7 +24,7 @@ class DistinctRelationMap(
         fun buildEqui(l: VectorReader, r: VectorReader): IntBinaryOperator
     }
 
-    private val accRel = Relation(allocator, schema)
+    private val accRel = Relation(allocator, vecTypes)
     private val keyCols = keyColumnNames.map { accRel[it] }
 
     private val hashColumn = IntVector.open(allocator, "xt/join-hash", false)

--- a/core/src/main/kotlin/xtdb/operator/join/BuildSide.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/BuildSide.kt
@@ -1,7 +1,6 @@
 package xtdb.operator.join
 
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.types.pojo.Schema
 import org.roaringbitmap.RoaringBitmap
 import xtdb.arrow.NullVector
 import xtdb.arrow.Relation
@@ -11,17 +10,18 @@ import xtdb.arrow.VectorReader
 import xtdb.expression.map.IndexHasher.Companion.hasher
 import xtdb.arrow.FieldName
 import xtdb.arrow.VectorType.Companion.I32
+import xtdb.arrow.VectorTypes
 import java.util.function.IntUnaryOperator
 
 class BuildSide(
     private val al: BufferAllocator,
-    val schema: Schema,
+    val vecTypes: VectorTypes,
     val keyColNames: List<String>,
     trackUnmatchedIdxs: Boolean,
     val withNilRow: Boolean,
     val inMemoryThreshold: Long = 100_000,
 ) : AutoCloseable {
-    val dataRel = Relation(al, schema)
+    val dataRel = Relation(al, vecTypes)
     private val hashCol = al.openVector("hashes", I32)
 
     var buildMap: BuildSideMap? = null; private set

--- a/core/src/main/kotlin/xtdb/operator/join/DiskHashJoin.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/DiskHashJoin.kt
@@ -1,7 +1,6 @@
 package xtdb.operator.join
 
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.types.pojo.Field
 import xtdb.ICursor
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
@@ -9,6 +8,7 @@ import xtdb.arrow.Vector.Companion.openVector
 import xtdb.operator.join.ComparatorFactory.Companion.build
 import xtdb.arrow.FieldName
 import xtdb.arrow.VectorType.Companion.I32
+import xtdb.arrow.VectorTypes
 import xtdb.util.closeOnCatch
 import java.util.function.Consumer
 
@@ -94,10 +94,10 @@ class DiskHashJoin(
         fun open(
             al: BufferAllocator,
             buildSide: BuildSide, probeCursor: ICursor,
-            probeFields: List<Field>, probeKeyColNames: List<FieldName>,
+            probeVecTypes: VectorTypes, probeKeyColNames: List<FieldName>,
             joinType: JoinType, comparatorFactory: ComparatorFactory,
         ): DiskHashJoin =
-            Relation(al, probeFields).use { tmpRel ->
+            Relation(al, probeVecTypes).use { tmpRel ->
                 Spill.open(al, tmpRel).use { spill ->
                     probeCursor.forEachRemaining { inRel ->
                         tmpRel.append(inRel)

--- a/core/src/main/kotlin/xtdb/operator/join/MemoryHashJoin.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/MemoryHashJoin.kt
@@ -1,6 +1,5 @@
 package xtdb.operator.join
 
-import org.apache.arrow.vector.types.pojo.Field
 import xtdb.ICursor
 import xtdb.arrow.RelationReader
 import xtdb.operator.join.ComparatorFactory.Companion.build
@@ -9,7 +8,7 @@ import java.util.function.Consumer
 
 class MemoryHashJoin(
     private val buildSide: BuildSide, private val probeCursor: ICursor,
-    private val probeFields: List<Field>?, private val probeKeyColNames: List<FieldName>,
+    private val probeColNames: List<FieldName>?, private val probeKeyColNames: List<FieldName>,
     private val joinType: JoinType, private val comparatorFactory: ComparatorFactory,
 ) : ICursor {
 
@@ -34,8 +33,8 @@ class MemoryHashJoin(
 
         if (advanced) return true
 
-        if (probeFields == null) return false // semi-join
-        val unmatchedBuildIdxsRel = buildSide.unmatchedIdxsRel(probeFields.map { it.name }, joinType) ?: return false
+        if (probeColNames == null) return false // semi-join
+        val unmatchedBuildIdxsRel = buildSide.unmatchedIdxsRel(probeColNames, joinType) ?: return false
         buildSide.clearMatches() // so that we don't keep yielding them
         c.accept(unmatchedBuildIdxsRel)
 

--- a/core/src/main/kotlin/xtdb/pgwire/PgType.kt
+++ b/core/src/main/kotlin/xtdb/pgwire/PgType.kt
@@ -902,10 +902,12 @@ sealed class PgType(
         }
 
         @JvmStatic
-        fun fromField(field: Field): PgType {
-            val xtType = field.asType
-            val pgTypes = xtType.mapTo(mutableSetOf()) { fromXtType(it) }.minus(Null)
+        fun fromVectorType(type: VectorType): PgType {
+            val pgTypes = type.mapTo(mutableSetOf()) { fromXtType(it) }.minus(Null)
             return unifyPgTypes(pgTypes)
         }
+
+        @JvmStatic
+        fun fromField(field: Field): PgType = fromVectorType(field.asType)
     }
 }

--- a/core/src/test/kotlin/xtdb/operator/join/BuildSideTest.kt
+++ b/core/src/test/kotlin/xtdb/operator/join/BuildSideTest.kt
@@ -13,8 +13,6 @@ import xtdb.test.AllocatorResolver
 import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.I32
 import xtdb.arrow.VectorType.Companion.maybe
-import xtdb.arrow.VectorType.Companion.ofType
-import xtdb.arrow.schema
 
 @ExtendWith(AllocatorResolver::class)
 class BuildSideTest {
@@ -29,10 +27,10 @@ class BuildSideTest {
 
     @Test
     fun testBuildSideWithDiskSpill(al: BufferAllocator) {
-        val schema = schema(
-            "id" ofType maybe(I32),
-            "name" ofType maybe(VectorType.UTF8),
-            "value" ofType maybe(I32)
+        val vecTypes = mapOf(
+            "id" to maybe(I32),
+            "name" to maybe(VectorType.UTF8),
+            "value" to maybe(I32)
         )
 
         val john = mapOf("id" to 1, "name" to "John", "value" to 100)
@@ -47,7 +45,7 @@ class BuildSideTest {
         Relation.openFromRows(al, rows).use { rel ->
             // without nil row
             BuildSide(
-                al, schema, listOf("id"),
+                al, vecTypes, listOf("id"),
                 trackUnmatchedIdxs = false,
                 withNilRow = false,
                 inMemoryThreshold = 5
@@ -90,7 +88,7 @@ class BuildSideTest {
 
             // with nil row
             BuildSide(
-                al, schema, listOf("id"),
+                al, vecTypes, listOf("id"),
                 trackUnmatchedIdxs = false,
                 withNilRow = true,
                 inMemoryThreshold = 5
@@ -130,10 +128,10 @@ class BuildSideTest {
 
     @Test
     fun testBuildSideWithoutDiskSpill(al: BufferAllocator) {
-        val schema = schema(
-            "id" ofType maybe(I32),
-            "name" ofType maybe(VectorType.UTF8),
-            "value" ofType maybe(I32)
+        val vecTypes = mapOf(
+            "id" to maybe(I32),
+            "name" to maybe(VectorType.UTF8),
+            "value" to maybe(I32)
         )
 
         val rows = listOf(
@@ -142,11 +140,11 @@ class BuildSideTest {
             mapOf("id" to 3, "name" to "Bob", "value" to 300)
         )
 
-        Relation(al, schema).use { rel ->
+        Relation(al, vecTypes).use { rel ->
             rel.writeRows(*rows.toTypedArray())
 
             BuildSide(
-                al, schema, listOf("id"),
+                al, vecTypes, listOf("id"),
                 trackUnmatchedIdxs = false,
                 withNilRow = false,
                 inMemoryThreshold = 5

--- a/src/test/clojure/xtdb/operator/group_by_test.clj
+++ b/src/test/clojure/xtdb/operator/group_by_test.clj
@@ -124,10 +124,10 @@
               v0 (tu/open-rel {:v [1 2 3]})
               v1 (tu/open-rel {:v [1 2.0 3]})]
     (let [sum-factory (group-by/->aggregate-factory {:f :sum, :from-name 'v,
-                                                     :from-field #xt/field {"v" [:union :i64 :f64]}
+                                                     :from-type #xt/type [:union :i64 :f64]
                                                      :to-name 'vsum, :zero-row? true})
           sum-spec (.build sum-factory tu/*allocator*)]
-      (t/is (= #xt/field {"vsum" [:? :f64]} (.getField sum-factory)))
+      (t/is (= #xt/type [:? :f64] (.getType sum-factory)))
       (try
 
         (.aggregate sum-spec v0 gm)
@@ -327,10 +327,10 @@
               k0 (Vector/fromList tu/*allocator* "k" [1 2 3])
               k1 (Vector/fromList tu/*allocator* "k" [4 5 6])]
 
-    (let [agg-factory (group-by/->aggregate-factory {:f :array-agg, :from-name 'k, :from-field #xt/field {"k" :i64}
+    (let [agg-factory (group-by/->aggregate-factory {:f :array-agg, :from-name 'k, :from-type #xt/type :i64
                                                      :to-name 'vs, :zero-row? true})]
       (util/with-open [agg-spec (.build agg-factory tu/*allocator*)]
-        (t/is (= #xt/type [:? :list :i64] (types/->type (.getField agg-factory))))
+        (t/is (= #xt/type [:? :list :i64] (.getType agg-factory)))
 
         (.aggregate agg-spec (vr/rel-reader [k0]) gm0)
         (.aggregate agg-spec (vr/rel-reader [k1]) gm1)

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -188,7 +188,6 @@
     {:op :pages
      :children []
      :vec-types out-vec-types
-     :fields fields
      :stats stats
      :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]}]
                  (cond-> (->cursor allocator schema pages)

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -182,10 +182,12 @@
                             (into {} (map (fn [[col-name vec-type]]
                                             [col-name (types/vec-type->field vec-type col-name)]))))
                    (rows->fields (into [] cat pages)))
+        out-vec-types (or vec-types (update-vals fields types/->type))
         ^Schema schema (Schema. (for [[col-name field] fields]
                                   (types/field-with-name field (str col-name))))]
     {:op :pages
      :children []
+     :vec-types out-vec-types
      :fields fields
      :stats stats
      :->cursor (fn [{:keys [allocator explain-analyze? tracer query-span]}]
@@ -197,13 +199,13 @@
   (s/cat :op #{:prn}
          :relation ::lp/ra-expression))
 
-(defmethod lp/emit-expr :prn [{:keys [relation]} _args]
-  (lp/unary-expr (lp/emit-expr relation _args)
-    (fn [{inner-fields :fields, :as inner-rel}]
+(defmethod lp/emit-expr :prn [{:keys [relation]} args]
+  (lp/unary-expr (lp/emit-expr relation args)
+    (fn [{inner-types :vec-types, :as inner-rel}]
       {:op :prn
        :stats (:stats inner-rel)
        :children [inner-rel]
-       :fields inner-fields
+       :vec-types inner-types
        :->cursor (fn [{:keys [explain-analyze? tracer query-span]}, ^ICursor in-cursor]
                    (cond-> (reify ICursor
                              (getCursorType [_] "prn")

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -250,9 +250,8 @@
                           (cond->> (not preserve-pages?) (into [] cat)))]
              (if with-types?
                {:res rows,
-                :types (->> (.getResultFields res)
-                            (into {} (map (juxt #(symbol (.getName ^Field %))
-                                                VectorType/fromField))))}
+                :types (->> (.getResultTypes res)
+                            (into {} (map (fn [[k v]] [(symbol k) v]))))}
                rows))))
        (finally
          (when close-q-src?


### PR DESCRIPTION
This is to cut down on transforms between the main body of code and the expression engine.

Previously, each operator would yield (and read, from its inner operators) `:fields`, now it yields `:vec-types`, `Map<String, VectorType>`.

Updated all of the operators, plus:
- Join/Aggregate Kotlin classes
- Query API boundary

I haven't changed anything about the vectors themselves, that's coming next. It's also remaining `Field`s to go down to disk, because the mapping between fields <-> vec-types needs to be broken to make them work for the EE. Coming soon.