### PR TITLE
feat(sql): add IS [NOT] DISTINCT FROM operator

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -211,6 +211,7 @@ expr
     | expr 'NOT'? 'LIKE_REGEX' xqueryPattern=exprPrimary ('FLAG' xqueryOptionFlag=exprPrimary)? # LikeRegexPredicate
     | expr postgresRegexOperator xqueryPattern=exprPrimary # PostgresRegexPredicate
     | expr 'IS' 'NOT'? 'NULL' # NullPredicate
+    | expr 'IS' 'NOT'? 'DISTINCT' 'FROM' expr # DistinctFromPredicate
 
     // period predicates
     | expr 'OVERLAPS' expr # PeriodOverlapsPredicate
@@ -712,6 +713,7 @@ predicatePart2
     | 'NOT'? 'LIKE_REGEX' xqueryPattern=exprPrimary ('FLAG' xqueryOptionFlag=exprPrimary)? # LikeRegexPredicatePart2
     | postgresRegexOperator xqueryPattern=exprPrimary # PostgresRegexPredicatePart2
     | 'IS' 'NOT'? 'NULL' # NullPredicatePart2
+    | 'IS' 'NOT'? 'DISTINCT' 'FROM' expr # DistinctFromPredicatePart2
     | compOp quantifier quantifiedComparisonPredicatePart3 # QuantifiedComparisonPredicatePart2
     ;
 

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -628,6 +628,7 @@
 (def ^:private shortcut-null-args?
   (complement (comp #{:is_true :is_false :is_null :true? :false? :nil? :boolean
                       :=== :null_eq :compare_nulls_first :compare_nulls_last
+                      :distinct_from
                       :period :str :_patch}
                     normalise-fn-name)))
 

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -1416,6 +1416,21 @@
         (list 'not expr)
         expr)))
 
+  (visitDistinctFromPredicate [this ctx]
+    (let [left (-> (.expr ctx 0) (.accept this))
+          right (-> (.expr ctx 1) (.accept this))
+          distinct-expr (list 'distinct-from left right)]
+      (if (.NOT ctx)
+        (list 'not distinct-expr)
+        distinct-expr)))
+
+  (visitDistinctFromPredicatePart2 [{:keys [pt1] :as this} ctx]
+    (let [right (-> (.expr ctx) (.accept (dissoc this :pt1)))
+          distinct-expr (list 'distinct-from pt1 right)]
+      (if (.NOT ctx)
+        (list 'not distinct-expr)
+        distinct-expr)))
+
   (visitBetweenPredicate [this ctx]
     (let [between-expr (list (cond
                                (.SYMMETRIC ctx) 'between-symmetric

--- a/docs/src/content/docs/reference/main/stdlib/predicates.md
+++ b/docs/src/content/docs/reference/main/stdlib/predicates.md
@@ -45,3 +45,6 @@ These aren't strictly predicates - they return the greatest/least value of their
 
 `expr IS [NOT] NULL`
 : returns true if `expr` is \[not\] null, false otherwise
+
+`expr1 IS [NOT] DISTINCT FROM expr2`
+: NULL-safe comparison. Returns true if `expr1` and `expr2` are \[not\] distinct - two NULLs are considered not distinct from each other, unlike standard equality.

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -402,7 +402,10 @@
     "foo.a IS NOT UNKNOWN" '(not (nil? f/a))
 
     "foo.a IS NULL" '(nil? f/a)
-    "foo.a IS NOT NULL" '(not (nil? f/a))))
+    "foo.a IS NOT NULL" '(not (nil? f/a))
+
+    "foo.a IS DISTINCT FROM foo.b" '(distinct-from f/a f/b)
+    "foo.a IS NOT DISTINCT FROM foo.b" '(not (distinct-from f/a f/b))))
 
 (t/deftest test-interval-exprs
   (t/are [sql expected]

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -164,6 +164,18 @@
                    {:table-info {#xt/table t1 #{"a"}}}))
         "implicit SELECT *"))
 
+(t/deftest test-is-distinct-from
+  (t/is (= [{:r false}] (xt/q tu/*node* "SELECT NULL IS DISTINCT FROM NULL AS r")))
+  (t/is (= [{:r true}] (xt/q tu/*node* "SELECT NULL IS NOT DISTINCT FROM NULL AS r")))
+  (t/is (= [{:r true}] (xt/q tu/*node* "SELECT 1 IS DISTINCT FROM NULL AS r")))
+  (t/is (= [{:r true}] (xt/q tu/*node* "SELECT NULL IS DISTINCT FROM 1 AS r")))
+  (t/is (= [{:r false}] (xt/q tu/*node* "SELECT 1 IS NOT DISTINCT FROM NULL AS r")))
+  (t/is (= [{:r true}] (xt/q tu/*node* "SELECT 1 IS NOT DISTINCT FROM 1 AS r")))
+  (t/is (= [{:r false}] (xt/q tu/*node* "SELECT 1 IS DISTINCT FROM 1 AS r")))
+  (t/is (= [{:r true}] (xt/q tu/*node* "SELECT 1 IS DISTINCT FROM 2 AS r")))
+  (t/is (= [{:r false}] (xt/q tu/*node* "SELECT 1 IS NOT DISTINCT FROM 2 AS r")))
+  (t/is (= [{:r "yes"}] (xt/q tu/*node* "SELECT CASE WHEN NULL IS NOT DISTINCT FROM NULL THEN 'yes' ELSE 'no' END AS r"))))
+
 (t/deftest test-case
   (t/is (=plan-file
          "basic-query-34"


### PR DESCRIPTION
## Summary
- Adds SQL standard `IS [NOT] DISTINCT FROM` NULL-safe comparison operators
- `a IS DISTINCT FROM b` returns true if values differ or exactly one is NULL
- `a IS NOT DISTINCT FROM b` returns true if both NULL or both non-NULL and equal

## Test plan
- [x] Parser tests verify correct AST generation
- [x] Integration tests cover all NULL semantics cases
- [x] Documentation added to stdlib predicates reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)