### PR TITLE
Ensure ReadOnlyLocalLog returns fresh latestSubmittedOffset

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
@@ -91,9 +91,8 @@ class ReadOnlyLocalLog(
         }
     }
 
-    @Volatile
-    override var latestSubmittedOffset: LogOffset = readLatestSubmittedOffset(logFilePath)
-        private set
+    override val latestSubmittedOffset: LogOffset
+        get() = readLatestSubmittedOffset(logFilePath)
 
     override fun appendMessage(message: Message) =
         throw Incorrect("Cannot append to read-only database log")
@@ -149,8 +148,6 @@ class ReadOnlyLocalLog(
         val newLatestOffset = readLatestSubmittedOffset(logFilePath)
 
         if (newLatestOffset <= currentOffset) return null
-
-        latestSubmittedOffset = newLatestOffset
 
         var lastOffset = currentOffset
         FileChannel.open(logFilePath, READ).use { ch ->


### PR DESCRIPTION
The cached latestSubmittedOffset could become stale between file updates and WatchService notifications.

This is particularly a problem on macOS where Java's WatchService uses polling [(~2s on JDK 21+)](https://github.com/mkartashev/jdk/blob/9d8b93b6e2fa7a6c81d96f82ae8f5de222027879/src/java.base/macosx/classes/sun/nio/fs/BsdFileSystem.java#L56) instead of native filesystem events.
But this issue could theoretically be seen on linux too.

This caused sync operations to see stale offset values and return immediately before new messages were processed in the read-only log tests.

This change move the source of truth for where we are in the log from the cache to the file itself.