### PR TITLE
tidy(db-cat): split components into storage/state/services, for #5212

### DIFF
--- a/core/src/main/clojure/xtdb/block_catalog.clj
+++ b/core/src/main/clojure/xtdb/block_catalog.clj
@@ -4,14 +4,14 @@
             [xtdb.serde :as serde]
             [xtdb.time :as time])
   (:import (xtdb.block.proto Block TxKey)
-           xtdb.catalog.BlockCatalog))
+           (xtdb.catalog BlockCatalog)))
 
 (defmethod ig/expand-key :xtdb/block-catalog [k {:keys [db-name]}]
   {k {:db-name db-name
       :buffer-pool (ig/ref :xtdb/buffer-pool)}})
 
 (defmethod ig/init-key :xtdb/block-catalog [_ {:keys [db-name buffer-pool]}]
-  (BlockCatalog. db-name buffer-pool))
+  (BlockCatalog. db-name (BlockCatalog/getLatestBlock buffer-pool)))
 
 (defn- <-TxKey [^TxKey tx-key]
   (serde/->TxKey (.getTxId tx-key) (time/micros->instant (.getSystemTime tx-key))))

--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -133,9 +133,12 @@
       :query-db (ig/ref :xtdb.db-catalog/for-query)}})
 
 (defmethod ig/init-key ::for-db [_ {{:keys [^Compactor compactor]} :base, :keys [query-db ^Database$Mode mode]}]
-  (if (= mode Database$Mode/READ_ONLY)
-    (.openForDatabase Compactor/NOOP query-db)
-    (.openForDatabase compactor query-db)))
+  (let [allocator (.getAllocator query-db)
+        db-storage (.getStorage query-db)
+        db-state (.getState query-db)]
+    (if (= mode Database$Mode/READ_ONLY)
+      (.openForDatabase Compactor/NOOP allocator db-storage db-state)
+      (.openForDatabase compactor allocator db-storage db-state))))
 
 (defmethod ig/halt-key! ::for-db [_ compactor-for-db]
   (util/close compactor-for-db))

--- a/core/src/main/clojure/xtdb/garbage_collector.clj
+++ b/core/src/main/clojure/xtdb/garbage_collector.clj
@@ -24,7 +24,10 @@
 
 (defmethod ig/init-key :xtdb/garbage-collector [_ {:keys [^Database$Catalog db-cat, enabled? blocks-to-keep garbage-lifetime approx-run-interval]}]
   ;; TODO multi-db
-  (let [gc (GarbageCollector$Impl. (.getPrimary db-cat) (GarbageCollector$Driver/real) blocks-to-keep garbage-lifetime approx-run-interval)]
+  (let [db (.getPrimary db-cat)
+        gc (GarbageCollector$Impl. (.getBufferPool db) (.getState db)
+                                   (GarbageCollector$Driver/real)
+                                   blocks-to-keep garbage-lifetime approx-run-interval)]
     (when enabled? (.start gc))
     gc))
 

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -17,7 +17,7 @@
            (xtdb.api.log Log Log$Cluster$Factory Log$Factory Log$Message$Tx Log$MessageMetadata)
            (xtdb.arrow Relation Vector)
            xtdb.catalog.BlockCatalog
-           (xtdb.database Database Database$Catalog Database$Mode)
+           (xtdb.database Database DatabaseStorage Database$Catalog Database$Mode)
            xtdb.indexer.LogProcessor
            xtdb.table.TableRef
            (xtdb.tx TxOp$DeleteDocs TxOp$EraseDocs TxOp$PatchDocs TxOp$PutDocs TxOp$Sql TxOpts TxWriter)
@@ -259,7 +259,9 @@
 (defmethod ig/init-key :xtdb.log/processor [_ {{:keys [meter-registry db-catalog]} :base
                                                :keys [allocator db indexer compactor block-flush-duration skip-txs enabled? ^Database$Mode mode]}]
   (when enabled?
-    (LogProcessor. allocator meter-registry db-catalog db indexer compactor block-flush-duration (set skip-txs)
+    (LogProcessor. allocator meter-registry db-catalog
+                   (.getStorage db) (.getState db)
+                   indexer compactor block-flush-duration (set skip-txs)
                    (or mode Database$Mode/READ_WRITE))))
 
 (defmethod ig/halt-key! :xtdb.log/processor [_ ^LogProcessor log-processor]

--- a/core/src/main/clojure/xtdb/tx_source.clj
+++ b/core/src/main/clojure/xtdb/tx_source.clj
@@ -207,7 +207,7 @@
                                 decode-record))
                          (catch Exception _ nil))
           refresh! (fn []
-                     (.refresh block-cat)
+                     (.refresh block-cat (BlockCatalog/getLatestBlock buffer-pool))
                      (.refresh table-cat)
                      (.refresh trie-cat))
           last-tx-key (when (or last-message (.getInitialScan tx-source-conf))

--- a/core/src/main/kotlin/xtdb/database/DatabaseState.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseState.kt
@@ -1,0 +1,19 @@
+package xtdb.database
+
+import xtdb.catalog.BlockCatalog
+import xtdb.catalog.TableCatalog
+import xtdb.indexer.LiveIndex
+import xtdb.trie.TrieCatalog
+
+data class DatabaseState(
+    val name: DatabaseName,
+    val blockCatalogOrNull: BlockCatalog?,
+    val tableCatalogOrNull: TableCatalog?,
+    val trieCatalogOrNull: TrieCatalog?,
+    val liveIndexOrNull: LiveIndex?,
+) {
+    val blockCatalog: BlockCatalog get() = blockCatalogOrNull ?: error("no block-catalog")
+    val tableCatalog: TableCatalog get() = tableCatalogOrNull ?: error("no table-catalog")
+    val trieCatalog: TrieCatalog get() = trieCatalogOrNull ?: error("no trie-catalog")
+    val liveIndex: LiveIndex get() = liveIndexOrNull ?: error("no live-index")
+}

--- a/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
@@ -1,0 +1,17 @@
+package xtdb.database
+
+import xtdb.api.log.Log
+import xtdb.metadata.PageMetadata
+import xtdb.storage.BufferPool
+
+data class DatabaseStorage(
+    val sourceLogOrNull: Log?,
+    val projectionLogOrNull: Log?,
+    val bufferPoolOrNull: BufferPool?,
+    val metadataManagerOrNull: PageMetadata.Factory?,
+) {
+    val sourceLog: Log get() = sourceLogOrNull ?: error("no source-log")
+    val projectionLog: Log get() = projectionLogOrNull ?: error("no projection-log")
+    val bufferPool: BufferPool get() = bufferPoolOrNull ?: error("no buffer-pool")
+    val metadataManager: PageMetadata.Factory get() = metadataManagerOrNull ?: error("no metadata-manager")
+}

--- a/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
@@ -2,6 +2,8 @@ package xtdb.garbage_collector
 
 import org.slf4j.LoggerFactory
 import xtdb.catalog.BlockCatalog
+import xtdb.catalog.BlockCatalog.Companion.allBlockFiles
+import xtdb.catalog.BlockCatalog.Companion.tableBlocks
 import xtdb.storage.BufferPool
 import xtdb.util.StringUtil.fromLexHex
 import java.nio.file.Path
@@ -32,7 +34,7 @@ class BlockGarbageCollector(
     fun garbageCollectBlocks(blocksToKeep: Int = this.blocksToKeep) {
         LOGGER.debug("Garbage collecting blocks, keeping $blocksToKeep blocks")
 
-        blockCatalog.allBlockFiles
+        bufferPool.allBlockFiles.toList()
             .dropLast(blocksToKeep)
             .let { blocks ->
                 LOGGER.debug("Deleting oldest ${blocks.size} block files")
@@ -43,7 +45,7 @@ class BlockGarbageCollector(
             .shuffled().take(100)
             .forEach { table ->
                 LOGGER.debug("Garbage collecting blocks for table {}, keeping {} blocks", table.sym, blocksToKeep)
-                blockCatalog.tableBlocks(table).toList()
+                bufferPool.tableBlocks(table).toList()
                     .dropLast(blocksToKeep)
                     .let { blocks ->
                         LOGGER.debug("Deleting oldest ${blocks.size} table block files")

--- a/core/src/main/kotlin/xtdb/garbage_collector/GarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/GarbageCollector.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.plus
 import org.slf4j.LoggerFactory
+import xtdb.catalog.BlockCatalog.Companion.blockFromLatest
 import xtdb.database.IDatabase
 import xtdb.table.TableRef
 import xtdb.time.microsAsInstant
@@ -72,7 +73,7 @@ interface GarbageCollector : Closeable {
         private val blockGc = BlockGarbageCollector(blockCatalog, bufferPool, blocksToKeep)
 
         private fun defaultGarbageAsOf(): Instant? =
-            blockCatalog.blockFromLatest(blocksToKeep)
+            bufferPool.blockFromLatest(blocksToKeep)
                 ?.let { it.latestCompletedTx.systemTime.microsAsInstant - garbageLifetime }
 
         // For testing

--- a/core/src/test/kotlin/xtdb/garbage_collector/GarbageCollectorMockDriver.kt
+++ b/core/src/test/kotlin/xtdb/garbage_collector/GarbageCollectorMockDriver.kt
@@ -1,7 +1,8 @@
 package xtdb.garbage_collector
 
 import kotlinx.coroutines.yield
-import xtdb.database.IDatabase
+import xtdb.database.DatabaseState
+import xtdb.storage.BufferPool
 import xtdb.table.TableRef
 import xtdb.trie.TrieKey
 import xtdb.util.debug
@@ -17,11 +18,10 @@ class GarbageCollectorMockDriver() : GarbageCollector.Driver.Factory {
     val deletedPaths = mutableListOf<Path>()
     val deletedTrieKeys = mutableMapOf<TableRef, MutableSet<TrieKey>>()
 
-    override fun create(db: IDatabase) = ForDatabase(db, nextSystemId++)
+    override fun create(bufferPool: BufferPool, dbState: DatabaseState) = ForDatabase(bufferPool, dbState, nextSystemId++)
 
-    inner class ForDatabase(val db: IDatabase, val systemId: Int) : GarbageCollector.Driver {
-        private val bufferPool = db.bufferPool
-        private val trieCatalog = db.trieCatalog
+    inner class ForDatabase(val bufferPool: BufferPool, val dbState: DatabaseState, val systemId: Int) : GarbageCollector.Driver {
+        private val trieCatalog = dbState.trieCatalog
 
         override suspend fun deletePath(path: Path) {
             yield()

--- a/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
@@ -10,6 +10,7 @@ import xtdb.api.storage.Storage
 import xtdb.block.proto.block
 import xtdb.block.proto.txKey
 import xtdb.cache.MemoryCache
+import xtdb.catalog.BlockCatalog.Companion.latestBlock
 import xtdb.garbage_collector.BlockGarbageCollector
 import xtdb.storage.BufferPool
 import xtdb.test.AllocatorResolver
@@ -62,7 +63,7 @@ class BlockGarbageCollectorTest {
                 assertBlockCount(bufferPool, table1BlockPath, 10)
                 assertBlockCount(bufferPool, table2BlockPath, 10)
 
-                val blockCat = BlockCatalog("xtdb", bufferPool)
+                val blockCat = BlockCatalog("xtdb", bufferPool.latestBlock)
 
                 val gc = BlockGarbageCollector(blockCat, bufferPool, blocksToKeep = 3)
 


### PR DESCRIPTION
## Summary

Single-writer block files (#5212) requires running two separate processors with separate catalog instances:
- Query processor (all nodes): indexes for freshness, never writes blocks
- Indexing processor (leader only): writes blocks to object store

Clean separation of State from I/O makes it easier to instantiate multiple independent catalog sets.
Each processor gets its own State instance; they share Storage.

This PR extracts `DatabaseStorage` and `DatabaseState` as separate data classes from `Database`, following a layered architecture:

- **Storage** (I/O layer): logs, buffer pool, metadata manager
- **State** (in-memory holders): catalogs, live index
- **Services** (orchestration): LogProcessor, Compactor, GarbageCollector

**Dependency aims:**
- Services talk to both Storage and State
- State talks to nothing at runtime - it only yields data, callers do I/O
- State uses Storage at startup only (to hydrate from disk)

This is "Functional Core, Imperative Shell" - state components are pure data holders, services handle all I/O.

In hexagonal architecture terms: State is the domain core, Storage is the ports/adapters layer, Services are the application layer that coordinates between them.

**Other changes:**
- Nullable fields use `fooOrNull` pattern with throwing getters - test mocks provide only what they need
- `IDatabase` interface removed - no longer necessary
- `Driver.Factory` interfaces take `dbStorage` and `dbState` directly, eliminating mock registration patterns

## Component placement

**DatabaseStorage** (I/O layer / ports & adapters):
- `sourceLog` / `projectionLog` - transaction logs
- `bufferPool` - manages Arrow file I/O
- `metadataManager` - page metadata factory

**DatabaseState** (in-memory state / domain core):
- `name` - database identifier
- `blockCatalog` - tracks completed blocks
- `tableCatalog` - table metadata
- `trieCatalog` - trie file catalog
- `liveIndex` - current block's in-memory index

## How Storage and State travel together

Services need both: State to know what exists, Storage to read/write files.
The `Driver.Factory` interfaces now take both as parameters:

```kotlin
interface Factory {
    fun create(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState): Driver
}
```

This pattern appears in Compactor, GarbageCollector, and LogProcessor.

## Nullable fields for testability

Both classes use nullable backing fields with throwing getters:

```kotlin
data class DatabaseStorage(
    val sourceLogOrNull: Log?,
    val bufferPoolOrNull: BufferPool?,
    // ...
) {
    val sourceLog: Log get() = sourceLogOrNull ?: error("no source-log")
    val bufferPool: BufferPool get() = bufferPoolOrNull ?: error("no buffer-pool")
}
```

Test mocks provide only what they need:
```kotlin
val dbStorage = DatabaseStorage(null, null, bufferPool, null)
val dbState = DatabaseState(name, null, null, trieCatalog, null)
```

This eliminated `IDatabase` interface - test mocks are simple data classes.

## Test plan

- [x] Compilation passes
- [x] Property tests pass (including simulation tests)

🤖 Generated with [Claude Code](https://claude.ai/code)