### PR TITLE
feat(monitoring): Add pushdowns to EXPLAIN ANALYZE

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -337,11 +337,21 @@
                                                     !segments (.iterator ^Iterable merge-tasks)
                                                     schema args)
                                  (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer
-                                                                                                    query-span 
+                                                                                                    query-span
                                                                                                     {"table.name" (.getTableName table)
                                                                                                      "schema.name" (.getSchemaName table)
                                                                                                      "db.name" (.getDbName table)}
-                                                                                                    (format "query.cursor.scan.%s" (.getTableName table))))))))))}))))
+                                                                                                    (format "query.cursor.scan.%s" (.getTableName table))
+                                                                                                    (not-empty
+                                                                                                     (merge-with merge
+                                                                                                                 (when pushdown-blooms
+                                                                                                                   (update-keys
+                                                                                                                    (update-vals pushdown-blooms (fn [b] {:bloom-filter b}))
+                                                                                                                    str))
+                                                                                                                 (update-keys
+                                                                                                                  (update-vals (into {} (filter val) (or pushdown-iids {}))
+                                                                                                                               (fn [s] {:iids s}))
+                                                                                                                  str)))))))))))}))))
 
 (defmethod lp/emit-expr :scan [scan-expr {:keys [^IScanEmitter scan-emitter db-cat scan-vec-types, param-types]}]
   (assert db-cat)

--- a/core/src/main/kotlin/xtdb/ICursor.kt
+++ b/core/src/main/kotlin/xtdb/ICursor.kt
@@ -25,6 +25,7 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
         val pageCount: Int
         val timeToFirstPage: Duration?
         val totalTime: Duration
+        val pushdowns: Map<String, Any>?
     }
 
     val cursorType: String
@@ -51,6 +52,7 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
             private val parentSpan: Span?,
             private val attributes: Map<String, String>? = null,
             private val spanName: String? = null,
+            override val pushdowns: Map<String, Any>? = null,
             private val clock: InstantSource = InstantSource.system()
         ) : ICursor by inner, ExplainAnalyze {
             override var pageCount: Int = 0; private set
@@ -121,5 +123,9 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
         @JvmStatic
         fun ICursor.wrapTracing(tracer: Tracer?, span: Span?, attributes: Map<String, String>?, spanName: String?): ICursor =
             TracingCursor(this, tracer, span, attributes, spanName)
+
+        @JvmStatic
+        fun ICursor.wrapTracing(tracer: Tracer?, span: Span?, attributes: Map<String, String>?, spanName: String?, pushdowns: Map<String, Any>?): ICursor =
+            TracingCursor(this, tracer, span, attributes, spanName, pushdowns)
     }
 }


### PR DESCRIPTION
```
   depth    |    op     | total_time  | time_to_first_page | page_count | row_count |                                       pushdowns                                        
------------+-----------+-------------+--------------------+------------+-----------+----------------------------------------------------------------------------------------
 ->         | project   | PT0.026544S | PT0.026456S        |          1 |         3 | 
   ->       | project   | PT0.026389S | PT0.026297S        |          1 |         3 | 
     ->     | semi-join | PT0.026385S | PT0.025602S        |          1 |         3 | 
       ->   | rename    | PT0.000166S | PT0.000049S        |          1 |         7 | 
         -> | table     | PT0.000153S | PT0.000006S        |          1 |         7 | 
       ->   | rename    | PT0.012458S | PT0.007516S        |          1 |         3 | 
         -> | scan      | PT0.012445S | PT0.00748S         |          1 |         3 | [["^ ","column","_id","bloom_filter",["^ ","cardinality",35],"iids",["^ ","count",7]]]
```