### PR TITLE
fix(logical-plan): Fix pushdown renaming for project, add explain-analyze for query-ra

### DIFF
--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -171,7 +171,7 @@
 
 (defn- plan-query [parsed-query query-opts]
   (cond
-    (vector? parsed-query) parsed-query
+    (vector? parsed-query) (with-meta parsed-query (select-keys query-opts [:explain? :explain-analyze?]))
     (instance? Sql$DirectlyExecutableStatementContext parsed-query) (sql/plan parsed-query query-opts)
 
     :else (throw (err/fault :unknown-query-type "Unknown query type"


### PR DESCRIPTION
Project operator didn't remap pushdown-blooms/pushdown-iids keys when renaming columns, so bloom filters arrived at the scan keyed by the project's output name rather than the scan's column name — silently disabling pushdown filtering through any project-with-rename.

Introduces `lp/with-col-mapping`: operators declare a `:col-mapping` ({output-col input-col}) on their emitted relation, and this function wraps `->cursor` to remap pushdown keys. Both rename and project now use this, replacing rename's ad-hoc remapping inside `->cursor`.

Also attaches `:explain-analyze?` as metadata on RA vectors in `plan-query`, so EXPLAIN ANALYZE works via `query-ra` — previously the flag was only propagated through SQL plan metadata.