### PR TITLE
build(docker): use docker bakefile for image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,103 +32,55 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/xtdb/xtdb
-          tags: |
+          tags: &tags |
             type=semver,pattern={{version}}
             type=schedule
             type=schedule,pattern=nightly-{{date 'YYYYMMDD'}}
             type=edge,branch=main
             type=sha,prefix=g
+          bake-target: standalone
 
       - name: AWS meta
         id: aws-meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/xtdb/xtdb-aws
-          tags: |
-            type=semver,pattern={{version}}
-            type=schedule
-            type=schedule,pattern=nightly-{{date 'YYYYMMDD'}}
-            type=edge,branch=main
-            type=sha,prefix=g
+          tags: *tags
+          bake-target: aws
 
       - name: Azure meta
         id: azure-meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/xtdb/xtdb-azure
-          tags: |
-            type=semver,pattern={{version}}
-            type=schedule
-            type=schedule,pattern=nightly-{{date 'YYYYMMDD'}}
-            type=edge,branch=main
-            type=sha,prefix=g
+          tags: *tags
+          bake-target: azure
 
       - name: Google Cloud meta
         id: google-cloud-meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/xtdb/xtdb-google-cloud
-          tags: |
-            type=semver,pattern={{version}}
-            type=schedule
-            type=schedule,pattern=nightly-{{date 'YYYYMMDD'}}
-            type=edge,branch=main
-            type=sha,prefix=g
+          tags: *tags
+          bake-target: google-cloud
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
 
-      - name: Build Uberjar
+      - name: Build Uberjars
         run: ./gradlew :docker:standalone:shadowJar :docker:aws:shadowJar :docker:azure:shadowJar :docker:google-cloud:shadowJar
 
-      - name: Push Standalone
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      - name: Build and push
+        uses: docker/bake-action@4ba453fbc2db7735392b93edf935aaf9b1e8eefc # v6.5.0
         with:
-          context: docker
-          platforms: linux/arm64/v8,linux/amd64
+          files: |
+            docker-bake.hcl
+            ${{ steps.standalone-meta.outputs.bake-file }}
+            ${{ steps.aws-meta.outputs.bake-file }}
+            ${{ steps.azure-meta.outputs.bake-file }}
+            ${{ steps.google-cloud-meta.outputs.bake-file }}
+          targets: default
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.standalone-meta.outputs.tags }}
-          labels: ${{ steps.standalone-meta.outputs.labels }}
-          build-args: |
-            VARIANT=standalone
-            GIT_SHA=${{ github.sha }}
-            XTDB_VERSION=${{ steps.standalone-meta.outputs.version }}
-
-      - name: Push Azure
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: docker
-          platforms: linux/arm64/v8,linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.azure-meta.outputs.tags }}
-          labels: ${{ steps.azure-meta.outputs.labels }}
-          build-args: |
-            VARIANT=azure
-            GIT_SHA=${{ github.sha }}
-            XTDB_VERSION=${{ steps.azure-meta.outputs.version }}
-
-      - name: Push AWS
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: docker
-          platforms: linux/arm64/v8,linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.aws-meta.outputs.tags }}
-          labels: ${{ steps.aws-meta.outputs.labels }}
-          build-args: |
-            VARIANT=aws
-            GIT_SHA=${{ github.sha }}
-            XTDB_VERSION=${{ steps.aws-meta.outputs.version }}
-
-      - name: Push Google Cloud
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: docker
-          platforms: linux/arm64/v8,linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.google-cloud-meta.outputs.tags }}
-          labels: ${{ steps.google-cloud-meta.outputs.labels }}
-          build-args: |
-            VARIANT=google-cloud
-            GIT_SHA=${{ github.sha }}
-            XTDB_VERSION=${{ steps.google-cloud-meta.outputs.version }}
+          set: |
+            *.args.GIT_SHA=${{ github.sha }}
+            *.args.XTDB_VERSION=${{ steps.standalone-meta.outputs.version }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,4 +1,52 @@
+// Docker Bake file for XTDB images.
+// Tags/labels are provided at build time via the metadata-action bake files.
+
+variable "GIT_SHA" {
+  default = ""
+}
+
+variable "XTDB_VERSION" {
+  default = "dev"
+}
+
+group "default" {
+  targets = ["standalone", "cloud"]
+}
+
+target "standalone" {
+  context    = "."
+  dockerfile = "docker/Dockerfile"
+  platforms  = ["linux/amd64", "linux/arm64/v8"]
+  tags       = ["ghcr.io/xtdb/xtdb:dev"]
+  args = {
+    VARIANT      = "standalone"
+    GIT_SHA      = GIT_SHA
+    XTDB_VERSION = XTDB_VERSION
+  }
+}
+
+target "cloud" {
+  name       = variant
+  matrix = {
+    variant = ["aws", "azure", "google-cloud"]
+  }
+  context    = "."
+  dockerfile = "docker/Dockerfile"
+  platforms  = ["linux/amd64", "linux/arm64/v8"]
+  tags       = ["ghcr.io/xtdb/xtdb-${variant}:dev"]
+  args = {
+    VARIANT      = variant
+    GIT_SHA      = GIT_SHA
+    XTDB_VERSION = XTDB_VERSION
+  }
+}
+
 target "bench" {
-  context = "modules/bench"
-  tags = ["ghcr.io/xtdb/xtdb-bench:latest"]
+  context    = "."
+  dockerfile = "modules/bench/Dockerfile"
+  platforms  = ["linux/amd64", "linux/arm64/v8"]
+  tags       = ["ghcr.io/xtdb/xtdb-bench:latest"]
+  args = {
+    GIT_SHA = GIT_SHA
+  }
 }


### PR DESCRIPTION
## Summary

- Replaces four separate `docker/build-push-action` steps with a single `docker/bake-action` call backed by `docker-bake.hcl`
- Standalone gets its own target (asymmetric `ghcr.io/xtdb/xtdb` name), cloud variants use a bakefile matrix
- Metadata-action bake files override tags/labels at build time; YAML anchors deduplicate tag config

## Test plan

- [ ] Verify `docker buildx bake --print` resolves targets correctly
- [ ] Run the docker workflow on this branch and check all four images are built and tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)