### PR TITLE
feat: add tries-deleted message s.t. we can run GC on an independent machine

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -224,6 +224,18 @@ class LogProcessor(
                         null
                     }
 
+                    is Message.TriesDeleted -> {
+                        if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == db.bufferPool.epoch) {
+                            val table = TableRef.parse(db.name, msg.tableName)
+                            val trieKeySet = msg.trieKeys.toSet()
+
+                            trieCatalog.deleteTries(table, trieKeySet)
+
+                            LOG.debug("Processed TriesDeleted: deleted ${trieKeySet.size} tries from table ${msg.tableName}")
+                        }
+                        null
+                    }
+
                     is Message.AttachDatabase -> {
                         requireNotNull(dbCatalog) { "attach-db received on non-primary database ${db.name}" }
                         val res = try {

--- a/core/src/main/proto/xtdb/log/proto/log.proto
+++ b/core/src/main/proto/xtdb/log/proto/log.proto
@@ -12,6 +12,7 @@ message LogMessage {
         TriesAdded tries_added = 2;
         AttachDatabase attach_database = 3;
         DetachDatabase detach_database = 4;
+        TriesDeleted tries_deleted = 5;
     }
 }
 
@@ -62,4 +63,11 @@ message AttachDatabase {
 
 message DetachDatabase {
     string db_name = 1;
+}
+
+message TriesDeleted {
+    int32 storage_version = 1;
+    int32 storage_epoch = 2;
+    string table_name = 3;
+    repeated string trie_keys = 4;
 }


### PR DESCRIPTION
This PR is the first step in adding a one-shot GC task and/or a separate garbage collecting XT instance.

Previously, deleteTries was called directly on the local trieCatalog, on the assumption that every node will try to delete the same garbage. With this change, we instead put a deleted-tries message on the log so that files GC'd by any machine on the cluster are removed from all trie-catalogs - this is so that we needn't run GC on every node.

Key design decisions:
- GC does NOT eagerly update the catalog - only LogProcessor does, avoiding the eager update issues seen with the Compactor
- If message emission fails, log warning but continue (deletion succeeded, message is to update the trie catalogs)