### PR TITLE
Build a custom JRE with jlink to shrink docker images 70%

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
-/build/resources/test/
-/src/test/
-/docs/
-.git
-docker-compose.yml
-Dockerfile.*
+# Ignore everything, then allow only what Docker builds need
+*
+
+!docker/standalone/
+!docker/aws/
+!docker/azure/
+!docker/google-cloud/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 # Ignore everything, then allow only what Docker builds need
 *
 
+!gradlew
+!gradle/wrapper/
+!build-logic/jlink/
 !docker/standalone/
 !docker/aws/
 !docker/azure/

--- a/build-logic/jlink/build.gradle.kts
+++ b/build-logic/jlink/build.gradle.kts
@@ -1,0 +1,50 @@
+plugins {
+    java
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+// To re-run:
+// 1) ./gradlew :docker:standalone:shadowJar
+// 2) jdeps --ignore-missing-deps --print-module-deps docker/standalone/build/libs/xtdb-standalone.jar
+val jlinkModules = listOf(
+    // from jdeps
+    "java.base", "java.compiler", "java.desktop", "java.instrument",
+    "java.naming", "java.prefs", "java.security.jgss", "java.sql",
+    "jdk.jdi", "jdk.management", "jdk.unsupported",
+
+    // manual additions
+    "java.logging",
+    "java.net.http",
+)
+
+val customJreDir = layout.buildDirectory.dir("custom-jre")
+
+val toolchainLauncher = extensions.getByType(JavaToolchainService::class.java)
+    .launcherFor(java.toolchain)
+
+tasks.register<Exec>("buildCustomJre") {
+    description = "Build a custom JRE using jlink"
+    val outputDir = customJreDir.get().asFile
+    val jlinkPath = toolchainLauncher.map {
+        it.metadata.installationPath.file("bin/jlink").asFile.absolutePath
+    }
+
+    inputs.property("modules", jlinkModules.joinToString(","))
+    inputs.property("jlinkPath", jlinkPath)
+    outputs.dir(outputDir)
+
+    doFirst { outputDir.deleteRecursively() }
+
+    commandLine(
+        jlinkPath.get(),
+        "--add-modules", jlinkModules.joinToString(","),
+        "--strip-debug", "--no-man-pages", "--no-header-files",
+        "--compress=zip-6",
+        "--output", outputDir.absolutePath
+    )
+}

--- a/build-logic/jlink/settings.gradle.kts
+++ b/build-logic/jlink/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "xtdb-jlink"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,8 +38,8 @@ VOLUME /var/lib/xtdb
 ENV GIT_SHA=${GIT_SHA}
 ENV XTDB_VERSION=${XTDB_VERSION}
 
-COPY ${VARIANT}/*.yaml ./
-COPY ${VARIANT}/build/libs/xtdb-${VARIANT}.jar xtdb.jar
+COPY docker/${VARIANT}/*.yaml ./
+COPY docker/${VARIANT}/build/libs/xtdb-${VARIANT}.jar xtdb.jar
 
 RUN addgroup -g 20000 xtdb && adduser -u 20000 -G xtdb -D -H xtdb
 RUN mkdir -p /home/xtdb && chown -R xtdb:xtdb /home/xtdb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,14 @@
-FROM eclipse-temurin:21-jre-alpine
+# Build JRE
+FROM eclipse-temurin:21-jdk-alpine AS jlink
+WORKDIR /build
+COPY gradlew gradlew
+COPY gradle/wrapper gradle/wrapper
+COPY build-logic/jlink/settings.gradle.kts settings.gradle.kts
+COPY build-logic/jlink/build.gradle.kts build.gradle.kts
+RUN chmod +x gradlew && ./gradlew buildCustomJre --no-daemon
+
+# Runtime
+FROM alpine:3.23.3
 
 ARG VARIANT=standalone
 ARG GIT_SHA
@@ -12,6 +22,13 @@ LABEL org.opencontainers.image.revision=${GIT_SHA}
 
 LABEL usage="Example docker-run options for custom logging configuration: \
 --volume .:/config --env JDK_JAVA_OPTIONS='-Dlogback.configurationFile=/config/logback.xml'"
+
+# For healthcheck
+RUN apk add --no-cache wget
+
+COPY --from=jlink /build/build/custom-jre /opt/java
+ENV PATH="/opt/java/bin:$PATH"
+ENV JAVA_HOME="/opt/java"
 
 WORKDIR /usr/local/lib/xtdb
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21
+FROM eclipse-temurin:21-jre-alpine
 
 ARG VARIANT=standalone
 ARG GIT_SHA
@@ -26,7 +26,7 @@ ENTRYPOINT ["java", \
 CMD ["-f", "config.yaml"]
 
 HEALTHCHECK --start-period=15s --timeout=3s \
-    CMD curl -f http://localhost:8080/healthz/alive || exit 1
+    CMD wget -q --spider http://localhost:8080/healthz/alive || exit 1
 
 EXPOSE 5432
 EXPOSE 3000
@@ -41,7 +41,7 @@ ENV XTDB_VERSION=${XTDB_VERSION}
 COPY ${VARIANT}/*.yaml ./
 COPY ${VARIANT}/build/libs/xtdb-${VARIANT}.jar xtdb.jar
 
-RUN groupadd -g 20000 xtdb && useradd -u 20000 -g 20000 -r xtdb
+RUN addgroup -g 20000 xtdb && adduser -u 20000 -G xtdb -D -H xtdb
 RUN mkdir -p /home/xtdb && chown -R xtdb:xtdb /home/xtdb
 RUN chown -R xtdb:xtdb /var/lib/xtdb
 

--- a/docker/scripts/build-aws-image.sh
+++ b/docker/scripts/build-aws-image.sh
@@ -2,15 +2,15 @@
 
 set -e
 (
-    cd $(dirname $0)/..
+    cd $(dirname $0)/../..
 
-    if [ "$1" == "--clean" ] || ! [ -e aws/build/libs/xtdb-aws.jar ]; then
-        ../gradlew :docker:aws:shadowJar
+    if [ "$1" == "--clean" ] || ! [ -e docker/aws/build/libs/xtdb-aws.jar ]; then
+        ./gradlew :docker:aws:shadowJar
     fi
 
     sha=$(git rev-parse --short HEAD)
 
     echo Building Docker image ...
-    docker build -t xtdb/xtdb-aws --build-arg VARIANT=aws --build-arg GIT_SHA="$sha" --build-arg XTDB_VERSION="${XTDB_VERSION:-2-SNAPSHOT}" --output type=docker -f Dockerfile .
+    docker build -t xtdb/xtdb-aws --build-arg VARIANT=aws --build-arg GIT_SHA="$sha" --build-arg XTDB_VERSION="${XTDB_VERSION:-2-SNAPSHOT}" --output type=docker -f docker/Dockerfile .
     echo Done
 )

--- a/docker/scripts/build-standalone-image.sh
+++ b/docker/scripts/build-standalone-image.sh
@@ -2,15 +2,15 @@
 
 set -e
 (
-    cd $(dirname $0)/..
+    cd $(dirname $0)/../..
 
-    if [ "$1" == "--clean" ] || ! [ -e standalone/build/libs/xtdb-standalone.jar ]; then
-        ../gradlew :docker:standalone:shadowJar
+    if [ "$1" == "--clean" ] || ! [ -e docker/standalone/build/libs/xtdb-standalone.jar ]; then
+        ./gradlew :docker:standalone:shadowJar
     fi
 
     sha=$(git rev-parse --short HEAD)
 
     echo Building Docker image ...
-    docker build -t ghcr.io/xtdb/xtdb:dev --build-arg VARIANT=standalone --build-arg GIT_SHA="$sha" --build-arg XTDB_VERSION="${XTDB_VERSION:-2-SNAPSHOT}" --output type=docker -f Dockerfile .
+    docker build -t ghcr.io/xtdb/xtdb:dev --build-arg VARIANT=standalone --build-arg GIT_SHA="$sha" --build-arg XTDB_VERSION="${XTDB_VERSION:-2-SNAPSHOT}" --output type=docker -f docker/Dockerfile .
     echo Done
 )

--- a/lang/docker-compose.yml
+++ b/lang/docker-compose.yml
@@ -1,12 +1,13 @@
 services:
   xtdb:
     build:
-      context: ../docker
+      context: ..
+      dockerfile: docker/Dockerfile
       args:
         VARIANT: standalone
     command: ["playground", "--port", "5439"]
     healthcheck:
-      test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/localhost/5439'"]
+      test: ["CMD", "nc", "-z", "localhost", "5439"]
       interval: 5s
       timeout: 3s
       retries: 3

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,7 @@
 rootProject.name = "xtdb"
 
+includeBuild("build-logic/jlink")
+
 include("api", "core", "main")
 project(":api").name = "xtdb-api"
 project(":core").name = "xtdb-core"


### PR DESCRIPTION
Inspired by [jbundle: Distributing Clojure Without the GraalVM Pain](https://avelino.run/jbundle-distributing-clojure-without-the-graalvm-pain/)

## Changes

- Use alpine as base for docker image
- Use jlink to build a custom JRE reducing image size from **565MB -> 160MB (71% reduction)**
- Wire the same custom JRE into local dev to keep dev and production environments aligned
- Add `-PfullJdk` escape hatch to bypass the above

## Motivation

The existing XTDB Docker images ship with a full JDK which (+ the xtdb jar) weighs in at 565MB.
By reducing this size we can reduce download times and volumes for users.

For contrast `postgres:17-alpine` comes in at 274MB.

## Size savings at each step

| Base image | Image size | Delta |
|-----------|-----------|-------|
| `eclipse-temurin:21` (full JDK) | **565MB** | — |
| `eclipse-temurin:21-jre-alpine` | **294MB** | -48% |
| `alpine:latest` + custom JRE | **160MB** | -71% total |