### PR TITLE
fix: add missing binary read/write for Time PgType

### DIFF
--- a/core/src/main/kotlin/xtdb/pgwire/PgType.kt
+++ b/core/src/main/kotlin/xtdb/pgwire/PgType.kt
@@ -397,7 +397,18 @@ sealed class PgType(
         typsend = "time_send",
         typreceive = "time_recv",
     ) {
+        override fun readBinary(data: ByteArray): LocalTime {
+            val micros = ByteBuffer.wrap(data).long
+            return LocalTime.ofNanoOfDay(micros * 1000)
+        }
+
         override fun readText(data: ByteArray): LocalTime = LocalTime.parse(readUtf8(data))
+
+        override fun writeBinary(env: PgSessionEnv, rdr: VectorReader, idx: Int): ByteArray {
+            val time = rdr.getObject(idx) as LocalTime
+            val micros = time.toNanoOfDay() / 1000
+            return ByteBuffer.allocate(8).putLong(micros).array()
+        }
 
         override fun writeText(env: PgSessionEnv, rdr: VectorReader, idx: Int): ByteArray {
             val time = rdr.getObject(idx) as LocalTime


### PR DESCRIPTION
Time type was missing readBinary and writeBinary implementations, causing "writeBinary unsupported on Time" errors when querying tables with time columns via JDBC binary protocol.

Came across this running yakbench, looks like it's been a long standing bug since e145c7c04.