### PR TITLE
feat(bench): Move scan benchmarks to standalone bench

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -294,6 +294,10 @@ allprojects {
                         jvmArgs += "-enableassertions"
                     }
 
+                    if (project.hasProperty("tmpDir")) {
+                        jvmArgs += "-Djava.io.tmpdir=${project.property("tmpDir")}"
+                    }
+
                     if (project.hasProperty("replPort"))
                         port.set(project.property("replPort").toString().toInt())
 
@@ -720,6 +724,13 @@ createBench("tpch", mapOf("scaleFactor" to "--scale-factor"))
 
 createBench("yakbench", mapOf(
     "scaleFactor" to "--scale-factor",
+    "noLoad" to "--no-load",
+    "nodeDir" to "--node-dir"
+))
+
+createBench("scan-perf", mapOf(
+    "nItems" to "--n-items",
+    "idType" to "--id-type",
     "noLoad" to "--no-load",
     "nodeDir" to "--node-dir"
 ))

--- a/modules/bench/src/main/clojure/xtdb/bench/scan_perf.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/scan_perf.clj
@@ -1,0 +1,279 @@
+(ns xtdb.bench.scan-perf
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [taoensso.tufte :as tufte :refer [p]]
+            [xtdb.api :as xt]
+            [xtdb.bench :as b]
+            [xtdb.compactor :as c]
+            [xtdb.datasets.scan-items :as scan-items]
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util]))
+
+(defn- get-conn ^java.sql.Connection [^xtdb.api.DataSource node]
+  (.build (.createConnectionBuilder node)))
+
+(defn- ?s [n]
+  (str "(" (str/join ", " (repeat n "?")) ")"))
+
+(defn- or-clause [col n]
+  (str/join " OR " (repeat n (str col " = ?"))))
+
+(defn get-distributed-items
+  "Fetch 1000 spread and 1000 clustered items for scan benchmarking."
+  [conn]
+  (let [n 1000
+        cnt (:cnt (first (xt/q conn ["SELECT count(*) as cnt FROM items"])))
+        step (max (quot cnt n) 1)
+        mid (quot cnt 2)
+
+        cols "_id, item$content_key, item$lang, item$length, item$published_at, item$author_name"
+
+        spread-1000 (vec (xt/q conn
+                               [(str "SELECT " cols " FROM ("
+                                     "  SELECT " cols ", row_number() OVER (ORDER BY _id) as rn"
+                                     "  FROM items"
+                                     ") AS numbered WHERE (rn - 1) % ? = 0"
+                                     "  ORDER BY rn"
+                                     "  LIMIT ?")
+                                step n]))
+
+        clustered-1000 (vec (xt/q conn
+                                  [(str "SELECT " cols " FROM ("
+                                        "  SELECT " cols ", row_number() OVER (ORDER BY _id) as rn"
+                                        "  FROM items"
+                                        ") AS numbered WHERE rn BETWEEN ? AND ?"
+                                        "  ORDER BY rn")
+                                   mid (+ mid n -1)]))]
+    {:spread-10 (vec (take-nth 100 spread-1000))
+     :spread-100 (vec (take-nth 10 spread-1000))
+     :spread-1000 spread-1000
+     :clustered-10 (vec (take 10 clustered-1000))
+     :clustered-100 (vec (take 100 clustered-1000))
+     :clustered-1000 clustered-1000
+     :langs (vec (distinct (map :item/lang spread-1000)))}))
+
+(defn scan-items-set-benchmark-queries
+  [{:keys [spread-10 spread-100 spread-1000 clustered-10 clustered-100 clustered-1000]}]
+  (let [ids #(mapv :xt/id %)]
+    [{:id :scan-spread-in-10
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 10))] (ids spread-10)))}
+     {:id :scan-clustered-in-10
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 10))] (ids clustered-10)))}
+     {:id :scan-spread-or-10
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "_id" 10))] (ids spread-10)))}
+     {:id :scan-clustered-or-10
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "_id" 10))] (ids clustered-10)))}
+
+     {:id :scan-spread-in-100
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 100))] (ids spread-100)))}
+     {:id :scan-clustered-in-100
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 100))] (ids clustered-100)))}
+
+     {:id :scan-spread-in-1000
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 1000))] (ids spread-1000)))}
+     {:id :scan-clustered-in-1000
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 1000))] (ids clustered-1000)))}]))
+
+(defn scan-items-by-content-key-queries
+  [{:keys [spread-10 spread-100 spread-1000 clustered-10 clustered-100 clustered-1000]}]
+  (let [ckeys #(mapv :item/content-key %)]
+    [{:id :content-key-spread-in-10
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 10))] (ckeys spread-10)))}
+     {:id :content-key-clustered-in-10
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 10))] (ckeys clustered-10)))}
+     {:id :content-key-spread-or-10
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "item$content_key" 10))] (ckeys spread-10)))}
+     {:id :content-key-clustered-or-10
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "item$content_key" 10))] (ckeys clustered-10)))}
+
+     {:id :content-key-spread-in-100
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 100))] (ckeys spread-100)))}
+     {:id :content-key-clustered-in-100
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 100))] (ckeys clustered-100)))}
+
+     {:id :content-key-spread-in-1000
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 1000))] (ckeys spread-1000)))}
+     {:id :content-key-clustered-in-1000
+      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 1000))] (ckeys clustered-1000)))}]))
+
+(defn scan-items-filter-queries
+  "Selective filter queries across different types and selectivities.
+   Targets ~0.05-12% selectivity so results reflect actual filter/pushdown behaviour
+   rather than full table scan I/O."
+  [{:keys [spread-1000 langs]}]
+  (let [lengths (sort (mapv :item/length spread-1000))
+        n-samples (count lengths)
+        ;; Pick a length value at the 99th percentile for a narrow BETWEEN (~1%)
+        len-p99 (nth lengths (int (* 0.99 n-samples)))
+        len-p98 (nth lengths (int (* 0.98 n-samples)))
+        ;; Pick a specific length value from the middle for point equality (~0.05%)
+        len-point (nth lengths (quot n-samples 2))
+
+        timestamps (sort (mapv :item/published-at spread-1000))
+        ;; Narrow timestamp window: top ~1% of the range
+        ts-p99 (nth timestamps (int (* 0.99 n-samples)))
+        ts-p98 (nth timestamps (int (* 0.98 n-samples)))
+
+        ;; Pick a single lang for equality (~12.5%)
+        lang-single (first langs)
+
+        ;; Pick a single author_name for equality (~1.5%, from pool of 64)
+        author-name-single (:item/author-name (first spread-1000))]
+
+    [;; String equality — single lang (~12.5%)
+     {:id :lang-eq
+      :f #(xt/q % ["SELECT _id FROM items WHERE item$lang = ?" lang-single])}
+
+     ;; String equality — single author_name (~1.5%)
+     {:id :author-name-eq
+      :f #(xt/q % ["SELECT _id FROM items WHERE item$author_name = ?" author-name-single])}
+
+     ;; Integer point equality (~0.05%)
+     {:id :length-eq
+      :f #(xt/q % ["SELECT _id FROM items WHERE item$length = ?" len-point])}
+
+     ;; Integer narrow range (~1%)
+     {:id :length-range-1pct
+      :f #(xt/q % ["SELECT _id FROM items WHERE item$length BETWEEN ? AND ?" len-p98 len-p99])}
+
+     ;; Timestamp narrow range (~1%)
+     {:id :published-range-1pct
+      :f #(xt/q % ["SELECT _id FROM items WHERE item$published_at BETWEEN ? AND ?" ts-p98 ts-p99])}
+
+     ;; Compound: string + integer (~6%)
+     {:id :lang-eq-and-length-gt
+      :f #(xt/q % ["SELECT _id FROM items WHERE item$lang = ? AND item$length > ?" lang-single len-p99])}
+
+     ;; Compound: string + timestamp (~0.75%)
+     {:id :author-and-published-gt
+      :f #(xt/q % ["SELECT _id FROM items WHERE item$author_name = ? AND item$published_at > ?" author-name-single ts-p99])}
+
+     ;; Sparse column (~0.1%)
+     {:id :doc-type-not-null
+      :f #(xt/q % ["SELECT _id FROM items WHERE item$doc_type IS NOT NULL"])}]))
+
+(defn- profile-data [pstats]
+  (let [rows (for [[id {:keys [n min p50 p90 p95 p99 max mean mad sum]}]
+                   (get pstats :stats {})]
+               {:id id :n n :min min :p50 p50 :p90 p90 :p95 p95 :p99 p99
+                :max max :mean mean :mad mad :sum sum})]
+    (sort-by :sum > rows)))
+
+(defn- profile [node iterations suite]
+  (with-open [conn (get-conn node)]
+    (let [_warmup (doseq [{:keys [f]} suite] (f conn))
+          [_ pstats] (tufte/profiled
+                      {}
+                      (doseq [{:keys [id f]} suite
+                              _ (range iterations)]
+                        (p id (f conn))))]
+      {:profile (profile-data @pstats)
+       :formatted (tufte/format-pstats pstats)})))
+
+(defmethod b/cli-flags :scan-perf [_]
+  [["-n" "--n-items N_ITEMS" "Number of items to generate"
+    :parse-fn parse-long
+    :default 1750000]
+   ["-t" "--id-type ID_TYPE" "ID type: uuid, string, keyword"
+    :parse-fn keyword
+    :default :uuid]
+   ["-h" "--help"]])
+
+(defmethod b/->benchmark :scan-perf [_ {:keys [n-items id-type seed no-load?]
+                                         :or {n-items 10000000 id-type :uuid seed 0}}]
+  (log/info {:n-items n-items :id-type id-type :seed seed :no-load? no-load?})
+
+  {:title "Scan Perf"
+   :benchmark-type :scan-perf
+   :seed seed
+   :parameters {:n-items n-items :id-type id-type :seed seed :no-load? no-load?}
+   :->state #(do {:!state (atom {})})
+   :tasks [(when-not no-load?
+             {:t :do
+              :stage :ingest
+              :tasks [{:t :call
+                       :stage :submit-docs
+                       :f (fn [{:keys [node random]}]
+                            (with-open [conn (get-conn node)]
+                              (scan-items/load-data! conn random n-items id-type)))}
+                      {:t :call
+                       :stage :await-transactions
+                       :f (fn [{:keys [node]}] (b/sync-node node))}
+                      {:t :call
+                       :stage :flush-block
+                       :f (fn [{:keys [node]}] (tu/flush-block! node))}]})
+
+           {:t :call
+            :stage :compact
+            :f (fn [{:keys [node]}] (c/compact-all! node nil))}
+
+           {:t :call
+            :stage :get-query-data
+            :f (fn [{:keys [node !state]}]
+                 (with-open [conn (get-conn node)]
+                   (swap! !state assoc :distributed-items (get-distributed-items conn))))}
+
+           {:t :call
+            :stage :profile-scan-sets
+            :f (fn [{:keys [node !state]}]
+                 (let [{:keys [distributed-items]} @!state
+                       {:keys [profile formatted]} (profile node 50 (scan-items-set-benchmark-queries distributed-items))]
+                   (swap! !state update :profiles assoc :scan-sets profile)
+                   (println formatted)))}
+
+           {:t :call
+            :stage :profile-scan-content-key
+            :f (fn [{:keys [node !state]}]
+                 (let [{:keys [distributed-items]} @!state
+                       {:keys [profile formatted]} (profile node 10 (scan-items-by-content-key-queries distributed-items))]
+                   (swap! !state update :profiles assoc :scan-content-key profile)
+                   (println formatted)))}
+
+           {:t :call
+            :stage :profile-scan-filters
+            :f (fn [{:keys [node !state]}]
+                 (let [{:keys [distributed-items]} @!state
+                       {:keys [profile formatted]} (profile node 5 (scan-items-filter-queries distributed-items))]
+                   (swap! !state update :profiles assoc :scan-filters profile)
+                   (println formatted)))}
+
+           {:t :call
+            :stage :output-profile-data
+            :f (fn [{:keys [!state] :as worker}]
+                 (let [{:keys [profiles]} @!state]
+                   (b/log-report worker {:profiles profiles})))}]})
+
+(comment
+  (try
+    (let [random (java.util.Random. 0)
+          n-items (* 10 1000 1000)
+          id-type :uuid
+          dir (util/->path "tmp/scan-perf")
+          clear-dir (fn [^java.nio.file.Path path]
+                      (when (util/path-exists path)
+                        (log/info "Clearing directory" path)
+                        (util/delete-dir path)))]
+      (println "Clear dir")
+      (clear-dir dir)
+      (with-open [node (tu/->local-node {:node-dir dir
+                                         :instant-src (java.time.InstantSource/system)})
+                  conn (get-conn node)]
+        (println "Load data")
+        (scan-items/load-data! conn random n-items id-type)
+        (println "Flush block")
+        (b/sync-node node)
+        (tu/flush-block! node)
+        (println "Compact")
+        (c/compact-all! node nil)
+        (println "Get Query Data")
+        (let [distributed-items (get-distributed-items conn)]
+          (println "Profile Scan Sets")
+          (println (:formatted (profile node 50 (scan-items-set-benchmark-queries distributed-items))))
+          (println "Profile Content Key")
+          (println (:formatted (profile node 10 (scan-items-by-content-key-queries distributed-items))))
+          (println "Profile Filters")
+          (println (:formatted (profile node 5 (scan-items-filter-queries distributed-items)))))))
+    (catch Exception e
+      (log/error e)))
+
+)

--- a/modules/bench/src/main/clojure/xtdb/bench/yakbench.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/yakbench.clj
@@ -116,14 +116,6 @@
                         (:id biggest-feed)]
                        (:titles biggest-feed))))}])
 
-(defn item-pk-lookup-queries
-  [item-ids]
-  (for [n [1 10 100 1000]
-        :let [ids (take n item-ids)]
-        :when (= (count ids) n)]
-    {:id (keyword (str "items-by-pks-" n))
-     :f #(xt/q % (vec (concat [(str "select _id, item$url from items where _id in " (?s n))]
-                              ids)))}))
 
 (defn user-specific-benchmarks-queries
   [{:keys [user-id user-email]}]
@@ -273,151 +265,6 @@
         {:id (:xt/id feed)
          :titles titles}))))
 
-(defn get-distributed-items
-  "Returns item data at various positions for scan benchmarking.
-   Fetches 1000 spread and 1000 clustered items with _id, content_key, lang, length, published_at.
-   Spread items are sampled via take-nth to maintain distribution across IID space."
-  [conn]
-  (let [n 1000
-        cnt (:cnt (first (xt/q conn ["SELECT count(*) as cnt FROM items"])))
-        step (max (quot cnt n) 1)
-        mid (quot cnt 2)
-
-        cols "_id, item$content_key, item$lang, item$length, item$published_at"
-
-        ;; Spread - evenly distributed across the IID space
-        spread-1000 (vec (xt/q conn
-                               [(str "SELECT " cols " FROM ("
-                                     "  SELECT " cols ", row_number() OVER (ORDER BY _id) as rn"
-                                     "  FROM items"
-                                     ") AS numbered WHERE (rn - 1) % ? = 0"
-                                     "  ORDER BY rn"
-                                     "  LIMIT ?")
-                                step n]))
-
-        ;; Clustered - consecutive from middle of IID space
-        clustered-1000 (vec (xt/q conn
-                                  [(str "SELECT " cols " FROM ("
-                                        "  SELECT " cols ", row_number() OVER (ORDER BY _id) as rn"
-                                        "  FROM items"
-                                        ") AS numbered WHERE rn BETWEEN ? AND ?"
-                                        "  ORDER BY rn")
-                                   mid (+ mid n -1)]))]
-    ;; Pre-sample for different sizes
-    {:spread-10 (vec (take-nth 100 spread-1000))
-     :spread-100 (vec (take-nth 10 spread-1000))
-     :spread-1000 spread-1000
-     :clustered-10 (vec (take 10 clustered-1000))
-     :clustered-100 (vec (take 100 clustered-1000))
-     :clustered-1000 clustered-1000
-     :langs (vec (distinct (map :item/lang spread-1000)))}))
-
-(defn- or-clause [col n]
-  (str/join " OR " (repeat n (str col " = ?"))))
-
-(defn scan-items-individual-benchmark-queries
-  "Generates benchmark queries for individual point lookups at different IID positions."
-  [{:keys [spread-10]}]
-  (for [[i item] (map-indexed vector spread-10)]
-    {:id (keyword (str "scan-p" (* i 10)))
-     :f #(xt/q % ["SELECT _id FROM items WHERE _id = ?" (:xt/id item)])}))
-
-(defn scan-items-set-benchmark-queries
-  "Generates benchmark queries for set lookups (IN and OR) with varying sizes on _id (IID path)."
-  [{:keys [spread-10 spread-100 spread-1000 clustered-10 clustered-100 clustered-1000]}]
-  (let [ids #(mapv :xt/id %)]
-    [{:id :scan-spread-in-10
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 10))] (ids spread-10)))}
-     {:id :scan-clustered-in-10
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 10))] (ids clustered-10)))}
-     {:id :scan-spread-or-10
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "_id" 10))] (ids spread-10)))}
-     {:id :scan-clustered-or-10
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "_id" 10))] (ids clustered-10)))}
-
-     {:id :scan-spread-in-100
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 100))] (ids spread-100)))}
-     {:id :scan-clustered-in-100
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 100))] (ids clustered-100)))}
-
-     {:id :scan-spread-in-1000
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 1000))] (ids spread-1000)))}
-     {:id :scan-clustered-in-1000
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 1000))] (ids clustered-1000)))}]))
-
-(defn scan-items-by-content-key-queries
-  "Generates benchmark queries for IN lookups on content_key (unique non-_id UUID column)."
-  [{:keys [spread-10 spread-100 spread-1000 clustered-10 clustered-100 clustered-1000]}]
-  (let [ckeys #(mapv :item/content-key %)]
-    [{:id :content-key-spread-in-10
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 10))] (ckeys spread-10)))}
-     {:id :content-key-clustered-in-10
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 10))] (ckeys clustered-10)))}
-     {:id :content-key-spread-or-10
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "item$content_key" 10))] (ckeys spread-10)))}
-     {:id :content-key-clustered-or-10
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "item$content_key" 10))] (ckeys clustered-10)))}
-
-     {:id :content-key-spread-in-100
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 100))] (ckeys spread-100)))}
-     {:id :content-key-clustered-in-100
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 100))] (ckeys clustered-100)))}
-
-     {:id :content-key-spread-in-1000
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 1000))] (ckeys spread-1000)))}
-     {:id :content-key-clustered-in-1000
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 1000))] (ckeys clustered-1000)))}]))
-
-(defn scan-items-filter-queries
-  "Generates benchmark queries for various filter types: equality, range, sparse."
-  [{:keys [spread-1000 langs]}]
-  (let [lengths (mapv :item/length spread-1000)
-        min-len (apply min lengths)
-        max-len (apply max lengths)
-        len-range (- max-len min-len)
-        ;; Thresholds for > filter selecting ~10%, ~25%, ~50% of rows
-        len-10pct (+ min-len (quot (* len-range 9) 10))
-        len-25pct (+ min-len (quot (* len-range 3) 4))
-        len-50pct (+ min-len (quot len-range 2))
-
-        timestamps (mapv :item/published-at spread-1000)
-        min-ts ^java.time.ZonedDateTime (reduce #(if (.isBefore ^java.time.ZonedDateTime %1 ^java.time.ZonedDateTime %2) %1 %2) timestamps)
-        max-ts (reduce #(if (.isAfter ^java.time.ZonedDateTime %1 ^java.time.ZonedDateTime %2) %1 %2) timestamps)
-        ts-range (.toMillis (java.time.Duration/between min-ts max-ts))
-        ;; Selectivity targets for timestamp
-        ts-10pct (.plus ^java.time.ZonedDateTime min-ts (java.time.Duration/ofMillis (quot (* ts-range 9) 10)))
-        ts-50pct (.plus ^java.time.ZonedDateTime min-ts (java.time.Duration/ofMillis (quot ts-range 2)))
-
-        n-langs (count langs)
-        _ (assert (>= n-langs 8) (str "Need at least 8 distinct langs for selectivity targets, got " n-langs))
-        langs-12pct (vec (take (quot n-langs 8) langs))
-        langs-25pct (vec (take (quot n-langs 4) langs))
-        langs-50pct (vec (take (quot n-langs 2) langs))]
-
-    [{:id :lang-select-12pct
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$lang IN " (?s (count langs-12pct)))] langs-12pct))}
-     {:id :lang-select-25pct
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$lang IN " (?s (count langs-25pct)))] langs-25pct))}
-     {:id :lang-select-50pct
-      :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$lang IN " (?s (count langs-50pct)))] langs-50pct))}
-
-     ;; Length range filters
-     {:id :length-select-10pct
-      :f #(xt/q % ["SELECT _id FROM items WHERE item$length > ?" len-10pct])}
-     {:id :length-select-25pct
-      :f #(xt/q % ["SELECT _id FROM items WHERE item$length > ?" len-25pct])}
-     {:id :length-select-50pct
-      :f #(xt/q % ["SELECT _id FROM items WHERE item$length > ?" len-50pct])}
-
-     ;; Timestamp range filters (recent items)
-     {:id :published-select-10pct
-      :f #(xt/q % ["SELECT _id FROM items WHERE item$published_at > ?" ts-10pct])}
-     {:id :published-select-50pct
-      :f #(xt/q % ["SELECT _id FROM items WHERE item$published_at > ?" ts-50pct])}
-
-     ;; Sparse column filter (~0.1% have doc_type)
-     {:id :doc-type-not-null
-      :f #(xt/q % ["SELECT _id FROM items WHERE item$doc_type IS NOT NULL"])}]))
 
 (defn profile-data
   [pstats]
@@ -577,8 +424,7 @@
                    (swap! !state merge {:max-user (get-max-user conn)
                                         :mean-user (get-mean-user conn)
                                         :active-users (get-active-users conn random scale-factor)
-                                        :biggest-feed (get-biggest-feed conn random)
-                                        :distributed-items (get-distributed-items conn)})))}
+                                        :biggest-feed (get-biggest-feed conn random)})))}
 
            {:t :call
             :stage :profile-global-queries
@@ -601,34 +447,6 @@
                  (let [{:keys [mean-user]} @!state
                        {:keys [profile formatted]} (profile node 50 (user-specific-benchmarks-queries mean-user))]
                    (swap! !state update :profiles assoc :mean-user profile)
-                   (println formatted)))}
-           {:t :call
-            :stage :profile-scan-items-individual
-            :f (fn [{:keys [node !state]}]
-                 (let [{:keys [distributed-items]} @!state
-                       {:keys [profile formatted]} (profile node 1000 (scan-items-individual-benchmark-queries distributed-items))]
-                   (swap! !state update :profiles assoc :scan-individual profile)
-                   (println formatted)))}
-           {:t :call
-            :stage :profile-scan-items-sets
-            :f (fn [{:keys [node !state]}]
-                 (let [{:keys [distributed-items]} @!state
-                       {:keys [profile formatted]} (profile node 50 (scan-items-set-benchmark-queries distributed-items))]
-                   (swap! !state update :profiles assoc :scan-sets profile)
-                   (println formatted)))}
-           {:t :call
-            :stage :profile-scan-content-key
-            :f (fn [{:keys [node !state]}]
-                 (let [{:keys [distributed-items]} @!state
-                       {:keys [profile formatted]} (profile node 10 (scan-items-by-content-key-queries distributed-items))]
-                   (swap! !state update :profiles assoc :scan-content-key profile)
-                   (println formatted)))}
-           {:t :call
-            :stage :profile-scan-filters
-            :f (fn [{:keys [node !state]}]
-                 (let [{:keys [distributed-items]} @!state
-                       {:keys [profile formatted]} (profile node 5 (scan-items-filter-queries distributed-items))]
-                   (swap! !state update :profiles assoc :scan-filters profile)
                    (println formatted)))}
            {:t :call
             :stage :inspect
@@ -665,8 +483,7 @@
         (let [max-user (get-max-user conn)
               mean-user (get-mean-user conn)
               active-users (get-active-users conn random scale)
-              biggest-feed (get-biggest-feed conn random)
-              distributed-items (get-distributed-items conn)]
+              biggest-feed (get-biggest-feed conn random)]
 
           (println "Profile Global")
           (println (:formatted (profile node 10 (benchmarks-queries active-users biggest-feed))))
@@ -674,13 +491,6 @@
           (println (:formatted (profile node 10 (user-specific-benchmarks-queries max-user))))
           (println "Profile Mean User")
           (println (:formatted (profile node 50 (user-specific-benchmarks-queries mean-user))))
-          (println "Profile Item Scan by IDs")
-          (println (:formatted (profile node 1000 (scan-items-individual-benchmark-queries distributed-items))))
-          (println (:formatted (profile node 50 (scan-items-set-benchmark-queries distributed-items))))
-          (println "Profile Item Scan by Content Key")
-          (println (:formatted (profile node 10 (scan-items-by-content-key-queries distributed-items))))
-          (println "Profile Filter Queries")
-          (println (:formatted (profile node 5 (scan-items-filter-queries distributed-items))))
           (println "Inspect")
           (inspect node {:max-user max-user
                          :active-users active-users}))))

--- a/modules/datasets/src/main/clojure/xtdb/datasets/scan_items.clj
+++ b/modules/datasets/src/main/clojure/xtdb/datasets/scan_items.clj
@@ -1,0 +1,51 @@
+(ns xtdb.datasets.scan-items
+  (:require [clojure.tools.logging :as log]
+            [xtdb.api :as xt]
+            [xtdb.bench.random :as random]))
+
+(def ^:private langs ["EN" "ES" "DE" "FR" "IT" "PT" "PL" "NL"])
+
+(defn- gen-id [random id-type i]
+  (case id-type
+    :uuid (random/next-uuid random)
+    :string (str (random/next-uuid random))
+    :keyword (keyword "item" (str i))))
+
+(defn- gen-item [^java.util.Random random cat-pool name-pool id-type i]
+  (let [categories (vec (repeatedly (random/next-int random 5) #(random/uniform-nth random cat-pool)))]
+    (cond-> {:xt/id (gen-id random id-type i)
+             :item/title (str "Item-" i)
+             :item/excerpt (random/next-string random (+ 40 (random/next-int random 120)))
+             :item/published-at (random/next-instant random 2020 2025)
+             :item/length (+ 100 (random/next-int random 2000))
+             :item/content-key (random/next-uuid random)
+             :item/lang (random/uniform-nth random langs)
+             :item/author-name (random/uniform-nth random name-pool)
+             :item/author-email (str (random/next-string random 8) "@example.com")
+             :item/author-url (str "https://example.com/author/" i)
+             :item/categories categories
+             :item/ingested-at (random/next-instant random 2020 2025)
+             :item/url (random/next-string random (+ 10 (random/next-int random 50)))}
+      (random/chance? random 0.001) (assoc :item/doc-type :item/direct
+                                           :item.direct/candidate-status (random/weighted-nth random [0.956 0.035 0.008] [:approved :failed :ingest-failed])))))
+
+(def ^:private batch-size 1000)
+
+(defn load-data!
+  "Generate and load `n-items` into the `items` table, streaming in batches to avoid holding
+   the full dataset in memory."
+  [conn ^java.util.Random random n-items id-type]
+  (log/info "Generating" n-items "items with id-type" id-type)
+  (let [cat-pool (vec (repeatedly 64 #(random/next-string random (+ 3 (random/next-int random 10)))))
+        name-pool (vec (repeatedly 64 #(random/next-string random (+ 6 (random/next-int random 20)))))
+        submit-batch! (fn [batch]
+                        (when (seq batch)
+                          (xt/submit-tx conn [(into [:put-docs :items] batch)])))]
+    (loop [i 0, batch []]
+      (if (>= i n-items)
+        (submit-batch! batch)
+        (let [batch (conj batch (gen-item random cat-pool name-pool id-type i))]
+          (if (= (count batch) batch-size)
+            (do (submit-batch! batch)
+                (recur (inc i) []))
+            (recur (inc i) batch)))))))


### PR DESCRIPTION
Yakbench generates all tables (users, feeds, subs, items, etc.) and uses UUID _id exclusively, making it overkill/unsuitable for measuring scan performance.

The new scan-perf benchmark has its own item generator with configurable _id types (uuid, string, keyword) and streams items in 1k batches to avoid holding the full dataset in memory — necessary for scaling to 100M+ items.

Filter queries target 0.05-12% selectivity (single-value equality, narrow BETWEEN, compound predicates) rather than the 10-50% ranges yakbench used, which were indistinguishable from full table scans.

Also adds -PtmpDir support for clojureRepl to avoid /tmp filling up during compaction of large datasets.

Run via: ./gradlew scan-perf -PnItems=100000 -PidType=uuid