### PR TITLE
feat(bench): add scan-perf and scan-perf-str nightly benchmarks

### DIFF
--- a/.github/workflows/nightly-benchmark-cleanup.yml
+++ b/.github/workflows/nightly-benchmark-cleanup.yml
@@ -1,6 +1,6 @@
 name: Nightly Benchmark Cleanup
 run-name: >-
-  Benchmark Cleanup: ${{ inputs.benchType == 'tpch' && 'TPC-H' || inputs.benchType == 'auctionmark' && 'AuctionMark' || inputs.benchType == 'readings' && 'Readings' || inputs.benchType == 'yakbench' && 'Yakbench' || inputs.benchType == 'clickbench' && 'ClickBench' || inputs.benchType == 'tsbs-iot' && 'TSBS IoT' || inputs.benchType == 'ingest-tx-overhead' && 'Ingest TX Overhead' || inputs.benchType == 'patch' && 'Patch' || inputs.benchType == 'products' && 'Products' || inputs.benchType == 'ts-devices' && 'TS Devices' || inputs.benchType == 'fusion' && 'Fusion' || inputs.benchType }}
+  Benchmark Cleanup: ${{ inputs.benchType == 'tpch' && 'TPC-H' || inputs.benchType == 'auctionmark' && 'AuctionMark' || inputs.benchType == 'readings' && 'Readings' || inputs.benchType == 'yakbench' && 'Yakbench' || inputs.benchType == 'clickbench' && 'ClickBench' || inputs.benchType == 'tsbs-iot' && 'TSBS IoT' || inputs.benchType == 'ingest-tx-overhead' && 'Ingest TX Overhead' || inputs.benchType == 'patch' && 'Patch' || inputs.benchType == 'products' && 'Products' || inputs.benchType == 'ts-devices' && 'TS Devices' || inputs.benchType == 'fusion' && 'Fusion' || inputs.benchType == 'scan-perf' && 'Scan Perf' || inputs.benchType == 'scan-perf-str' && 'Scan Perf Str' || inputs.benchType }}
 
 on:
   workflow_dispatch:
@@ -21,6 +21,8 @@ on:
           - products
           - ts-devices
           - fusion
+          - scan-perf
+          - scan-perf-str
       status:
         description: 'Status of the benchmark'
         required: true
@@ -553,6 +555,8 @@ jobs:
             products) bench_friendly="Products" ;;
             ts-devices) bench_friendly="TS Devices" ;;
             fusion) bench_friendly="Fusion" ;;
+            scan-perf) bench_friendly="Scan Perf" ;;
+            scan-perf-str) bench_friendly="Scan Perf Str" ;;
             *) bench_friendly="$bench" ;;
           esac
 
@@ -624,6 +628,8 @@ jobs:
           [ "$type" = "products" ] && type="Products"
           [ "$type" = "ts-devices" ] && type="TS Devices"
           [ "$type" = "fusion" ] && type="Fusion"
+          [ "$type" = "scan-perf" ] && type="Scan Perf"
+          [ "$type" = "scan-perf-str" ] && type="Scan Perf Str"
 
           status="${{ steps.derive.outputs.bench_status || inputs.status }}"
           if [ "$status" = "success" ]; then
@@ -787,6 +793,8 @@ jobs:
             products) FRIENDLY_NAME="Products" ;;
             ts-devices) FRIENDLY_NAME="TS Devices" ;;
             fusion) FRIENDLY_NAME="Fusion" ;;
+            scan-perf) FRIENDLY_NAME="Scan Perf" ;;
+            scan-perf-str) FRIENDLY_NAME="Scan Perf Str" ;;
             *) FRIENDLY_NAME="$BENCH_TYPE" ;;
           esac
 
@@ -835,7 +843,7 @@ jobs:
             const queue = [
               'tpch', 'yakbench', 'readings', 'auctionmark',
               'clickbench', 'tsbs-iot', 'ingest-tx-overhead',
-              'patch', 'products', 'ts-devices', 'fusion'
+              'patch', 'products', 'ts-devices', 'fusion', 'scan-perf', 'scan-perf-str'
             ];
             const current = '${{ inputs.benchType }}';
             const idx = queue.indexOf(current);

--- a/.github/workflows/nightly-benchmark-scan-perf-str.yml
+++ b/.github/workflows/nightly-benchmark-scan-perf-str.yml
@@ -1,0 +1,41 @@
+name: Nightly Benchmark Scan Perf Str
+run-name: "Scan Perf Str (N Items: ${{ inputs.scan_perf_n_items || '10000000' }})"
+
+on:
+  workflow_dispatch:
+    inputs:
+      scan_perf_n_items:
+        description: 'Number of items'
+        required: false
+        default: '10000000'
+        type: string
+      run_queue:
+        description: 'Part of nightly benchmark queue (set by suite workflow)'
+        required: false
+        default: 'false'
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+  actions: write
+  packages: write
+
+concurrency:
+  group: nightly-benchmark-scan-perf-str
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'xtdb/xtdb' }}
+    uses: ./.github/workflows/run-nightly-benchmark.yml
+    with:
+      bench_type: scan-perf-str
+      job_display_name: Scan Perf Str
+      branch: ${{ github.ref_name }}
+      timeout_minutes: 120
+      benchmark_timeout: PT3H
+      scan_perf_n_items: ${{ inputs.scan_perf_n_items || '10000000' }}
+      scan_perf_id_type: string
+      run_queue: ${{ inputs.run_queue || 'false' }}
+    secrets: inherit

--- a/.github/workflows/nightly-benchmark-scan-perf.yml
+++ b/.github/workflows/nightly-benchmark-scan-perf.yml
@@ -1,0 +1,46 @@
+name: Nightly Benchmark Scan Perf
+run-name: "Scan Perf (N Items: ${{ inputs.scan_perf_n_items || '10000000' }}, ID Type: ${{ inputs.scan_perf_id_type || 'uuid' }})"
+
+on:
+  workflow_dispatch:
+    inputs:
+      scan_perf_n_items:
+        description: 'Number of items'
+        required: false
+        default: '10000000'
+        type: string
+      scan_perf_id_type:
+        description: 'ID type (uuid, string, keyword)'
+        required: false
+        default: 'uuid'
+        type: string
+      run_queue:
+        description: 'Part of nightly benchmark queue (set by suite workflow)'
+        required: false
+        default: 'false'
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+  actions: write
+  packages: write
+
+concurrency:
+  group: nightly-benchmark-scan-perf
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'xtdb/xtdb' }}
+    uses: ./.github/workflows/run-nightly-benchmark.yml
+    with:
+      bench_type: scan-perf
+      job_display_name: Scan Perf
+      branch: ${{ github.ref_name }}
+      timeout_minutes: 120
+      benchmark_timeout: PT3H
+      scan_perf_n_items: ${{ inputs.scan_perf_n_items || '10000000' }}
+      scan_perf_id_type: ${{ inputs.scan_perf_id_type || 'uuid' }}
+      run_queue: ${{ inputs.run_queue || 'false' }}
+    secrets: inherit

--- a/.github/workflows/run-nightly-benchmark.yml
+++ b/.github/workflows/run-nightly-benchmark.yml
@@ -141,6 +141,16 @@ on:
         required: false
         default: ''
         type: string
+      scan_perf_n_items:
+        description: 'Number of items for scan-perf benchmark'
+        required: false
+        default: ''
+        type: string
+      scan_perf_id_type:
+        description: 'ID type for scan-perf benchmark (uuid, string, keyword)'
+        required: false
+        default: ''
+        type: string
       run_queue:
         description: 'Whether this run is part of the nightly benchmark queue'
         required: false
@@ -330,6 +340,8 @@ jobs:
           FUSION_READING_COUNT: ${{ inputs.fusion_reading_count }}
           FUSION_DURATION: ${{ inputs.fusion_duration }}
           FUSION_THREADS: ${{ inputs.fusion_threads }}
+          SCAN_PERF_N_ITEMS: ${{ inputs.scan_perf_n_items }}
+          SCAN_PERF_ID_TYPE: ${{ inputs.scan_perf_id_type }}
           RUN_QUEUE: ${{ inputs.run_queue }}
         run: |
           helm dependency update ./modules/bench/cloud/helm
@@ -420,6 +432,13 @@ jobs:
           fi
           if [ -n "$FUSION_THREADS" ]; then
             HELM_ARGS+=(--set "fusion.threads=${FUSION_THREADS}")
+          fi
+          if [ -n "$SCAN_PERF_N_ITEMS" ]; then
+            HELM_ARGS+=(--set "scan-perf.nItems=${SCAN_PERF_N_ITEMS}")
+            HELM_ARGS+=(--set "scan-perf-str.nItems=${SCAN_PERF_N_ITEMS}")
+          fi
+          if [ -n "$SCAN_PERF_ID_TYPE" ]; then
+            HELM_ARGS+=(--set "scan-perf.idType=${SCAN_PERF_ID_TYPE}")
           fi
           if [ "$RUN_QUEUE" = "true" ]; then
             HELM_ARGS+=(--set "providerConfig.env.RUN_QUEUE=true")
@@ -540,6 +559,8 @@ jobs:
           FUSION_READING_COUNT: ${{ inputs.fusion_reading_count }}
           FUSION_DURATION: ${{ inputs.fusion_duration }}
           FUSION_THREADS: ${{ inputs.fusion_threads }}
+          SCAN_PERF_N_ITEMS: ${{ inputs.scan_perf_n_items }}
+          SCAN_PERF_ID_TYPE: ${{ inputs.scan_perf_id_type }}
           GIT_SHA: ${{ github.sha }}
           GIT_BRANCH: ${{ inputs.branch }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
@@ -579,6 +600,8 @@ jobs:
           [ -n "$FUSION_READING_COUNT" ] && CONFIG_PARTS+=("Readings: ${FUSION_READING_COUNT}")
           [ -n "$FUSION_DURATION" ] && CONFIG_PARTS+=("Duration: ${FUSION_DURATION}")
           [ -n "$FUSION_THREADS" ] && CONFIG_PARTS+=("Threads: ${FUSION_THREADS}")
+          [ -n "$SCAN_PERF_N_ITEMS" ] && CONFIG_PARTS+=("N Items: ${SCAN_PERF_N_ITEMS}")
+          [ -n "$SCAN_PERF_ID_TYPE" ] && CONFIG_PARTS+=("ID Type: ${SCAN_PERF_ID_TYPE}")
           # Join with " | "
           if [ ${#CONFIG_PARTS[@]} -gt 0 ]; then
             CONFIG_INFO=$(printf " | %s" "${CONFIG_PARTS[@]}")

--- a/modules/bench/cloud/helm/templates/benchmark-scan-perf.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-scan-perf.yaml
@@ -1,0 +1,303 @@
+{{- if eq .Values.benchType "scan-perf" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: scan-perf
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: xtdb
+    app.kubernetes.io/component: benchmark
+  annotations:
+    {{- if .Values.git.sha }}
+    xtdb.com/git-sha: {{ .Values.git.sha | quote }}
+    {{- end }}
+    {{- if .Values.git.branch }}
+    xtdb.com/git-branch: {{ .Values.git.branch | quote }}
+    {{- end }}
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        {{- $user := .Values.providerConfig.podLabels | default (dict) -}}
+        {{- $base := dict "app.kubernetes.io/name" "xtdb" "app.kubernetes.io/component" "benchmark" -}}
+        {{- $labels := merge (dict) $user $base -}}
+        {{- toYaml $labels | nindent 8 }}
+      annotations:
+        "helm.sh/hook": pre-install,pre-upgrade
+        "helm.sh/hook-delete-policy": before-hook-creation
+    spec:
+      shareProcessNamespace: true
+      nodeSelector:
+        {{- toYaml .Values.providerConfig.nodeSelector | nindent 8 }}
+      serviceAccountName: xtdb-service-account
+      restartPolicy: Never
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: xtdb-yaml-config
+          configMap:
+            name: xtdb-yaml-config
+        - name: local-disk-cache
+          emptyDir:
+            sizeLimit: {{ .Values.xtdbConfig.localDiskCache.sizeLimit }}
+        - name: dumps
+          emptyDir:
+            sizeLimit: {{ .Values.dumpUpload.volumeSizeLimit }}
+        - name: dump-upload-scripts
+          configMap:
+            name: dump-upload-scripts
+            defaultMode: 0755
+      initContainers:
+      - name: wait-for-kafka
+        image: busybox
+        command: ['sh', '-c', 'until nc -z -w 2 {{ include "xtdb.kafka.host" .Values.xtdbConfig.kafkaBootstrapServers }} {{ include "xtdb.kafka.port" .Values.xtdbConfig.kafkaBootstrapServers }}; do echo waiting for kafka; sleep 5; done;']
+        resources:
+          requests:
+            memory: "256Mi"
+          limits:
+            memory: "256Mi"
+      containers:
+        - name: xtdb-node
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - mountPath: /var/lib/xtdb-config/xtdbconfig.yaml
+              name: xtdb-yaml-config
+              subPath: xtdbconfig.yaml
+            - name: local-disk-cache
+              mountPath: /var/lib/xtdb/buffers/
+            - name: dumps
+              mountPath: /dumps
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: xtdb-env-config
+            {{- if .Values.providerConfig.existingSecret }}
+            - secretRef:
+                name: {{ .Values.providerConfig.existingSecret }}
+            {{- end }}
+          env:
+            - name: XTDB_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- if .Values.git.sha }}
+            - name: GIT_SHA
+              value: {{ .Values.git.sha | quote }}
+            {{- end }}
+            {{- if .Values.git.branch }}
+            - name: GIT_BRANCH
+              value: {{ .Values.git.branch | quote }}
+            {{- end }}
+            - name: GITHUB_REPOSITORY
+              value: {{ .Values.git.repo | default "xtdb/xtdb" | quote }}
+            - name: GITHUB_RUN_ID
+              value: {{ .Values.git.runId | default "" | quote }}
+          args:
+            - scan-perf
+            - -f
+            - "/var/lib/xtdb-config/xtdbconfig.yaml"
+            - --n-items
+            - {{ index .Values "scan-perf" "nItems" | quote }}
+            - --id-type
+            - {{ index .Values "scan-perf" "idType" | quote }}
+            {{- if .Values.timeout }}
+            - --timeout
+            - {{ .Values.timeout | quote }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+        - name: dump-uploader
+          image: mcr.microsoft.com/azure-cli:latest
+          command: ["/bin/bash", "/scripts/upload-dumps.sh"]
+          volumeMounts:
+            - name: dumps
+              mountPath: /dumps
+            - name: dump-upload-scripts
+              mountPath: /scripts
+          resources:
+            {{- toYaml .Values.dumpUpload.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: xtdb-env-config
+            {{- if .Values.providerConfig.existingSecret }}
+            - secretRef:
+                name: {{ .Values.providerConfig.existingSecret }}
+            {{- end }}
+          env:
+            - name: AZURE_STORAGE_ACCOUNT
+              value: {{ .Values.providerConfig.env.AZURE_STORAGE_ACCOUNT | default "" | quote }}
+            - name: AZURE_STORAGE_CONTAINER
+              value: {{ .Values.providerConfig.env.AZURE_STORAGE_CONTAINER | default "" | quote }}
+            - name: AZURE_DUMPS_CONTAINER
+              value: {{ .Values.providerConfig.env.AZURE_DUMPS_CONTAINER | default "" | quote }}
+            - name: XTDB_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- if .Values.git.branch }}
+            - name: GIT_BRANCH
+              value: {{ .Values.git.branch | quote }}
+            {{- end }}
+            - name: GITHUB_REPOSITORY
+              value: {{ .Values.git.repo | default "xtdb/xtdb" | quote }}
+            - name: BENCH_TYPE
+              value: {{ .Values.benchType | quote }}
+{{- else if eq .Values.benchType "scan-perf-str" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: scan-perf-str
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: xtdb
+    app.kubernetes.io/component: benchmark
+  annotations:
+    {{- if .Values.git.sha }}
+    xtdb.com/git-sha: {{ .Values.git.sha | quote }}
+    {{- end }}
+    {{- if .Values.git.branch }}
+    xtdb.com/git-branch: {{ .Values.git.branch | quote }}
+    {{- end }}
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        {{- $user := .Values.providerConfig.podLabels | default (dict) -}}
+        {{- $base := dict "app.kubernetes.io/name" "xtdb" "app.kubernetes.io/component" "benchmark" -}}
+        {{- $labels := merge (dict) $user $base -}}
+        {{- toYaml $labels | nindent 8 }}
+      annotations:
+        "helm.sh/hook": pre-install,pre-upgrade
+        "helm.sh/hook-delete-policy": before-hook-creation
+    spec:
+      shareProcessNamespace: true
+      nodeSelector:
+        {{- toYaml .Values.providerConfig.nodeSelector | nindent 8 }}
+      serviceAccountName: xtdb-service-account
+      restartPolicy: Never
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: xtdb-yaml-config
+          configMap:
+            name: xtdb-yaml-config
+        - name: local-disk-cache
+          emptyDir:
+            sizeLimit: {{ .Values.xtdbConfig.localDiskCache.sizeLimit }}
+        - name: dumps
+          emptyDir:
+            sizeLimit: {{ .Values.dumpUpload.volumeSizeLimit }}
+        - name: dump-upload-scripts
+          configMap:
+            name: dump-upload-scripts
+            defaultMode: 0755
+      initContainers:
+      - name: wait-for-kafka
+        image: busybox
+        command: ['sh', '-c', 'until nc -z -w 2 {{ include "xtdb.kafka.host" .Values.xtdbConfig.kafkaBootstrapServers }} {{ include "xtdb.kafka.port" .Values.xtdbConfig.kafkaBootstrapServers }}; do echo waiting for kafka; sleep 5; done;']
+        resources:
+          requests:
+            memory: "256Mi"
+          limits:
+            memory: "256Mi"
+      containers:
+        - name: xtdb-node
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - mountPath: /var/lib/xtdb-config/xtdbconfig.yaml
+              name: xtdb-yaml-config
+              subPath: xtdbconfig.yaml
+            - name: local-disk-cache
+              mountPath: /var/lib/xtdb/buffers/
+            - name: dumps
+              mountPath: /dumps
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: xtdb-env-config
+            {{- if .Values.providerConfig.existingSecret }}
+            - secretRef:
+                name: {{ .Values.providerConfig.existingSecret }}
+            {{- end }}
+          env:
+            - name: XTDB_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- if .Values.git.sha }}
+            - name: GIT_SHA
+              value: {{ .Values.git.sha | quote }}
+            {{- end }}
+            {{- if .Values.git.branch }}
+            - name: GIT_BRANCH
+              value: {{ .Values.git.branch | quote }}
+            {{- end }}
+            - name: GITHUB_REPOSITORY
+              value: {{ .Values.git.repo | default "xtdb/xtdb" | quote }}
+            - name: GITHUB_RUN_ID
+              value: {{ .Values.git.runId | default "" | quote }}
+          args:
+            - scan-perf-str
+            - -f
+            - "/var/lib/xtdb-config/xtdbconfig.yaml"
+            - --n-items
+            - {{ index .Values "scan-perf-str" "nItems" | quote }}
+            {{- if .Values.timeout }}
+            - --timeout
+            - {{ .Values.timeout | quote }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+        - name: dump-uploader
+          image: mcr.microsoft.com/azure-cli:latest
+          command: ["/bin/bash", "/scripts/upload-dumps.sh"]
+          volumeMounts:
+            - name: dumps
+              mountPath: /dumps
+            - name: dump-upload-scripts
+              mountPath: /scripts
+          resources:
+            {{- toYaml .Values.dumpUpload.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: xtdb-env-config
+            {{- if .Values.providerConfig.existingSecret }}
+            - secretRef:
+                name: {{ .Values.providerConfig.existingSecret }}
+            {{- end }}
+          env:
+            - name: AZURE_STORAGE_ACCOUNT
+              value: {{ .Values.providerConfig.env.AZURE_STORAGE_ACCOUNT | default "" | quote }}
+            - name: AZURE_STORAGE_CONTAINER
+              value: {{ .Values.providerConfig.env.AZURE_STORAGE_CONTAINER | default "" | quote }}
+            - name: AZURE_DUMPS_CONTAINER
+              value: {{ .Values.providerConfig.env.AZURE_DUMPS_CONTAINER | default "" | quote }}
+            - name: XTDB_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- if .Values.git.branch }}
+            - name: GIT_BRANCH
+              value: {{ .Values.git.branch | quote }}
+            {{- end }}
+            - name: GITHUB_REPOSITORY
+              value: {{ .Values.git.repo | default "xtdb/xtdb" | quote }}
+            - name: BENCH_TYPE
+              value: {{ .Values.benchType | quote }}
+{{- end }}

--- a/modules/bench/cloud/helm/values.yaml
+++ b/modules/bench/cloud/helm/values.yaml
@@ -40,6 +40,13 @@ fusion:
   duration: "PT30M"
   threads: 4
 
+scan-perf:
+  nItems: 10000000
+  idType: uuid
+
+scan-perf-str:
+  nItems: 10000000
+
 ingestTxOverhead:
   docCount: 100000
   batchSizes: "1000,100,10,1"

--- a/modules/bench/cloud/metrics/main.tf
+++ b/modules/bench/cloud/metrics/main.tf
@@ -205,6 +205,19 @@ locals {
       metric_name     = "throughput"
       dashboard_idx   = 10
     }
+    scan-perf = {
+      name            = "Scan Perf"
+      display_name    = "Scan Perf"
+      logic_app_name  = var.scan_perf_anomaly_logic_app_name
+      enabled         = var.scan_perf_anomaly_alert_enabled
+      param_name      = "n-items"
+      param_path      = "parameters['n-items']"
+      param_value     = var.scan_perf_anomaly_n_items
+      param_is_string = false
+      metric_path     = "'time-taken-ms'"
+      metric_name     = "duration_minutes"
+      dashboard_idx   = 11
+    }
   }
 
   # Dashboard part positions (5 cols wide, 4 rows tall each, 4 columns)
@@ -221,6 +234,7 @@ locals {
     8 = { x = 0, y = 8 }
     9  = { x = 5, y = 8 }
     10 = { x = 10, y = 8 }
+    11 = { x = 15, y = 8 }
   }
 
   # Filter expressions per benchmark (string params quoted, numeric params use todouble)

--- a/modules/bench/cloud/metrics/variables.tf
+++ b/modules/bench/cloud/metrics/variables.tf
@@ -307,3 +307,22 @@ variable "fusion_anomaly_devices" {
   type        = number
   default     = 10000
 }
+
+# Scan Perf anomaly detection configuration
+variable "scan_perf_anomaly_logic_app_name" {
+  description = "Logic App name for scheduled Scan Perf anomaly detection"
+  type        = string
+  default     = "xtdb-bench-scan-perf-anomaly-schedule"
+}
+
+variable "scan_perf_anomaly_alert_enabled" {
+  description = "Whether the Scan Perf anomaly detection Logic App is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "scan_perf_anomaly_n_items" {
+  description = "Scan Perf n-items count to scope anomaly detection to"
+  type        = number
+  default     = 10000000
+}

--- a/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/charts.clj
+++ b/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/charts.clj
@@ -128,7 +128,17 @@
                  :title "TS Devices Benchmark Performance"
                  :filter-param "size"
                  :filter-value "small"
-                 :filter-is-string true}})
+                 :filter-is-string true}
+   "scan-perf-str" {:benchmark-name "Scan Perf Str"
+                    :title "Scan Perf Str Benchmark Performance"
+                    :filter-param "n-items"
+                    :filter-value 10000000
+                    :filter-is-string false}
+   "scan-perf" {:benchmark-name "Scan Perf"
+                :title "Scan Perf Benchmark Performance"
+                :filter-param "n-items"
+                :filter-value 10000000
+                :filter-is-string false}})
 
 (defn plot-benchmark-timeseries
   "Plot a benchmark timeseries chart from Azure Log Analytics.

--- a/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/log_parsing.clj
+++ b/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/log_parsing.clj
@@ -225,6 +225,22 @@
      :benchmark-total-time-ms benchmark-total-time-ms
      :benchmark-summary benchmark-summary}))
 
+(defmethod parse-log "scan-perf" [_benchmark-type log-file-path]
+  (let [content (slurp log-file-path)
+        lines (str/split-lines content)
+        profiles-line (first (filter #(str/includes? % "\"profiles\":") lines))
+        profiles (when profiles-line
+                   (try
+                     (:profiles (json/parse-string profiles-line true))
+                     (catch Exception _ nil)))
+        {:keys [benchmark-total-time-ms benchmark-summary]} (parse-benchmark-summary lines)]
+    {:profiles profiles
+     :benchmark-total-time-ms benchmark-total-time-ms
+     :benchmark-summary benchmark-summary}))
+
+(defmethod parse-log "scan-perf-str" [_ log-file-path]
+  (parse-log "scan-perf" log-file-path))
+
 (defn load-summary
   "Load and parse a benchmark log file, returning summary with benchmark type."
   [benchmark-type log-file-path]

--- a/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/tasks.clj
+++ b/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/tasks.clj
@@ -58,7 +58,17 @@
                                    :log-file log-file-path})))
         "products" nil
         "ts-devices" nil
-        "fusion" nil)
+        "fusion" nil
+        "scan-perf" (when (or (nil? (:profiles parsed-summary))
+                              (empty? (:profiles parsed-summary)))
+                      (throw (ex-info "No profile data found in log file"
+                                      {:benchmark-type "scan-perf"
+                                       :log-file log-file-path})))
+        "scan-perf-str" (when (or (nil? (:profiles parsed-summary))
+                                  (empty? (:profiles parsed-summary)))
+                          (throw (ex-info "No profile data found in log file"
+                                          {:benchmark-type "scan-perf-str"
+                                           :log-file log-file-path}))))
       (summary/render-summary parsed-summary {:format format}))))
 
 (defn plot-benchmark-timeseries
@@ -162,7 +172,7 @@
   (println "  plot-benchmark-timeseries [options] <benchmark-type>")
   (println "      Plot a benchmark timeseries chart from Azure Log Analytics.")
   (println "      Options: --scale-factor SF, --repo owner/repo, --branch branch")
-  (println "      Supported: tpch, yakbench, auctionmark, readings, clickbench, tsbs-iot, ingest-tx-overhead, patch, products, ts-devices, fusion")
+  (println "      Supported: tpch, yakbench, auctionmark, readings, clickbench, tsbs-iot, ingest-tx-overhead, patch, products, ts-devices, fusion, scan-perf, scan-perf-str")
   (println)
   (println "Kubernetes Commands (output JSON):")
   (println "  inspect-deployment [--namespace NS]")

--- a/modules/bench/src/main/clojure/xtdb/bench/scan_perf.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/scan_perf.clj
@@ -173,7 +173,7 @@
 (defmethod b/cli-flags :scan-perf [_]
   [["-n" "--n-items N_ITEMS" "Number of items to generate"
     :parse-fn parse-long
-    :default 1750000]
+    :default 10000000]
    ["-t" "--id-type ID_TYPE" "ID type: uuid, string, keyword"
     :parse-fn keyword
     :default :uuid]
@@ -242,6 +242,61 @@
             :f (fn [{:keys [!state] :as worker}]
                  (let [{:keys [profiles]} @!state]
                    (b/log-report worker {:profiles profiles})))}]})
+
+(defmethod b/cli-flags :scan-perf-str [_]
+  [["-n" "--n-items N_ITEMS" "Number of items to generate"
+    :parse-fn parse-long
+    :default 10000000]
+   ["-h" "--help"]])
+
+(defmethod b/->benchmark :scan-perf-str [_ {:keys [n-items seed no-load?]
+                                              :or {n-items 10000000 seed 0}}]
+  (let [id-type :string]
+    (log/info {:n-items n-items :id-type id-type :seed seed :no-load? no-load?})
+
+    {:title "Scan Perf Str"
+     :benchmark-type :scan-perf-str
+     :seed seed
+     :parameters {:n-items n-items :id-type id-type :seed seed :no-load? no-load?}
+     :->state #(do {:!state (atom {})})
+     :tasks [(when-not no-load?
+               {:t :do
+                :stage :ingest
+                :tasks [{:t :call
+                         :stage :submit-docs
+                         :f (fn [{:keys [node random]}]
+                              (with-open [conn (get-conn node)]
+                                (scan-items/load-data! conn random n-items id-type)))}
+                        {:t :call
+                         :stage :await-transactions
+                         :f (fn [{:keys [node]}] (b/sync-node node))}
+                        {:t :call
+                         :stage :flush-block
+                         :f (fn [{:keys [node]}] (tu/flush-block! node))}]})
+
+             {:t :call
+              :stage :compact
+              :f (fn [{:keys [node]}] (c/compact-all! node nil))}
+
+             {:t :call
+              :stage :get-query-data
+              :f (fn [{:keys [node !state]}]
+                   (with-open [conn (get-conn node)]
+                     (swap! !state assoc :distributed-items (get-distributed-items conn))))}
+
+             {:t :call
+              :stage :profile-scan-sets
+              :f (fn [{:keys [node !state]}]
+                   (let [{:keys [distributed-items]} @!state
+                         {:keys [profile formatted]} (profile node 50 (scan-items-set-benchmark-queries distributed-items))]
+                     (swap! !state update :profiles assoc :scan-sets profile)
+                     (println formatted)))}
+
+             {:t :call
+              :stage :output-profile-data
+              :f (fn [{:keys [!state] :as worker}]
+                   (let [{:keys [profiles]} @!state]
+                     (b/log-report worker {:profiles profiles})))}]}))
 
 (comment
   (try


### PR DESCRIPTION
The scan-perf benchmark was already implemented but lacked nightly CI infrastructure. scan-perf-str is a new variant that hardcodes string _id type and only runs the scan-sets profiling stage — the only stage where _id type meaningfully affects performance.

Both benchmarks default to 10M items to better surface pushdown performance differences at scale.