### PR TITLE
fix: restore semi-join IID pushdown for UUID columns

### DIFF
--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -402,9 +402,9 @@
                            pushdown-iids (->> build-key-col-names
                                               (mapv (fn [col-name]
                                                       (let [^VectorType build-col-type (get build-vec-types col-name)]
-                                                        (when (or (and (= build-col-type #xt.arrow/type :varbinary)
+                                                        (when (or (and (= build-col-type #xt/type :varbinary)
                                                                        (str/ends-with? col-name "/_iid"))
-                                                                  (= build-col-type #xt.arrow/type :uuid))
+                                                                  (= build-col-type #xt/type :uuid))
                                                           (TreeSet. Bytes/COMPARATOR))))))
                            cmp-factory (->cmp-factory {:build-vec-types build-vec-types
                                                        :probe-vec-types probe-vec-types


### PR DESCRIPTION
Commit 0e95847ee (#5153) introduced a type mismatch when comparing VectorType against ArrowType. The comparison used #xt.arrow/type (which returns ArrowType) instead of #xt/type (which returns VectorType), causing the equality check to always fail.

This disabled IID pushdown for all UUID _id lookups, resulting in full table scans instead of targeted row retrieval for queries like SELECT ... WHERE _id IN (...).

The fix changes the type literals to use the correct VectorType form.

Adds regression test to verify IID pushdown works via EXPLAIN ANALYZE.