### PR TITLE
Exhaustive allocator metrics

### DIFF
--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -18,7 +18,7 @@
 (def ^:dynamic *page-size* 1024)
 
 (defn- open-compactor [{:keys [metrics-registry threads]}]
-  (Compactor$Impl. (Compactor$Driver/real metrics-registry *page-size* *recency-partition*)
+  (Compactor$Impl. (Compactor$Driver/real *page-size* *recency-partition*)
                    metrics-registry
                    (jc/->JobCalculator)
                    *ignore-signal-block?* threads))

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -706,9 +706,6 @@
       (openForDatabase [_ allocator db-storage db-state live-index crash-logger]
         (let [db-name (.getName db-state)]
           (util/with-close-on-catch [allocator (util/->child-allocator allocator (str "indexer/" db-name))]
-            ;; TODO add db-name to allocator gauge
-            (metrics/add-allocator-gauge metrics-registry "indexer.allocator.allocated_memory" allocator)
-
             (->IndexerForDatabase allocator (:node-id config) q-src
                                   db-name db-storage db-state
                                   live-index (.getTableCatalog db-state)

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -221,7 +221,6 @@
         table-cat (or table-cat (.getTableCatalog db-state))
         latest-completed-tx (.getLatestCompletedTx block-cat)]
     (util/with-close-on-catch [allocator (util/->child-allocator allocator "live-index")]
-      (metrics/add-allocator-gauge meter-registry "live-index.allocator.allocated_memory" allocator)
       (let [tables (HashMap.)]
         (->LiveIndex allocator buffer-pool
                      block-cat table-cat

--- a/core/src/main/clojure/xtdb/metrics.clj
+++ b/core/src/main/clojure/xtdb/metrics.clj
@@ -53,9 +53,6 @@
              tag (.tag tag-key tag-value))
          (.register reg)))))
 
-(defn add-allocator-gauge [reg meter-name ^BufferAllocator allocator]
-  (add-gauge reg meter-name (fn [] (.getAllocatedMemory allocator)) {:unit "bytes"}))
-
 (defn- register-gauge! [^MeterRegistry reg, ^Gauge$Builder g]
   (doto (.register g reg)
     (as-> ^Gauge registered

--- a/core/src/main/clojure/xtdb/metrics.clj
+++ b/core/src/main/clojure/xtdb/metrics.clj
@@ -1,9 +1,10 @@
 (ns xtdb.metrics
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [integrant.core :as ig]
             [xtdb.node :as xtn]
             [xtdb.util :as util])
-  (:import (io.micrometer.core.instrument Counter Gauge MeterRegistry Tag Timer Timer$Sample)
+  (:import (io.micrometer.core.instrument Counter Gauge Gauge$Builder MeterRegistry Tag Timer Timer$Sample)
            (io.micrometer.core.instrument.binder MeterBinder)
            (io.micrometer.core.instrument.binder.jvm ClassLoaderMetrics JvmGcMetrics JvmHeapPressureMetrics JvmMemoryMetrics JvmThreadMetrics)
            (io.micrometer.core.instrument.binder.system ProcessorMetrics)
@@ -54,6 +55,40 @@
 
 (defn add-allocator-gauge [reg meter-name ^BufferAllocator allocator]
   (add-gauge reg meter-name (fn [] (.getAllocatedMemory allocator)) {:unit "bytes"}))
+
+(defn- register-gauge! [^MeterRegistry reg, ^Gauge$Builder g]
+  (doto (.register g reg)
+    (as-> ^Gauge registered
+      (log/debug "Registered allocator gauge:" (.getId registered)))))
+
+(defn- allocator-gauge-builders [^BufferAllocator alloc, name]
+  (concat [(-> (Gauge/builder (str name ".allocated") #(.getAllocatedMemory alloc))
+               (.baseUnit "bytes"))]
+          (when (< (.getLimit alloc) Long/MAX_VALUE)
+            [(-> (Gauge/builder (str name ".limit") #(.getLimit alloc))
+                 (.baseUnit "bytes"))])))
+
+(defn register-root-allocator-meters! [^MeterRegistry reg, ^BufferAllocator alloc]
+  (doseq [^Gauge$Builder g (allocator-gauge-builders alloc "xtdb.allocator.root.memory")]
+    (register-gauge! reg g)))
+
+(defn root-allocator-listener
+  "Registers exhaustive and exclusive memory-usage meters for certain RootAllocator children.
+   Database allocator is expected to be named 'database/<db-name>'"
+  [^MeterRegistry reg]
+  ; An allocator listener with a naming convention for allocators is enough for now.
+  ; A BufferAllocator wrapper would enable explicit child allocator settings at their creation site.
+  (reify org.apache.arrow.memory.AllocationListener
+    (^void onChildAdded [_, ^BufferAllocator parent, ^BufferAllocator child]
+      (let [[parent-name db-name] (str/split (.getName parent) #"/" 2)
+            [child-name] (str/split (.getName child) #"/" 2)]
+        (when (or (and (instance? org.apache.arrow.memory.RootAllocator parent)
+                       (not= child-name "database"))
+                  (= parent-name "database"))
+          (doseq [g (allocator-gauge-builders child "xtdb.allocator.memory")]
+            (register-gauge! reg (-> g
+                                     (.tag "allocator" child-name)
+                                     (.tag "database" (or db-name ""))))))))))
 
 (defn start-span ^Span [^Tracer tracer ^String span-name {:keys [^Span parent-span attributes]}]
   (let [span-builder (if parent-span

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -43,13 +43,17 @@
 (defmethod ig/init-key :xtdb/config [_ cfg] cfg)
 
 (defmethod ig/expand-key :xtdb/allocator [k ^Xtdb$Config config]
-  {k {:allocator (.getAllocator config)}})
+  {k {:allocator (.getAllocator config)
+      :meter-registry (ig/ref ::metrics/registry)}})
 
-(defmethod ig/init-key :xtdb/allocator [_ {:keys [allocator]}]
+(defmethod ig/init-key :xtdb/allocator [_ {:keys [allocator meter-registry]}]
   (if allocator
     {:allocator allocator, :close? false}
-
-    {:allocator (RootAllocator. (long (* 0.9 (util/max-direct-memory))))
+    {:allocator (let [limit (long (* 0.9 (util/max-direct-memory)))]
+                  (if meter-registry
+                    (doto (RootAllocator. (metrics/root-allocator-listener meter-registry) limit)
+                      (->> (metrics/register-root-allocator-meters! meter-registry)))
+                    (RootAllocator. limit)))
      :close? true}))
 
 (defmethod ig/resolve-key :xtdb/allocator [_ {:keys [allocator]}]

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -480,8 +480,6 @@
                                         (.maximumSize 4096)
                                         (.build))))]
 
-    (some-> metrics-registry (metrics/add-allocator-gauge "query_source.allocator.allocated_memory" allocator))
-
     (map->QuerySource deps)))
 
 (defmethod ig/init-key ::query-source [_ deps]

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -89,7 +89,7 @@ object Storage {
         override fun open(
             allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
             dbName: DatabaseName, meterRegistry: MeterRegistry?, storageVersion: StorageVersion
-        ): BufferPool = MemoryStorage(allocator, meterRegistry, epoch)
+        ): BufferPool = MemoryStorage(allocator, epoch)
     }
 
     @JvmStatic

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -72,12 +72,10 @@ interface Compactor : AutoCloseable {
 
         companion object {
             @JvmStatic
-            fun real(meterRegistry: MeterRegistry?, pageSize: Int, recencyPartition: RecencyPartition?) =
+            fun real(pageSize: Int, recencyPartition: RecencyPartition?) =
                 object : Factory {
                     override fun create(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers) = object : Driver {
                         private val al = allocator.openChildAllocator("compactor")
-                            .also { meterRegistry?.register(it) }
-
                         private val log = dbStorage.sourceLog
                         private val bp = dbStorage.bufferPool
                         private val mm = dbStorage.metadataManager

--- a/core/src/main/kotlin/xtdb/storage/LocalStorage.kt
+++ b/core/src/main/kotlin/xtdb/storage/LocalStorage.kt
@@ -38,7 +38,7 @@ internal class LocalStorage(
     val rootPath: Path,
 ) : BufferPool, IEvictBufferTest, Closeable {
 
-    private val allocator = allocator.openChildAllocator("buffer-pool").also { meterRegistry?.register(it) }
+    private val allocator = allocator.openChildAllocator("buffer-pool")
 
     private val arrowFooterCache: Cache<Path, ArrowFooter> = arrowFooterCache()
     private val recordBatchRequests: Counter? = meterRegistry?.counter("record-batch-requests")

--- a/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
+++ b/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
@@ -1,6 +1,5 @@
 package xtdb.storage
 
-import io.micrometer.core.instrument.MeterRegistry
 import org.apache.arrow.memory.ArrowBuf
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.ipc.message.ArrowFooter
@@ -17,7 +16,6 @@ import xtdb.error.Unsupported
 import xtdb.trie.FileSize
 import xtdb.util.closeOnCatch
 import xtdb.util.openChildAllocator
-import xtdb.util.register
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.channels.Channels.newChannel
@@ -26,11 +24,10 @@ import java.util.*
 
 internal class MemoryStorage(
     allocator: BufferAllocator,
-    meterRegistry: MeterRegistry? = null,
     override val epoch: StorageEpoch
 ) : BufferPool, IEvictBufferTest {
 
-    private val allocator = allocator.openChildAllocator("buffer-pool").also { meterRegistry?.register(it) }
+    private val allocator = allocator.openChildAllocator("buffer-pool")
 
     private val memoryStore: NavigableMap<Path, ArrowBuf> = TreeMap()
 

--- a/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
@@ -43,7 +43,7 @@ internal class RemoteBufferPool(
     dbName: DatabaseName,
 ) : BufferPool, IEvictBufferTest, Closeable {
 
-    private val allocator = allocator.openChildAllocator("buffer-pool").also { meterRegistry?.register(it) }
+    private val allocator = allocator.openChildAllocator("buffer-pool")
 
     private val arrowFooterCache = arrowFooterCache()
 

--- a/core/src/main/kotlin/xtdb/util/ArrowUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/ArrowUtil.kt
@@ -1,7 +1,5 @@
 package xtdb.util
 
-import io.micrometer.core.instrument.Gauge
-import io.micrometer.core.instrument.MeterRegistry
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.ValueVector
 import org.apache.arrow.vector.complex.ListVector
@@ -9,12 +7,6 @@ import org.apache.arrow.vector.complex.UnionVector
 
 internal fun BufferAllocator.openChildAllocator(name: String) =
     newChildAllocator(name, 0, Long.MAX_VALUE)
-
-internal fun MeterRegistry.register(al: BufferAllocator) {
-    Gauge.builder("${al.name}.allocator.allocated_memory", al) { it.allocatedMemory.toDouble() }
-        .baseUnit("bytes")
-        .register(this@register)
-}
 
 fun ValueVector.openSlice(offset: Int = 0, len: Int = valueCount): ValueVector =
     when {

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -473,8 +473,7 @@
     (t/is (= #{:tags :name :value}
              (set (keys (first res)))))
     (t/is (empty? (set/difference #{"system.cpu.count"
-                                    "live-index.allocator.allocated_memory"
-                                    "buffer-pool.allocator.allocated_memory"
+                                    "xtdb.allocator.memory.allocated"
                                     "jvm.memory.used"
                                     "node.tx.latestSubmittedMsgId"}
                                   (into #{} (map :name) res)))


### PR DESCRIPTION
From commit message:

Added memory metrics (allocated, limit) for all interesting arrow allocators:
- guarantees covering all child allocators (actually adds some missing allocators)
- single metric for all child allocators, tagged by allocator-name and db-name, making it directly configurable by users
- no need to explicitly set up metrics for each allocator

<img width="2749" height="819" alt="image" src="https://github.com/user-attachments/assets/99153d0c-6d87-4405-a2f7-ac9714387f8c" />
