### PR TITLE
bench: implement TSBS-style query execution for IoT benchmark

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -695,7 +695,10 @@ createBench("tsbs-iot", mapOf(
     "file" to "--file",
     "deviceCount" to "--devices",
     "timestampStart" to "--timestamp-start",
-    "timestampEnd" to "--timestamp-end"
+    "timestampEnd" to "--timestamp-end",
+    "queryIterations" to "--query-iterations",
+    "workers" to "--workers",
+    "burnIn" to "--burn-in"
 ))
 
 createBench("patch", mapOf("docCount" to "--doc-count", "patchCount" to "--patch-count"))


### PR DESCRIPTION
## Summary

- Implements all 13 TSBS IoT queries with dynamic parameterization
- Reports per-query-type statistics (min, mean, p50, p90, p95, p99, max)

## Query Types

| Query | Description |
|-------|-------------|
| last-loc-by-truck | Last location for specific trucks |
| last-loc-per-truck | Last location for all trucks in a fleet |
| low-fuel | Trucks with fuel < 10% |
| high-load | Trucks with load > 90% capacity |
| stationary-trucks | Trucks with avg velocity < 1 in time window |
| long-driving-sessions | Drove > 3h in 4-hour window |
| long-daily-sessions | Drove > 10h in 24-hour window |
| avg-vs-projected-fuel | Actual vs nominal fuel per fleet |
| avg-daily-driving-duration | Avg hours driven per day per driver |
| avg-daily-driving-session | Avg session length per driver per day |
| avg-load | Average load per truck model per fleet |
| daily-activity | Hours active per day per fleet/model |
| breakdown-frequency | Breakdown events per model |