### PR TITLE
fix(order-by): IndexOutOfBoundsException in k-way merge with DESC ordering

### DIFF
--- a/core/src/main/clojure/xtdb/operator/order_by.clj
+++ b/core/src/main/clojure/xtdb/operator/order_by.clj
@@ -85,9 +85,11 @@
                   col-comparator (expr.comp/->comparator read-col1 read-col2 null-ordering)
 
                   ^Comparator
-                  comparator (cond-> ^Comparator (fn [left right]
-                                                   (.applyAsInt col-comparator left right))
-                               (= :desc direction) (.reversed))]
+                  comparator (if (= :desc direction)
+                               (fn [left right]
+                                 (- (.applyAsInt col-comparator left right)))
+                               (fn [left right]
+                                 (.applyAsInt col-comparator left right)))]
               (if acc
                 (.thenComparing acc comparator)
                 comparator)))

--- a/src/test/clojure/xtdb/operator/order_by_test.clj
+++ b/src/test/clojure/xtdb/operator/order_by_test.clj
@@ -1,7 +1,10 @@
 (ns xtdb.operator.order-by-test
   (:require [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.node :as xtn]
             [xtdb.operator.order-by :as order-by]
-            [xtdb.test-util :as tu]))
+            [xtdb.test-util :as tu])
+  (:import (java.time Instant Duration)))
 
 (t/use-fixtures :each tu/with-allocator)
 
@@ -41,19 +44,19 @@
   (let [table-with-nil [{:a 12.4, :b 10}, {:a nil, :b 15}, {:a 100, :b 83}, {:a 83.0, :b 100}]]
     (t/is (= [{:b 15}, {:a 12.4, :b 10}, {:a 83.0, :b 100}, {:a 100, :b 83}]
              (tu/query-ra '[:order-by {:order-specs [[a {:null-ordering :nulls-first}]]}
-                          [:table {:param ?table}]]
+                            [:table {:param ?table}]]
                           {:args {:table table-with-nil}}))
           "nulls first")
 
     (t/is (= [{:a 12.4, :b 10}, {:a 83.0, :b 100}, {:a 100, :b 83}, {:b 15}]
              (tu/query-ra '[:order-by {:order-specs [[a {:null-ordering :nulls-last}]]}
-                          [:table {:param ?table}]]
+                            [:table {:param ?table}]]
                           {:args {:table table-with-nil}}))
           "nulls last")
 
     (t/is (= [{:a 12.4, :b 10}, {:a 83.0, :b 100}, {:a 100, :b 83}, {:b 15}]
              (tu/query-ra '[:order-by {:order-specs [[a]]}
-                          [:table {:param ?table}]]
+                            [:table {:param ?table}]]
                           {:args {:table table-with-nil}}))
           "default nulls last")))
 
@@ -67,3 +70,35 @@
                              [::tu/pages batches]]
                             {}))
             "spilling to disk"))))
+
+(t/deftest test-order-by-temporal-range-5269
+  ;; #5269 — IOOBE in ORDER BY DESC with external sort.
+  ;; .reversed() on the k-way merge comparator swapped index arguments between
+  ;; relations with different row counts, reading past the smaller one's buffer.
+  (with-redefs [order-by/*block-size* (int 10)]
+    (with-open [node (xtn/start-node (merge tu/*node-opts*
+                                            {:compactor {:threads 0}
+                                             :indexer {:rows-per-block 10}}))]
+      (let [base-vf (Instant/parse "2020-01-01T00:00:00Z")]
+        (doseq [batch (partition-all 10 (range 24))]
+          (xt/execute-tx node (mapv (fn [i]
+                                      [:put-docs {:into :docs
+                                                  :valid-from (.plus base-vf (Duration/ofMinutes i))}
+                                       {:xt/id "doc1" :val i}])
+                                    batch))))
+
+      (t/testing "ORDER BY valid from ascending"
+        (let [results-asc (xt/q node "FROM docs FOR VALID_TIME ALL SELECT id, _valid_from ORDER BY _valid_from")]
+          (t/is (= 24 (count results-asc)))
+          (t/is (= #xt/zdt "2020-01-01T00:00Z[UTC]"
+                   (:xt/valid-from (first results-asc))))
+          (t/is (= #xt/zdt "2020-01-01T00:23Z[UTC]"
+                   (:xt/valid-from (last results-asc))))))
+
+      (t/testing "ORDER BY valid from descending"
+        (let [results-desc (xt/q node "FROM docs FOR VALID_TIME ALL SELECT id, _valid_from ORDER BY _valid_from DESC")]
+          (t/is (= 24 (count results-desc)))
+          (t/is (= #xt/zdt "2020-01-01T00:23Z[UTC]"
+                   (:xt/valid-from (first results-desc))))
+          (t/is (= #xt/zdt "2020-01-01T00:00Z[UTC]"
+                   (:xt/valid-from (last results-desc)))))))))


### PR DESCRIPTION
## Summary

`Comparator.reversed()` in the k-way merge swapped index arguments between relations.
When spill files had different row counts (the first file is typically smaller), this read past the smaller file's buffer.

The fix negates the comparison result instead of swapping arguments, reversing sort order while keeping each index paired with its own file's data.

Resolves #5269

## Changes

- **`order_by.clj`**: Replace `.reversed()` with result negation in `mk-rel-comparator`
- **`order_by_test.clj`**: Add test reproducing the bug with 24 rows and small block size

## Testing

- `test-order-by-temporal-range-5269` — fails without fix, passes with it