### PR TITLE
feat!: separating out JSON-LD as a separate fallback type, default to simple JSON (#5156)

### DIFF
--- a/api/src/main/kotlin/xtdb/JsonLdSerde.kt
+++ b/api/src/main/kotlin/xtdb/JsonLdSerde.kt
@@ -1,0 +1,253 @@
+@file:JvmName("JsonLdSerde")
+
+package xtdb
+
+import clojure.lang.*
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+import xtdb.error.*
+import xtdb.error.Anomaly.Companion.CATEGORY
+import xtdb.error.Busy.Companion.BUSY
+import xtdb.error.Conflict.Companion.CONFLICT
+import xtdb.error.Fault.Companion.FAULT
+import xtdb.error.Forbidden.Companion.FORBIDDEN
+import xtdb.error.Incorrect.Companion.INCORRECT
+import xtdb.error.Interrupted.Companion.INTERRUPTED
+import xtdb.error.NotFound.Companion.NOT_FOUND
+import xtdb.error.Unavailable.Companion.UNAVAILABLE
+import xtdb.error.Unsupported.Companion.UNSUPPORTED
+import java.io.InputStream
+import java.io.OutputStream
+import java.math.BigDecimal
+import java.time.*
+import java.util.*
+import xtdb.table.TableRef
+import xtdb.time.Interval
+import xtdb.time.asInterval
+
+/**
+ * JSON-LD serializer with @type/@value wrappers for non-native JSON types
+ * @suppress
+ */
+object AnyJsonLdSerde : KSerializer<Any> {
+    @OptIn(ExperimentalSerializationApi::class)
+    override val descriptor = SerialDescriptor("xtdb.any", JsonElement.serializer().descriptor)
+
+    private fun JsonElement.asString() = (this as? JsonPrimitive)?.takeIf { it.isString }?.content
+    private fun JsonElement.asStringOrThrow() = asString() ?: throw jsonIAEwithMessage("@value must be string!", this)
+    private fun JsonElement.asLong() = (this as? JsonPrimitive)?.longOrNull
+    private fun JsonElement.asDouble() = (this as? JsonPrimitive)?.doubleOrNull
+
+    private fun toThrowable(type: String, obj: JsonObject): Throwable {
+        val errorMessage = obj["xtdb.error/message"]?.asString()
+
+        val dataObj = obj["xtdb.error/data"] as? JsonObject
+
+        @Suppress("UNCHECKED_CAST")
+        val errorData = PersistentHashMap.create(
+            dataObj?.fromLdValue()?.let { it as Map<String, *> }
+                ?.mapKeys { (k, _) -> Keyword.intern(k) }
+        )
+
+        fun IPersistentMap.withCategory(cat: Keyword) = assoc(CATEGORY, cat)
+
+        return when (type) {
+            "xt:incorrect" -> Incorrect(errorMessage, errorData.withCategory(INCORRECT))
+            "xt:unsupported" -> Unsupported(errorMessage, errorData.withCategory(UNSUPPORTED))
+            "xt:conflict" -> Conflict(errorMessage, errorData.withCategory(CONFLICT))
+            "xt:fault" -> Fault(errorMessage, errorData.withCategory(FAULT))
+            "xt:interrupted" -> Interrupted(errorMessage, errorData.withCategory(INTERRUPTED))
+            "xt:not-found" -> NotFound(errorMessage, errorData.withCategory(NOT_FOUND))
+            "xt:forbidden" -> Forbidden(errorMessage, errorData.withCategory(FORBIDDEN))
+            "xt:busy" -> Busy(errorMessage, errorData.withCategory(BUSY))
+            "xt:unavailable" -> Unavailable(errorMessage, errorData.withCategory(UNAVAILABLE))
+            "xt:error" -> ExceptionInfo(errorMessage, PersistentHashMap.create(errorData))
+            else -> throw jsonIAE("unknown-error-type", obj)
+        }
+    }
+
+    private val ANOMALY_TYPES = setOf(
+        "xt:incorrect", "xt:unsupported", "xt:conflict", "xt:fault", "xt:interrupted",
+        "xt:not-found", "xt:forbidden", "xt:busy", "xt:unavailable", "xt:error"
+    )
+
+    fun JsonElement.fromLdValue(): Any? = when (this) {
+        is JsonArray -> map { it.fromLdValue() }
+        is JsonObject -> {
+            val type = (this["@type"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+
+            if (type == null) {
+                mapValues { (_, v) -> v.fromLdValue() }.toMap()
+            } else {
+                val value = this["@value"] ?: throw jsonIAEwithMessage("@value can't be null!", this)
+                when (type) {
+                    "xt:long" ->
+                        value.asLong()
+                            ?: value.asString()?.toLong()
+                            ?: throw jsonIAEwithMessage("@value must be long!", this)
+
+                    "xt:double" ->
+                        value.asDouble()
+                            ?: value.asString()?.toDouble()
+                            ?: throw jsonIAEwithMessage("@value must be double!", this)
+
+                    "xt:decimal" -> value.asStringOrThrow().toBigDecimal()
+
+                    "xt:instant" -> Instant.parse(value.asStringOrThrow())
+                    "xt:timestamptz" -> ZonedDateTime.parse(value.asStringOrThrow())
+                    "xt:timestamp" -> LocalDateTime.parse(value.asStringOrThrow())
+                    "xt:date" -> LocalDate.parse(value.asStringOrThrow())
+                    "xt:time" -> LocalTime.parse(value.asStringOrThrow())
+                    "xt:duration" -> Duration.parse(value.asStringOrThrow())
+                    "xt:interval" -> value.asStringOrThrow().asInterval()
+                    "xt:timeZone" -> ZoneId.of(value.asStringOrThrow())
+                    "xt:period" -> Period.parse(value.asStringOrThrow())
+                    "xt:keyword" -> Keyword.intern(value.asStringOrThrow())
+                    "xt:symbol" -> Symbol.intern(value.asStringOrThrow())
+                    "xt:uuid" -> UUID.fromString(value.asStringOrThrow())
+                    "xt:set" -> (value as? JsonArray ?: throw jsonIAEwithMessage(
+                        "@value must be array!",
+                        this
+                    )).map { it.fromLdValue() }.toSet()
+
+                    "xt:table" -> {
+                        val obj = value as? JsonObject ?: throw jsonIAEwithMessage("@value must be object!", this)
+                        TableRef(
+                            obj["db"]?.asStringOrThrow() ?: throw jsonIAEwithMessage("db is required!", this),
+                            obj["schema"]?.asString() ?: "public",
+                            obj["table"]?.asStringOrThrow() ?: throw jsonIAEwithMessage("table is required!", this)
+                        )
+                    }
+
+                    in ANOMALY_TYPES -> toThrowable(
+                        type,
+                        value as? JsonObject ?: throw jsonIAEwithMessage(
+                            "@value must be object!",
+                            this
+                        )
+                    )
+
+                    else -> throw jsonIAE("unknown-json-ld-type", this)
+                }
+            }
+        }
+
+        is JsonNull -> null
+
+        is JsonPrimitive -> if (isString) content else booleanOrNull ?: longOrNull ?: doubleOrNull
+        ?: throw jsonIAE("unknown-json-primitive", this)
+    }
+
+    fun Any?.toJsonLdElement(type: String) = mapOf("@type" to type, "@value" to toString()).toJsonLdElement()
+
+    fun Throwable.toJsonLdElement(): JsonElement {
+        val type = when (this) {
+            is Incorrect -> "xt:incorrect"
+            is Unsupported -> "xt:unsupported"
+            is Conflict -> "xt:conflict"
+            is Fault -> "xt:fault"
+            is Interrupted -> "xt:interrupted"
+            is NotFound -> "xt:not-found"
+            is Forbidden -> "xt:forbidden"
+            is Busy -> "xt:busy"
+            is Unavailable -> "xt:unavailable"
+            else -> "xt:error"
+        }
+        return mapOf(
+            "@type" to type,
+            "@value" to listOfNotNull(
+                "xtdb.error/message" to message,
+                (this as? IExceptionInfo)?.let {
+                    "xtdb.error/data" to (data as Map<*, *>).mapKeys { (k, _) -> (k as? Keyword)?.sym?.toString() ?: k }
+                        .minus("cognitect.anomalies/category")
+                }
+            ).toMap()
+        ).toJsonLdElement()
+    }
+
+    fun Any?.toJsonLdElement(): JsonElement = when (this) {
+        null -> JsonNull
+        is String -> JsonPrimitive(this)
+        is BigDecimal -> toJsonLdElement("xt:decimal")
+        is Number -> JsonPrimitive(this)
+        is Boolean -> JsonPrimitive(this)
+        is Map<*, *> -> JsonObject(map { (k, v) ->
+            when (k) {
+                is Keyword -> k.sym.toString() to v.toJsonLdElement()
+                else -> k.toString() to v.toJsonLdElement()
+            }
+        }.toMap())
+
+        is Set<*> -> mapOf("@type" to "xt:set", "@value" to toList()).toJsonLdElement()
+        is Collection<*> -> JsonArray(map { it.toJsonLdElement() })
+        is Keyword -> sym.toJsonLdElement("xt:keyword")
+        is Symbol -> toJsonLdElement("xt:symbol")
+        is UUID -> toJsonLdElement("xt:uuid")
+        is ZonedDateTime -> toJsonLdElement("xt:timestamptz")
+        is Instant -> toJsonLdElement("xt:instant")
+        is LocalDate -> toJsonLdElement("xt:date")
+        is LocalTime -> toJsonLdElement("xt:time")
+        is LocalDateTime -> toJsonLdElement("xt:timestamp")
+        is ZoneId -> toJsonLdElement("xt:timeZone")
+        is Period -> toJsonLdElement("xt:period")
+        is Date -> toInstant().toJsonLdElement()
+        is Duration -> toJsonLdElement("xt:duration")
+        is Interval -> toJsonLdElement("xt:interval")
+        is TableRef -> mapOf(
+            "@type" to "xt:table",
+            "@value" to mapOf("db" to dbName, "schema" to schemaName, "table" to tableName)
+        ).toJsonLdElement()
+
+        is Throwable -> toJsonLdElement()
+        else -> throw Incorrect("unknown type: ${this.javaClass.name}")
+    }
+
+    override fun deserialize(decoder: Decoder) =
+        // top-level will be not-null, nested values may not be
+        decoder.decodeSerializableValue(JsonElement.serializer()).fromLdValue()!!
+
+    override fun serialize(encoder: Encoder, value: Any) =
+        encoder.encodeSerializableValue(JsonElement.serializer(), value.toJsonLdElement())
+}
+
+/**
+ * @suppress
+ */
+@JvmField
+val JSON_LD_SERDE = Json {
+    serializersModule =
+        SerializersModule {
+            contextual(AnyJsonLdSerde)
+        }
+}
+
+private fun decodeError(value: String, cause: Throwable) =
+    Incorrect("Error decoding JSON-LD", "xtdb/json-ld-decode-error", mapOf("json" to value), cause)
+
+/**
+ * @suppress
+ */
+@Suppress("unused")
+@OptIn(ExperimentalSerializationApi::class)
+fun decodeJsonLd(json: String): Any =
+    try {
+        JSON_LD_SERDE.decodeFromString(AnyJsonLdSerde, json)
+    } catch (e: Exception) {
+        throw decodeError(json, e)
+    }
+
+/**
+ * @suppress
+ */
+fun encodeJsonLd(value: Any): String = JSON_LD_SERDE.encodeToString(value)
+
+/**
+ * @suppress
+ */
+@Suppress("unused")
+fun encodeJsonLdToBytes(value: Any): ByteArray = encodeJsonLd(value).toByteArray(Charsets.UTF_8)

--- a/api/src/main/kotlin/xtdb/JsonSerde.kt
+++ b/api/src/main/kotlin/xtdb/JsonSerde.kt
@@ -10,170 +10,32 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
-import xtdb.error.*
-import xtdb.error.Anomaly.Companion.CATEGORY
-import xtdb.error.Busy.Companion.BUSY
-import xtdb.error.Conflict.Companion.CONFLICT
-import xtdb.error.Fault.Companion.FAULT
-import xtdb.error.Forbidden.Companion.FORBIDDEN
-import xtdb.error.Incorrect.Companion.INCORRECT
-import xtdb.error.Interrupted.Companion.INTERRUPTED
-import xtdb.error.NotFound.Companion.NOT_FOUND
-import xtdb.error.Unavailable.Companion.UNAVAILABLE
-import xtdb.error.Unsupported.Companion.UNSUPPORTED
-import xtdb.util.kebabToCamelCase
+import xtdb.AnyJsonLdSerde.fromLdValue
+import xtdb.AnyJsonLdSerde.toJsonLdElement
+import xtdb.error.Incorrect
 import java.io.InputStream
 import java.io.OutputStream
 import java.math.BigDecimal
 import java.time.*
+import java.time.temporal.Temporal
 import java.util.*
 import xtdb.table.TableRef
 import xtdb.time.Interval
-import xtdb.time.asInterval
 
 /**
+ * Simple JSON serializer - non-native types become strings
+ * Uses JSON-LD to deserialize because JSON-LD is a superset of JSON
+ *
  * @suppress
  */
 object AnySerde : KSerializer<Any> {
     @OptIn(ExperimentalSerializationApi::class)
     override val descriptor = SerialDescriptor("xtdb.any", JsonElement.serializer().descriptor)
 
-    private fun JsonElement.asString() = (this as? JsonPrimitive)?.takeIf { it.isString }?.content
-    private fun JsonElement.asStringOrThrow() = asString() ?: throw jsonIAEwithMessage("@value must be string!", this)
-    private fun JsonElement.asLong() = (this as? JsonPrimitive)?.longOrNull
-    private fun JsonElement.asDouble() = (this as? JsonPrimitive)?.doubleOrNull
-
-    private fun toThrowable(type: String, obj: JsonObject): Throwable {
-        val errorMessage = obj["xtdb.error/message"]?.asString()
-
-        val dataObj = obj["xtdb.error/data"] as? JsonObject
-
-        @Suppress("UNCHECKED_CAST")
-        val errorData = PersistentHashMap.create(
-            dataObj?.toValue()?.let { it as Map<String, *> }
-                ?.mapKeys { (k, _) -> Keyword.intern(k) }
-        )
-
-        fun IPersistentMap.withCategory(cat: Keyword) = assoc(CATEGORY, cat)
-
-        return when (type) {
-            "xt:incorrect" -> Incorrect(errorMessage, errorData.withCategory(INCORRECT))
-            "xt:unsupported" -> Unsupported(errorMessage, errorData.withCategory(UNSUPPORTED))
-            "xt:conflict" -> Conflict(errorMessage, errorData.withCategory(CONFLICT))
-            "xt:fault" -> Fault(errorMessage, errorData.withCategory(FAULT))
-            "xt:interrupted" -> Interrupted(errorMessage, errorData.withCategory(INTERRUPTED))
-            "xt:not-found" -> NotFound(errorMessage, errorData.withCategory(NOT_FOUND))
-            "xt:forbidden" -> Forbidden(errorMessage, errorData.withCategory(FORBIDDEN))
-            "xt:busy" -> Busy(errorMessage, errorData.withCategory(BUSY))
-            "xt:unavailable" -> Unavailable(errorMessage, errorData.withCategory(UNAVAILABLE))
-            "xt:error" -> ExceptionInfo(errorMessage, PersistentHashMap.create(errorData))
-            else -> throw jsonIAE("unknown-error-type", obj)
-        }
-    }
-
-    private val ANOMALY_TYPES = setOf(
-        "xt:incorrect", "xt:unsupported", "xt:conflict", "xt:fault", "xt:interrupted",
-        "xt:not-found", "xt:forbidden", "xt:busy", "xt:unavailable", "xt:error"
-    )
-
-    fun JsonElement.toValue(): Any? = when (this) {
-        is JsonArray -> map { it.toValue() }
-        is JsonObject -> {
-            val type = (this["@type"] as? JsonPrimitive)?.takeIf { it.isString }?.content
-
-            if (type == null) {
-                mapValues { (_, v) -> v.toValue() }.toMap()
-            } else {
-                val value = this["@value"] ?: throw jsonIAEwithMessage("@value can't be null!", this)
-                when (type) {
-                    "xt:long" ->
-                        value.asLong()
-                            ?: value.asString()?.toLong()
-                            ?: throw jsonIAEwithMessage("@value must be long!", this)
-
-                    "xt:double" ->
-                        value.asDouble()
-                            ?: value.asString()?.toDouble()
-                            ?: throw jsonIAEwithMessage("@value must be double!", this)
-
-                    "xt:decimal" -> value.asStringOrThrow().toBigDecimal()
-
-                    "xt:instant" -> Instant.parse(value.asStringOrThrow())
-                    "xt:timestamptz" -> ZonedDateTime.parse(value.asStringOrThrow())
-                    "xt:timestamp" -> LocalDateTime.parse(value.asStringOrThrow())
-                    "xt:date" -> LocalDate.parse(value.asStringOrThrow())
-                    "xt:time" -> LocalTime.parse(value.asStringOrThrow())
-                    "xt:duration" -> Duration.parse(value.asStringOrThrow())
-                    "xt:interval" -> value.asStringOrThrow().asInterval()
-                    "xt:timeZone" -> ZoneId.of(value.asStringOrThrow())
-                    "xt:period" -> Period.parse(value.asStringOrThrow())
-                    "xt:keyword" -> Keyword.intern(value.asStringOrThrow())
-                    "xt:symbol" -> Symbol.intern(value.asStringOrThrow())
-                    "xt:uuid" -> UUID.fromString(value.asStringOrThrow())
-                    "xt:set" -> (value as? JsonArray ?: throw jsonIAEwithMessage(
-                        "@value must be array!",
-                        this
-                    )).map { it.toValue() }.toSet()
-
-                    "xt:table" -> {
-                        val obj = value as? JsonObject ?: throw jsonIAEwithMessage("@value must be object!", this)
-                        TableRef(
-                            obj["db"]?.asStringOrThrow() ?: throw jsonIAEwithMessage("db is required!", this),
-                            obj["schema"]?.asString() ?: "public",
-                            obj["table"]?.asStringOrThrow() ?: throw jsonIAEwithMessage("table is required!", this)
-                        )
-                    }
-
-                    in ANOMALY_TYPES -> toThrowable(
-                        type,
-                        value as? JsonObject ?: throw jsonIAEwithMessage(
-                            "@value must be object!",
-                            this
-                        )
-                    )
-
-                    else -> throw jsonIAE("unknown-json-ld-type", this)
-                }
-            }
-        }
-
-        is JsonNull -> null
-
-        is JsonPrimitive -> if (isString) content else booleanOrNull ?: longOrNull ?: doubleOrNull
-        ?: throw jsonIAE("unknown-json-primitive", this)
-    }
-
-    private fun Any?.toJsonLdElement(type: String) = mapOf("@type" to type, "@value" to toString()).toJsonElement()
-
-    private fun Throwable.toJsonLdElement(): JsonElement {
-        val type = when (this) {
-            is Incorrect -> "xt:incorrect"
-            is Unsupported -> "xt:unsupported"
-            is Conflict -> "xt:conflict"
-            is Fault -> "xt:fault"
-            is Interrupted -> "xt:interrupted"
-            is NotFound -> "xt:not-found"
-            is Forbidden -> "xt:forbidden"
-            is Busy -> "xt:busy"
-            is Unavailable -> "xt:unavailable"
-            else -> "xt:error"
-        }
-        return mapOf(
-            "@type" to type,
-            "@value" to listOfNotNull(
-                "xtdb.error/message" to message,
-                (this as? IExceptionInfo)?.let {
-                    "xtdb.error/data" to (data as Map<*, *>).mapKeys { (k, _) -> (k as? Keyword)?.sym?.toString() ?: k }
-                        .minus("cognitect.anomalies/category")
-                }
-            ).toMap()
-        ).toJsonElement()
-    }
-
     private fun Any?.toJsonElement(): JsonElement = when (this) {
         null -> JsonNull
         is String -> JsonPrimitive(this)
-        is BigDecimal -> toJsonLdElement("xt:decimal")
+        is BigDecimal -> JsonPrimitive(toString())
         is Number -> JsonPrimitive(this)
         is Boolean -> JsonPrimitive(this)
         is Map<*, *> -> JsonObject(map { (k, v) ->
@@ -182,33 +44,25 @@ object AnySerde : KSerializer<Any> {
                 else -> k.toString() to v.toJsonElement()
             }
         }.toMap())
-
-        is Set<*> -> mapOf("@type" to "xt:set", "@value" to toList()).toJsonElement()
+        is Set<*> -> JsonArray(map { it.toJsonElement() })
         is Collection<*> -> JsonArray(map { it.toJsonElement() })
-        is Keyword -> sym.toJsonLdElement("xt:keyword")
-        is Symbol -> toJsonLdElement("xt:symbol")
-        is UUID -> toJsonLdElement("xt:uuid")
-        is ZonedDateTime -> toJsonLdElement("xt:timestamptz")
-        is Instant -> toJsonLdElement("xt:instant")
-        is LocalDate -> toJsonLdElement("xt:date")
-        is LocalTime -> toJsonLdElement("xt:time")
-        is LocalDateTime -> toJsonLdElement("xt:timestamp")
-        is ZoneId -> toJsonLdElement("xt:timeZone")
-        is Period -> toJsonLdElement("xt:period")
+        is Keyword -> JsonPrimitive(sym.toString())
+        is Symbol -> JsonPrimitive(toString())
+        is UUID -> JsonPrimitive(toString())
+        is Temporal -> JsonPrimitive(toString())
+        is ZoneId -> JsonPrimitive(toString())
+        is Period -> JsonPrimitive(toString())
         is Date -> toInstant().toJsonElement()
-        is Duration -> toJsonLdElement("xt:duration")
-        is Interval -> toJsonLdElement("xt:interval")
-        is TableRef -> mapOf(
-            "@type" to "xt:table",
-            "@value" to mapOf("db" to dbName, "schema" to schemaName, "table" to tableName)
-        ).toJsonElement()
+        is Duration -> JsonPrimitive(toString())
+        is Interval -> JsonPrimitive(toString())
+        is TableRef -> toJsonLdElement()
         is Throwable -> toJsonLdElement()
         else -> throw Incorrect("unknown type: ${this.javaClass.name}")
     }
 
     override fun deserialize(decoder: Decoder) =
         // top-level will be not-null, nested values may not be
-        decoder.decodeSerializableValue(JsonElement.serializer()).toValue()!!
+        decoder.decodeSerializableValue(JsonElement.serializer()).fromLdValue()!!
 
     override fun serialize(encoder: Encoder, value: Any) =
         encoder.encodeSerializableValue(JsonElement.serializer(), value.toJsonElement())

--- a/core/src/main/kotlin/xtdb/pgwire/PgType.kt
+++ b/core/src/main/kotlin/xtdb/pgwire/PgType.kt
@@ -24,6 +24,7 @@ import xtdb.arrow.VectorType.Companion.VAR_BINARY
 import xtdb.arrow.unsupported
 import xtdb.decode as jsonDecode
 import xtdb.encode as jsonEncode
+import xtdb.encodeJsonLd
 import xtdb.pg.codec.decode
 import xtdb.pg.codec.encode
 import xtdb.pgwire.TypCategory.*
@@ -763,11 +764,30 @@ sealed class PgType(
 
         override fun readText(data: ByteArray): Any = jsonDecode(ByteArrayInputStream(data))
 
-        override fun writeBinary(env: PgSessionEnv, rdr: VectorReader, idx: Int): ByteArray =
+        override fun writeBinary(env: PgSessionEnv, rdr: VectorReader, idx: Int) =
             jsonEncode(rdr.getObject(idx)!!).toByteArray()
 
-        override fun writeText(env: PgSessionEnv, rdr: VectorReader, idx: Int): ByteArray =
+        override fun writeText(env: PgSessionEnv, rdr: VectorReader, idx: Int) =
             jsonEncode(rdr.getObject(idx)!!).toByteArray()
+    }
+
+    data object JsonLd : PgType(
+        typname = "json",
+        xtType = null,
+        oid = 114,
+        typcategory = USER_DEFINED,
+        typsend = "json_send",
+        typreceive = "json_recv",
+    ) {
+        override fun readBinary(data: ByteArray): Any = jsonDecode(ByteArrayInputStream(data))
+
+        override fun readText(data: ByteArray): Any = jsonDecode(ByteArrayInputStream(data))
+
+        override fun writeBinary(env: PgSessionEnv, rdr: VectorReader, idx: Int) =
+            encodeJsonLd(rdr.getObject(idx)!!).toByteArray()
+
+        override fun writeText(env: PgSessionEnv, rdr: VectorReader, idx: Int) =
+            encodeJsonLd(rdr.getObject(idx)!!).toByteArray()
     }
 
     data object Jsonb : PgType(
@@ -811,6 +831,7 @@ sealed class PgType(
         @JvmField val PG_TIMESTAMPTZ = TimestampTz
         @JvmField val PG_DATE = Date
         @JvmField val PG_JSON = Json
+        @JvmField val PG_JSON_LD = JsonLd
         @JvmField val PG_TRANSIT = Transit
 
         // All concrete PgTypes (excluding Default and Null which are special)

--- a/docs/src/content/docs/drivers/nodejs.md
+++ b/docs/src/content/docs/drivers/nodejs.md
@@ -65,6 +65,7 @@ const sql = postgres({
 
   connection: {
     // Record objects will be returned fully typed using the transit format:
+    // Options: "json" (default, simple strings), "json-ld" (structured with @type/@value), "transit"
     fallback_output_format: "transit",
   },
 

--- a/src/test/kotlin/xtdb/JsonLdSerdeTest.kt
+++ b/src/test/kotlin/xtdb/JsonLdSerdeTest.kt
@@ -1,0 +1,163 @@
+package xtdb
+
+import clojure.lang.Keyword
+import clojure.lang.Symbol
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import xtdb.error.Incorrect
+import xtdb.error.Unsupported
+import java.math.BigDecimal
+import java.time.*
+import java.util.*
+
+class JsonLdSerdeTest {
+
+    private fun Any?.assertRoundTrip(expectedJson: String) {
+        val actualJson = JSON_LD_SERDE.encodeToString(this)
+        assertEquals(expectedJson, actualJson)
+        assertEquals(this, JSON_LD_SERDE.decodeFromString(actualJson))
+    }
+
+    private fun Any?.assertRoundTrip(expectedJson: String, expectedThis: Any) {
+        val actualJson = JSON_LD_SERDE.encodeToString(this)
+        assertEquals(expectedJson, actualJson)
+        assertEquals(expectedThis, JSON_LD_SERDE.decodeFromString(actualJson))
+    }
+
+    @Test
+    fun `roundtrips JSON literals`() {
+        null.assertRoundTrip("null")
+
+        listOf(42L, "bell", true, mapOf("a" to 12.5, "b" to "bar"))
+            .assertRoundTrip("""[42,"bell",true,{"a":12.5,"b":"bar"}]""")
+        mapOf(Keyword.intern("c") to "foo")
+            .assertRoundTrip("""{"c":"foo"}""", mapOf("c" to "foo"))
+    }
+
+    @Test
+    fun `parses JSON-LD numbers`() {
+        assertEquals(42L, JSON_LD_SERDE.decodeFromString<Any>("{ \"@type\": \"xt:long\", \"@value\": 42 }"))
+        assertEquals(42L, JSON_LD_SERDE.decodeFromString<Any>("{ \"@type\": \"xt:long\", \"@value\": \"42\" }"))
+
+        assertEquals(42.0, JSON_LD_SERDE.decodeFromString<Any>("{ \"@type\": \"xt:double\", \"@value\": 42 }"))
+        assertEquals(42.0, JSON_LD_SERDE.decodeFromString<Any>("{ \"@type\": \"xt:double\", \"@value\": 42.0 }"))
+        assertEquals(42.0, JSON_LD_SERDE.decodeFromString<Any>("{ \"@type\": \"xt:double\", \"@value\": \"42.0\" }"))
+    }
+
+    @Test
+    fun `round-trips big-decimals`() {
+        BigDecimal("1.0010").assertRoundTrip("""{"@type":"xt:decimal","@value":"1.0010"}""")
+
+        "1.0010000000000000000".let {
+            BigDecimal(it).assertRoundTrip("""{"@type":"xt:decimal","@value":"$it"}""")
+        }
+
+        "1001000000000000000000023421.21923989823429893842".let {
+            BigDecimal(it).assertRoundTrip("""{"@type":"xt:decimal","@value":"$it"}""")
+        }
+    }
+
+    @Test
+    fun `date round-tripped to instant`() {
+        val instant = Instant.parse("2023-01-01T12:34:56.789Z")
+        val date = Date.from(instant)
+        val json = JSON_LD_SERDE.encodeToString<Any?>(date)
+        assertEquals("""{"@type":"xt:instant","@value":"2023-01-01T12:34:56.789Z"}""", json)
+        assertEquals(instant, JSON_LD_SERDE.decodeFromString<Any?>(json))
+    }
+
+    @Test
+    fun `round-trips java-time`() {
+        "2023-01-01T12:34:56.789Z".let { inst ->
+            Instant.parse(inst)
+                .assertRoundTrip("""{"@type":"xt:instant","@value":"$inst"}""")
+        }
+
+        "2023-08-01T12:34:56.789+01:00[Europe/London]".let { zdt ->
+            ZonedDateTime.parse(zdt)
+                .assertRoundTrip("""{"@type":"xt:timestamptz","@value":"$zdt"}""")
+        }
+
+        "PT3H5M12.423S".let { d ->
+            Duration.parse(d).assertRoundTrip("""{"@type":"xt:duration","@value":"$d"}""")
+        }
+
+        "Europe/London".let { tz ->
+            ZoneId.of(tz)
+                .assertRoundTrip("""{"@type":"xt:timeZone","@value":"$tz"}""")
+        }
+
+        "2023-08-01".let { ld ->
+            LocalDate.parse(ld)
+                .assertRoundTrip("""{"@type":"xt:date","@value":"$ld"}""")
+        }
+
+        "2023-08-01T12:34:56.789".let { ldt ->
+            LocalDateTime.parse(ldt)
+                .assertRoundTrip("""{"@type":"xt:timestamp","@value":"$ldt"}""")
+        }
+
+        "13:31:55".let { lt ->
+            LocalTime.parse(lt)
+                .assertRoundTrip("""{"@type":"xt:time","@value":"$lt"}""")
+        }
+    }
+
+    @Test
+    fun `round-trips keywords`() {
+        Keyword.intern("foo-bar").assertRoundTrip("""{"@type":"xt:keyword","@value":"foo-bar"}""")
+        Keyword.intern("xt", "id").assertRoundTrip("""{"@type":"xt:keyword","@value":"xt/id"}""")
+    }
+
+    @Test
+    fun `round-trips symbols`() {
+        Symbol.intern("foo-bar").assertRoundTrip("""{"@type":"xt:symbol","@value":"foo-bar"}""")
+        Symbol.intern("xt", "id").assertRoundTrip("""{"@type":"xt:symbol","@value":"xt/id"}""")
+    }
+
+    @Test
+    fun `round-trips sets`() {
+        emptySet<Any>().assertRoundTrip("""{"@type":"xt:set","@value":[]}""")
+        setOf(4L, 5L, 6.0).assertRoundTrip("""{"@type":"xt:set","@value":[4,5,6.0]}""")
+    }
+
+    @Test
+    fun shouldDeserializeIncorrect() {
+        Incorrect(
+            message = "sort your request out!",
+            errorCode = "xtdb/malformed-req",
+            data = mapOf("a" to 1L),
+        ).assertRoundTrip(
+            """{
+              "@type": "xt:incorrect",
+              "@value": {
+                "xtdb.error/message": "sort your request out!",
+                "xtdb.error/data": {
+                  "xtdb.error/code": {"@type":"xt:keyword","@value":"xtdb/malformed-req"},
+                  "a": 1
+                }
+              }
+            }""".trimJson()
+        )
+    }
+
+    @Test
+    fun shouldDeserializeUnsupported() {
+        Unsupported(
+            message = "ruh roh.",
+            errorCode = "xtdb/boom",
+            mapOf("a" to 1L)
+        ).assertRoundTrip(
+            """{
+              "@type": "xt:unsupported",
+              "@value": {
+                "xtdb.error/message": "ruh roh.",
+                "xtdb.error/data": {
+                  "xtdb.error/code": {"@type":"xt:keyword","@value":"xtdb/boom"},
+                  "a": 1
+                }
+              }
+            }""".trimJson()
+        )
+    }
+}


### PR DESCRIPTION
resolves #5156.

At some point in the 2.2 line we've fixed the pgwire return types so that it now returns correct JSON-LD. That said, users were expecting it to return 'simple' JSON (i.e. timestamps as ISO strings), so this is effectively reverting back to the previous behaviour.

Notes:
- I've done this by _keeping_ JSON-LD as a distinct fallback-output-format; defaulting to simple JSON.
- For throwables and other XT internal types, I've kept to returning JSON-LD even in 'simple' JSON - these are our types, and therefore our chosen JSON representations
- JSON decoding uses the JSON-LD decoder, because JSON-LD is a superset of JSON - so we can use one decoder for both.