### PR TITLE
Fix: RemoteBufferPool throwing FileAlreadyExistsException on AWS EKS + S3

### DIFF
--- a/core/src/main/kotlin/xtdb/api/storage/ObjectStore.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/ObjectStore.kt
@@ -6,8 +6,7 @@ import kotlinx.serialization.modules.polymorphic
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.file.Path
-import java.nio.file.StandardOpenOption.CREATE
-import java.nio.file.StandardOpenOption.WRITE
+import java.nio.file.StandardOpenOption.*
 import java.util.*
 import java.util.concurrent.CompletableFuture
 import com.google.protobuf.Any as ProtoAny
@@ -57,11 +56,13 @@ interface ObjectStore : AutoCloseable {
     /**
      * Asynchronously writes the object to the given path.
      *
+     * Replaces any existing file at the given path.
+     *
      * If the object doesn't exist, the CompletableFuture completes with an IllegalStateException.
      */
     fun getObject(k: Path, outPath: Path): CompletableFuture<Path> =
         getObject(k).thenApply { buf ->
-            FileChannel.open(outPath, CREATE, WRITE).use { it.write(buf) }
+            FileChannel.open(outPath, CREATE, WRITE, TRUNCATE_EXISTING).use { it.write(buf) }
             outPath
         }
 

--- a/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.subclass
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.FileTransformerConfiguration
 import software.amazon.awssdk.core.async.AsyncRequestBody
 import software.amazon.awssdk.core.async.AsyncResponseTransformer
 import software.amazon.awssdk.regions.Region
@@ -155,7 +156,7 @@ class S3(
     }
 
     override fun getObject(k: Path, outPath: Path) = scope.future {
-        getObject(k, AsyncResponseTransformer.toFile(outPath)).await()
+        getObject(k, AsyncResponseTransformer.toFile(outPath, FileTransformerConfiguration.defaultCreateOrReplaceExisting())).await()
         outPath
     }
 


### PR DESCRIPTION
There were frequent FileAlreadyExistsException errors thrown by the RemoteBufferPool in an AWS EKS + S3 environment.

The exception is actually expected from what I can see, because RemoteBufferPool.getFooter() does a DiskCache.getObject() for downloading an object for the first time, but DiskCache has already done createTempPath() for storing that object, so the file always exists for this code path.

The reason for this to manifest in our soak environment maybe that it is an AWS EKS + S3 environment, and XTDB storage is handled by Java with its UnixFileSystemProvider. I tried to reproduce the issue on my laptop within minio-test.clj, but I wasn't able to, possibly because a LinuxFileSystemProvider is used in that case with a more permissive file-creation behavior.

The fix allows for files to be replaced by ObjectStore.getObject(), as that was already the case for the (Azure) BlobStorage implementation (`outPath.deleteIfExists()`). So it brings that change to the default implementation and the S3 implementation.

I have tested the change in the soak environment and I don't see those exceptions anymore, which I was seeing always at XTDB startup and frequently afterwards. It may be worth double-checking that this "replace" behaviour of ObjectStore.getObject() is actually ok for all cases, although, as said, it was already the case for the Azure BlobStorage.

Closes #5177, closes #4256