### PR TITLE
fix: Add specific override converting ZonedDateTime to OffsetDateTime on JsonSerde.

### DIFF
--- a/api/src/main/kotlin/xtdb/JsonSerde.kt
+++ b/api/src/main/kotlin/xtdb/JsonSerde.kt
@@ -49,6 +49,7 @@ object AnySerde : KSerializer<Any> {
         is Keyword -> JsonPrimitive(sym.toString())
         is Symbol -> JsonPrimitive(toString())
         is UUID -> JsonPrimitive(toString())
+        is ZonedDateTime -> JsonPrimitive(toOffsetDateTime().toString())
         is Temporal -> JsonPrimitive(toString())
         is ZoneId -> JsonPrimitive(toString())
         is Period -> JsonPrimitive(toString())

--- a/src/test/kotlin/xtdb/JsonSerdeTest.kt
+++ b/src/test/kotlin/xtdb/JsonSerdeTest.kt
@@ -59,12 +59,19 @@ class JsonSerdeTest {
     }
 
     @Test
+    fun `encodes ZonedDateTime as OffsetDateTime string`() {
+        // ZonedDateTime.toString() produces "[zone]" suffix which breaks JS Date parsing, so we encode as OffsetDateTime
+        assertEquals("\"2023-08-01T12:34:56.789+01:00\"",
+            JSON_SERDE.encodeToString<Any>(ZonedDateTime.parse("2023-08-01T12:34:56.789+01:00[Europe/London]")))
+
+        assertEquals("\"2026-01-01T10:00:00.001Z\"",
+            JSON_SERDE.encodeToString<Any>(ZonedDateTime.parse("2026-01-01T10:00:00.001Z[UTC]")))
+    }
+
+    @Test
     fun `encodes java-time as strings`() {
         assertEquals("\"2023-01-01T12:34:56.789Z\"",
             JSON_SERDE.encodeToString<Any>(Instant.parse("2023-01-01T12:34:56.789Z")))
-
-        assertEquals("\"2023-08-01T12:34:56.789+01:00[Europe/London]\"",
-            JSON_SERDE.encodeToString<Any>(ZonedDateTime.parse("2023-08-01T12:34:56.789+01:00[Europe/London]")))
 
         assertEquals("\"PT3H5M12.423S\"",
             JSON_SERDE.encodeToString<Any>(Duration.parse("PT3H5M12.423S")))


### PR DESCRIPTION
Github actions: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Ajson-string-zdt-returned-as-odt

Following our last set of `JSONSerde` changes, we were returning `ZonedDateTime` encoded strings when writing out simple JSON strings for union typed columns with timestamp-tz, ie:
```
"2026-01-01T10:00:00.001Z[UTC]"
```

This value, while ISO 8601 compliant, is potentially unparseable (ie, for JavaScript users using Date.parse() or similar) - so we've opted to switch back to the previous behavior where we converted to `OffsetDateTime` and returned the string of this, ie:
```
"2026-01-01T10:00:00.001Z"
```

### Metabase Example

Following the same metabase test defined in #5156, I have the following documents locally:
```
(xt/execute-tx node [[:sql "INSERT INTO docs (_id, v) VALUES (1, ?)" [#xt/instant "2024-01-01T00:00:00Z"]]
                     [:sql "INSERT INTO docs (_id, v) VALUES (2, ?)" [#xt/zoned-date-time "2024-01-02T00:00:00Z[UTC]"]]
                     [:sql "INSERT INTO docs (_id, v) VALUES (3, '2024-01-01T00:00:00Z')"]
                     [:sql "INSERT INTO docs (_id) VALUES (4)"]])
```

On main, I get back the following after calling `SELECT * FROM docs`:
<img width="658" height="620" alt="image" src="https://github.com/user-attachments/assets/9881d262-04ee-429d-9ae2-759fad89d6cd" />

Following this change, I get back the following:
<img width="604" height="364" alt="image" src="https://github.com/user-attachments/assets/b903cf54-23ca-4919-a810-3745baa4fb7f" />
