### PR TITLE
Add readOnlyDatabases node config option

### DIFF
--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -79,6 +79,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         var garbageCollector: GarbageCollectorConfig = GarbageCollectorConfig(),
         var tracer: TracerConfig = TracerConfig(),
         var txSink: TxSinkConfig? = null,
+        var readOnlyDatabases: Boolean = false,
         var nodeId: String = System.getenv("XTDB_NODE_ID") ?: randomUUID().toString().takeWhile { it != '-' }
     ) {
         var allocator: BufferAllocator? = null
@@ -122,6 +123,8 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             garbageCollector(GarbageCollectorConfig().also(configure))
 
         fun txSink(txSink: TxSinkConfig) = apply { this.txSink = txSink }
+
+        fun readOnlyDatabases(readOnlyDatabases: Boolean = true) = apply { this.readOnlyDatabases = readOnlyDatabases }
 
         fun defaultTz(defaultTz: ZoneId) = apply { this.defaultTz = defaultTz }
 

--- a/src/test/clojure/xtdb/read_only_node_test.clj
+++ b/src/test/clojure/xtdb/read_only_node_test.clj
@@ -1,0 +1,43 @@
+(ns xtdb.read-only-node-test
+  (:require [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.log :as xt-log]
+            [xtdb.node :as xtn]
+            [xtdb.util :as util]))
+
+(t/deftest read-only-node-rejects-writes
+  (with-open [node (-> (xtn/->config {})
+                       (.readOnlyDatabases true)
+                       (.open))]
+    (t/is (thrown-with-msg? Exception #"read-only"
+                            (xt/submit-tx node [[:put-docs :foo {:xt/id "test"}]]))
+          "read-only node rejects writes to primary database")))
+
+(t/deftest read-only-node-follows-read-write-node
+  (util/with-tmp-dirs #{node-dir}
+    (with-open [rw-node (xtn/start-node {:log [:local {:path (.resolve node-dir "log")}]
+                                         :storage [:local {:path (.resolve node-dir "objects")}]})]
+
+      (xt/submit-tx rw-node [[:put-docs :foo {:xt/id "from-rw"}]])
+
+      (with-open [ro-node (-> (xtn/->config {:log [:local {:path (.resolve node-dir "log")}]
+                                             :storage [:local {:path (.resolve node-dir "objects")}]})
+                              (.readOnlyDatabases true)
+                              (.open))]
+
+        (xt-log/sync-node ro-node)
+
+        (t/is (= [{:xt/id "from-rw"}]
+                 (xt/q ro-node "SELECT * FROM foo"))
+              "read-only node can read data written by read-write node")
+
+        (t/is (thrown-with-msg? Exception #"read-only"
+                                (xt/submit-tx ro-node [[:put-docs :foo {:xt/id "from-ro"}]]))
+              "read-only node rejects writes")
+
+        (xt/submit-tx rw-node [[:put-docs :foo {:xt/id "from-rw", :v 2}]])
+        (xt-log/sync-node ro-node)
+
+        (t/is (= [{:xt/id "from-rw", :v 2}]
+                 (xt/q ro-node "SELECT * FROM foo"))
+              "read-only node sees updated data from read-write node")))))


### PR DESCRIPTION
When `readOnlyDatabases` is enabled, all databases on the node will run in `READ_ONLY` mode (including `xtdb`).

This is useful when you want to ensure an entire node is `READ_ONLY`.
An example of this is TxSink which has no need to write to the database log or object store.
Another example of this is read-only replicas which need only read access to the log & object store.

I haven't made this available as a user configured option yet because there hasn't been an ask for it.