### PR TITLE
S3 client bump and prevent bytearray copies

### DIFF
--- a/core/src/main/kotlin/xtdb/api/storage/ObjectStore.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/ObjectStore.kt
@@ -68,6 +68,8 @@ interface ObjectStore : AutoCloseable {
 
     /**
      * Stores an object in the object store.
+     *
+     * The provided ByteBuffer must not be modified during the execution of this method.
      */
     fun putObject(k: Path, buf: ByteBuffer): CompletableFuture<Unit>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 antlr = "4.13.2"
 arrow = "18.3.0"
 arrow-adbc = "0.21.0"
-aws-sdk = "2.25.50"
+aws-sdk = "2.41.27"
 azure = "1.13.1"
 azure-storage = "12.27.0"
 clojure = "1.12.0"

--- a/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
@@ -100,7 +100,7 @@ class S3(
                     val contentLength = buf.remaining().toLong()
                     val partNum = idx + 1
 
-                    val partResp = client.uploadPart(AsyncRequestBody.fromByteBuffer(buf)) {
+                    val partResp = client.uploadPart(AsyncRequestBody.fromByteBufferUnsafe(buf)) {
                         it.bucket(bucket)
                         it.key(s3Key)
                         it.uploadId(uploadId)
@@ -179,7 +179,7 @@ class S3(
 
             val contentLength = buf.remaining().toLong()
 
-            client.putObject(AsyncRequestBody.fromByteBuffer(buf)) {
+            client.putObject(AsyncRequestBody.fromByteBufferUnsafe(buf)) {
                 it.bucket(bucket)
                 it.key(s3Key)
                 it.contentLength(contentLength)


### PR DESCRIPTION
Please see commit messages.

Has been tested in our soak environment for some hours already: same memory configuration that consistently threw OOMs previously, does no more.