### PR TITLE
fix(sql): support Postgres-style backreferences (\N) in REGEXP_REPLACE

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1112,8 +1112,17 @@
                     `(boolean (re-find (compile-regex ~(or re-literal `(resolve-string ~needle-code)) ~flags)
                                        (resolve-string ~haystack-code))))}))
 
+(defn- postgres-backrefs->java
+  "Converts \\N backreferences to Java's $N in a single pass.
+  Handles \\\\ (literal backslash) first so \\\\1 isn't mistaken for a backref."
+  ^String [^String replacement]
+  (str/replace replacement #"\\(\\|\d+)"
+             (fn [[_ group]]
+               (if (= group "\\") "\\\\" (str "$" group)))))
+
 (defmethod codegen-call [:regexp_replace :utf8] [{:keys [pattern replacement start n flags]}]
-  (let [flag-map {\s [Pattern/DOTALL]
+  (let [replacement (postgres-backrefs->java replacement)
+        flag-map {\s [Pattern/DOTALL]
                   \i [Pattern/CASE_INSENSITIVE, Pattern/UNICODE_CASE]
                   \m [Pattern/MULTILINE]}
 

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -404,7 +404,74 @@
   (t/is (= [{:out "example.com"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('http://example.com/some/path', '^https?://(?:www\\.)?([^/]+)/.*$', '\\1') AS out")))
 
   ;; \\1 in replacement = literal backslash + '1', not a backreference
-  (t/is (= [{:out "f\\1\\1b\\1r"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('foobar', '(a|e|i|o|u)', '\\\\1') AS out"))))
+  (t/is (= [{:out "f\\1\\1b\\1r"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('foobar', '(a|e|i|o|u)', '\\\\1') AS out")))
+
+  ;; multiple capture groups with postgres-style backrefs
+  (t/is (= [{:out "bar-foo"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('foo-bar', '(\\w+)-(\\w+)', '\\2-\\1') AS out")))
+
+  ;; \0 whole-match backref
+  (t/is (= [{:out "[foo] [bar]"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('foo bar', '(\\w+)', '[\\0]') AS out")))
+
+  ;; mixed $1 and \2 in the same replacement
+  (t/is (= [{:out "bar-foo"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('foo-bar', '(\\w+)-(\\w+)', '\\2-$1') AS out"))))
+
+(t/deftest test-postgres-backrefs->java
+  (let [convert @#'expr/postgres-backrefs->java]
+    (t/testing "no backrefs - passthrough"
+      (t/is (= "hello" (convert "hello")))
+      (t/is (= "" (convert "")))
+      (t/is (= "plain text with spaces" (convert "plain text with spaces"))))
+
+    (t/testing "single backref"
+      (t/is (= "$1" (convert "\\1")))
+      (t/is (= "$0" (convert "\\0")))
+      (t/is (= "$9" (convert "\\9"))))
+
+    (t/testing "multi-digit backref"
+      (t/is (= "$12" (convert "\\12")))
+      (t/is (= "$99" (convert "\\99")))
+      (t/is (= "$123" (convert "\\123"))))
+
+    (t/testing "multiple backrefs"
+      (t/is (= "$2-$1" (convert "\\2-\\1")))
+      (t/is (= "[$1] [$2] [$3]" (convert "[\\1] [\\2] [\\3]"))))
+
+    (t/testing "adjacent backrefs"
+      (t/is (= "$1$2" (convert "\\1\\2")))
+      (t/is (= "$1$2$3" (convert "\\1\\2\\3"))))
+
+    (t/testing "escaped backslash (\\\\) preserved as literal backslash"
+      ;; \\ in input (two chars: \ \) → \\ in output (preserved)
+      (t/is (= "\\\\" (convert "\\\\")))
+      (t/is (= "a\\\\b" (convert "a\\\\b"))))
+
+    (t/testing "escaped backslash followed by digit = literal backslash + digit, not backref"
+      ;; \\1 in input (three chars: \ \ 1) → \\ consumes the first two, 1 remains literal
+      (t/is (= "\\\\1" (convert "\\\\1")))
+      ;; \\1\\2 → literal backslash + 1, literal backslash + 2
+      (t/is (= "\\\\1\\\\2" (convert "\\\\1\\\\2"))))
+
+    (t/testing "java-style $N passes through unchanged"
+      (t/is (= "$1" (convert "$1")))
+      (t/is (= "$2 and $3" (convert "$2 and $3"))))
+
+    (t/testing "mixed $N and \\N"
+      (t/is (= "$2-$1" (convert "\\2-$1")))
+      (t/is (= "$1$2" (convert "$1\\2"))))
+
+    (t/testing "backref with surrounding text"
+      (t/is (= "prefix-$1-suffix" (convert "prefix-\\1-suffix")))
+      (t/is (= " $1 " (convert " \\1 "))))
+
+    (t/testing "lone backslash passes through unchanged"
+      ;; \a, \z etc - not a backref, not an escaped backslash
+      ;; the function doesn't touch these (Java's Matcher treats \x as literal x)
+      (t/is (= "\\a" (convert "\\a")))
+      (t/is (= "\\n" (convert "\\n")))
+      ;; trailing lone backslash - also passes through
+      ;; (Java's Matcher.replaceAll would throw on this, but that's not our problem)
+      (t/is (= "trailing\\" (convert "trailing\\")))
+      (t/is (= "\\" (convert "\\"))))))
 
 (t/deftest test-bool-test-expr
   (t/are [sql expected]

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -398,7 +398,13 @@
 
   (t/is (= [{:out "fxxbxr"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('foobar', '(a|e|i|o|u)', 'x') AS out")))
   (t/is (= [{:out "fxxbxr"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('foobar', '(a|e|i|o|u)', 'x') AS out")))
-  (t/is (= [{:out "f o  o b a r"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('foobar', '(a|e|i|o|u)', ' $1 ') AS out"))))
+  ;; $1 (Java-style) and \1 (Postgres-style) both work as backreferences
+  (t/is (= [{:out "f o  o b a r"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('foobar', '(a|e|i|o|u)', ' $1 ') AS out")))
+  (t/is (= [{:out "f o  o b a r"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('foobar', '(a|e|i|o|u)', ' \\1 ') AS out")))
+  (t/is (= [{:out "example.com"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('http://example.com/some/path', '^https?://(?:www\\.)?([^/]+)/.*$', '\\1') AS out")))
+
+  ;; \\1 in replacement = literal backslash + '1', not a backreference
+  (t/is (= [{:out "f\\1\\1b\\1r"}] (xt/q tu/*node* "SELECT REGEXP_REPLACE('foobar', '(a|e|i|o|u)', '\\\\1') AS out"))))
 
 (t/deftest test-bool-test-expr
   (t/are [sql expected]


### PR DESCRIPTION
REGEXP_REPLACE replacement strings use \1, \2 etc for backreferences in Postgres (and most SQL databases per POSIX convention), but Java's Matcher.replaceAll() uses $1, $2. We were passing the replacement string through as-is, so \1 was silently treated as the literal character '1'.

Implemented in the expression engine (as `postgres-backrefs->java`) means it runs at query time on the actual resolved replacement string, which is the correct layer for bridging Postgres replacement semantics to Java's Matcher.

Discovered while comparing clickbench query results against Postgres - Q29 (REGEXP_REPLACE for domain extraction) was returning literal 1.

Closes #5278