### PR TITLE
feat(sql): add LEAD/LAG window functions

### DIFF
--- a/docs/src/content/docs/reference/main/sql/queries.md
+++ b/docs/src/content/docs/reference/main/sql/queries.md
@@ -175,7 +175,10 @@ const binaryOp = rr.Sequence("<value>", rr.HorizontalChoice("+", "-", "*", "/"),
 
 const fn = rr.Sequence("<function name>", "(", rr.ZeroOrMore("<value>", ",", "skip"), ")")
 
-const wfn = rr.Sequence("ROW_NUMBER", "(", ")", "OVER", "(", "<window>", ")")
+const rowNumber = rr.Sequence("ROW_NUMBER", "(", ")")
+const leadLagOffset = rr.Optional(rr.Sequence(",", "<offset>"), "skip")
+const leadLag = rr.Sequence(rr.Choice(0, "LEAD", "LAG"), "(", "<value>", leadLagOffset, ")")
+const wfn = rr.Sequence(rr.Choice(0, rowNumber, leadLag), "OVER", "(", "<window>", ")")
 
 const cast = rr.Sequence("CAST", "(", "<value>", "AS", "<data type>", ")")
 const caseValue = rr.Sequence("<value>", rr.ZeroOrMore(rr.Sequence("WHEN", "<value>", "THEN", "<value>"), ","))
@@ -260,6 +263,12 @@ const wfnOrder = rr.Sequence("ORDER", "BY", rr.OneOrMore(rr.Sequence("<value>", 
 
 return rr.Diagram(rr.Optional(wfnPartition), rr.Optional(wfnOrder))
 ```
+
+Note:
+
+- `LEAD`/`LAG` currently only support column references, not arbitrary expressions.
+- The default value parameter to `LEAD`/`LAG` is not yet supported.
+- `IGNORE NULLS` with `LEAD`/`LAG` is not yet supported.
 
 ## Nested sub-queries
 

--- a/src/test/clojure/xtdb/operator/window_test.clj
+++ b/src/test/clojure/xtdb/operator/window_test.clj
@@ -85,3 +85,82 @@
                          {:a 3 :b 80}
                          {:a 3 :b 90}]]))
           "partition by + order-by")))
+
+(deftest test-lead-lag-window-functions
+  (letfn [(run-test
+            [window-spec projection-specs batches]
+            (let [window-name (gensym "window")]
+              (-> (tu/query-ra [:window {:windows {window-name window-spec}
+                                         :projections (mapv (fn [[col-name projection]]
+                                                              {col-name {:window-name window-name
+                                                                         :window-agg projection}}) projection-specs)}
+                                [::tu/pages '{a #xt/type :i64, b #xt/type :i64} batches]])
+                  set)))]
+
+    (t/testing "LAG function"
+      (t/is (= #{{:a 1, :b 10}
+                 {:a 1, :b 20, :prevb 10}
+                 {:a 1, :b 30, :prevb 20}
+                 {:a 2, :b 40}
+                 {:a 2, :b 50, :prevb 40}}
+               (run-test '{:partition-cols [a]
+                           :order-specs [[b]]}
+                         '{prevb (lag b 1)}
+                         [[{:a 1 :b 10}
+                           {:a 1 :b 20}
+                           {:a 1 :b 30}
+                           {:a 2 :b 40}
+                           {:a 2 :b 50}]]))
+            "lag returns previous value within partition, null when no previous row")
+
+      (t/is (= #{{:a 1, :b 10}
+                 {:a 1, :b 20}
+                 {:a 1, :b 30, :prevb 10}}
+               (run-test '{:partition-cols [a]
+                           :order-specs [[b]]}
+                         '{prevb (lag b 2)}
+                         [[{:a 1 :b 10}
+                           {:a 1 :b 20}
+                           {:a 1 :b 30}]]))
+            "lag with offset 2"))
+
+    (t/testing "LEAD function"
+      (t/is (= #{{:a 1, :b 10, :nextb 20}
+                 {:a 1, :b 20, :nextb 30}
+                 {:a 1, :b 30}
+                 {:a 2, :b 40, :nextb 50}
+                 {:a 2, :b 50}}
+               (run-test '{:partition-cols [a]
+                           :order-specs [[b]]}
+                         '{nextb (lead b 1)}
+                         [[{:a 1 :b 10}
+                           {:a 1 :b 20}
+                           {:a 1 :b 30}
+                           {:a 2 :b 40}
+                           {:a 2 :b 50}]]))
+            "lead returns next value within partition, null when no next row")
+
+      (t/is (= #{{:a 1, :b 10, :nextb 30}
+                 {:a 1, :b 20}
+                 {:a 1, :b 30}}
+               (run-test '{:partition-cols [a]
+                           :order-specs [[b]]}
+                         '{nextb (lead b 2)}
+                         [[{:a 1 :b 10}
+                           {:a 1 :b 20}
+                           {:a 1 :b 30}]]))
+            "lead with offset 2"))
+
+    (t/testing "across multiple batches"
+      (t/is (= #{{:a 1, :b 10}
+                 {:a 1, :b 20, :prevb 10}
+                 {:a 1, :b 30, :prevb 20}
+                 {:a 1, :b 40, :prevb 30}}
+               (run-test '{:partition-cols [a]
+                           :order-specs [[b]]}
+                         '{prevb (lag b 1)}
+                         [[{:a 1 :b 10}
+                           {:a 1 :b 20}]
+                          [{:a 1 :b 30}
+                           {:a 1 :b 40}]]))
+            "lag works across batches"))))

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -983,6 +983,50 @@
              (xt/q tu/*node* "SELECT a, b, ROW_NUMBER() OVER (PARTITION BY y ORDER BY z) AS rn FROM docs"))
           "no existing columns")))
 
+(t/deftest test-lead-lag-window-functions
+  (xt/submit-tx tu/*node* [[:put-docs :docs
+                            {:xt/id 0, :a 1, :b 10}
+                            {:xt/id 1, :a 1, :b 20}
+                            {:xt/id 2, :a 1, :b 30}
+                            {:xt/id 3, :a 2, :b 40}
+                            {:xt/id 4, :a 2, :b 50}]])
+
+  (t/is (= #{{:a 1, :b 10}
+             {:a 1, :b 20, :prevb 10}
+             {:a 1, :b 30, :prevb 20}
+             {:a 2, :b 40}
+             {:a 2, :b 50, :prevb 40}}
+           (->> (xt/q tu/*node* "SELECT a, b, LAG(b, 1) OVER (PARTITION BY a ORDER BY b) AS prevb FROM docs")
+                set))
+        "LAG returns previous value within partition")
+
+  (t/is (= #{{:a 1, :b 10, :nextb 20}
+             {:a 1, :b 20, :nextb 30}
+             {:a 1, :b 30}
+             {:a 2, :b 40, :nextb 50}
+             {:a 2, :b 50}}
+           (->> (xt/q tu/*node* "SELECT a, b, LEAD(b, 1) OVER (PARTITION BY a ORDER BY b) AS nextb FROM docs")
+                set))
+        "LEAD returns next value within partition")
+
+  (t/is (= #{{:a 1, :b 10, :nextb 30}
+             {:a 1, :b 20}
+             {:a 1, :b 30}
+             {:a 2, :b 40}
+             {:a 2, :b 50}}
+           (->> (xt/q tu/*node* "SELECT a, b, LEAD(b, 2) OVER (PARTITION BY a ORDER BY b) AS nextb FROM docs")
+                set))
+        "LEAD with offset 2")
+
+  (t/is (= #{{:a 1, :b 10}
+             {:a 1, :b 20, :prevb 10}
+             {:a 1, :b 30, :prevb 20}
+             {:a 2, :b 40}
+             {:a 2, :b 50, :prevb 40}}
+           (->> (xt/q tu/*node* "SELECT a, b, LAG(b) OVER (PARTITION BY a ORDER BY b) AS prevb FROM docs")
+                set))
+        "LAG with default offset of 1"))
+
 (t/deftest test-operators-with-unresolved-column-references-3640
   (t/is (=plan-file
          "test-group-by-with-unresolved-column-reference"


### PR DESCRIPTION
## Summary
- Implements LEAD and LAG window functions
- LEAD(col, offset): returns value from `offset` rows after current row within partition
- LAG(col, offset): returns value from `offset` rows before current row within partition

## Limitations
- Currently only supports column references, not arbitrary expressions
- IGNORE NULLS and default value parameters not yet implemented

## Test plan
- [x] Operator-level tests in `window_test.clj`
- [x] SQL integration tests in `sql_test.clj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)