### PR TITLE
[bench] tsbs-iot add queries

### DIFF
--- a/.github/workflows/nightly-benchmark-tsbs-iot.yml
+++ b/.github/workflows/nightly-benchmark-tsbs-iot.yml
@@ -9,6 +9,21 @@ on:
         required: false
         default: '2000'
         type: string
+      query_iterations:
+        description: 'Query iterations per type'
+        required: false
+        default: '20'
+        type: string
+      workers:
+        description: 'Parallel query workers'
+        required: false
+        default: '4'
+        type: string
+      burn_in:
+        description: 'Burn-in queries (discarded from stats)'
+        required: false
+        default: '5'
+        type: string
       timestamp_start:
         description: 'Timestamp Start (ISO-8601)'
         required: false
@@ -40,6 +55,9 @@ jobs:
       bench_type: tsbs-iot
       job_display_name: TSBS IoT
       tsbs_device_count: ${{ inputs.devices || '2000' }}
+      tsbs_query_iterations: ${{ inputs.query_iterations || '20' }}
+      tsbs_workers: ${{ inputs.workers || '4' }}
+      tsbs_burn_in: ${{ inputs.burn_in || '5' }}
       branch: ${{ github.ref_name }}
       timeout_minutes: 120
       benchmark_timeout: PT3H

--- a/.github/workflows/run-nightly-benchmark.yml
+++ b/.github/workflows/run-nightly-benchmark.yml
@@ -76,6 +76,21 @@ on:
         required: false
         default: ''
         type: string
+      tsbs_query_iterations:
+        description: 'Query iterations per type for TSBS IoT benchmark'
+        required: false
+        default: ''
+        type: string
+      tsbs_workers:
+        description: 'Parallel query workers for TSBS IoT benchmark'
+        required: false
+        default: ''
+        type: string
+      tsbs_burn_in:
+        description: 'Burn-in queries (discarded from stats) for TSBS IoT benchmark'
+        required: false
+        default: ''
+        type: string
       ingest_tx_overhead_doc_count:
         description: 'Document count for ingest-tx-overhead benchmark'
         required: false
@@ -277,6 +292,9 @@ jobs:
           CLICKBENCH_SIZE: ${{ inputs.clickbench_size }}
           CLICKBENCH_LIMIT: ${{ inputs.clickbench_limit }}
           TSBS_DEVICE_COUNT: ${{ inputs.tsbs_device_count }}
+          TSBS_QUERY_ITERATIONS: ${{ inputs.tsbs_query_iterations }}
+          TSBS_WORKERS: ${{ inputs.tsbs_workers }}
+          TSBS_BURN_IN: ${{ inputs.tsbs_burn_in }}
           INGEST_TX_OVERHEAD_DOC_COUNT: ${{ inputs.ingest_tx_overhead_doc_count }}
           INGEST_TX_OVERHEAD_BATCH_SIZES: ${{ inputs.ingest_tx_overhead_batch_sizes }}
           PATCH_DOC_COUNT: ${{ inputs.patch_doc_count }}
@@ -331,6 +349,15 @@ jobs:
           fi
           if [ -n "$TSBS_DEVICE_COUNT" ]; then
             HELM_ARGS+=(--set "tsbs-iot.devices=${TSBS_DEVICE_COUNT}")
+          fi
+          if [ -n "$TSBS_QUERY_ITERATIONS" ]; then
+            HELM_ARGS+=(--set "tsbs-iot.queryIterations=${TSBS_QUERY_ITERATIONS}")
+          fi
+          if [ -n "$TSBS_WORKERS" ]; then
+            HELM_ARGS+=(--set "tsbs-iot.workers=${TSBS_WORKERS}")
+          fi
+          if [ -n "$TSBS_BURN_IN" ]; then
+            HELM_ARGS+=(--set "tsbs-iot.burnIn=${TSBS_BURN_IN}")
           fi
           if [ -n "$INGEST_TX_OVERHEAD_DOC_COUNT" ]; then
             HELM_ARGS+=(--set "ingestTxOverhead.docCount=${INGEST_TX_OVERHEAD_DOC_COUNT}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -697,7 +697,10 @@ createBench("tsbs-iot", mapOf(
     "file" to "--file",
     "deviceCount" to "--devices",
     "timestampStart" to "--timestamp-start",
-    "timestampEnd" to "--timestamp-end"
+    "timestampEnd" to "--timestamp-end",
+    "queryIterations" to "--query-iterations",
+    "workers" to "--workers",
+    "burnIn" to "--burn-in"
 ))
 
 createBench("fusion", mapOf(

--- a/modules/bench/cloud/helm/templates/benchmark-tsbs-iot.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-tsbs-iot.yaml
@@ -110,6 +110,12 @@ spec:
             - {{ index .Values "tsbs-iot" "timestampStart" | quote }}
             - --timestamp-end
             - {{ index .Values "tsbs-iot" "timestampEnd" | quote }}
+            - --query-iterations
+            - {{ index .Values "tsbs-iot" "queryIterations" | default 100 | quote }}
+            - --workers
+            - {{ index .Values "tsbs-iot" "workers" | default 1 | quote }}
+            - --burn-in
+            - {{ index .Values "tsbs-iot" "burnIn" | default 0 | quote }}
             {{- if .Values.timeout }}
             - --timeout
             - {{ .Values.timeout | quote }}

--- a/modules/bench/cloud/helm/values.yaml
+++ b/modules/bench/cloud/helm/values.yaml
@@ -52,6 +52,9 @@ ts-devices:
 
 tsbs-iot:
   devices: 2000
+  queryIterations: 20
+  workers: 4
+  burnIn: 5
   timestampStart: "2020-01-01T00:00:00Z"
   timestampEnd: "2020-01-07T00:00:00Z"
 

--- a/modules/bench/cloud/metrics/variables.tf
+++ b/modules/bench/cloud/metrics/variables.tf
@@ -211,7 +211,7 @@ variable "tsbs_iot_anomaly_logic_app_name" {
 variable "tsbs_iot_anomaly_alert_enabled" {
   description = "Whether the TSBS IoT anomaly detection Logic App is enabled"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "tsbs_iot_anomaly_devices" {

--- a/modules/bench/cloud/metrics/variables.tf
+++ b/modules/bench/cloud/metrics/variables.tf
@@ -211,7 +211,7 @@ variable "tsbs_iot_anomaly_logic_app_name" {
 variable "tsbs_iot_anomaly_alert_enabled" {
   description = "Whether the TSBS IoT anomaly detection Logic App is enabled"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "tsbs_iot_anomaly_devices" {

--- a/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/log_parsing.clj
+++ b/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/log_parsing.clj
@@ -126,7 +126,7 @@
                      stage-lines)
         {:keys [benchmark-total-time-ms benchmark-summary]} (parse-benchmark-summary lines)]
     {:all-stages stages
-     :query-stages (filterv #(= "queries" (name (:stage %))) stages)
+     :query-stages (filterv #(= "query-stats" (name (:stage %))) stages)
      :ingest-stages (filterv #(contains? #{"gen+submit-docs" "submit-docs" "sync" "finish-block" "compact" "ingest"} (name (:stage %))) stages)
      :benchmark-total-time-ms benchmark-total-time-ms
      :benchmark-summary benchmark-summary}))

--- a/modules/bench/src/main/clojure/xtdb/bench/fusion.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/fusion.clj
@@ -106,7 +106,7 @@
 
      ;; Credential/controller fields (sparse, like production)
      :certificate-credential-id (when (random/chance? rng 0.3)
-                                   (str "cert-" (random/next-uuid rng)))
+                                  (str "cert-" (random/next-uuid rng)))
      :controller-listing-id (when (random/chance? rng 0.4)
                               (str "ctrl-" (random/next-uuid rng)))
 
@@ -353,25 +353,20 @@
         (b/finish-block! node)
         (b/compact! node))})
 
-(defn run-query
-  "Execute a HugSQL sqlvec against XTDB node"
-  [node sqlvec opts]
-  (xt/q node sqlvec opts))
-
 (defn exec-system-settings [node system-id opts]
-  (run-query node (query-system-settings-sqlvec {:system-id system-id}) opts))
+  (xt/q node (query-system-settings-sqlvec {:system-id system-id}) opts))
 
 (defn exec-readings-for-system [node system-id start end opts]
-  (run-query node (query-readings-for-system-sqlvec {:system-id system-id :start start :end end}) opts))
+  (xt/q node (query-readings-for-system-sqlvec {:system-id system-id :start start :end end}) opts))
 
 (defn exec-system-count-over-time [node start end opts]
-  (run-query node (query-system-count-over-time-sqlvec {:start start :end end}) opts))
+  (xt/q node (query-system-count-over-time-sqlvec {:start start :end end}) opts))
 
 (defn exec-readings-range-bins [node start end opts]
-  (run-query node (query-readings-range-bins-sqlvec {:start start :end end}) opts))
+  (xt/q node (query-readings-range-bins-sqlvec {:start start :end end}) opts))
 
 (defn exec-cumulative-registration [node start end opts]
-  (run-query node (query-cumulative-registration-sqlvec {:start start :end end}) opts))
+  (xt/q node (query-cumulative-registration-sqlvec {:start start :end end}) opts))
 
 ;; OLTP mixed workload procs
 

--- a/modules/bench/src/main/clojure/xtdb/bench/stats.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/stats.clj
@@ -21,6 +21,33 @@
         p99 (if (pos? n) (sorted (idx 0.99)) 0)]
     {:mean mean :median median :p90 p90 :p99 p99 :min mn :max mx}))
 
+(defn percentile
+  "Calculate percentile from sorted timings"
+  [sorted-timings p]
+  (let [n (count sorted-timings)
+        idx (min (dec n) (int (* p n)))]
+    (nth sorted-timings idx)))
+
+(defn timing-stats
+  "Calculate statistics from a collection of timing values (in nanoseconds).
+   Returns map with count, total-ms, min-ms, max-ms, mean-ms, and percentiles."
+  [timings-ns]
+  (when (seq timings-ns)
+    (let [sorted (vec (sort timings-ns))
+          n (count sorted)
+          total-ns (reduce + sorted)
+          mean-ns (/ total-ns n)
+          ->ms #(/ % 1e6)]
+      {:count n
+       :total-ms (->ms total-ns)
+       :min-ms (->ms (first sorted))
+       :max-ms (->ms (last sorted))
+       :mean-ms (->ms mean-ns)
+       :p50-ms (->ms (percentile sorted 0.50))
+       :p90-ms (->ms (percentile sorted 0.90))
+       :p95-ms (->ms (percentile sorted 0.95))
+       :p99-ms (->ms (percentile sorted 0.99))})))
+
 (defn draw-lognormal
   "Draw a log-normal random variable using the underlying normal distribution
   parameters `mu` (mean) and `sigma` (standard deviation)."

--- a/modules/bench/src/main/clojure/xtdb/bench/stats.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/stats.clj
@@ -3,50 +3,48 @@
 (defn round-down [x]
   (long (Math/floor (double x))))
 
-(defn distribution-stats
-  "Compute summary statistics from a sequence of numeric counts."
-  [counts]
-  (let [counts (vec (map long counts))
-        n (count counts)
-        sorted (vec (sort counts))
-        mean (if (pos? n) (/ (reduce + 0 sorted) (double n)) 0.0)
-        mn (if (pos? n) (first sorted) 0)
-        mx (if (pos? n) (peek sorted) 0)
-        idx (fn [p]
-              (cond
-                (zero? n) 0
-                :else (-> (Math/floor (* p (dec n))) long (max 0) (min (dec n)))))
-        median (if (pos? n) (sorted (idx 0.5)) 0)
-        p90 (if (pos? n) (sorted (idx 0.90)) 0)
-        p99 (if (pos? n) (sorted (idx 0.99)) 0)]
-    {:mean mean :median median :p90 p90 :p99 p99 :min mn :max mx}))
-
 (defn percentile
-  "Calculate percentile from sorted timings"
-  [sorted-timings p]
-  (let [n (count sorted-timings)
-        idx (min (dec n) (int (* p n)))]
-    (nth sorted-timings idx)))
+  "Calculate percentile from sorted values.
+   Uses nearest-rank method: returns value at index floor(p * n)."
+  [sorted-vals p]
+  (let [n (count sorted-vals)
+        idx (-> (* p (dec n)) Math/floor long (max 0) (min (dec n)))]
+    (nth sorted-vals idx)))
+
+(defn distribution-stats
+  "Compute summary statistics from a sequence of numeric values.
+   Returns map with :count, :total, :min, :max, :mean, and percentiles (:p50, :p90, :p95, :p99)."
+  [values]
+  (when (seq values)
+    (let [sorted (vec (sort values))
+          n (count sorted)
+          total (reduce + 0 sorted)
+          mean (/ total (double n))]
+      {:count n
+       :total total
+       :min (first sorted)
+       :max (peek sorted)
+       :mean mean
+       :p50 (percentile sorted 0.50)
+       :p90 (percentile sorted 0.90)
+       :p95 (percentile sorted 0.95)
+       :p99 (percentile sorted 0.99)})))
 
 (defn timing-stats
   "Calculate statistics from a collection of timing values (in nanoseconds).
    Returns map with count, total-ms, min-ms, max-ms, mean-ms, and percentiles."
   [timings-ns]
-  (when (seq timings-ns)
-    (let [sorted (vec (sort timings-ns))
-          n (count sorted)
-          total-ns (reduce + sorted)
-          mean-ns (/ total-ns n)
-          ->ms #(/ % 1e6)]
-      {:count n
-       :total-ms (->ms total-ns)
-       :min-ms (->ms (first sorted))
-       :max-ms (->ms (last sorted))
-       :mean-ms (->ms mean-ns)
-       :p50-ms (->ms (percentile sorted 0.50))
-       :p90-ms (->ms (percentile sorted 0.90))
-       :p95-ms (->ms (percentile sorted 0.95))
-       :p99-ms (->ms (percentile sorted 0.99))})))
+  (when-let [stats (distribution-stats timings-ns)]
+    (let [->ms #(/ % 1e6)]
+      {:count (:count stats)
+       :total-ms (->ms (:total stats))
+       :min-ms (->ms (:min stats))
+       :max-ms (->ms (:max stats))
+       :mean-ms (->ms (:mean stats))
+       :p50-ms (->ms (:p50 stats))
+       :p90-ms (->ms (:p90 stats))
+       :p95-ms (->ms (:p95 stats))
+       :p99-ms (->ms (:p99 stats))})))
 
 (defn draw-lognormal
   "Draw a log-normal random variable using the underlying normal distribution

--- a/modules/bench/src/main/clojure/xtdb/bench/tsbs.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/tsbs.clj
@@ -198,7 +198,9 @@
    (fn [acc query]
      (when (Thread/interrupted) (throw (InterruptedException.)))
      (let [query-type (:query-type query)
-           timing-ns (b/execute-query node query)]
+           start-ns (System/nanoTime)
+           _ (xt/q node (:sqlvec query))
+           timing-ns (- (System/nanoTime) start-ns)]
        (when progress-atom (swap! progress-atom inc))
        (update acc query-type (fnil conj []) timing-ns)))
    {}

--- a/modules/bench/src/main/clojure/xtdb/bench/tsbs.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/tsbs.clj
@@ -1,12 +1,489 @@
 (ns xtdb.bench.tsbs
-  (:require [clojure.test :as t]
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.test :as t]
             [clojure.tools.logging :as log]
             [xtdb.api :as xt]
             [xtdb.bench :as b]
             [xtdb.time :as time]
             [xtdb.tsbs :as tsbs]
             [xtdb.util :as util])
-  (:import (java.time Duration LocalTime)))
+  (:import (java.time Duration Instant LocalTime)
+           (java.util Random)
+           (java.util.concurrent Executors ExecutorService TimeUnit)))
+
+;; TSBS fleet choices (from pkg/data/usecases/iot/truck.go)
+(def fleet-choices ["East" "West" "North" "South"])
+
+(defn- random-fleet
+  "Pick a random fleet using the benchmark seed"
+  [^Random rng]
+  (nth fleet-choices (.nextInt rng (count fleet-choices))))
+
+(defn- random-trucks
+  "Pick n random truck names from the available trucks"
+  [^Random rng truck-names n]
+  (let [available (vec truck-names)
+        cnt (count available)]
+    (if (<= cnt n)
+      available
+      (->> (repeatedly n #(.nextInt rng cnt))
+           distinct
+           (take n)
+           (mapv #(nth available %))))))
+
+(defn- random-window
+  "Pick a random time window of given duration within the data range.
+   Returns nil if window-duration > data range (can't fit window in available data)."
+  [^Random rng ^Instant min-time ^Instant max-time ^Duration window-duration]
+  (let [range-millis (- (.toEpochMilli max-time) (.toEpochMilli min-time))
+        window-millis (.toMillis window-duration)]
+    (when-not (> window-millis range-millis)
+      (let [max-start (- range-millis window-millis)
+            start-offset (if (pos? max-start) (.nextLong rng max-start) 0)
+            window-start (Instant/ofEpochMilli (+ (.toEpochMilli min-time) start-offset))
+            window-end (.plus window-start window-duration)]
+        [window-start window-end]))))
+
+(defn- gen-last-loc-by-truck
+  "LastLocByTruck - last location for specific random trucks"
+  [{:keys [rng truck-names]}]
+  (let [trucks (random-trucks rng truck-names 5)
+        ;; Build IN clause with positional params: WHERE t.name IN (?, ?, ?, ?, ?)
+        placeholders (str/join ", " (repeat (count trucks) "?"))
+        sql (format "SELECT t.name, t.driver, r.longitude, r.latitude
+                     FROM trucks t
+                     JOIN readings r ON r._id = t._id
+                     WHERE t.name IN (%s)" placeholders)]
+    {:query-type :last-loc-by-truck
+     :sql sql
+     :params (vec trucks)}))
+
+(defn- gen-last-loc-per-truck
+  "LastLocPerTruck - last location for all trucks in a random fleet"
+  [{:keys [rng]}]
+  (let [fleet (random-fleet rng)]
+    {:query-type :last-loc-per-truck
+     :sql "SELECT t.name, t.driver, r.longitude, r.latitude
+           FROM trucks t
+           JOIN readings r ON r._id = t._id
+           WHERE t.name IS NOT NULL AND t.fleet = ?"
+     :params [fleet]}))
+
+(defn- gen-low-fuel
+  "TrucksWithLowFuel - trucks with fuel < 10% in a random fleet"
+  [{:keys [rng]}]
+  (let [fleet (random-fleet rng)]
+    {:query-type :low-fuel
+     :sql "SELECT t.name, t.driver, d.fuel_state
+           FROM trucks t
+           JOIN diagnostics d ON d._id = t._id
+           WHERE t.name IS NOT NULL
+             AND t.fleet = ?
+             AND d.fuel_state < 0.1"
+     :params [fleet]}))
+
+(defn- gen-high-load
+  "TrucksWithHighLoad - trucks with load > 90% capacity in a random fleet"
+  [{:keys [rng]}]
+  (let [fleet (random-fleet rng)]
+    {:query-type :high-load
+     :sql "SELECT t.name, t.driver, d.current_load, t.load_capacity,
+                  (d.current_load / t.load_capacity) AS load_pct
+           FROM trucks t
+           JOIN diagnostics d ON d._id = t._id
+           WHERE t.name IS NOT NULL
+             AND t.fleet = ?
+             AND d.current_load / t.load_capacity > 0.9"
+     :params [fleet]}))
+
+(defn- gen-stationary-trucks
+  "StationaryTrucks - trucks with avg velocity < 1 in random 10-min window.
+   Returns nil if data range < 10 minutes."
+  [{:keys [rng min-time max-time]}]
+  (when-let [[window-start window-end] (random-window rng min-time max-time (Duration/ofMinutes 10))]
+    (let [fleet (random-fleet rng)]
+      {:query-type :stationary-trucks
+       :sql "SELECT t.name, t.driver, AVG(r.velocity) AS avg_velocity
+             FROM trucks t
+             JOIN readings FOR VALID_TIME BETWEEN ? AND ? AS r ON r._id = t._id
+             WHERE t.name IS NOT NULL AND t.fleet = ?
+             GROUP BY t.name, t.driver
+             HAVING AVG(r.velocity) < 1"
+       :params [window-start window-end fleet]})))
+
+(defn- gen-long-driving-sessions
+  "TrucksWithLongDrivingSessions - drove > 220 mins in random 4-hour window.
+   Returns nil if data range < 4 hours."
+  [{:keys [rng min-time max-time]}]
+  (when-let [[window-start window-end] (random-window rng min-time max-time (Duration/ofHours 4))]
+    (let [fleet (random-fleet rng)]
+      {:query-type :long-driving-sessions
+       ;; TSBS uses 10-minute buckets, counts periods with avg velocity > 1, requires > 22 periods
+       ;; 22 periods × 10 min = 220 min = 3.67 hours of driving in 4 hour window
+       :sql "WITH base AS (
+               SELECT t.name, t.driver, r.velocity,
+                      FLOOR(EXTRACT(EPOCH FROM r._valid_from) / 600) AS ten_min_bucket
+               FROM trucks t
+               JOIN readings FOR VALID_TIME BETWEEN ? AND ? AS r ON r._id = t._id
+               WHERE t.name IS NOT NULL AND t.fleet = ?
+             ),
+             driving_periods AS (
+               SELECT name, driver, ten_min_bucket
+               FROM base
+               GROUP BY name, driver, ten_min_bucket
+               HAVING AVG(velocity) > 1
+             )
+             SELECT name, driver, COUNT(*) AS driving_periods
+             FROM driving_periods
+             GROUP BY name, driver
+             HAVING COUNT(*) > 22"
+       :params [window-start window-end fleet]})))
+
+(defn- gen-long-daily-sessions
+  "TrucksWithLongDailySessions - drove > 10 hours in random 24-hour window.
+   Returns nil if data range < 24 hours."
+  [{:keys [rng min-time max-time]}]
+  (when-let [[window-start window-end] (random-window rng min-time max-time (Duration/ofHours 24))]
+    (let [fleet (random-fleet rng)]
+      {:query-type :long-daily-sessions
+       ;; TSBS uses 10-minute buckets, requires > 60 periods = 600 min = 10 hours
+       :sql "WITH base AS (
+               SELECT t.name, t.driver, r.velocity,
+                      FLOOR(EXTRACT(EPOCH FROM r._valid_from) / 600) AS ten_min_bucket
+               FROM trucks t
+               JOIN readings FOR VALID_TIME BETWEEN ? AND ? AS r ON r._id = t._id
+               WHERE t.name IS NOT NULL AND t.fleet = ?
+             ),
+             driving_periods AS (
+               SELECT name, driver, ten_min_bucket
+               FROM base
+               GROUP BY name, driver, ten_min_bucket
+               HAVING AVG(velocity) > 1
+             )
+             SELECT name, driver, COUNT(*) AS driving_periods
+             FROM driving_periods
+             GROUP BY name, driver
+             HAVING COUNT(*) > 60"
+       :params [window-start window-end fleet]})))
+
+(defn- gen-avg-vs-projected-fuel-consumption
+  "AvgVsProjectedFuelConsumption - actual vs nominal fuel per fleet (no random params)"
+  [_state]
+  {:query-type :avg-vs-projected-fuel-consumption
+   :sql "SELECT t.fleet,
+                AVG(r.fuel_consumption) AS avg_fuel_consumption,
+                AVG(t.nominal_fuel_consumption) AS projected_fuel_consumption
+         FROM trucks t
+         JOIN readings FOR ALL VALID_TIME AS r ON r._id = t._id
+         WHERE t.fleet IS NOT NULL
+           AND t.nominal_fuel_consumption IS NOT NULL
+           AND r.velocity > 1
+         GROUP BY t.fleet"
+   :params []})
+
+(defn- gen-avg-daily-driving-duration
+  "AvgDailyDrivingDuration - average hours driven per day per driver (no random params)"
+  [_state]
+  {:query-type :avg-daily-driving-duration
+   ;; TSBS: 10-min buckets, count periods with avg velocity > 1, divide by 6 to get hours
+   :sql "WITH base AS (
+           SELECT t.name, t.driver, t.fleet, r.velocity,
+                  DATE_TRUNC(DAY, r._valid_from) AS day_bucket,
+                  FLOOR(EXTRACT(EPOCH FROM r._valid_from) / 600) AS ten_min_bucket
+           FROM trucks t
+           JOIN readings FOR ALL VALID_TIME AS r ON r._id = t._id
+           WHERE t.name IS NOT NULL
+         ),
+         ten_min_driving AS (
+           SELECT name, driver, fleet, day_bucket, ten_min_bucket
+           FROM base
+           GROUP BY name, driver, fleet, day_bucket, ten_min_bucket
+           HAVING AVG(velocity) > 1
+         ),
+         daily_hours AS (
+           SELECT name, driver, fleet, day_bucket,
+                  CAST(COUNT(*) AS DOUBLE PRECISION) / 6.0 AS hours_driven
+           FROM ten_min_driving
+           GROUP BY name, driver, fleet, day_bucket
+         )
+         SELECT fleet, name, driver, AVG(hours_driven) AS avg_daily_hours
+         FROM daily_hours
+         GROUP BY fleet, name, driver"
+   :params []})
+
+(defn- gen-avg-daily-driving-session
+  "AvgDailyDrivingSession - avg session duration per driver per day (no random params)
+   Uses LAG/LEAD to detect driving session transitions (velocity > 5 = driving).
+   Calculates average duration of driving sessions, matching TSBS semantics."
+  [_state]
+  {:query-type :avg-daily-driving-session
+   :sql "WITH readings_bucketed AS (
+           SELECT t.name, t._id AS truck_id,
+                  FLOOR(EXTRACT(EPOCH FROM r._valid_from) / 600) AS ten_min_bucket,
+                  AVG(r.velocity) > 5 AS driving
+           FROM trucks t
+           JOIN readings FOR ALL VALID_TIME AS r ON r._id = t._id
+           WHERE t.name IS NOT NULL
+           GROUP BY t.name, t._id, FLOOR(EXTRACT(EPOCH FROM r._valid_from) / 600)
+         ),
+         status_with_prev AS (
+           SELECT name, truck_id, ten_min_bucket, driving,
+                  LAG(driving) OVER (PARTITION BY truck_id ORDER BY ten_min_bucket) AS prev_driving
+           FROM readings_bucketed
+         ),
+         status_changes AS (
+           SELECT name, ten_min_bucket AS start_bucket, driving,
+                  LEAD(ten_min_bucket) OVER (PARTITION BY truck_id ORDER BY ten_min_bucket) AS stop_bucket
+           FROM status_with_prev
+           WHERE driving <> prev_driving OR prev_driving IS NULL
+         )
+         SELECT name,
+                DATE_TRUNC(DAY, TIMESTAMP '1970-01-01' + start_bucket * INTERVAL '600 seconds') AS day_bucket,
+                AVG((stop_bucket - start_bucket) * 10.0) AS avg_session_duration_min
+         FROM status_changes
+         WHERE driving = true AND stop_bucket IS NOT NULL
+         GROUP BY name, DATE_TRUNC(DAY, TIMESTAMP '1970-01-01' + start_bucket * INTERVAL '600 seconds')
+         ORDER BY name, day_bucket"
+   :params []})
+
+(defn- gen-avg-load
+  "AvgLoad - average load per truck model per fleet (no random params)"
+  [_state]
+  {:query-type :avg-load
+   :sql "SELECT t.fleet, t.model, t.load_capacity,
+                AVG(d.current_load / t.load_capacity) AS avg_load_pct
+         FROM trucks t
+         JOIN diagnostics FOR ALL VALID_TIME AS d ON d._id = t._id
+         WHERE t.name IS NOT NULL
+         GROUP BY t.fleet, t.model, t.load_capacity"
+   :params []})
+
+(defn- gen-daily-activity
+  "DailyTruckActivity - fraction of day active per fleet/model (no random params)"
+  [_state]
+  {:query-type :daily-activity
+   ;; TSBS: 10-min buckets, counts active periods, divides by 144 (10-min periods per day)
+   :sql "WITH base AS (
+           SELECT t.fleet, t.model, t._id AS truck_id, d.status,
+                  DATE_TRUNC(DAY, d._valid_from) AS day_bucket,
+                  FLOOR(EXTRACT(EPOCH FROM d._valid_from) / 600) AS ten_min_bucket
+           FROM trucks t
+           JOIN diagnostics FOR ALL VALID_TIME AS d ON d._id = t._id
+           WHERE t.name IS NOT NULL
+         ),
+         active_periods AS (
+           SELECT fleet, model, truck_id, day_bucket, ten_min_bucket
+           FROM base
+           GROUP BY fleet, model, truck_id, day_bucket, ten_min_bucket
+           HAVING AVG(status) < 1
+         )
+         SELECT fleet, model, day_bucket,
+                CAST(COUNT(*) AS DOUBLE PRECISION) / 144.0 AS daily_activity
+         FROM active_periods
+         GROUP BY fleet, model, day_bucket
+         ORDER BY day_bucket"
+   :params []})
+
+(defn- gen-breakdown-frequency
+  "TruckBreakdownFrequency - breakdown events per model (no random params)
+   Uses LEAD to detect transitions from working (status > 0) to broken (status = 0)."
+  [_state]
+  {:query-type :breakdown-frequency
+   :sql "WITH diagnostics_with_next AS (
+           SELECT t.model, t._id AS truck_id, d.status,
+                  LEAD(d.status) OVER (PARTITION BY t._id ORDER BY d._valid_from) AS next_status
+           FROM trucks t
+           JOIN diagnostics FOR ALL VALID_TIME AS d ON d._id = t._id
+           WHERE t.name IS NOT NULL
+         ),
+         breakdown_events AS (
+           SELECT model, truck_id
+           FROM diagnostics_with_next
+           WHERE status > 0 AND next_status = 0
+         )
+         SELECT model, COUNT(*) AS breakdown_count
+         FROM breakdown_events
+         GROUP BY model
+         HAVING COUNT(*) > 0"
+   :params []})
+
+;; All query generators in TSBS order
+(def query-generators
+  [gen-last-loc-by-truck
+   gen-last-loc-per-truck
+   gen-low-fuel
+   gen-high-load
+   gen-stationary-trucks
+   gen-long-driving-sessions
+   gen-long-daily-sessions
+   gen-avg-vs-projected-fuel-consumption
+   gen-avg-daily-driving-duration
+   gen-avg-daily-driving-session
+   gen-avg-load
+   gen-daily-activity
+   gen-breakdown-frequency])
+
+(defn- execute-query
+  "Execute a single query and return timing in nanoseconds"
+  [node {:keys [sql params]}]
+  (let [start (System/nanoTime)
+        _ (if (seq params)
+            (xt/q node (into [sql] params))
+            (xt/q node sql))
+        end (System/nanoTime)]
+    (- end start)))
+
+(defn- percentile
+  "Calculate percentile from sorted timings"
+  [sorted-timings p]
+  (let [n (count sorted-timings)
+        idx (min (dec n) (int (* p n)))]
+    (nth sorted-timings idx)))
+
+(defn- calculate-stats
+  "Calculate statistics from a collection of timing values (in nanoseconds)"
+  [timings-ns]
+  (when (seq timings-ns)
+    (let [sorted (vec (sort timings-ns))
+          n (count sorted)
+          total-ns (reduce + sorted)
+          mean-ns (/ total-ns n)
+          ->ms #(/ % 1e6)]
+      {:count n
+       :total-ms (->ms total-ns)
+       :min-ms (->ms (first sorted))
+       :max-ms (->ms (last sorted))
+       :mean-ms (->ms mean-ns)
+       :p50-ms (->ms (percentile sorted 0.50))
+       :p90-ms (->ms (percentile sorted 0.90))
+       :p95-ms (->ms (percentile sorted 0.95))
+       :p99-ms (->ms (percentile sorted 0.99))})))
+
+;; All possible query types (for detecting skipped queries)
+(def ^:private all-query-types
+  #{:last-loc-by-truck :last-loc-per-truck :low-fuel :high-load
+    :stationary-trucks :long-driving-sessions :long-daily-sessions
+    :avg-vs-projected-fuel-consumption :avg-daily-driving-duration :avg-daily-driving-session
+    :avg-load :daily-activity :breakdown-frequency})
+
+(defn- generate-queries
+  "Generate n query instances for each query type.
+   Returns {:queries [...] :skipped #{...}} where skipped contains query types
+   that couldn't be generated (e.g. window duration > data range)."
+  [state n]
+  (let [all-results (for [gen query-generators
+                          _ (range n)]
+                      (gen state))
+        queries (filterv some? all-results)
+        ;; Determine which types were skipped by comparing with what we got
+        generated-types (into #{} (map :query-type) queries)
+        skipped-types (set/difference all-query-types generated-types)]
+    (when (seq skipped-types)
+      (log/warn (format "Skipping query types (insufficient data range): %s"
+                        (str/join ", " (map name skipped-types)))))
+    {:queries queries
+     :skipped skipped-types}))
+
+(defn- run-query-batch
+  "Run a batch of queries, return timings grouped by query-type.
+   If progress-atom is provided, increments it after each query."
+  [node queries progress-atom]
+  (reduce
+   (fn [acc query]
+     (when (Thread/interrupted) (throw (InterruptedException.)))
+     (let [query-type (:query-type query)
+           timing-ns (execute-query node query)]
+       (when progress-atom (swap! progress-atom inc))
+       (update acc query-type (fnil conj []) timing-ns)))
+   {}
+   queries))
+
+(defn- progress-logger
+  "Start a background thread that logs progress every interval-ms.
+   Returns a function to stop the logger."
+  [progress-atom total interval-ms]
+  (let [running (atom true)
+        thread (Thread.
+                (fn []
+                  (while @running
+                    (Thread/sleep interval-ms)
+                    (when @running
+                      (let [done @progress-atom
+                            pct (if (pos? total) (* 100.0 (/ done total)) 0.0)]
+                        (log/info (format "Progress: %d/%d queries (%.1f%%)" done total pct)))))))]
+    (.start thread)
+    (fn []
+      (reset! running false)
+      (.interrupt thread))))
+
+(defn- run-queries-single-threaded
+  "Run all queries single-threaded"
+  [node queries progress-atom]
+  (run-query-batch node queries progress-atom))
+
+(defn- run-queries-parallel
+  "Run queries with multiple workers using a thread pool"
+  [node queries workers progress-atom]
+  (let [^ExecutorService executor (Executors/newFixedThreadPool workers)
+        ;; Partition queries across workers
+        query-batches (partition-all (max 1 (quot (count queries) workers)) queries)
+        futures (mapv #(.submit executor ^Callable (fn [] (run-query-batch node % progress-atom)))
+                      query-batches)]
+    (try
+      ;; Collect results from all workers
+      (reduce
+       (fn [acc fut]
+         (let [batch-result (.get fut)]
+           (merge-with into acc batch-result)))
+       {}
+       futures)
+      (finally
+        (.shutdown executor)
+        (.awaitTermination executor 1 TimeUnit/HOURS)))))
+
+(defn- run-queries
+  "Run all queries with the specified configuration"
+  [node queries {:keys [workers burn-in]}]
+  (let [burn-in-count (min burn-in (count queries))
+
+        ;; Run burn-in queries (discard timings)
+        _ (when (pos? burn-in-count)
+            (log/info (format "Running %d burn-in queries..." burn-in-count))
+            (run-query-batch node (take burn-in-count queries) nil))
+
+        ;; Run remaining queries and collect timings
+        queries-for-stats (drop burn-in-count queries)
+        total (count queries-for-stats)
+        _ (log/info (format "Running %d queries with %d workers..." total workers))
+
+        ;; Set up progress tracking (log every 60 seconds)
+        progress-atom (atom 0)
+        stop-logger (progress-logger progress-atom total 60000)
+
+        timings-by-type (try
+                          (if (= 1 workers)
+                            (run-queries-single-threaded node queries-for-stats progress-atom)
+                            (run-queries-parallel node queries-for-stats workers progress-atom))
+                          (finally
+                            (stop-logger)))]
+    timings-by-type))
+
+(defn- format-stats-row
+  "Format a single query type's stats as a string"
+  [query-type stats]
+  (format "%-25s %6d queries | min: %8.2f | mean: %8.2f | p50: %8.2f | p90: %8.2f | p95: %8.2f | p99: %8.2f | max: %8.2f ms"
+          (name query-type)
+          (:count stats)
+          (:min-ms stats)
+          (:mean-ms stats)
+          (:p50-ms stats)
+          (:p90-ms stats)
+          (:p95-ms stats)
+          (:p99-ms stats)
+          (:max-ms stats)))
+
+;; ============ CLI and Benchmark Definition ============
 
 (defmethod b/cli-flags :tsbs-iot [_]
   [[nil "--devices DEVICES"
@@ -24,6 +501,22 @@
    [nil "--file TXS_FILE"
     :id :txs-file
     :parse-fn util/->path]
+
+   ;; Query execution options (TSBS-style)
+   [nil "--query-iterations ITERATIONS"
+    :id :query-iterations
+    :default 100
+    :parse-fn parse-long]
+
+   [nil "--workers WORKERS"
+    :id :workers
+    :default 1
+    :parse-fn parse-long]
+
+   [nil "--burn-in BURN_IN"
+    :id :burn-in
+    :default 0
+    :parse-fn parse-long]
 
    ["-h" "--help"]])
 
@@ -49,10 +542,20 @@
        :total-diagnostics total-diagnostics
        :total-rows total-rows})))
 
-(defmethod b/->benchmark :tsbs-iot [_ {:keys [seed txs-file devices timestamp-start timestamp-end], :or {seed 0}, :as opts}]
+(defmethod b/->benchmark :tsbs-iot [_ {:keys [seed txs-file devices timestamp-start timestamp-end
+                                              query-iterations workers burn-in]
+                                       :or {seed 0
+                                            query-iterations 100
+                                            workers 1
+                                            burn-in 0}
+                                       :as opts}]
   (when-let [est (and (not txs-file) (estimate-row-count devices timestamp-start timestamp-end))]
     (log/info (format "TSBS-IoT scale: %d devices × %.1f days = %,d total rows (%,d readings + %,d diagnostics)"
                       (:devices est) (:days est) (:total-rows est) (:total-readings est) (:total-diagnostics est))))
+
+  (log/info (format "Query config: %d iterations × %d query types = %,d total queries, %d workers, burn-in=%d"
+                    query-iterations (count query-generators) (* query-iterations (count query-generators))
+                    workers burn-in))
 
   {:title "TSBS IoT"
    :benchmark-type :tsbs-iot
@@ -61,7 +564,11 @@
                 :txs-file txs-file
                 :devices devices
                 :timestamp-start timestamp-start
-                :timestamp-end timestamp-end}
+                :timestamp-end timestamp-end
+                :query-iterations query-iterations
+                :workers workers
+                :burn-in burn-in}
+   :->state (fn [] {:!state (atom {:rng (Random. seed)})})
    :tasks [{:t :do
             :stage :ingest
             :tasks [(letfn [(submit-txs [node txs]
@@ -106,25 +613,112 @@
                      :stage :compact
                      :f (fn [{:keys [node]}] (b/compact! node))}]}
 
-           ;; TODO more queries
+           ;; Query setup - discover data characteristics for parameterized queries
            {:t :call
-            :stage :queries
-            :f (fn [{:keys [node]}]
-                 (let [readings-count (:row-count (first (xt/q node "SELECT COUNT(*) row_count FROM readings FOR ALL VALID_TIME")))
-                       diagnostics-count (:row-count (first (xt/q node "SELECT COUNT(*) row_count FROM diagnostics FOR ALL VALID_TIME")))
-                       total-count (+ readings-count diagnostics-count)]
-                   (log/info (format "TSBS-IoT final counts: %,d readings + %,d diagnostics = %,d total rows"
-                                     readings-count diagnostics-count total-count))))}]})
+            :stage :query-setup
+            :f (fn [{:keys [node !state]}]
+                 (let [;; Get all truck names for random selection
+                       truck-names (mapv :name (xt/q node "SELECT name FROM trucks ORDER BY name"))
+                       ;; Debug: check a sample row
+                       sample-row (first (xt/q node "SELECT * FROM readings FOR ALL VALID_TIME LIMIT 1"))
+                       _ (log/info (format "Sample readings row: %s" (pr-str sample-row)))
+                       ;; Get time range from readings
+                       readings-count (-> (xt/q node "SELECT COUNT(*) AS cnt FROM readings FOR ALL VALID_TIME")
+                                          first :cnt)
+                       _ (log/info (format "Readings table has %d rows" readings-count))
+                       ;; Get min/max valid_from
+                       time-bounds (first (xt/q node
+                                                "SELECT MIN(_valid_from) AS min_time, MAX(_valid_from) AS max_time
+                                                 FROM readings FOR ALL VALID_TIME"))
+                       _ (log/info (format "Time bounds from valid_from: %s" (pr-str time-bounds)))
+                       ;; If valid_from is null, try system_from
+                       time-bounds (if (nil? (:min-time time-bounds))
+                                     (let [sys-bounds (first (xt/q node
+                                                                   "SELECT MIN(_system_from) AS min_time, MAX(_system_from) AS max_time
+                                                                    FROM readings FOR ALL SYSTEM_TIME"))]
+                                       (log/info (format "Time bounds from system_from: %s" (pr-str sys-bounds)))
+                                       sys-bounds)
+                                     time-bounds)
+                       ;; Convert to Instant if needed (query returns ZonedDateTime)
+                       min-time (some-> (:min-time time-bounds) time/->instant)
+                       max-time (some-> (:max-time time-bounds) time/->instant)]
+                   (log/info (format "Query setup: %d trucks, time=%s to %s"
+                                     (count truck-names) min-time max-time))
+                   (when (nil? min-time)
+                     (throw (ex-info "Could not determine time bounds from readings table"
+                                     {:readings-count readings-count
+                                      :time-bounds time-bounds
+                                      :sample-row sample-row})))
+                   (swap! !state assoc
+                          :truck-names truck-names
+                          :min-time min-time
+                          :max-time max-time)
+                   {:truck-count (count truck-names)
+                    :time-range [min-time max-time]}))}
+
+           ;; Generate all query instances
+           {:t :call
+            :stage :generate-queries
+            :f (fn [{:keys [!state]}]
+                 (let [state @!state
+                       {:keys [queries skipped]} (generate-queries state query-iterations)
+                       active-types (- (count query-generators) (count skipped))]
+                   (log/info (format "Generated %d query instances (%d types × %d iterations, %d types skipped)"
+                                     (count queries) active-types query-iterations (count skipped)))
+                   (swap! !state assoc :queries queries)
+                   {:query-count (count queries)
+                    :query-types active-types
+                    :skipped-types (vec skipped)
+                    :iterations query-iterations}))}
+
+           ;; Execute all queries and collect stats
+           {:t :call
+            :stage :run-queries
+            :f (fn [{:keys [node !state] :as worker}]
+                 (let [{:keys [queries]} @!state
+                       timings-by-type (run-queries node queries
+                                                    {:workers workers
+                                                     :burn-in burn-in})
+                       stats-by-type (into {}
+                                           (map (fn [[qt timings]]
+                                                  [qt (calculate-stats timings)]))
+                                           timings-by-type)
+                       ;; Calculate overall stats
+                       all-timings (into [] cat (vals timings-by-type))
+                       overall-stats (calculate-stats all-timings)]
+
+                   ;; Log per-query-type stats to console
+                   (log/info "Query execution complete. Results by query type:")
+                   (doseq [[query-type stats] (sort-by key stats-by-type)]
+                     (log/info (format-stats-row query-type stats)))
+                   (log/info (str (apply str (repeat 120 "-"))))
+                   (log/info (format-stats-row :OVERALL overall-stats))
+
+                   ;; Output stats as JSON for consumption
+                   (b/log-report worker {:stage :query-stats
+                                         :stats-by-type stats-by-type
+                                         :overall-stats overall-stats
+                                         :total-queries (count all-timings)})
+
+                   {:stats-by-type stats-by-type
+                    :overall-stats overall-stats
+                    :total-queries (count all-timings)
+                    :total-time-ms (:total-ms overall-stats)}))}]})
 
 ;; not intended to be run as a test - more for ease of REPL dev
 (t/deftest ^:benchmark run-iot
   (util/with-tmp-dirs #{node-tmp-dir}
-    (-> (b/->benchmark :tsbs-iot {:devices 40, :timestamp-start #inst "2020-01-01", :timestamp-end #inst "2020-01-07"})
+    (-> (b/->benchmark :tsbs-iot {:devices 40
+                                  :timestamp-start #inst "2020-01-01"
+                                  :timestamp-end #inst "2020-01-07"
+                                  :query-iterations 100
+                                  :workers 4})
         (b/run-benchmark {:node-dir node-tmp-dir}))))
 
 (t/deftest ^:benchmark run-iot-from-file
   (util/with-tmp-dirs #{node-tmp-dir}
     (log/debug "tmp-dir:" node-tmp-dir)
 
-    (-> (b/->benchmark :tsbs-iot {:txs-file #xt/path "/home/james/tmp/tsbs.transit.json"})
+    (-> (b/->benchmark :tsbs-iot {:txs-file #xt/path "/home/james/tmp/tsbs.transit.json"
+                                  :query-iterations 100})
         (b/run-benchmark {:node-dir node-tmp-dir}))))

--- a/modules/bench/src/main/clojure/xtdb/bench/tsbs.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/tsbs.clj
@@ -51,35 +51,31 @@
 
 (defn- gen-last-loc-by-truck
   "LastLocByTruck - last location for specific random trucks"
-  [{:keys [rng truck-names max-time]}]
+  [{:keys [rng truck-names]}]
   (let [trucks (random-trucks rng truck-names 5)]
     {:query-type :last-loc-by-truck
-     :sqlvec (query-last-loc-by-truck-sqlvec {:truck-names trucks
-                                              :as-of-time max-time})}))
+     :sqlvec (query-last-loc-by-truck-sqlvec {:truck-names trucks})}))
 
 (defn- gen-last-loc-per-truck
   "LastLocPerTruck - last location for all trucks in a random fleet"
-  [{:keys [rng max-time]}]
+  [{:keys [rng]}]
   (let [fleet (random-fleet rng)]
     {:query-type :last-loc-per-truck
-     :sqlvec (query-last-loc-per-truck-sqlvec {:fleet fleet
-                                               :as-of-time max-time})}))
+     :sqlvec (query-last-loc-per-truck-sqlvec {:fleet fleet})}))
 
 (defn- gen-low-fuel
   "TrucksWithLowFuel - trucks with fuel < 10% in a random fleet"
-  [{:keys [rng max-time]}]
+  [{:keys [rng]}]
   (let [fleet (random-fleet rng)]
     {:query-type :low-fuel
-     :sqlvec (query-low-fuel-sqlvec {:fleet fleet
-                                     :as-of-time max-time})}))
+     :sqlvec (query-low-fuel-sqlvec {:fleet fleet})}))
 
 (defn- gen-high-load
   "TrucksWithHighLoad - trucks with load > 90% capacity in a random fleet"
-  [{:keys [rng max-time]}]
+  [{:keys [rng]}]
   (let [fleet (random-fleet rng)]
     {:query-type :high-load
-     :sqlvec (query-high-load-sqlvec {:fleet fleet
-                                      :as-of-time max-time})}))
+     :sqlvec (query-high-load-sqlvec {:fleet fleet})}))
 
 (defn- gen-stationary-trucks
   "StationaryTrucks - trucks with avg velocity < 1 in random 10-min window.

--- a/modules/bench/src/main/clojure/xtdb/bench/tsbs.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/tsbs.clj
@@ -51,31 +51,35 @@
 
 (defn- gen-last-loc-by-truck
   "LastLocByTruck - last location for specific random trucks"
-  [{:keys [rng truck-names]}]
+  [{:keys [rng truck-names max-time]}]
   (let [trucks (random-trucks rng truck-names 5)]
     {:query-type :last-loc-by-truck
-     :sqlvec (query-last-loc-by-truck-sqlvec {:truck-names trucks})}))
+     :sqlvec (query-last-loc-by-truck-sqlvec {:truck-names trucks
+                                              :as-of-time max-time})}))
 
 (defn- gen-last-loc-per-truck
   "LastLocPerTruck - last location for all trucks in a random fleet"
-  [{:keys [rng]}]
+  [{:keys [rng max-time]}]
   (let [fleet (random-fleet rng)]
     {:query-type :last-loc-per-truck
-     :sqlvec (query-last-loc-per-truck-sqlvec {:fleet fleet})}))
+     :sqlvec (query-last-loc-per-truck-sqlvec {:fleet fleet
+                                               :as-of-time max-time})}))
 
 (defn- gen-low-fuel
   "TrucksWithLowFuel - trucks with fuel < 10% in a random fleet"
-  [{:keys [rng]}]
+  [{:keys [rng max-time]}]
   (let [fleet (random-fleet rng)]
     {:query-type :low-fuel
-     :sqlvec (query-low-fuel-sqlvec {:fleet fleet})}))
+     :sqlvec (query-low-fuel-sqlvec {:fleet fleet
+                                     :as-of-time max-time})}))
 
 (defn- gen-high-load
   "TrucksWithHighLoad - trucks with load > 90% capacity in a random fleet"
-  [{:keys [rng]}]
+  [{:keys [rng max-time]}]
   (let [fleet (random-fleet rng)]
     {:query-type :high-load
-     :sqlvec (query-high-load-sqlvec {:fleet fleet})}))
+     :sqlvec (query-high-load-sqlvec {:fleet fleet
+                                      :as-of-time max-time})}))
 
 (defn- gen-stationary-trucks
   "StationaryTrucks - trucks with avg velocity < 1 in random 10-min window.

--- a/modules/bench/src/main/resources/xtdb/bench/tsbs.sql
+++ b/modules/bench/src/main/resources/xtdb/bench/tsbs.sql
@@ -24,7 +24,7 @@ FROM trucks t
 JOIN diagnostics d ON d._id = t._id
 WHERE t.name IS NOT NULL
   AND t.fleet = :fleet
-  AND d.current_load / t.load_capacity > 0.9
+  AND d.current_load / CAST(t.load_capacity AS DOUBLE PRECISION) > 0.9
 
 -- :name query-stationary-trucks :? :*
 SELECT t.name, t.driver, AVG(r.velocity) AS avg_velocity
@@ -147,7 +147,7 @@ ORDER BY name, day_bucket
 
 -- :name query-avg-load :? :*
 SELECT t.fleet, t.model, t.load_capacity,
-       AVG(d.current_load / t.load_capacity) AS avg_load_pct
+       AVG(d.current_load / CAST(t.load_capacity AS DOUBLE PRECISION)) AS avg_load_pct
 FROM trucks t
 JOIN diagnostics FOR ALL VALID_TIME AS d ON d._id = t._id
 WHERE t.name IS NOT NULL

--- a/modules/bench/src/main/resources/xtdb/bench/tsbs.sql
+++ b/modules/bench/src/main/resources/xtdb/bench/tsbs.sql
@@ -1,19 +1,19 @@
 -- :name query-last-loc-by-truck :? :*
 SELECT t.name, t.driver, r.longitude, r.latitude
 FROM trucks t
-JOIN readings r ON r._id = t._id
+JOIN readings FOR VALID_TIME AS OF :as-of-time AS r ON r._id = t._id
 WHERE t.name IN (:v*:truck-names)
 
 -- :name query-last-loc-per-truck :? :*
 SELECT t.name, t.driver, r.longitude, r.latitude
 FROM trucks t
-JOIN readings r ON r._id = t._id
+JOIN readings FOR VALID_TIME AS OF :as-of-time AS r ON r._id = t._id
 WHERE t.name IS NOT NULL AND t.fleet = :fleet
 
 -- :name query-low-fuel :? :*
 SELECT t.name, t.driver, d.fuel_state
 FROM trucks t
-JOIN diagnostics d ON d._id = t._id
+JOIN diagnostics FOR VALID_TIME AS OF :as-of-time AS d ON d._id = t._id
 WHERE t.name IS NOT NULL
   AND t.fleet = :fleet
   AND d.fuel_state < 0.1
@@ -21,7 +21,7 @@ WHERE t.name IS NOT NULL
 -- :name query-high-load :? :*
 SELECT t.name, t.driver, d.current_load
 FROM trucks t
-JOIN diagnostics d ON d._id = t._id
+JOIN diagnostics FOR VALID_TIME AS OF :as-of-time AS d ON d._id = t._id
 WHERE t.name IS NOT NULL
   AND t.fleet = :fleet
   AND d.current_load / CAST(t.load_capacity AS DOUBLE PRECISION) > 0.9

--- a/modules/bench/src/main/resources/xtdb/bench/tsbs.sql
+++ b/modules/bench/src/main/resources/xtdb/bench/tsbs.sql
@@ -1,0 +1,193 @@
+-- :name query-last-loc-by-truck :? :*
+SELECT t.name, t.driver, r.longitude, r.latitude
+FROM trucks t
+JOIN readings r ON r._id = t._id
+WHERE t.name IN (:v*:truck-names)
+
+-- :name query-last-loc-per-truck :? :*
+SELECT t.name, t.driver, r.longitude, r.latitude
+FROM trucks t
+JOIN readings r ON r._id = t._id
+WHERE t.name IS NOT NULL AND t.fleet = :fleet
+
+-- :name query-low-fuel :? :*
+SELECT t.name, t.driver, d.fuel_state
+FROM trucks t
+JOIN diagnostics d ON d._id = t._id
+WHERE t.name IS NOT NULL
+  AND t.fleet = :fleet
+  AND d.fuel_state < 0.1
+
+-- :name query-high-load :? :*
+SELECT t.name, t.driver, d.current_load
+FROM trucks t
+JOIN diagnostics d ON d._id = t._id
+WHERE t.name IS NOT NULL
+  AND t.fleet = :fleet
+  AND d.current_load / t.load_capacity > 0.9
+
+-- :name query-stationary-trucks :? :*
+SELECT t.name, t.driver, AVG(r.velocity) AS avg_velocity
+FROM trucks t
+JOIN readings FOR VALID_TIME BETWEEN :window-start AND :window-end AS r ON r._id = t._id
+WHERE t.name IS NOT NULL AND t.fleet = :fleet
+GROUP BY t.name, t.driver
+HAVING AVG(r.velocity) < 1
+
+-- :name query-long-driving-sessions :? :*
+WITH base AS (
+  SELECT t.name, t.driver, r.velocity,
+         FLOOR(EXTRACT(EPOCH FROM r._valid_from) / 600) AS ten_min_bucket
+  FROM trucks t
+  JOIN readings FOR VALID_TIME BETWEEN :window-start AND :window-end AS r ON r._id = t._id
+  WHERE t.name IS NOT NULL AND t.fleet = :fleet
+),
+driving_periods AS (
+  SELECT name, driver, ten_min_bucket
+  FROM base
+  GROUP BY name, driver, ten_min_bucket
+  HAVING AVG(velocity) > 1
+)
+SELECT name, driver
+FROM driving_periods
+GROUP BY name, driver
+HAVING COUNT(*) > 22
+
+-- :name query-long-daily-sessions :? :*
+WITH base AS (
+  SELECT t.name, t.driver, r.velocity,
+         FLOOR(EXTRACT(EPOCH FROM r._valid_from) / 600) AS ten_min_bucket
+  FROM trucks t
+  JOIN readings FOR VALID_TIME BETWEEN :window-start AND :window-end AS r ON r._id = t._id
+  WHERE t.name IS NOT NULL AND t.fleet = :fleet
+),
+driving_periods AS (
+  SELECT name, driver, ten_min_bucket
+  FROM base
+  GROUP BY name, driver, ten_min_bucket
+  HAVING AVG(velocity) > 1
+)
+SELECT name, driver
+FROM driving_periods
+GROUP BY name, driver
+HAVING COUNT(*) > 60
+
+-- :name query-avg-vs-projected-fuel-consumption :? :*
+SELECT t.fleet,
+       AVG(r.fuel_consumption) AS avg_fuel_consumption,
+       AVG(t.nominal_fuel_consumption) AS projected_fuel_consumption
+FROM trucks t
+JOIN readings FOR ALL VALID_TIME AS r ON r._id = t._id
+WHERE t.name IS NOT NULL
+  AND t.fleet IS NOT NULL
+  AND t.nominal_fuel_consumption IS NOT NULL
+  AND r.velocity > 1
+GROUP BY t.fleet
+
+-- :name query-avg-daily-driving-duration :? :*
+WITH base AS (
+  SELECT t.name, t.driver, t.fleet, r.velocity,
+         DATE_TRUNC(DAY, r._valid_from) AS day_bucket,
+         FLOOR(EXTRACT(EPOCH FROM r._valid_from) / 600) AS ten_min_bucket
+  FROM trucks t
+  JOIN readings FOR ALL VALID_TIME AS r ON r._id = t._id
+  WHERE t.name IS NOT NULL
+),
+ten_min_driving AS (
+  SELECT name, driver, fleet, day_bucket, ten_min_bucket
+  FROM base
+  GROUP BY name, driver, fleet, day_bucket, ten_min_bucket
+  HAVING AVG(velocity) > 1
+),
+daily_hours AS (
+  SELECT name, driver, fleet, day_bucket,
+         CAST(COUNT(*) AS DOUBLE PRECISION) / 6.0 AS hours_driven
+  FROM ten_min_driving
+  GROUP BY name, driver, fleet, day_bucket
+)
+SELECT fleet, name, driver, AVG(hours_driven) AS avg_daily_hours
+FROM daily_hours
+GROUP BY fleet, name, driver
+
+-- :name query-avg-daily-driving-session :? :*
+SELECT name, day_bucket, AVG(session_duration_min) AS avg_session_duration_min
+FROM (
+  WITH readings_with_bucket AS (
+    SELECT t.name, t._id AS truck_id, r.velocity,
+           FLOOR(EXTRACT(EPOCH FROM r._valid_from) / 600) AS ten_min_bucket
+    FROM trucks t
+    JOIN readings FOR ALL VALID_TIME AS r ON r._id = t._id
+    WHERE t.name IS NOT NULL
+  ),
+  readings_bucketed AS (
+    SELECT name, truck_id, ten_min_bucket,
+           AVG(velocity) > 5 AS driving
+    FROM readings_with_bucket
+    GROUP BY name, truck_id, ten_min_bucket
+  ),
+  status_with_prev AS (
+    SELECT name, truck_id, ten_min_bucket, driving,
+           LAG(driving) OVER (PARTITION BY truck_id ORDER BY ten_min_bucket) AS prev_driving
+    FROM readings_bucketed
+  ),
+  status_changes AS (
+    SELECT name, truck_id, ten_min_bucket AS start_bucket, driving,
+           LEAD(ten_min_bucket) OVER (PARTITION BY truck_id ORDER BY ten_min_bucket) AS stop_bucket
+    FROM status_with_prev
+    WHERE driving <> prev_driving OR prev_driving IS NULL
+  )
+  SELECT name,
+         FLOOR(start_bucket / 144) AS day_bucket,
+         (stop_bucket - start_bucket) * 10.0 AS session_duration_min
+  FROM status_changes
+  WHERE driving = true AND stop_bucket IS NOT NULL
+) sessions
+GROUP BY name, day_bucket
+ORDER BY name, day_bucket
+
+-- :name query-avg-load :? :*
+SELECT t.fleet, t.model, t.load_capacity,
+       AVG(d.current_load / t.load_capacity) AS avg_load_pct
+FROM trucks t
+JOIN diagnostics FOR ALL VALID_TIME AS d ON d._id = t._id
+WHERE t.name IS NOT NULL
+GROUP BY t.fleet, t.model, t.load_capacity
+
+-- :name query-daily-activity :? :*
+WITH base AS (
+  SELECT t.fleet, t.model, t._id AS truck_id, d.status,
+         DATE_TRUNC(DAY, d._valid_from) AS day_bucket,
+         FLOOR(EXTRACT(EPOCH FROM d._valid_from) / 600) AS ten_min_bucket
+  FROM trucks t
+  JOIN diagnostics FOR ALL VALID_TIME AS d ON d._id = t._id
+  WHERE t.name IS NOT NULL
+),
+active_periods AS (
+  SELECT fleet, model, truck_id, day_bucket, ten_min_bucket
+  FROM base
+  GROUP BY fleet, model, truck_id, day_bucket, ten_min_bucket
+  HAVING AVG(status) < 1
+)
+SELECT fleet, model, day_bucket,
+       CAST(COUNT(*) AS DOUBLE PRECISION) / 144.0 AS daily_activity
+FROM active_periods
+GROUP BY fleet, model, day_bucket
+ORDER BY day_bucket
+
+-- :name query-breakdown-frequency :? :*
+WITH diagnostics_with_next AS (
+  SELECT t.model, t._id AS truck_id, d.status,
+         LEAD(d.status) OVER (PARTITION BY t._id ORDER BY d._valid_from) AS next_status
+  FROM trucks t
+  JOIN diagnostics FOR ALL VALID_TIME AS d ON d._id = t._id
+  WHERE t.name IS NOT NULL
+),
+breakdown_events AS (
+  SELECT model, truck_id
+  FROM diagnostics_with_next
+  WHERE status > 0 AND next_status = 0
+)
+SELECT model, COUNT(*) AS breakdown_count
+FROM breakdown_events
+GROUP BY model
+HAVING COUNT(*) > 0

--- a/modules/bench/src/main/resources/xtdb/bench/tsbs.sql
+++ b/modules/bench/src/main/resources/xtdb/bench/tsbs.sql
@@ -3,7 +3,7 @@ SELECT t.name, t.driver, r.longitude, r.latitude
 FROM trucks t
 CROSS JOIN LATERAL (
   SELECT longitude, latitude FROM readings FOR ALL VALID_TIME
-  WHERE _id = t._id ORDER BY _valid_from DESC FETCH FIRST 1 ROW ONLY
+  WHERE _id = t._id ORDER BY _valid_from DESC LIMIT 1
 ) AS r
 WHERE t.name IN (:v*:truck-names)
 
@@ -12,7 +12,7 @@ SELECT t.name, t.driver, r.longitude, r.latitude
 FROM trucks t
 CROSS JOIN LATERAL (
   SELECT longitude, latitude FROM readings FOR ALL VALID_TIME
-  WHERE _id = t._id ORDER BY _valid_from DESC FETCH FIRST 1 ROW ONLY
+  WHERE _id = t._id ORDER BY _valid_from DESC LIMIT 1
 ) AS r
 WHERE t.name IS NOT NULL AND t.fleet = :fleet
 
@@ -21,7 +21,7 @@ SELECT t.name, t.driver, d.fuel_state
 FROM trucks t
 CROSS JOIN LATERAL (
   SELECT fuel_state FROM diagnostics FOR ALL VALID_TIME
-  WHERE _id = t._id ORDER BY _valid_from DESC FETCH FIRST 1 ROW ONLY
+  WHERE _id = t._id ORDER BY _valid_from DESC LIMIT 1
 ) AS d
 WHERE t.name IS NOT NULL
   AND t.fleet = :fleet
@@ -32,7 +32,7 @@ SELECT t.name, t.driver, d.current_load
 FROM trucks t
 CROSS JOIN LATERAL (
   SELECT current_load FROM diagnostics FOR ALL VALID_TIME
-  WHERE _id = t._id ORDER BY _valid_from DESC FETCH FIRST 1 ROW ONLY
+  WHERE _id = t._id ORDER BY _valid_from DESC LIMIT 1
 ) AS d
 WHERE t.name IS NOT NULL
   AND t.fleet = :fleet

--- a/modules/datasets/src/main/clojure/xtdb/tsbs.clj
+++ b/modules/datasets/src/main/clojure/xtdb/tsbs.clj
@@ -140,7 +140,9 @@
                    :tags tags
                    :timestamp timestamp
                    :doc (-> (zipmap (get tables table) (map (some-fn parse-long parse-double) cells))
-                            (assoc :xt/id (get tags pk), :xt/valid-from timestamp))})
+                            (assoc :xt/id (get tags pk)
+                                   :xt/valid-from timestamp
+                                   :xt/valid-to (.plus ^Instant timestamp log-interval)))})
 
                 (split-by-ts)
                 (without-unchanged-tags)


### PR DESCRIPTION
Implements all 13 TSBS IoT queries:

Queries now match TSBS IoT benchmark suite:
1. last-loc-by-truck - specific truck lookups
2. last-loc-per-truck - fleet-wide location (these are internal to last-loc in tsbs)
3. low-fuel - threshold < 10%
4. high-load - threshold > 90% capacity
5. stationary-trucks - avg velocity < 1 in time window
6. long-driving-sessions - 4-hour window analysis
7. long-daily-sessions - 24-hour window analysis
8. avg-vs-projected-fuel - actual vs nominal per fleet
9. avg-daily-driving-duration - hours driven per driver per day
10. avg-daily-driving-session - driving periods with CTEs
11. avg-load - per fleet/model
12. daily-activity - active hours per day
13. breakdown-frequency - breakdown events per model

Uses the tsbs execution model:
- Add parameterized query generators for all 13 IoT query types
- Each query instance gets randomized parameters (time windows, trucks, fleets)
- Support multiple query iterations (--query-iterations, default 100, tsbs uses 1000)
- Support parallel workers (--workers, default 1)
- Support burn-in queries (--burn-in, discard timing for warmup queries)
- Calculate and report full statistics: count, min, max, mean, p50, p90, p95, p99

Uses DATE_TRUNC for time bucketing, CTEs for complex queries, and XTDB's FOR VALID_TIME BETWEEN for temporal queries, LAG for avg-daily-driving-session and LEAD for breakdown-frequency.

Slightly better performance using CTEs over LATERAL joins.

## Performance

I compared XTDB and timescaledb, with a reasonable outcome for XTDB I thought:
  
Query Categories & Results

Point-in-time (current state): XTDB wins significantly
- last-loc-*, low-fuel, high-load
- Bitemporality gives us current state "for free" - no aggregation needed
- TimescaleDB must scan and aggregate to find latest values

Time-window aggregates: TimescaleDB wins
- stationary-trucks, long-driving-sessions, long-daily-sessions
- TimescaleDB chunks are time-aligned -> "last 10 minutes" hits one chunk
- XTDB pages are entity-aligned -> must visit all entity pages, extract recent data from each (correct me if I'm wrong)
- Crushes us on stationary-trucks, I don't know how they got 3ms

Full-history aggregates: TimescaleDB wins
- avg-*, daily-activity, breakdown-frequency
- Possibly just competing with postgres query engine here
- Could also benefit from time-alignment

Parameters: 2000 trucks, 7 days, 20 queries/type, 4 workers, burn-in=10
Estimated rows: 8.1M (4.0M readings + 4.0M diagnostics)

| Query | XTDB (ms) | TSDB (ms) | Winner | Factor |
  |---------------------------------------|-----------|-----------|--------|---------|
  | **POINT-IN-TIME (CURRENT STATE)** |
  | last-loc-by-truck | 1264.4 | 6297.6 | XTDB | 5.0x |
  | last-loc-per-truck | 1832.8 | 6297.6 | XTDB | 3.4x |
  | low-fuel | 1228.7 | 5333.1 | XTDB | 4.3x |
  | high-load | 1751.8 | 5323.2 | XTDB | 3.0x |
  | **TIME-WINDOW AGGREGATES** |
  | stationary-trucks | 1560.2 | 3.8 | TSDB | *407.4x |
  | long-driving-sessions | 1653.2 | 47.4 | TSDB | *34.9x |
  | long-daily-sessions | 1594.3 | 279.9 | TSDB | 5.7x |
  | **FULL-HISTORY AGGREGATES** |
  | avg-vs-projected-fuel-consumption | 3195.8 | 273.6 | TSDB | *11.7x |
  | avg-daily-driving-duration | 5383.7 | 2345.4 | TSDB | 2.3x |
  | avg-daily-driving-session | 3158.8 | 2419.2 | TSDB | 1.3x |
  | avg-load | 3738.7 | 160.3 | TSDB | *23.3x |
  | daily-activity | 4903.3 | 2560.8 | TSDB | 1.9x |
  | breakdown-frequency | 3074.4 | 2186.6 | TSDB | 1.4x |

These definitely could be dashboard type queries for truck counts in the thousands but would be taxing beyond that.