### PR TITLE
tidy(allium): verify specs against code, fix discrepancies

### DIFF
--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -1,14 +1,15 @@
 -- live-index.allium
 --
--- NOTE: generated, unverified. may contain errors.
---
 -- Scope: In-memory staging for transactions before block compaction
 -- Includes: LiveIndex, LiveTable, row operations, transaction lifecycle, snapshot visibility
 -- Excludes: Block storage, trie serialization, Arrow memory management
 --
 -- Concurrency model:
 --   - Single-writer thread: all transaction operations (StartTransaction, LogPut,
---     CommitTransaction, AbortTransaction, FinishBlock, NextBlock) execute serially
+--     CommitTransaction, AbortTransaction, FinishBlock, NextBlock) execute serially.
+--     This is enforced structurally: the LogProcessor (see db.allium) processes
+--     source-log messages sequentially, and all transaction lifecycle happens
+--     within that sequential processing loop.
 --   - Multiple concurrent readers: snapshots can be held and read concurrently
 --   - Writes don't block reads: persistent data structures ensure existing snapshots
 --     remain valid while new transactions commit
@@ -44,18 +45,29 @@ value ValidTimeRange {
 }
 
 value Row {
+    -- Stored as a row in an Arrow relation.
+    -- The op column is an Arrow union with three legs: put, delete, erase.
+    -- See: LiveTable.kt (liveRelation, txRelation)
     iid: IID
     system_from: Timestamp
     valid_time: ValidTimeRange
-    op: Put | Delete | Erase
+    op: Op
+}
+
+union Op {
+    -- Arrow DenseUnion: exactly one leg is populated per row.
+    put: Put
+    delete: Delete
+    erase: Erase
 }
 
 value Put {
+    -- The put leg is a struct containing the document columns.
     doc: Document
 }
 
-value Delete { }
-value Erase { }
+value Delete { }   -- null marker in the "delete" leg
+value Erase { }    -- null marker in the "erase" leg
 
 ------------------------------------------------------------
 -- Entities
@@ -151,18 +163,25 @@ rule StartTransaction {
 }
 
 rule GetTableTx {
+    -- Idempotent: returns the existing LiveTableTx if one already exists for this tx and table.
+    -- See: live_index.clj (computeIfAbsent on table-txs)
     when: GetTableTx(tx, table_ref)
-
-    let existing_table = tx.index.tables.find(t => t.table_ref = table_ref)
 
     requires: tx.status = active
 
-    ensures: LiveTableTx.created(
-        transaction: tx,
-        table_ref: table_ref,
-        live_table: existing_table,
-        rows: {}
-    )
+    let existing_table_tx = tx.table_txs.find(tt => tt.table_ref = table_ref)
+
+    ensures:
+        if existing_table_tx != null:
+            existing_table_tx
+        else:
+            let existing_table = tx.index.tables.find(t => t.table_ref = table_ref)
+            LiveTableTx.created(
+                transaction: tx,
+                table_ref: table_ref,
+                live_table: existing_table,
+                rows: {}
+            )
 }
 
 ------------------------------------------------------------
@@ -178,8 +197,7 @@ rule LogPut {
         iid: iid,
         system_from: table_tx.transaction.system_from,
         valid_time: valid_time,
-        op: put,
-        doc: doc
+        op: Op.put(Put{ doc: doc })
     })
 }
 
@@ -192,8 +210,7 @@ rule LogDelete {
         iid: iid,
         system_from: table_tx.transaction.system_from,
         valid_time: valid_time,
-        op: delete,
-        doc: null
+        op: Op.delete(Delete{})
     })
 }
 
@@ -206,8 +223,7 @@ rule LogErase {
         iid: iid,
         system_from: table_tx.transaction.system_from,
         valid_time: erase_valid_time,
-        op: erase,
-        doc: null
+        op: Op.erase(Erase{})
     })
 }
 

--- a/allium/memory-hash-trie.allium
+++ b/allium/memory-hash-trie.allium
@@ -1,7 +1,5 @@
 -- memory-hash-trie.allium
 --
--- NOTE: generated, unverified. may contain errors.
---
 -- Scope: In-memory hierarchical hash trie for row index organization
 -- Includes: MemoryHashTrie, MutableMemoryHashTrie, Node (Branch/Leaf), log compaction
 -- Excludes: Arrow serialization, disk persistence, ArrowHashTrie
@@ -89,8 +87,12 @@ entity Leaf extends Node {
     log: List<Integer>         -- UNSORTED indices (recent additions, up to log_limit)
     log_count: Integer         -- number of valid entries in log
 
-    -- Mutable cache for merged result (breaks pure immutability for performance)
-    sorted_data_cache: List<Integer>?
+    -- Volatile cache for merged result.
+    -- Multiple concurrent readers may race on this field; since the result is
+    -- deterministic, the worst case is redundant computation.
+    -- Must be @Volatile to ensure visibility across threads on weak memory models.
+    -- See: MemoryHashTrie.kt (Leaf.sortedData)
+    sorted_data_cache: volatile List<Integer>?
 
     total_count: data.count + log_count
 }
@@ -228,7 +230,9 @@ rule SplitIntoBranch {
             if buckets[bucket_idx] != null:
                 Leaf.created(
                     path: leaf.path.append(bucket_idx),
-                    data: buckets[bucket_idx]
+                    data: buckets[bucket_idx],
+                    log: empty_log(trie.log_limit),
+                    log_count: 0
                 )
             else:
                 null

--- a/core/src/main/kotlin/xtdb/trie/MemoryHashTrie.kt
+++ b/core/src/main/kotlin/xtdb/trie/MemoryHashTrie.kt
@@ -92,7 +92,10 @@ class MemoryHashTrie(
         val data: IntArray = IntArray(0),
         val log: IntArray = IntArray(logLimit),
         private val logCount: Int = 0,
-        private var sortedData: IntArray? = null
+        // Volatile: concurrent readers may race on mergeSort; the result is deterministic
+        // so the worst case is redundant computation, but without volatile a reader on a
+        // weak memory model might never see the cached value.
+        @Volatile private var sortedData: IntArray? = null
     ) : Node {
 
         override val hashChildren = null

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -257,6 +257,11 @@ rule ProcessTriesAddedMessage {
 -- read-only nodes wait for blocks to appear from the primary.
 
 rule LeaderFinishesBlock {
+    -- log_timestamp is the log timestamp of the message that triggered the flush
+    -- (either the transaction that filled the block, or a FlushBlock message).
+    -- This becomes the as_of for trie registration, used later by GC to determine
+    -- deletion eligibility. The 24-hour garbage_lifetime grace period absorbs
+    -- any practical difference between these two sources.
     when: BlockFlushNeeded(log_timestamp)
 
     requires: database.mode == read_write
@@ -276,12 +281,20 @@ rule LeaderFinishesBlock {
         -- Register tries locally.
         trie_cat/trie_catalog.addTries(tries, log_timestamp)
 
+        -- Update table catalog with new metadata from finished tables.
+        -- The leader updates in-memory via finishBlock (merges delta metadata);
+        -- the follower achieves the same result via refresh (reloads from object store).
+        -- See: table_catalog.clj (finishBlock), TableCatalog (refresh)
+        table_catalog.finishBlock(finished_tables)
+
         -- Persist block to object store.
         Block.created(
             block_index: block_index,
             latest_completed_tx: live_index.latest_completed_tx,
             latest_processed_msg_id: log_processor.latest_processed_msg_id
         )
+
+        block_catalog.refresh(block)
 
         -- Reset for next block.
         live_index.nextBlock()

--- a/dev/doc/gc.allium
+++ b/dev/doc/gc.allium
@@ -48,9 +48,9 @@ config {
 -- This ensures recently-superseded tries survive long enough for in-flight queries to finish.
 --
 -- L0 files are excluded from trie GC.
--- L0 files are the input to L0→L1 compaction, and compaction timing is unpredictable.
--- The time-based grace period used by trie GC cannot guarantee that compaction has
--- finished reading an L0 file before it becomes eligible for deletion.
+-- L0 forms a complete set of the data, so if anything goes wrong with deeper levels
+-- we can reconstruct them entirely from the L0s. This has proved valuable on several
+-- occasions during compactor development.
 -- L0 files are small relative to compacted data (one per block, typically ~100K rows)
 -- so the storage overhead of retaining them is negligible.
 -- See: trie_catalog.clj (garbage-fn)

--- a/dev/doc/gc.allium
+++ b/dev/doc/gc.allium
@@ -40,17 +40,26 @@ config {
 
 -- A trie is eligible for deletion when:
 --   1. Its state is garbage (set by addTries when a new trie supersedes it).
---   2. Its level is not 0 (L0 files are never garbage-collected; they are ephemeral).
+--   2. Its level is not 0 (see below).
 --   3. Its garbage_as_of is <= the as_of threshold.
 --
 -- The as_of threshold provides a grace period:
 --   as_of = system_time_of(block[latest - config.blocks_to_keep]) - config.garbage_lifetime
 -- This ensures recently-superseded tries survive long enough for in-flight queries to finish.
+--
+-- L0 files are excluded from trie GC.
+-- L0 files are the input to L0→L1 compaction, and compaction timing is unpredictable.
+-- The time-based grace period used by trie GC cannot guarantee that compaction has
+-- finished reading an L0 file before it becomes eligible for deletion.
+-- L0 files are small relative to compacted data (one per block, typically ~100K rows)
+-- so the storage overhead of retaining them is negligible.
+-- See: trie_catalog.clj (garbage-fn)
 
 -- GC is scheduled externally on a periodic timer.
 -- See: garbage_collector/GarbageCollector.kt (scheduleGc)
 
 -- Returns the system_time of the block at `n` positions back from latest.
+-- Returns null if fewer than `n` blocks exist.
 -- See: buffer_pool/BufferPool.kt (blockFromLatest)
 deferred latest_block_system_time(n: Int) -> Instant?
 
@@ -58,7 +67,13 @@ rule GarbageCollectorRuns {
     -- See: garbage_collector/GarbageCollector.kt
     when: GarbageCollectionScheduled()  -- external, periodic
 
-    let as_of = latest_block_system_time(config.blocks_to_keep) - config.garbage_lifetime
+    let block_time = latest_block_system_time(config.blocks_to_keep)
+
+    -- If there aren't enough blocks yet, skip GC entirely.
+    -- See: GarbageCollector.kt (defaultGarbageAsOf returning null, short-circuit via ?: return)
+    requires: block_time != null
+
+    let as_of = block_time - config.garbage_lifetime
 
     let eligible = trie_cat/trie_catalog.tries.values.flatten
         .filter(t => t.trie_state == garbage

--- a/dev/doc/trie-cat.allium
+++ b/dev/doc/trie-cat.allium
@@ -113,15 +113,34 @@ context {
 
 entity TrieCatalog {
     -- See: trie/TrieCatalog.kt, trie_catalog.clj
-    -- Per-table map of trie key to trie details, grouped by shard (level, recency, part).
-    -- Each shard tracks live, nascent and garbage sets independently.
-    tries: Map<TableRef, Map<TrieKey, TrieDetails>>
-
+    --
+    -- Per-table catalog, keyed by shard = (level, recency, part).
+    -- Each shard holds three ordered lists (by block_index descending): live, nascent, garbage.
+    -- Also tracks max_block_index per shard for staleness detection.
+    --
     -- addTries(tries, as_of): register new tries, transitioning superseded inputs to garbage.
-    --   Each TrieDetails carries its own table reference.
     -- refresh: rebuild the entire catalog from block metadata in the object store.
     --   Used by read-only followers after a new block appears.
     -- deleteTries(tries): remove garbage entries from the catalog after file deletion.
+    tries: Map<TableRef, Map<Shard, ShardState>>
+}
+
+value Shard = (level: Long, recency: LocalDate?, part: List<Long>)
+
+value ShardState {
+    live: List<TrieDetails>       -- ordered by block_index descending
+    nascent: List<TrieDetails>    -- ordered by block_index descending
+    garbage: List<TrieDetails>    -- ordered by block_index descending
+    max_block_index: Long
+}
+
+------------------------------------------------------------
+-- Config
+------------------------------------------------------------
+
+config {
+    branch_factor: Integer = 4
+    file_size_target: Long = 104857600   -- 100 MB
 }
 
 ------------------------------------------------------------
@@ -133,8 +152,197 @@ rule TriesAdded {
     when: TriesAdded(tries, as_of)
 
     ensures:
-        trie_catalog.addTries(tries, as_of)
+        for each trie in tries:
+            trie_catalog.applyTrieNotification(trie, as_of)
 }
+
+rule ApplyTrieNotification {
+    -- Idempotent: stale notifications (already-seen block indices) are skipped.
+    -- Messages have a total ordering within their shard, so we only ever prepend.
+    -- See: trie_catalog.clj (apply-trie-notification, stale-msg?)
+    when: ApplyTrieNotification(trie, as_of)
+
+    let shard = (trie.level, trie.recency, trie.part)
+    let shard_state = trie_catalog.tries[trie.table][shard]
+
+    requires: not stale(shard_state, trie.block_index)
+    -- stale iff shard_state.max_block_index >= trie.block_index
+
+    ensures: InsertTrie(trie, as_of)
+}
+
+------------------------------------------------------------
+-- Rules: InsertTrie
+--
+-- The insertion strategy varies by level and recency.
+-- Key concepts:
+--   Levelled: the new trie supersedes partial (< file_size_target) predecessors
+--     in the same shard. Used for L1C, L2H.
+--   Tiered: the new trie is added alongside existing tries without superseding.
+--     Used for L1H, L2+C, L3+H.
+--   Nascent: the trie is not yet queryable; it becomes live when a completion
+--     condition is met (L1C arrives for L1H; all partition siblings arrive for L2+).
+--
+-- See: trie_catalog.clj (insert-trie)
+------------------------------------------------------------
+
+rule InsertTrie_L0 {
+    -- L0 files are always live immediately.
+    when: InsertTrie(trie, as_of) where trie.level == 0
+
+    ensures:
+        add trie as :live to shard [0, trie.recency, trie.part]
+}
+
+rule InsertTrie_L1H {
+    -- L1H files are nascent until the corresponding L1C file arrives.
+    -- When the L1C with the same (or later) block_index appears, it marks them live.
+    -- See: trie_catalog.clj (insert-trie, level 1 with recency)
+    when: InsertTrie(trie, as_of) where trie.level == 1 and trie.recency != null
+
+    let l1c_shard = trie_catalog.tries[trie.table][(1, null, trie.part)]
+    let l1c_latest = l1c_shard.live.first   -- highest block_index
+
+    let state =
+        if l1c_latest != null and l1c_latest.block_index >= trie.block_index:
+            :live    -- L1C already exists that covers this block
+        else:
+            :nascent -- wait for L1C
+
+    ensures:
+        add trie as state to shard [1, trie.recency, trie.part]
+        -- Track recency so that when L1C arrives, it can find these L1H files.
+        record l1h_recency(trie.block_index, trie.recency)
+}
+
+rule InsertTrie_L1C {
+    -- L1C is levelled: supersedes partial (< file_size_target) L1C files.
+    -- Also supersedes L0 files and marks pending L1H files as live.
+    -- See: trie_catalog.clj (insert-trie, level 1 without recency)
+    when: InsertTrie(trie, as_of) where trie.level == 1 and trie.recency == null
+
+    ensures:
+        -- 1. Mark any L1H files for this block_index as live.
+        for each recency in l1h_recencies(trie.block_index):
+            mark_block_index_live(shard [1, recency, []], trie.block_index)
+
+        -- 2. Supersede partial L1C files (levelled insertion).
+        supersede_partial([1, null, []], trie, as_of)
+        add trie as :live to shard [1, null, []]
+
+        -- 3. Supersede L0 files up to this block_index.
+        supersede_by_block_index([0, null, []], trie.block_index, as_of)
+}
+
+rule InsertTrie_L2H {
+    -- L2H is levelled: supersedes partial L2H files and the L1H inputs.
+    -- See: trie_catalog.clj (insert-trie, level 2 with recency)
+    when: InsertTrie(trie, as_of) where trie.level == 2 and trie.recency != null
+
+    ensures:
+        -- Supersede partial L2H files (levelled insertion).
+        supersede_partial([2, trie.recency, trie.part], trie, as_of)
+        add trie as :live to shard [2, trie.recency, trie.part]
+
+        -- Supersede L1H inputs up to this block_index.
+        supersede_by_block_index([1, trie.recency, []], trie.block_index, as_of)
+}
+
+rule InsertTrie_General {
+    -- L2+C, L3+H: tiered with partition-group completion.
+    -- The trie starts as nascent. When all siblings in the partition group
+    -- (branch_factor siblings sharing the same parent part prefix) are present,
+    -- all become live and the prior level is superseded.
+    -- See: trie_catalog.clj (insert-trie, default case)
+    when: InsertTrie(trie, as_of)
+        where not (trie.level == 0
+                   or (trie.level == 1)
+                   or (trie.level == 2 and trie.recency != null))
+
+    ensures:
+        add trie as :nascent to shard [trie.level, trie.recency, trie.part]
+
+        if completed_part_group(trie):
+            -- All branch_factor siblings exist for this block_index.
+            mark_part_group_live(trie)
+
+            -- Supersede prior level: parent shard at (level - 1, recency, pop(part)).
+            let parent_part = if trie.part.non_empty: trie.part.pop else trie.part
+            supersede_by_block_index(
+                [trie.level - 1, trie.recency, parent_part],
+                trie.block_index, as_of
+            )
+}
+
+------------------------------------------------------------
+-- Rules: Supersession helpers
+------------------------------------------------------------
+
+rule supersede_partial {
+    -- Levelled supersession: mark live tries as garbage if they are partial
+    -- (data_file_size < file_size_target) and have block_index <= the new trie's.
+    -- See: trie_catalog.clj (supersede-partial-tries)
+    when: supersede_partial(shard, new_trie, as_of)
+
+    ensures:
+        for each live_trie in shard.live
+            where live_trie.data_file_size < config.file_size_target
+              and live_trie.block_index <= new_trie.block_index:
+            transition live_trie to :garbage with garbage_as_of = as_of
+}
+
+rule supersede_by_block_index {
+    -- Unconditional supersession: mark all live tries as garbage
+    -- if their block_index <= the given block_index.
+    -- See: trie_catalog.clj (supersede-by-block-idx)
+    when: supersede_by_block_index(shard, block_index, as_of)
+
+    ensures:
+        for each live_trie in shard.live
+            where live_trie.block_index <= block_index:
+            transition live_trie to :garbage with garbage_as_of = as_of
+}
+
+rule completed_part_group {
+    -- True when all branch_factor siblings at (level, recency, parent_part ++ [0..3])
+    -- have max_block_index >= the new trie's block_index.
+    -- See: trie_catalog.clj (completed-part-group?, sibling-tries)
+    when: completed_part_group(trie) -> Boolean
+
+    let parent_part = trie.part.pop
+    ensures:
+        for each p in 0..(config.branch_factor - 1):
+            let sibling_shard = trie_catalog.tries[trie.table][(trie.level, trie.recency, parent_part ++ [p])]
+            sibling_shard.max_block_index >= trie.block_index
+}
+
+rule mark_part_group_live {
+    -- Transition all nascent tries at the given block_index across the partition group to live.
+    -- See: trie_catalog.clj (mark-part-group-live, mark-block-idx-live)
+    when: mark_part_group_live(trie)
+
+    let parent_part = trie.part.pop
+    ensures:
+        for each p in 0..(config.branch_factor - 1):
+            let shard = [trie.level, trie.recency, parent_part ++ [p]]
+            mark_block_index_live(shard, trie.block_index)
+}
+
+rule mark_block_index_live {
+    -- Find a nascent trie at the given block_index and transition it to live.
+    -- See: trie_catalog.clj (mark-block-idx-live)
+    when: mark_block_index_live(shard, block_index)
+
+    let nascent_trie = shard.nascent.find(t => t.block_index == block_index)
+
+    ensures:
+        if nascent_trie != null:
+            transition nascent_trie from :nascent to :live
+}
+
+------------------------------------------------------------
+-- Rules: Refresh and Delete
+------------------------------------------------------------
 
 rule FollowerRefreshes {
     -- Read-only nodes refresh the catalog from the object store after a block appears.


### PR DESCRIPTION
## Summary

- Reviewed all six Allium specs against their implementations to identify where spec and code diverge
- Fixed the specs where the code was correct, fixed the code where the spec revealed a real issue
- Formalised the `addTries` algorithm in trie-cat.allium (previously deferred as a black box)

### Spec corrections

- **live-index**: `GetTableTx` is idempotent (`computeIfAbsent`), not create-every-time. Row op modelled as Arrow union, not flat fields. Single-writer constraint noted as structurally enforced by LogProcessor.
- **memory-hash-trie**: `SplitIntoBranch` shows explicit defaults for new leaves. `sorted_data_cache` documented as volatile.
- **db**: `LeaderFinishesBlock` now includes `table_catalog.finishBlock` and `block_catalog.refresh`. Timestamp semantics documented.
- **gc**: L0 exclusion explained (compaction timing unpredictable, storage cost negligible). Null `block_time` guard added.
- **trie-cat**: `addTries` fully formalised — insertion strategy per level, levelled vs tiered supersession, nascent→live transitions, partition group completion. Catalog entity restructured around `Shard`/`ShardState`.

### Code fix

- **MemoryHashTrie**: `sortedData` now `@Volatile` to ensure visibility across concurrent readers on weak memory models.

## Test plan

- [x] `MutableMemoryHashTrieTest` passes with the `@Volatile` change