### PR TITLE
feat(monitoring): Add attributes field to EXPLAIN ANALYZE, populate with table name for scan.

### DIFF
--- a/core/src/main/kotlin/xtdb/ICursor.kt
+++ b/core/src/main/kotlin/xtdb/ICursor.kt
@@ -26,6 +26,7 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
         val timeToFirstPage: Duration?
         val totalTime: Duration
         val pushdowns: Map<String, Any>?
+        val cursorAttributes: Map<String, String>?
     }
 
     val cursorType: String
@@ -104,6 +105,7 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
                 }
             }
 
+            override val cursorAttributes get() = attributes
             override val explainAnalyze get() = this
 
             @Suppress("RedundantOverride")

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -592,25 +592,6 @@
 (deftest cancel_big_query
   (test-cancel "FROM GENERATE_SERIES(1,10000000) AS system(_id) ORDER BY _id"))
 
-(deftest jdbc-prepared-query-close-test
-  (with-open [conn (jdbc-conn {"prepareThreshold" 1
-                               "preparedStatementCacheQueries" 0
-                               "preparedStatementCacheMiB" 0})]
-    ;; the Driver now creates a couple of statements.
-    ;; we do close this, but the PG driver appears to retain it
-    (t/is (= #{"S_1" "S_2"} (set (keys (:prepared-statements @(:conn-state (get-last-conn)))))))
-
-    (dotimes [i 3]
-      (with-open [stmt (.prepareStatement conn (format "SELECT a.a FROM (VALUES (%s)) a (a)" i))]
-        (.executeQuery stmt)))
-
-    (t/testing "no portal should remain, they are closed by sync, explicit close or rebinding the unnamed portal"
-      (t/is (empty? (:portals @(:conn-state (get-last-conn))))))
-
-    (t/testing "the last statement should still exist as they last the duration of the session and are only closed by
-                an explicit close message, which the pg driver sends between execs"
-      ;; S_5 because initial qs, then i == 3
-      (t/is (= #{"S_1" "S_2" "S_5"} (set (keys (:prepared-statements @(:conn-state (get-last-conn))))))))))
 
 (defn psql-available?
   "Returns true if psql is available in $PATH"


### PR DESCRIPTION
PR also includes:

- test(pgwire): Move fragile statement lifecycle test from JDBC to protocol level.


```
   depth    |    op     |                            attributes                             | total_time  | time_to_first_page | page_count | row_count |                                       pushdowns                                        
------------+-----------+-------------------------------------------------------------------+-------------+--------------------+------------+-----------+----------------------------------------------------------------------------------------
 ->         | project   |                                                                   | PT0.004995S | PT0.004911S        |          1 |         7 | 
   ->       | project   |                                                                   | PT0.004981S | PT0.004891S        |          1 |         7 | 
     ->     | semi-join |                                                                   | PT0.004977S | PT0.004105S        |          1 |         7 | 
       ->   | rename    |                                                                   | PT0.000083S | PT0.000022S        |          1 |         7 | 
         -> | table     |                                                                   | PT0.000074S | PT0.000003S        |          1 |         7 | 
       ->   | rename    |                                                                   | PT0.002995S | PT0.000571S        |          1 |         7 | 
         -> | scan      | ["^ ","table.name","bar","schema.name","public","db.name","xtdb"] | PT0.00298S  | PT0.000551S        |          1 |         7 | [["^ ","column","_id","bloom_filter",["^ ","cardinality",35],"iids",["^ ","count",7]]]```