### PR TITLE
Rename TxSink to TxSource

### DIFF
--- a/core/src/main/clojure/xtdb/db_catalog.clj
+++ b/core/src/main/clojure/xtdb/db_catalog.clj
@@ -26,15 +26,15 @@
       :buffer-pool (ig/ref :xtdb/buffer-pool)
       :metadata-manager (ig/ref :xtdb.metadata/metadata-manager)
       :live-index (ig/ref :xtdb.indexer/live-index)
-      :tx-sink (ig/ref :xtdb.tx-sink/for-db)}})
+      :tx-source (ig/ref :xtdb.tx-source/for-db)}})
 
 (defmethod ig/init-key ::for-query [_ {:keys [allocator db-name db-config block-cat table-cat
                                               trie-cat log buffer-pool metadata-manager
-                                              live-index tx-sink]}]
+                                              live-index tx-source]}]
   (Database. db-name db-config allocator block-cat table-cat trie-cat
              log buffer-pool metadata-manager live-index
              live-index ; snap-src
-             nil nil tx-sink))
+             nil nil tx-source))
 
 (defmethod ig/expand-key :xtdb/db-catalog [k _]
   {k {:base {:allocator (ig/ref :xtdb/allocator)
@@ -62,7 +62,7 @@
 
          ::for-query (assoc opts :db-config db-config)
 
-         :xtdb.tx-sink/for-db (assoc opts :tx-sink-conf (.getTxSink conf))
+         :xtdb.tx-source/for-db (assoc opts :tx-source-conf (.getTxSource conf))
          :xtdb.indexer/for-db opts
          :xtdb.compactor/for-db (assoc opts :mode mode)
          :xtdb.log/processor (assoc opts :indexer-conf indexer-conf :mode mode)}

--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -76,8 +76,8 @@
 (defmethod apply-config! :garbage-collector [config _ opts]
   (apply-config! config :xtdb/garbage-collector opts))
 
-(defmethod apply-config! :tx-sink [config _ opts]
-  (apply-config! config :xtdb/tx-sink opts))
+(defmethod apply-config! :tx-source [config _ opts]
+  (apply-config! config :xtdb/tx-source opts))
 
 (defmethod apply-config! ::default [_ k _]
   (log/warn "Unknown configuration key:" k))

--- a/core/src/main/kotlin/xtdb/api/TxSourceConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/TxSourceConfig.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.UseSerializers
 import xtdb.api.log.Log
 
 @Serializable
-data class TxSinkConfig(
+data class TxSourceConfig(
     var dbName: String = "xtdb",
     var format: String = "transit+json",
     var outputLog: Log.Factory = Log.inMemoryLog,

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -78,7 +78,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         var authn: Authenticator.Factory = UserTable(),
         var garbageCollector: GarbageCollectorConfig = GarbageCollectorConfig(),
         var tracer: TracerConfig = TracerConfig(),
-        var txSink: TxSinkConfig? = null,
+        var txSource: TxSourceConfig? = null,
         var readOnlyDatabases: Boolean = false,
         var nodeId: String = System.getenv("XTDB_NODE_ID") ?: randomUUID().toString().takeWhile { it != '-' }
     ) {
@@ -122,7 +122,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         fun garbageCollector(configure: GarbageCollectorConfig.() -> Unit) =
             garbageCollector(GarbageCollectorConfig().also(configure))
 
-        fun txSink(txSink: TxSinkConfig) = apply { this.txSink = txSink }
+        fun txSource(txSource: TxSourceConfig) = apply { this.txSource = txSource }
 
         fun readOnlyDatabases(readOnlyDatabases: Boolean = true) = apply { this.readOnlyDatabases = readOnlyDatabases }
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -25,7 +25,7 @@ import xtdb.database.proto.DatabaseMode
 import xtdb.indexer.LiveIndex
 import xtdb.indexer.LogProcessor
 import xtdb.indexer.Snapshot
-import xtdb.indexer.Indexer.TxSink
+import xtdb.indexer.Indexer.TxSource
 import xtdb.metadata.PageMetadata
 import xtdb.storage.BufferPool
 import xtdb.trie.TrieCatalog
@@ -43,7 +43,7 @@ interface IDatabase {
     val metadataManager: PageMetadata.Factory
     val logProcessor: LogProcessor
     val compactor: Compactor.ForDatabase
-    val txSink: TxSink?
+    val txSource: TxSource?
 }
 
 data class Database(
@@ -58,7 +58,7 @@ data class Database(
 
     val logProcessorOrNull: LogProcessor?,
     private val compactorOrNull: Compactor.ForDatabase?,
-    override val txSink: TxSink?,
+    override val txSource: TxSource?,
 ): IDatabase {
     override val logProcessor: LogProcessor get() = logProcessorOrNull ?: error("log processor not initialised")
     override val compactor: Compactor.ForDatabase get() = compactorOrNull ?: error("compactor not initialised")

--- a/core/src/main/kotlin/xtdb/indexer/Indexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Indexer.kt
@@ -20,7 +20,7 @@ interface Indexer : AutoCloseable {
         fun addTxRow(txKey: TransactionKey, error: Throwable?)
     }
 
-    interface TxSink {
+    interface TxSource {
         fun onCommit(txKey: TransactionKey, liveIdxTx: LiveIndex.Tx)
     }
 

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -63,7 +63,7 @@ data class MockDatabase(
     override val log: Log get() = unsupported("log")
     override val metadataManager: PageMetadata.Factory get() = unsupported("metadataManager")
     override val logProcessor: LogProcessor get() = unsupported("logProcessor")
-    override val txSink: Indexer.TxSink get() = unsupported("txSink")
+    override val txSource: Indexer.TxSource get() = unsupported("txSource")
     fun withCompactor(compactor: Compactor.ForDatabase) = copy(compactorOrNull = compactor)
 }
 

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -69,7 +69,7 @@ class MockDb(
 
     override val logProcessor: LogProcessor get() = unsupported("logProcessor")
     override val compactor: Compactor.ForDatabase get() = unsupported("compactor")
-    override val txSink: Indexer.TxSink get() = unsupported("txSink")
+    override val txSource: Indexer.TxSource get() = unsupported("txSource")
 }
 
 private val LOGGER = CompactorMockDriver::class.logger

--- a/main/src/main/clojure/xtdb/main.clj
+++ b/main/src/main/clojure/xtdb/main.clj
@@ -21,7 +21,7 @@
   (println " * `playground`: starts a 'playground', an in-memory node which accepts any database name, creating it if required")
   (println " * `reset-compactor <db-name>`: resets the compacted files on the given node.")
   (println " * `export-snapshot <db-name>`: exports a consistent snapshot of object storage for the given database.")
-  (println " * `tx-sink`: runs a node which replicates the transaction log to an external log")
+  (println " * `tx-source`: runs a node which replicates the transaction log to an external log")
   (newline)
   (println "For more information about any command, run `<command> --help`, e.g. `playground --help`"))
 
@@ -159,15 +159,15 @@
 
     ((requiring-resolve 'xtdb.compactor.reset/reset-compactor!) (file->node-opts file) db-name {:dry-run? dry-run?})))
 
-(def tx-sink-cli-spec
+(def tx-source-cli-spec
   [config-file-opt
    ["-h" "--help"]])
 
-(defn- tx-sink! [args]
-  (let [{{:keys [file]} :options} (-> (parse-args args tx-sink-cli-spec)
+(defn- tx-source! [args]
+  (let [{{:keys [file]} :options} (-> (parse-args args tx-source-cli-spec)
                                       (handling-arg-errors-or-help))]
-    (util/with-open [_node ((requiring-resolve 'xtdb.tx-sink/open!) (file->node-opts file))]
-      (log/info "Tx Sink node started")
+    (util/with-open [_node ((requiring-resolve 'xtdb.tx-source/open!) (file->node-opts file))]
+      (log/info "Tx Source node started")
       @(shutdown-hook-promise))))
 
 (def export-snapshot-cli-spec
@@ -279,9 +279,9 @@
                             (reset-compactor! more-args)
                             (System/exit 0))
 
-        "tx-sink" (do
-                    (tx-sink! more-args)
-                    (System/exit 0))
+        "tx-source" (do
+                      (tx-source! more-args)
+                      (System/exit 0))
 
         "export-snapshot" (do
                             (export-snapshot! more-args)

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -420,7 +420,7 @@
   ([node] (get-output-log node "xtdb"))
   ([node db-name]
    (-> (database-or-null node db-name)
-       (.getTxSink)
+       (.getTxSource)
        :output-log)))
 
 (defn get-trie-cat


### PR DESCRIPTION
I got the name wrong initially, time to rectify that 🤦‍♂️

> [!WARNING]
> ### Breaking Changes
> The command to start TxSource is now `tx-source`.
> Config is now specified under `txSource` like so:
> ```yaml
> txSource:
>   outputLog: !Kafka
>     cluster: kafkaCluster
>     topic: output-topic
> ```

No other changes are expected as a result of this PR