### PR TITLE
feat: split source and replica log, part 2 (#5212)

### DIFF
--- a/core/src/main/clojure/xtdb/compactor/reset.clj
+++ b/core/src/main/clojure/xtdb/compactor/reset.clj
@@ -13,7 +13,7 @@
            xtdb.table.TableRef
            (xtdb.trie Trie)))
 
-(defn reset-compactor! [node-opts db-name {:keys [dry-run?]}]
+(defn reset-compactor! [node-opts ^String db-name {:keys [dry-run?]}]
   (let [config (doto (xtn/->config node-opts)
                  (-> (.getCompactor) (.threads 0))
                  (.setServer nil)

--- a/core/src/main/clojure/xtdb/db_catalog.clj
+++ b/core/src/main/clojure/xtdb/db_catalog.clj
@@ -72,7 +72,7 @@
          :xtdb.metadata/metadata-manager opts
          :xtdb/log (assoc opts :factory (.getLog db-config) :mode mode)
          :xtdb/source-log opts
-         :xtdb/replica-log opts
+         :xtdb/replica-log (assoc opts :factory (.getLog db-config) :mode mode)
          :xtdb/buffer-pool (assoc opts :factory (.getStorage db-config) :mode mode)
 
          ::storage opts

--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -126,7 +126,7 @@
   (let [db (.getPrimary db-cat)
         ^Server server (-> (handler {:meter-registry meter-registry
                                      :db db
-                                     :initial-target-message-id (.getLatestSubmittedMsgId (.getLogProcessor db))
+                                     :initial-target-message-id (.getLatestSubmittedMsgId (.getSourceLog db))
                                      :node node})
                            (j/run-jetty {:host (some-> host (.getHostAddress)), :port port, :async? true, :join? false}))]
 

--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -14,7 +14,7 @@
            [java.net InetAddress]
            org.eclipse.jetty.server.Server
            (xtdb.api Xtdb$Config)
-           (xtdb.api.log Log$Message$FlushBlock)
+           (xtdb.api.log SourceMessage$FlushBlock)
            (xtdb.api.metrics HealthzConfig)
            xtdb.api.Xtdb$Config
            (xtdb.database Database Database$Catalog)
@@ -83,7 +83,7 @@
                 ["/system/finish-block" {:name :finish-block
                                          :post (fn [{:keys [^Database db]}]
                                                  (try
-                                                   (let [flush-msg (Log$Message$FlushBlock. (or (.getCurrentBlockIndex (.getBlockCatalog db)) -1))
+                                                   (let [flush-msg (SourceMessage$FlushBlock. (or (.getCurrentBlockIndex (.getBlockCatalog db)) -1))
                                                          msg-id @(.appendMessage (.getSourceLog db) flush-msg)]
                                                      {:status 200, :body "Block flush message sent successfully."
                                                       :headers {"X-XTDB-Message-Id" (str msg-id)}})

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -28,7 +28,7 @@
            (java.time Instant)
            (org.apache.arrow.memory BufferAllocator)
            xtdb.api.TransactionKey
-           (xtdb.api.log SourceMessage$ResolvedTx)
+           (xtdb.api.log ReplicaMessage$ResolvedTx)
            (xtdb.arrow Relation Relation$ILoader RelationAsStructReader RelationReader RowCopier SingletonListReader VectorReader)
            (xtdb.error Anomaly$Caller Interrupted)
            (xtdb.indexer CrashLogger Indexer Indexer$ForDatabase LiveIndex LiveIndex$Tx LiveTable$Tx OpIndexer RelationIndexer Snapshot Snapshot$Source)
@@ -576,12 +576,12 @@
     m))
 
 (defn- ->resolved-tx [^TransactionKey tx-key committed? error table-data]
-  (SourceMessage$ResolvedTx. (.getTxId tx-key)
-                            (time/instant->micros (.getSystemTime tx-key))
-                            committed?
-                            (if error (serde/write-transit error) (byte-array 0))
-                            table-data
-                            nil))
+  (ReplicaMessage$ResolvedTx. (.getTxId tx-key)
+                              (time/instant->micros (.getSystemTime tx-key))
+                              committed?
+                              (if error (serde/write-transit error) (byte-array 0))
+                              table-data
+                              nil))
 
 (defn- commit [tx-key ^LiveIndex$Tx live-idx-tx committed? error]
   (let [table-data (build-table-data live-idx-tx)]

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -28,7 +28,7 @@
            (java.time Instant)
            (org.apache.arrow.memory BufferAllocator)
            xtdb.api.TransactionKey
-           (xtdb.api.log Log$Message$ResolvedTx)
+           (xtdb.api.log SourceMessage$ResolvedTx)
            (xtdb.arrow Relation Relation$ILoader RelationAsStructReader RelationReader RowCopier SingletonListReader VectorReader)
            (xtdb.error Anomaly$Caller Interrupted)
            (xtdb.indexer CrashLogger Indexer Indexer$ForDatabase LiveIndex LiveIndex$Tx LiveTable$Tx OpIndexer RelationIndexer Snapshot Snapshot$Source)
@@ -576,7 +576,7 @@
     m))
 
 (defn- ->resolved-tx [^TransactionKey tx-key committed? error table-data]
-  (Log$Message$ResolvedTx. (.getTxId tx-key)
+  (SourceMessage$ResolvedTx. (.getTxId tx-key)
                             (time/instant->micros (.getSystemTime tx-key))
                             committed?
                             (if error (serde/write-transit error) (byte-array 0))

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -17,7 +17,7 @@
            (org.apache.arrow.memory BufferAllocator)
            (java.io ByteArrayInputStream)
            (xtdb.api IndexerConfig TransactionKey)
-           (xtdb.api.log SourceMessage$ResolvedTx)
+           (xtdb.api.log ReplicaMessage$ResolvedTx)
            xtdb.storage.BufferPool
            (xtdb.arrow Relation Relation$StreamLoader)
            (xtdb.catalog BlockCatalog TableCatalog)

--- a/core/src/main/clojure/xtdb/indexer/live_index.clj
+++ b/core/src/main/clojure/xtdb/indexer/live_index.clj
@@ -17,7 +17,7 @@
            (org.apache.arrow.memory BufferAllocator)
            (java.io ByteArrayInputStream)
            (xtdb.api IndexerConfig TransactionKey)
-           (xtdb.api.log Log$Message$ResolvedTx)
+           (xtdb.api.log SourceMessage$ResolvedTx)
            xtdb.storage.BufferPool
            (xtdb.arrow Relation Relation$StreamLoader)
            (xtdb.catalog BlockCatalog TableCatalog)

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -275,7 +275,7 @@
 (defn sync-db
   ([db] (sync-db db nil))
   ([^Database db, ^Duration timeout]
-   (let [msg-id (.getLatestSubmittedMsgId (.getLogProcessor db))]
+   (let [msg-id (.getLatestSubmittedMsgId (.getSourceLog db))]
      (await-db db msg-id timeout))))
 
 (defn await-node

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -15,7 +15,7 @@
            java.util.concurrent.TimeUnit
            org.apache.arrow.memory.BufferAllocator
            (xtdb.api IndexerConfig TransactionKey Xtdb$Config)
-           (xtdb.api.log Log Log$Cluster$Factory Log$Factory Log$Message$Tx Log$MessageMetadata)
+           (xtdb.api.log Log Log$Cluster$Factory Log$Factory SourceMessage$Tx Log$MessageMetadata)
            (xtdb.arrow Relation Vector)
            xtdb.catalog.BlockCatalog
            (xtdb.database Database DatabaseStorage Database$Catalog Database$Mode)
@@ -205,8 +205,8 @@
 (defmethod ig/init-key :xtdb/log [_ {:keys [buffer-pool, ^Log$Factory factory, ^Database$Mode mode]
                                      {:keys [log-clusters]} :base}]
   (let [log (if (= mode Database$Mode/READ_ONLY)
-              (.openReadOnlyLog factory log-clusters)
-              (.openLog factory log-clusters))
+              (.openReadOnlySourceLog factory log-clusters)
+              (.openSourceLog factory log-clusters))
         latest-completed-tx (some-> (BlockCatalog/getLatestBlock buffer-pool)
                                     (.getLatestCompletedTx)
                                     (block-cat/<-TxKey))]
@@ -236,7 +236,7 @@
         default-tz (:default-tz opts default-tz)]
     (util/rethrowing-cause
       (let [^Log$MessageMetadata message-meta @(.appendMessage log
-                                                               (Log$Message$Tx. (serialize-tx-ops allocator (->TxOps tx-ops)
+                                                               (SourceMessage$Tx. (serialize-tx-ops allocator (->TxOps tx-ops)
                                                                                                   (-> (select-keys opts [:authn :default-db])
                                                                                                       (assoc :default-tz (:default-tz opts default-tz)
                                                                                                              :system-time (some-> system-time time/expect-instant))))))]

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -24,7 +24,7 @@
            (xtdb.adbc XtdbConnection XtdbConnection$Node)
            (xtdb.antlr Sql$DirectlyExecutableStatementContext)
            (xtdb.api DataSource TransactionResult Xtdb Xtdb$CompactorNode Xtdb$Config Xtdb$ExecutedTx Xtdb$SubmittedTx Xtdb$XtdbInternal)
-           (xtdb.api.log Log$Message$Tx Log$MessageMetadata)
+           (xtdb.api.log SourceMessage$Tx Log$MessageMetadata)
            xtdb.api.module.XtdbModule$Factory
            (xtdb.database Database Database$Catalog)
            xtdb.error.Anomaly
@@ -169,7 +169,7 @@
             log (.getSourceLog db)
             tx-opts (.withFallbackTz tx-opts default-tz)]
         (util/rethrowing-cause
-         (let [tx-msg (Log$Message$Tx. (TxWriter/serializeTxOps tx-ops allocator tx-opts))
+         (let [tx-msg (SourceMessage$Tx. (TxWriter/serializeTxOps tx-ops allocator tx-opts))
                ^Log$MessageMetadata message-meta @(.appendMessage log tx-msg)]
            (Xtdb$SubmittedTx. (MsgIdUtil/offsetToMsgId (.getEpoch log) (.getLogOffset message-meta))))))
       (catch Anomaly e

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -74,7 +74,7 @@
         (metrics/wrap-query query-timer))))
 
 (defn- await-msg-result [node ^Database db msg-id]
-  (or (let [^TransactionResult tx-res (-> @(.awaitAsync (.getLogProcessor db) msg-id)
+  (or (let [^TransactionResult tx-res (-> @(.awaitSourceMessageAsync (.getReplicaIndexer db) msg-id)
                                           (util/rethrowing-cause))]
         (when (and tx-res
                    (= (.getTxId tx-res) msg-id))

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -23,7 +23,8 @@
             [xtdb.types :as types]
             [xtdb.util :as util]
             [xtdb.vector.writer :as vw]
-            [clojure.test :as t])
+            [clojure.test :as t]
+            [clojure.core :as c])
   (:import io.micrometer.core.instrument.Counter
            [java.io Closeable DataInputStream EOFException IOException PushbackInputStream]
            [java.lang Thread$State]
@@ -2012,3 +2013,6 @@
                                                                          :playground? true}))]
        (log/infof "Playground started at postgres://%s:%d" (.getHostAddress host) port)
        srv))))
+
+(comment
+  (user/set-log-level! 'xtdb.pgwire :debug))

--- a/core/src/main/clojure/xtdb/tx_source.clj
+++ b/core/src/main/clojure/xtdb/tx_source.clj
@@ -12,7 +12,7 @@
   (:import (org.apache.arrow.memory BufferAllocator)
            (xtdb TaggedValue)
            (xtdb.api TxSourceConfig Xtdb Xtdb$Config)
-           (xtdb.api.log Log Log$Message Log$Message$Tx)
+           (xtdb.api.log Log SourceMessage SourceMessage$Tx)
            (xtdb.arrow Relation RelationReader)
            (xtdb.catalog BlockCatalog TableCatalog)
            xtdb.database.DatabaseState
@@ -112,7 +112,7 @@
                                         :ops (map #(dissoc % :system-from) events)}))
                                 (into []))}
                   encode-fn
-                  Log$Message$Tx.)}))
+                  SourceMessage$Tx.)}))
 
 (def ^:dynamic *after-block-hook* nil)
 
@@ -187,7 +187,7 @@
                                                     (read-table-rows-from-ipc allocator db-name schema-and-table ipc-bytes)))
                                              (into []))}
                                encode-fn
-                               Log$Message$Tx.)))))))
+                               SourceMessage$Tx.)))))))
 
 (defmethod ig/init-key ::for-db [_ {:keys [^TxSourceConfig tx-source-conf ^Log output-log
                                            ^DatabaseState db-state allocator buffer-pool
@@ -202,7 +202,7 @@
           last-message (try
                          (let [decode-record (->decode-fn (keyword (.getFormat tx-source-conf)))]
                            (->> (.readLastMessage output-log)
-                                Log$Message/.encode
+                                SourceMessage/.encode
                                 decode-record))
                          (catch Exception _ nil))
           refresh! (fn []
@@ -227,7 +227,7 @@
   (when (and tx-source-conf
              (.getEnable tx-source-conf)
              (= db-name (.getDbName tx-source-conf)))
-    (.openLog (.getOutputLog tx-source-conf) log-clusters)))
+    (.openSourceLog (.getOutputLog tx-source-conf) log-clusters)))
 
 (defmethod ig/halt-key! ::output-log [_ output-log]
   (util/close output-log))

--- a/core/src/main/clojure/xtdb/tx_source.clj
+++ b/core/src/main/clojure/xtdb/tx_source.clj
@@ -173,13 +173,13 @@
 (defrecord TxSource [^BufferAllocator allocator ^Log output-log encode-fn ^BlockCatalog block-cat db-name last-tx-key]
   Indexer$TxSource
   (onCommit [_ resolved-tx]
-    (let [tx-key (serde/->TxKey (.getTxId resolved-tx)
-                                (time/micros->instant (.getSystemTimeMicros resolved-tx)))]
+    (let [system-time (time/micros->instant (.getSystemTimeMicros resolved-tx))
+          tx-key (serde/->TxKey (.getTxId resolved-tx) system-time)]
       (when (or (nil? last-tx-key) (gt tx-key last-tx-key))
         (let [table-data (.getTableData resolved-tx)]
           @(.appendMessage output-log
                            (-> {:transaction {:id tx-key}
-                                :system-time (.getSystemTime tx-key)
+                                :system-time system-time
                                 :source {:db db-name
                                          :block-idx (inc (or (.getCurrentBlockIndex block-cat) -1))}
                                 :tables (->> table-data

--- a/core/src/main/kotlin/xtdb/api/log/DbOp.kt
+++ b/core/src/main/kotlin/xtdb/api/log/DbOp.kt
@@ -1,0 +1,9 @@
+package xtdb.api.log
+
+import xtdb.database.Database
+import xtdb.database.DatabaseName
+
+sealed interface DbOp {
+    data class Attach(val dbName: DatabaseName, val config: Database.Config) : DbOp
+    data class Detach(val dbName: DatabaseName) : DbOp
+}

--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -43,6 +43,9 @@ class InMemoryLog<M> @JvmOverloads constructor(
         override fun openReadOnlySourceLog(clusters: Map<LogClusterAlias, Cluster>) =
             ReadOnlyLog(openSourceLog(clusters))
 
+        override fun openReplicaLog(clusters: Map<LogClusterAlias, Cluster>) =
+            InMemoryLog<ReplicaMessage>(instantSource, epoch, coroutineContext)
+
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.inMemoryLog = inMemoryLog {  }
         }

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -39,13 +39,14 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.Int.Companion.SIZE_BYTES as INT_BYTES
 import kotlin.Long.Companion.SIZE_BYTES as LONG_BYTES
 
-class LocalLog(
+class LocalLog<M>(
     rootPath: Path,
+    private val codec: MessageCodec<M>,
     private val instantSource: InstantSource,
     override val epoch: Int,
     val useInstantSourceForNonTx: Boolean,
     coroutineContext: CoroutineContext = Dispatchers.Default
-) : Log {
+) : Log<M> {
     private val scope = CoroutineScope(coroutineContext)
     companion object {
         private val Path.logFilePath get() = resolve("LOG")
@@ -91,36 +92,37 @@ class LocalLog(
             }
         }
 
-        private fun FileChannel.readMessage(): Record? {
-            val pos = position()
-            val headerBuf = ByteBuffer.allocateDirect(1 + INT_BYTES + LONG_BYTES)
-                .also { read(it); it.flip() }
-
-            check(headerBuf.get() == RECORD_SEPARATOR) { "log file corrupted at $pos - expected record separator" }
-            val size = headerBuf.getInt()
-
-            val message =
-                Message.parse(ByteBuffer.allocate(size).also { read(it); it.flip() }.array())
-                    ?: return null
-
-            return Record(pos, fromMicros(headerBuf.getLong()), message)
-                .also { position(pos + messageSizeBytes(size)) }
-        }
     }
 
-    internal data class NewMessage(
-        val message: Message,
-        val onCommit: CompletableDeferred<Record>
+    private fun FileChannel.readMessage(): Record<M>? {
+        val pos = position()
+        val headerBuf = ByteBuffer.allocateDirect(1 + INT_BYTES + LONG_BYTES)
+            .also { read(it); it.flip() }
+
+        check(headerBuf.get() == RECORD_SEPARATOR) { "log file corrupted at $pos - expected record separator" }
+        val size = headerBuf.getInt()
+
+        val message =
+            codec.decode(ByteBuffer.allocate(size).also { read(it); it.flip() }.array())
+                ?: return null
+
+        return Record(pos, fromMicros(headerBuf.getLong()), message)
+            .also { position(pos + messageSizeBytes(size)) }
+    }
+
+    internal data class NewMessage<M>(
+        val message: M,
+        val onCommit: CompletableDeferred<Record<M>>
     )
 
-    private val appendCh = Channel<NewMessage>(capacity = 10)
+    private val appendCh = Channel<NewMessage<M>>(capacity = 10)
 
     private val logFilePath = rootPath.logFilePath
 
     private val logFileChannel =
         FileChannel.open(logFilePath.createParentDirectories(), CREATE, WRITE, APPEND)
 
-    private fun writeMessages(msgs: List<NewMessage>): Array<Record> {
+    private fun writeMessages(msgs: List<NewMessage<M>>): Array<Record<M>> {
         val initialOffset = logFileChannel.position()
 
         try {
@@ -129,7 +131,7 @@ class LocalLog(
                 // we only use the instantSource for Tx messages so that the tests
                 // that check files can be deterministic
                 val ts = if (msg is Message.Tx || useInstantSourceForNonTx) instantSource.instant() else Instant.now()
-                val payload = msg.encode()
+                val payload = codec.encode(msg)
                 val size = payload.size
                 val offset = logFileChannel.position()
 
@@ -162,7 +164,7 @@ class LocalLog(
         private set
 
     @Volatile
-    private var committedCh = MutableSharedFlow<Record>(extraBufferCapacity = 100)
+    private var committedCh = MutableSharedFlow<Record<M>>(extraBufferCapacity = 100)
 
     private val mutex = Mutex()
 
@@ -200,20 +202,20 @@ class LocalLog(
         }
     }
 
-    override fun appendMessage(message: Message) =
+    override fun appendMessage(message: M) =
         scope.future {
-            val onCommit = CompletableDeferred<Record>()
+            val onCommit = CompletableDeferred<Record<M>>()
             appendCh.send(NewMessage(message, onCommit))
             val record = onCommit.await()
             MessageMetadata(record.logOffset, record.logTimestamp)
         }
 
-    override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer {
-        override fun openTx() = object : AtomicProducer.Tx {
-            private val buffer = mutableListOf<Pair<Message, CompletableFuture<MessageMetadata>>>()
+    override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer<M> {
+        override fun openTx() = object : AtomicProducer.Tx<M> {
+            private val buffer = mutableListOf<Pair<M, CompletableFuture<MessageMetadata>>>()
             private var isOpen = true
 
-            override fun appendMessage(message: Message): CompletableFuture<MessageMetadata> {
+            override fun appendMessage(message: M): CompletableFuture<MessageMetadata> {
                 check(isOpen) { "Transaction already closed" }
                 val future = CompletableFuture<MessageMetadata>()
                 buffer.add(message to future)
@@ -242,7 +244,7 @@ class LocalLog(
         override fun close() {}
     }
 
-    override fun readLastMessage(): Message? {
+    override fun readLastMessage(): M? {
         if (latestSubmittedOffset < 0) return null
 
         return FileChannel.open(logFilePath).use { ch ->
@@ -251,10 +253,10 @@ class LocalLog(
         }
     }
 
-    override fun tailAll(subscriber: Subscriber, latestProcessedOffset: LogOffset): Subscription {
+    override fun tailAll(subscriber: Subscriber<M>, latestProcessedOffset: LogOffset): Subscription {
         var latestCompletedOffset = latestProcessedOffset
 
-        val ch = Channel<Record>(100)
+        val ch = Channel<Record<M>>(100)
 
         val subscription = scope.launch(SupervisorJob()) {
             launch {
@@ -309,7 +311,7 @@ class LocalLog(
         return Subscription { runBlocking { withTimeout(5.seconds) { subscription.cancelAndJoin() } } }
     }
 
-    override fun subscribe(subscriber: GroupSubscriber): Subscription {
+    override fun subscribe(subscriber: GroupSubscriber<M>): Subscription {
         val offsets = subscriber.onPartitionsAssigned(listOf(0))
         val nextOffset = offsets[0] ?: 0L
         val subscription = tailAll(subscriber, nextOffset - 1)
@@ -356,10 +358,10 @@ class LocalLog(
         fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
         override fun openLog(clusters: Map<LogClusterAlias, Cluster>) =
-            LocalLog(path, instantSource, epoch, useInstantSourceForNonTx, coroutineContext)
+            LocalLog(path, Message.Codec, instantSource, epoch, useInstantSourceForNonTx, coroutineContext)
 
         override fun openReadOnlyLog(clusters: Map<LogClusterAlias, Cluster>) =
-            ReadOnlyLocalLog(path, epoch, coroutineContext)
+            ReadOnlyLocalLog(path, Message.Codec, epoch, coroutineContext)
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.localLog = localLog {

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -21,7 +21,6 @@ import xtdb.database.proto.localLog
 import xtdb.time.InstantUtil.asMicros
 import xtdb.time.InstantUtil.fromMicros
 import java.io.DataInputStream
-import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
 import java.nio.channels.ClosedByInterruptException
@@ -130,7 +129,7 @@ class LocalLog<M>(
                 val (msg) = msgs[idx]
                 // we only use the instantSource for Tx messages so that the tests
                 // that check files can be deterministic
-                val ts = if (msg is Message.Tx || useInstantSourceForNonTx) instantSource.instant() else Instant.now()
+                val ts = if (msg is SourceMessage.Tx || useInstantSourceForNonTx) instantSource.instant() else Instant.now()
                 val payload = codec.encode(msg)
                 val size = payload.size
                 val offset = logFileChannel.position()
@@ -357,11 +356,11 @@ class LocalLog<M>(
         fun useInstantSourceForNonTx() = apply { this.useInstantSourceForNonTx = true }
         fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
-        override fun openLog(clusters: Map<LogClusterAlias, Cluster>) =
-            LocalLog(path, Message.Codec, instantSource, epoch, useInstantSourceForNonTx, coroutineContext)
+        override fun openSourceLog(clusters: Map<LogClusterAlias, Cluster>) =
+            LocalLog(path, SourceMessage.Codec, instantSource, epoch, useInstantSourceForNonTx, coroutineContext)
 
-        override fun openReadOnlyLog(clusters: Map<LogClusterAlias, Cluster>) =
-            ReadOnlyLocalLog(path, Message.Codec, epoch, coroutineContext)
+        override fun openReadOnlySourceLog(clusters: Map<LogClusterAlias, Cluster>) =
+            ReadOnlyLocalLog(path, SourceMessage.Codec, epoch, coroutineContext)
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.localLog = localLog {

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -50,6 +50,7 @@ interface Log<M> : AutoCloseable {
     interface Factory {
         fun openSourceLog(clusters: Map<LogClusterAlias, Cluster>): Log<SourceMessage>
         fun openReadOnlySourceLog(clusters: Map<LogClusterAlias, Cluster>): Log<SourceMessage>
+        fun openReplicaLog(clusters: Map<LogClusterAlias, Cluster>): Log<ReplicaMessage>
 
         fun writeTo(dbConfig: DatabaseConfig.Builder)
 

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
@@ -29,11 +29,12 @@ class ReadOnlyLocalLog<M>(
     private val rootPath: Path,
     private val codec: MessageCodec<M>,
     override val epoch: Int,
-    coroutineContext: CoroutineContext = Dispatchers.Default
+    coroutineContext: CoroutineContext = Dispatchers.Default,
+    private val logFileName: String = "LOG"
 ) : Log<M> {
 
     private val scope = CoroutineScope(coroutineContext)
-    private val logFilePath = rootPath.resolve("LOG")
+    private val logFilePath = rootPath.resolve(logFileName)
 
     companion object {
         private fun messageSizeBytes(size: Int) = 1 + INT_BYTES + LONG_BYTES + size + LONG_BYTES
@@ -122,7 +123,7 @@ class ReadOnlyLocalLog<M>(
                         var logModified = false
                         for (event in key.pollEvents()) {
                             val changedPath = event.context() as? Path
-                            if (changedPath?.name == "LOG") {
+                            if (changedPath?.name == logFileName) {
                                 logModified = true
                             }
                         }

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLog.kt
@@ -2,8 +2,8 @@ package xtdb.api.log
 
 import xtdb.error.Incorrect
 
-class ReadOnlyLog(private val delegate: Log) : Log by delegate {
-    override fun appendMessage(message: Log.Message) =
+class ReadOnlyLog<M>(private val delegate: Log<M>) : Log<M> by delegate {
+    override fun appendMessage(message: M) =
         throw Incorrect("Cannot append to read-only database log")
 
     override fun openAtomicProducer(transactionalId: String) =

--- a/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
@@ -1,0 +1,137 @@
+package xtdb.api.log
+
+import com.google.protobuf.ByteString
+import xtdb.database.Database
+import xtdb.log.proto.ReplicaLogMessage
+import xtdb.log.proto.TrieDetails
+import xtdb.log.proto.attachDatabase
+import xtdb.log.proto.blockBoundary
+import xtdb.log.proto.blockUploaded
+import xtdb.log.proto.detachDatabase
+import xtdb.log.proto.replicaLogMessage
+import xtdb.log.proto.resolvedTx
+import xtdb.log.proto.triesAdded
+import xtdb.storage.StorageEpoch
+import xtdb.trie.BlockIndex
+import java.nio.ByteBuffer
+
+sealed interface ReplicaMessage {
+
+    fun encode(): ByteArray
+
+    companion object Codec : MessageCodec<ReplicaMessage> {
+        private const val PROTOBUF_HEADER: Byte = 3
+
+        override fun encode(message: ReplicaMessage): ByteArray = message.encode()
+
+        override fun decode(bytes: ByteArray): ReplicaMessage? = parse(ByteBuffer.wrap(bytes).position(1))
+
+        fun parse(buffer: ByteBuffer): ReplicaMessage? =
+            ReplicaLogMessage.parseFrom(buffer.duplicate().position(1))
+                .let { msg ->
+                    when (msg.messageCase) {
+                        ReplicaLogMessage.MessageCase.RESOLVED_TX -> msg.resolvedTx.let {
+                            val dbOp = when (it.dbOpCase) {
+                                xtdb.log.proto.ResolvedTx.DbOpCase.ATTACH_DATABASE ->
+                                    it.attachDatabase.let { a -> DbOp.Attach(a.dbName, Database.Config.fromProto(a.config)) }
+                                xtdb.log.proto.ResolvedTx.DbOpCase.DETACH_DATABASE ->
+                                    DbOp.Detach(it.detachDatabase.dbName)
+                                else -> null
+                            }
+                            ResolvedTx(
+                                it.txId, it.systemTimeMicros, it.committed,
+                                it.error.toByteArray(),
+                                it.tableDataMap.mapValues { (_, v) -> v.toByteArray() },
+                                dbOp
+                            )
+                        }
+
+                        ReplicaLogMessage.MessageCase.TRIES_ADDED -> msg.triesAdded.let {
+                            TriesAdded(it.storageVersion, it.storageEpoch, it.triesList)
+                        }
+
+                        ReplicaLogMessage.MessageCase.BLOCK_BOUNDARY -> BlockBoundary(msg.blockBoundary.blockIndex)
+
+                        ReplicaLogMessage.MessageCase.BLOCK_UPLOADED -> msg.blockUploaded.let {
+                            BlockUploaded(it.blockIndex, it.latestProcessedMsgId, it.storageEpoch)
+                        }
+
+                        else -> null
+                    }
+                }
+    }
+
+    sealed class ProtobufMessage : ReplicaMessage {
+        abstract fun toLogMessage(): ReplicaLogMessage
+
+        final override fun encode(): ByteArray =
+            toLogMessage().let {
+                ByteBuffer.allocate(1 + it.serializedSize).apply {
+                    put(PROTOBUF_HEADER)
+                    put(it.toByteArray())
+                    flip()
+                }.array()
+            }
+    }
+
+    data class ResolvedTx(
+        val txId: MessageId,
+        val systemTimeMicros: Long,
+        val committed: Boolean,
+        val error: ByteArray,
+        val tableData: Map<String, ByteArray>,
+        val dbOp: DbOp? = null
+    ) : ProtobufMessage() {
+        override fun toLogMessage() = replicaLogMessage {
+            resolvedTx = resolvedTx {
+                this.txId = this@ResolvedTx.txId
+                this.systemTimeMicros = this@ResolvedTx.systemTimeMicros
+                this.committed = this@ResolvedTx.committed
+                this.error = ByteString.copyFrom(this@ResolvedTx.error)
+                this@ResolvedTx.tableData.forEach { (k, v) ->
+                    this.tableData[k] = ByteString.copyFrom(v)
+                }
+                when (val op = this@ResolvedTx.dbOp) {
+                    is DbOp.Attach -> attachDatabase = attachDatabase {
+                        this.dbName = op.dbName
+                        this.config = op.config.serializedConfig
+                    }
+
+                    is DbOp.Detach -> detachDatabase = detachDatabase {
+                        this.dbName = op.dbName
+                    }
+
+                    null -> {}
+                }
+            }
+        }
+    }
+
+    data class TriesAdded(
+        val storageVersion: Int, val storageEpoch: StorageEpoch, val tries: List<TrieDetails>
+    ) : ProtobufMessage() {
+        override fun toLogMessage() = replicaLogMessage {
+            triesAdded = triesAdded {
+                storageVersion = this@TriesAdded.storageVersion
+                storageEpoch = this@TriesAdded.storageEpoch
+                tries.addAll(this@TriesAdded.tries)
+            }
+        }
+    }
+
+    data class BlockBoundary(val blockIndex: BlockIndex) : ProtobufMessage() {
+        override fun toLogMessage() = replicaLogMessage {
+            blockBoundary = blockBoundary { this.blockIndex = this@BlockBoundary.blockIndex }
+        }
+    }
+
+    data class BlockUploaded(val blockIndex: BlockIndex, val latestProcessedMsgId: MessageId, val storageEpoch: StorageEpoch) : ProtobufMessage() {
+        override fun toLogMessage() = replicaLogMessage {
+            blockUploaded = blockUploaded {
+                this.blockIndex = this@BlockUploaded.blockIndex
+                this.latestProcessedMsgId = this@BlockUploaded.latestProcessedMsgId
+                this.storageEpoch = this@BlockUploaded.storageEpoch
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/xtdb/api/log/SourceMessage.kt
+++ b/core/src/main/kotlin/xtdb/api/log/SourceMessage.kt
@@ -1,0 +1,197 @@
+package xtdb.api.log
+
+import com.google.protobuf.ByteString
+import xtdb.database.Database
+import xtdb.database.DatabaseName
+import xtdb.log.proto.SourceLogMessage
+import xtdb.log.proto.TrieDetails
+import xtdb.log.proto.attachDatabase
+import xtdb.log.proto.blockBoundary
+import xtdb.log.proto.blockUploaded
+import xtdb.log.proto.detachDatabase
+import xtdb.log.proto.flushBlock
+import xtdb.log.proto.sourceLogMessage
+import xtdb.log.proto.resolvedTx
+import xtdb.log.proto.triesAdded
+import xtdb.storage.StorageEpoch
+import xtdb.trie.BlockIndex
+import java.nio.ByteBuffer
+
+sealed interface SourceMessage {
+
+    fun encode(): ByteArray
+
+    companion object Codec : MessageCodec<SourceMessage> {
+        private const val TX_HEADER: Byte = -1
+        private const val LEGACY_FLUSH_BLOCK_HEADER: Byte = 2
+        private const val PROTOBUF_HEADER: Byte = 3
+
+        override fun encode(message: SourceMessage): ByteArray = message.encode()
+
+        override fun decode(bytes: ByteArray): SourceMessage? = parse(bytes)
+
+        @JvmStatic
+        fun parse(bytes: ByteArray) =
+            when (bytes[0]) {
+                TX_HEADER -> Tx(bytes)
+                LEGACY_FLUSH_BLOCK_HEADER -> null
+                PROTOBUF_HEADER -> ProtobufMessage.parse(ByteBuffer.wrap(bytes).position(1))
+
+                else -> throw IllegalArgumentException("Unknown message type: ${bytes[0]}")
+            }
+    }
+
+    class Tx(val payload: ByteArray) : SourceMessage {
+        override fun encode(): ByteArray = payload
+    }
+
+    sealed class ProtobufMessage : SourceMessage {
+        abstract fun toLogMessage(): SourceLogMessage
+
+        final override fun encode(): ByteArray =
+            toLogMessage().let {
+                ByteBuffer.allocate(1 + it.serializedSize).apply {
+                    put(PROTOBUF_HEADER)
+                    put(it.toByteArray())
+                    flip()
+                }.array()
+            }
+
+        companion object {
+            fun parse(buffer: ByteBuffer): ProtobufMessage? =
+                SourceLogMessage.parseFrom(buffer.duplicate().position(1))
+                    .let { msg ->
+                        when (msg.messageCase) {
+                            SourceLogMessage.MessageCase.FLUSH_BLOCK ->
+                                msg.flushBlock
+                                    .takeIf { it.hasExpectedBlockIdx() }
+                                    ?.expectedBlockIdx
+                                    ?.let { FlushBlock(it) }
+
+                            SourceLogMessage.MessageCase.TRIES_ADDED -> msg.triesAdded.let {
+                                TriesAdded(it.storageVersion, it.storageEpoch, it.triesList)
+                            }
+
+                            SourceLogMessage.MessageCase.ATTACH_DATABASE -> msg.attachDatabase.let {
+                                AttachDatabase(it.dbName, Database.Config.fromProto(it.config))
+                            }
+
+                            SourceLogMessage.MessageCase.DETACH_DATABASE -> DetachDatabase(msg.detachDatabase.dbName)
+
+                            SourceLogMessage.MessageCase.BLOCK_UPLOADED -> msg.blockUploaded.let {
+                                BlockUploaded(it.blockIndex, it.latestProcessedMsgId, it.storageEpoch)
+                            }
+
+                            SourceLogMessage.MessageCase.BLOCK_BOUNDARY -> BlockBoundary(msg.blockBoundary.blockIndex)
+
+                            SourceLogMessage.MessageCase.RESOLVED_TX -> msg.resolvedTx.let {
+                                val dbOp = when (it.dbOpCase) {
+                                    xtdb.log.proto.ResolvedTx.DbOpCase.ATTACH_DATABASE ->
+                                        it.attachDatabase.let { a -> DbOp.Attach(a.dbName, Database.Config.fromProto(a.config)) }
+                                    xtdb.log.proto.ResolvedTx.DbOpCase.DETACH_DATABASE ->
+                                        DbOp.Detach(it.detachDatabase.dbName)
+                                    else -> null
+                                }
+                                ResolvedTx(
+                                    it.txId, it.systemTimeMicros, it.committed,
+                                    it.error.toByteArray(),
+                                    it.tableDataMap.mapValues { (_, v) -> v.toByteArray() },
+                                    dbOp
+                                )
+                            }
+
+                            else -> null
+                        }
+                    }
+        }
+    }
+
+    data class FlushBlock(val expectedBlockIdx: BlockIndex?) : ProtobufMessage() {
+        override fun toLogMessage() = sourceLogMessage {
+            flushBlock = flushBlock { this@FlushBlock.expectedBlockIdx?.let { expectedBlockIdx = it } }
+        }
+    }
+
+    data class TriesAdded(
+        val storageVersion: Int, val storageEpoch: StorageEpoch, val tries: List<TrieDetails>
+    ) : ProtobufMessage() {
+        override fun toLogMessage() = sourceLogMessage {
+            triesAdded = triesAdded {
+                storageVersion = this@TriesAdded.storageVersion
+                storageEpoch = this@TriesAdded.storageEpoch
+                tries.addAll(this@TriesAdded.tries)
+            }
+        }
+    }
+
+    data class AttachDatabase(val dbName: DatabaseName, val config: Database.Config) : ProtobufMessage() {
+        override fun toLogMessage() = sourceLogMessage {
+            attachDatabase = attachDatabase {
+                this.dbName = this@AttachDatabase.dbName
+                this.config = this@AttachDatabase.config.serializedConfig
+            }
+        }
+    }
+
+    data class DetachDatabase(val dbName: DatabaseName) : ProtobufMessage() {
+        override fun toLogMessage() = sourceLogMessage {
+            detachDatabase = detachDatabase {
+                this.dbName = this@DetachDatabase.dbName
+            }
+        }
+    }
+
+    data class BlockUploaded(val blockIndex: BlockIndex, val latestProcessedMsgId: MessageId, val storageEpoch: StorageEpoch) : ProtobufMessage() {
+        override fun toLogMessage() = sourceLogMessage {
+            blockUploaded = blockUploaded {
+                this.blockIndex = this@BlockUploaded.blockIndex
+                this.latestProcessedMsgId = this@BlockUploaded.latestProcessedMsgId
+                this.storageEpoch = this@BlockUploaded.storageEpoch
+            }
+        }
+    }
+
+    data class BlockBoundary(val blockIndex: BlockIndex) : ProtobufMessage() {
+        override fun toLogMessage() = sourceLogMessage {
+            blockBoundary = blockBoundary { this.blockIndex = this@BlockBoundary.blockIndex }
+        }
+    }
+
+    sealed interface DbOp {
+        data class Attach(val dbName: DatabaseName, val config: Database.Config) : DbOp
+        data class Detach(val dbName: DatabaseName) : DbOp
+    }
+
+    data class ResolvedTx(
+        val txId: MessageId,
+        val systemTimeMicros: Long,
+        val committed: Boolean,
+        val error: ByteArray,
+        val tableData: Map<String, ByteArray>,
+        val dbOp: DbOp? = null
+    ) : ProtobufMessage() {
+        override fun toLogMessage() = sourceLogMessage {
+            resolvedTx = resolvedTx {
+                this.txId = this@ResolvedTx.txId
+                this.systemTimeMicros = this@ResolvedTx.systemTimeMicros
+                this.committed = this@ResolvedTx.committed
+                this.error = ByteString.copyFrom(this@ResolvedTx.error)
+                this@ResolvedTx.tableData.forEach { (k, v) ->
+                    this.tableData[k] = ByteString.copyFrom(v)
+                }
+                when (val op = this@ResolvedTx.dbOp) {
+                    is DbOp.Attach -> attachDatabase = attachDatabase {
+                        this.dbName = op.dbName
+                        this.config = op.config.serializedConfig
+                    }
+
+                    is DbOp.Detach -> detachDatabase = detachDatabase {
+                        this.dbName = op.dbName
+                    }
+
+                    null -> {}
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.future.await
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.time.withTimeout
 import xtdb.api.log.Log
-import xtdb.api.log.Log.Message.TriesAdded
+import xtdb.api.log.SourceMessage.TriesAdded
 import xtdb.api.log.Watchers
 import xtdb.api.storage.Storage
 import xtdb.arrow.Relation

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -14,6 +14,7 @@ import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionResult
 import xtdb.api.YAML_SERDE
 import xtdb.api.log.Log
+import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.SourceMessage
 import xtdb.api.log.MessageId
 import xtdb.api.log.Watchers
@@ -81,7 +82,7 @@ data class Database(
     val liveIndex: LiveIndex get() = replicaIndexer.liveIndex
 
     val sourceLog: Log<SourceMessage> get() = storage.sourceLog
-    val replicaLog: Log<SourceMessage> get() = storage.replicaLog
+    val replicaLog: Log<ReplicaMessage> get() = storage.replicaLog
     val bufferPool: BufferPool get() = storage.bufferPool
     val metadataManager: PageMetadata.Factory get() = storage.metadataManager
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -155,7 +155,7 @@ data class Database(
             private suspend fun Database.await(msgId: MessageId) {
                 logProcessor.awaitAsync(msgId).await()
             }
-            private suspend fun Database.sync() = await(logProcessor.latestSubmittedMsgId)
+            private suspend fun Database.sync() = await(sourceLog.latestSubmittedMsgId)
 
             private suspend fun Catalog.awaitAll0(token: String) = coroutineScope {
                 val basis = token.decodeTxBasisToken()

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -81,8 +81,8 @@ data class Database(
     val trieCatalog: TrieCatalog get() = queryState.trieCatalog
     val liveIndex: LiveIndex get() = replicaIndexer.liveIndex
 
-    val sourceLog: Log get() = storage.sourceLog
-    val replicaLog: Log get() = storage.replicaLog
+    val sourceLog: Log<Log.Message> get() = storage.sourceLog
+    val replicaLog: Log<Log.Message> get() = storage.replicaLog
     val bufferPool: BufferPool get() = storage.bufferPool
     val metadataManager: PageMetadata.Factory get() = storage.metadataManager
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -14,10 +14,9 @@ import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionResult
 import xtdb.api.YAML_SERDE
 import xtdb.api.log.Log
-import xtdb.api.log.Log.Message
+import xtdb.api.log.SourceMessage
 import xtdb.api.log.MessageId
 import xtdb.api.log.Watchers
-import xtdb.util.MsgIdUtil.offsetToMsgId
 import xtdb.api.storage.Storage
 import xtdb.api.storage.Storage.applyStorage
 import xtdb.catalog.BlockCatalog
@@ -81,8 +80,8 @@ data class Database(
     val trieCatalog: TrieCatalog get() = queryState.trieCatalog
     val liveIndex: LiveIndex get() = replicaIndexer.liveIndex
 
-    val sourceLog: Log<Log.Message> get() = storage.sourceLog
-    val replicaLog: Log<Log.Message> get() = storage.replicaLog
+    val sourceLog: Log<SourceMessage> get() = storage.sourceLog
+    val replicaLog: Log<SourceMessage> get() = storage.replicaLog
     val bufferPool: BufferPool get() = storage.bufferPool
     val metadataManager: PageMetadata.Factory get() = storage.metadataManager
 
@@ -96,15 +95,15 @@ data class Database(
     override fun hashCode() = Objects.hash(name)
 
     fun sendFlushBlockMessage(): Log.MessageMetadata = runBlocking {
-        sourceLog.appendMessage(Message.FlushBlock(blockCatalog.currentBlockIndex ?: -1)).await()
+        sourceLog.appendMessage(SourceMessage.FlushBlock(blockCatalog.currentBlockIndex ?: -1)).await()
     }
 
     fun sendAttachDbMessage(dbName: DatabaseName, config: Config): Log.MessageMetadata = runBlocking {
-        sourceLog.appendMessage(Message.AttachDatabase(dbName, config)).await()
+        sourceLog.appendMessage(SourceMessage.AttachDatabase(dbName, config)).await()
     }
 
     fun sendDetachDbMessage(dbName: DatabaseName): Log.MessageMetadata = runBlocking {
-        sourceLog.appendMessage(Message.DetachDatabase(dbName)).await()
+        sourceLog.appendMessage(SourceMessage.DetachDatabase(dbName)).await()
     }
 
     @Serializable

--- a/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
@@ -1,18 +1,19 @@
 package xtdb.database
 
 import xtdb.api.log.Log
+import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.SourceMessage
 import xtdb.metadata.PageMetadata
 import xtdb.storage.BufferPool
 
 data class DatabaseStorage(
     val sourceLogOrNull: Log<SourceMessage>?,
-    val replicaLogOrNull: Log<SourceMessage>?,
+    val replicaLogOrNull: Log<ReplicaMessage>?,
     val bufferPoolOrNull: BufferPool?,
     val metadataManagerOrNull: PageMetadata.Factory?,
 ) {
     val sourceLog: Log<SourceMessage> get() = sourceLogOrNull ?: error("no source-log")
-    val replicaLog: Log<SourceMessage> get() = replicaLogOrNull ?: error("no replica-log")
+    val replicaLog: Log<ReplicaMessage> get() = replicaLogOrNull ?: error("no replica-log")
     val bufferPool: BufferPool get() = bufferPoolOrNull ?: error("no buffer-pool")
     val metadataManager: PageMetadata.Factory get() = metadataManagerOrNull ?: error("no metadata-manager")
 }

--- a/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
@@ -1,17 +1,18 @@
 package xtdb.database
 
 import xtdb.api.log.Log
+import xtdb.api.log.SourceMessage
 import xtdb.metadata.PageMetadata
 import xtdb.storage.BufferPool
 
 data class DatabaseStorage(
-    val sourceLogOrNull: Log<Log.Message>?,
-    val replicaLogOrNull: Log<Log.Message>?,
+    val sourceLogOrNull: Log<SourceMessage>?,
+    val replicaLogOrNull: Log<SourceMessage>?,
     val bufferPoolOrNull: BufferPool?,
     val metadataManagerOrNull: PageMetadata.Factory?,
 ) {
-    val sourceLog: Log<Log.Message> get() = sourceLogOrNull ?: error("no source-log")
-    val replicaLog: Log<Log.Message> get() = replicaLogOrNull ?: error("no replica-log")
+    val sourceLog: Log<SourceMessage> get() = sourceLogOrNull ?: error("no source-log")
+    val replicaLog: Log<SourceMessage> get() = replicaLogOrNull ?: error("no replica-log")
     val bufferPool: BufferPool get() = bufferPoolOrNull ?: error("no buffer-pool")
     val metadataManager: PageMetadata.Factory get() = metadataManagerOrNull ?: error("no metadata-manager")
 }

--- a/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
@@ -5,13 +5,13 @@ import xtdb.metadata.PageMetadata
 import xtdb.storage.BufferPool
 
 data class DatabaseStorage(
-    val sourceLogOrNull: Log?,
-    val replicaLogOrNull: Log?,
+    val sourceLogOrNull: Log<Log.Message>?,
+    val replicaLogOrNull: Log<Log.Message>?,
     val bufferPoolOrNull: BufferPool?,
     val metadataManagerOrNull: PageMetadata.Factory?,
 ) {
-    val sourceLog: Log get() = sourceLogOrNull ?: error("no source-log")
-    val replicaLog: Log get() = replicaLogOrNull ?: error("no replica-log")
+    val sourceLog: Log<Log.Message> get() = sourceLogOrNull ?: error("no source-log")
+    val replicaLog: Log<Log.Message> get() = replicaLogOrNull ?: error("no replica-log")
     val bufferPool: BufferPool get() = bufferPoolOrNull ?: error("no buffer-pool")
     val metadataManager: PageMetadata.Factory get() = metadataManagerOrNull ?: error("no metadata-manager")
 }

--- a/core/src/main/kotlin/xtdb/indexer/Indexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Indexer.kt
@@ -2,7 +2,7 @@ package xtdb.indexer
 
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
-import xtdb.api.log.SourceMessage
+import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.MessageId
 import xtdb.arrow.VectorReader
 import xtdb.database.DatabaseName
@@ -18,13 +18,13 @@ interface Indexer : AutoCloseable {
         fun indexTx(
             msgId: MessageId, msgTimestamp: Instant, txOps: VectorReader?,
             systemTime: Instant?, defaultTz: ZoneId?, user: String?, userMetadata: Any?
-        ): SourceMessage.ResolvedTx
+        ): ReplicaMessage.ResolvedTx
 
-        fun addTxRow(txKey: TransactionKey, error: Throwable?): SourceMessage.ResolvedTx
+        fun addTxRow(txKey: TransactionKey, error: Throwable?): ReplicaMessage.ResolvedTx
     }
 
     interface TxSource {
-        fun onCommit(resolvedTx: SourceMessage.ResolvedTx)
+        fun onCommit(resolvedTx: ReplicaMessage.ResolvedTx)
     }
 
     companion object {

--- a/core/src/main/kotlin/xtdb/indexer/Indexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Indexer.kt
@@ -2,7 +2,7 @@ package xtdb.indexer
 
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
-import xtdb.api.log.Log
+import xtdb.api.log.SourceMessage
 import xtdb.api.log.MessageId
 import xtdb.arrow.VectorReader
 import xtdb.database.DatabaseName
@@ -18,13 +18,13 @@ interface Indexer : AutoCloseable {
         fun indexTx(
             msgId: MessageId, msgTimestamp: Instant, txOps: VectorReader?,
             systemTime: Instant?, defaultTz: ZoneId?, user: String?, userMetadata: Any?
-        ): Log.Message.ResolvedTx
+        ): SourceMessage.ResolvedTx
 
-        fun addTxRow(txKey: TransactionKey, error: Throwable?): Log.Message.ResolvedTx
+        fun addTxRow(txKey: TransactionKey, error: Throwable?): SourceMessage.ResolvedTx
     }
 
     interface TxSource {
-        fun onCommit(resolvedTx: Log.Message.ResolvedTx)
+        fun onCommit(resolvedTx: SourceMessage.ResolvedTx)
     }
 
     companion object {

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -2,7 +2,7 @@ package xtdb.indexer
 
 import org.apache.arrow.vector.types.pojo.Field
 import xtdb.api.TransactionKey
-import xtdb.api.log.Log
+import xtdb.api.log.SourceMessage
 import xtdb.arrow.VectorType
 import xtdb.table.TableRef
 import xtdb.trie.BlockIndex
@@ -37,7 +37,7 @@ interface LiveIndex : Snapshot.Source, AutoCloseable {
 
     fun startTx(txKey: TransactionKey): Tx
 
-    fun importTx(resolvedTx: Log.Message.ResolvedTx)
+    fun importTx(resolvedTx: SourceMessage.ResolvedTx)
 
     fun isFull(): Boolean
     fun finishBlock(blockIdx: BlockIndex): Map<TableRef, LiveTable.FinishedBlock>

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -2,7 +2,7 @@ package xtdb.indexer
 
 import org.apache.arrow.vector.types.pojo.Field
 import xtdb.api.TransactionKey
-import xtdb.api.log.SourceMessage
+import xtdb.api.log.ReplicaMessage
 import xtdb.arrow.VectorType
 import xtdb.table.TableRef
 import xtdb.trie.BlockIndex
@@ -37,7 +37,7 @@ interface LiveIndex : Snapshot.Source, AutoCloseable {
 
     fun startTx(txKey: TransactionKey): Tx
 
-    fun importTx(resolvedTx: SourceMessage.ResolvedTx)
+    fun importTx(resolvedTx: ReplicaMessage.ResolvedTx)
 
     fun isFull(): Boolean
     fun finishBlock(blockIdx: BlockIndex): Map<TableRef, LiveTable.FinishedBlock>

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -1,14 +1,11 @@
 package xtdb.indexer
 
 import xtdb.api.log.MessageId
-import java.util.concurrent.CompletableFuture
 
 interface LogProcessor : AutoCloseable {
     val latestProcessedMsgId: MessageId
     val latestProcessedOffset: Long
     val ingestionError: Throwable?
-
-    fun awaitAsync(msgId: MessageId): CompletableFuture<*>
 
     override fun close()
 }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -6,7 +6,6 @@ import java.util.concurrent.CompletableFuture
 interface LogProcessor : AutoCloseable {
     val latestProcessedMsgId: MessageId
     val latestProcessedOffset: Long
-    val latestSubmittedMsgId: MessageId
     val ingestionError: Throwable?
 
     fun awaitAsync(msgId: MessageId): CompletableFuture<*>

--- a/core/src/main/kotlin/xtdb/indexer/ReplicaLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ReplicaLogProcessor.kt
@@ -98,9 +98,6 @@ class ReplicaLogProcessor @JvmOverloads constructor(
         if (msgIdToEpoch(it) == epoch) msgIdToOffset(it) else -1
     } ?: -1
 
-    override val latestSubmittedMsgId: MessageId
-        get() = offsetToMsgId(epoch, log.latestSubmittedOffset)
-
     private val watchers = Watchers(latestProcessedMsgId)
 
     override val ingestionError get() = watchers.exception

--- a/core/src/main/kotlin/xtdb/indexer/ReplicaLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ReplicaLogProcessor.kt
@@ -59,6 +59,7 @@ class ReplicaLogProcessor @JvmOverloads constructor(
     private val liveIndex: LiveIndex,
     private val compactor: Compactor.ForDatabase,
     private val skipTxs: Set<MessageId>,
+    private val watchers: Watchers,
     private val maxBufferedRecords: Int = 1024,
     private val dbCatalog: Database.Catalog? = null,
     private val txSource: Indexer.TxSource? = null
@@ -97,8 +98,6 @@ class ReplicaLogProcessor @JvmOverloads constructor(
     override val latestProcessedOffset = blockCatalog.latestProcessedMsgId?.let {
         if (msgIdToEpoch(it) == epoch) msgIdToOffset(it) else -1
     } ?: -1
-
-    private val watchers = Watchers(latestProcessedMsgId)
 
     override val ingestionError get() = watchers.exception
 
@@ -265,5 +264,4 @@ class ReplicaLogProcessor @JvmOverloads constructor(
         watchers.notify(msgId, e)
     }
 
-    override fun awaitAsync(msgId: MessageId) = watchers.awaitAsync(msgId)
 }

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
@@ -3,7 +3,7 @@ package xtdb.indexer
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
 import xtdb.api.log.Log
-import xtdb.api.log.Log.Message
+import xtdb.api.log.SourceMessage
 import xtdb.api.log.MessageId
 import xtdb.api.storage.Storage
 import xtdb.arrow.Relation
@@ -34,7 +34,7 @@ import java.time.ZonedDateTime
 private val LOG = SourceLogProcessor::class.logger
 
 /**
- * Subscribes to the source log and resolves Message.Tx records into Message.ResolvedTx,
+ * Subscribes to the source log and resolves SourceMessage.Tx records into SourceMessage.ResolvedTx,
  * then forwards the amended records to the replica processor via processRecords.
  * All other message types pass through unchanged.
  *
@@ -51,7 +51,7 @@ class SourceLogProcessor(
     private val skipTxs: Set<MessageId>,
     private val readOnly: Boolean = false,
     flushTimeout: Duration = Duration.ofMinutes(5),
-) : Log.Subscriber<Log.Message> {
+) : Log.Subscriber<SourceMessage> {
 
     private val log = dbStorage.sourceLog
     private val epoch = log.epoch
@@ -104,7 +104,7 @@ class SourceLogProcessor(
 
     private val flusher = Flusher(flushTimeout, blockCatalog)
 
-    private fun resolveTx(msgId: MessageId, record: Log.Record<Message>, msg: Message.Tx): Message.ResolvedTx {
+    private fun resolveTx(msgId: MessageId, record: Log.Record<SourceMessage>, msg: SourceMessage.Tx): SourceMessage.ResolvedTx {
         return if (skipTxs.isNotEmpty() && skipTxs.contains(msgId)) {
             LOG.warn("Skipping transaction id $msgId - within XTDB_SKIP_TXS")
 
@@ -139,7 +139,7 @@ class SourceLogProcessor(
         }
     }
 
-    private fun finishBlock(systemTime: Instant): Log.Record<Log.Message> {
+    private fun finishBlock(systemTime: Instant): Log.Record<SourceMessage> {
         val blockIdx = (blockCatalog.currentBlockIndex ?: -1) + 1
         LOG.debug("finishing block: 'b${blockIdx.asLexHex}'...")
 
@@ -155,7 +155,7 @@ class SourceLogProcessor(
                     .build()
             }
             log.appendMessage(
-                Message.TriesAdded(Storage.VERSION, bufferPool.epoch, addedTries)
+                SourceMessage.TriesAdded(Storage.VERSION, bufferPool.epoch, addedTries)
             )
 
             finishedBlocks.forEach { (table, _) ->
@@ -183,18 +183,18 @@ class SourceLogProcessor(
             bufferPool.putObject(BlockCatalog.blockFilePath(blockIdx), ByteBuffer.wrap(block.toByteArray()))
             blockCatalog.refresh(block)
 
-            log.appendMessage(Message.BlockUploaded(blockIdx, latestProcessedMsgId, bufferPool.epoch))
+            log.appendMessage(SourceMessage.BlockUploaded(blockIdx, latestProcessedMsgId, bufferPool.epoch))
         }
 
         liveIndex.nextBlock()
         LOG.debug("finished block: 'b${blockIdx.asLexHex}'.")
 
-        return Log.Record(-1, systemTime, Message.BlockBoundary(blockIdx))
+        return Log.Record(-1, systemTime, SourceMessage.BlockBoundary(blockIdx))
     }
 
-    override fun processRecords(records: List<Log.Record<Log.Message>>) {
+    override fun processRecords(records: List<Log.Record<SourceMessage>>) {
         if (!readOnly && flusher.checkBlockTimeout(blockCatalog, liveIndex)) {
-            val flushMessage = Message.FlushBlock(blockCatalog.currentBlockIndex ?: -1)
+            val flushMessage = SourceMessage.FlushBlock(blockCatalog.currentBlockIndex ?: -1)
             val offset = log.appendMessage(flushMessage).get().logOffset
             flusher.flushedTxId = offsetToMsgId(epoch, offset)
         }
@@ -208,7 +208,7 @@ class SourceLogProcessor(
                 latestProcessedMsgId = msgId
 
                 when (val msg = record.message) {
-                    is Message.Tx -> {
+                    is SourceMessage.Tx -> {
                         val resolvedTx = resolveTx(msgId, record, msg)
 
                         val blockBoundary = if (liveIndex.isFull()) finishBlock(record.logTimestamp) else null
@@ -219,7 +219,7 @@ class SourceLogProcessor(
                         )
                     }
 
-                    is Message.FlushBlock -> {
+                    is SourceMessage.FlushBlock -> {
                         val expectedBlockIdx = msg.expectedBlockIdx
                         val blockBoundary =
                             if (expectedBlockIdx != null && expectedBlockIdx == (blockCatalog.currentBlockIndex ?: -1L))
@@ -229,7 +229,7 @@ class SourceLogProcessor(
                         listOfNotNull(record, blockBoundary)
                     }
 
-                    is Message.AttachDatabase -> {
+                    is SourceMessage.AttachDatabase -> {
                         val error = try {
                             if (msg.dbName == "xtdb" || msg.dbName in secondaryDatabases)
                                 throw Conflict("Database already exists", "xtdb/db-exists", mapOf("db-name" to msg.dbName))
@@ -237,13 +237,13 @@ class SourceLogProcessor(
                             null
                         } catch (e: Anomaly.Caller) { e }
 
-                        val dbOp = if (error == null) Message.DbOp.Attach(msg.dbName, msg.config) else null
+                        val dbOp = if (error == null) SourceMessage.DbOp.Attach(msg.dbName, msg.config) else null
                         val resolvedTx = indexer.addTxRow(TransactionKey(msgId, record.logTimestamp), error)
                             .copy(dbOp = dbOp)
                         listOf(Log.Record(record.logOffset, record.logTimestamp, resolvedTx))
                     }
 
-                    is Message.DetachDatabase -> {
+                    is SourceMessage.DetachDatabase -> {
                         val error = try {
                             when {
                                 msg.dbName == "xtdb" ->
@@ -257,13 +257,13 @@ class SourceLogProcessor(
                             }
                         } catch (e: Anomaly.Caller) { e }
 
-                        val dbOp = if (error == null) Message.DbOp.Detach(msg.dbName) else null
+                        val dbOp = if (error == null) SourceMessage.DbOp.Detach(msg.dbName) else null
                         val resolvedTx = indexer.addTxRow(TransactionKey(msgId, record.logTimestamp), error)
                             .copy(dbOp = dbOp)
                         listOf(Log.Record(record.logOffset, record.logTimestamp, resolvedTx))
                     }
 
-                    is Message.TriesAdded -> {
+                    is SourceMessage.TriesAdded -> {
                         // Compactor appends TriesAdded to the source log.
                         // We need to update the source's trie catalog so that
                         // finishBlock writes correct partition info to block files.
@@ -274,7 +274,7 @@ class SourceLogProcessor(
                         listOf(record)
                     }
 
-                    is Message.BlockUploaded, is Message.ResolvedTx, is Message.BlockBoundary -> listOf(record)
+                    is SourceMessage.BlockUploaded, is SourceMessage.ResolvedTx, is SourceMessage.BlockBoundary -> listOf(record)
                 }
             }
         } catch (e: Throwable) {

--- a/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
+++ b/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
@@ -13,7 +13,7 @@ import java.time.InstantSource
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.CompletableFuture
 
-class RecordingLog(private val instantSource: InstantSource, messages: List<Log.Message>) : Log {
+class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M>) : Log<M> {
     override val epoch = 0
     val messages = messages.toMutableList()
 
@@ -38,10 +38,9 @@ class RecordingLog(private val instantSource: InstantSource, messages: List<Log.
     override var latestSubmittedOffset: LogOffset = -1
         private set
 
-    override fun appendMessage(message: Log.Message): CompletableFuture<Log.MessageMetadata> {
+    override fun appendMessage(message: M): CompletableFuture<Log.MessageMetadata> {
         messages.add(message)
 
-        // See comment in InMemoryLog
         val ts = if (message is Log.Message.Tx) instantSource.instant() else Instant.now()
 
         return CompletableFuture.completedFuture(
@@ -52,14 +51,14 @@ class RecordingLog(private val instantSource: InstantSource, messages: List<Log.
         )
     }
 
-    override fun readLastMessage(): Log.Message? = messages.lastOrNull()
+    override fun readLastMessage(): M? = messages.lastOrNull()
 
-    override fun openAtomicProducer(transactionalId: String) = object : Log.AtomicProducer {
-        override fun openTx() = object : Log.AtomicProducer.Tx {
-            private val buffer = mutableListOf<Pair<Log.Message, CompletableFuture<Log.MessageMetadata>>>()
+    override fun openAtomicProducer(transactionalId: String) = object : Log.AtomicProducer<M> {
+        override fun openTx() = object : Log.AtomicProducer.Tx<M> {
+            private val buffer = mutableListOf<Pair<M, CompletableFuture<Log.MessageMetadata>>>()
             private var isOpen = true
 
-            override fun appendMessage(message: Log.Message): CompletableFuture<Log.MessageMetadata> {
+            override fun appendMessage(message: M): CompletableFuture<Log.MessageMetadata> {
                 check(isOpen) { "Transaction already closed" }
                 val future = CompletableFuture<Log.MessageMetadata>()
                 buffer.add(message to future)
@@ -89,11 +88,11 @@ class RecordingLog(private val instantSource: InstantSource, messages: List<Log.
     }
 
     override fun tailAll(
-        subscriber: Log.Subscriber,
+        subscriber: Log.Subscriber<M>,
         latestProcessedOffset: LogOffset
     ): Log.Subscription = error("tailAll")
 
-    override fun subscribe(subscriber: Log.GroupSubscriber): Log.Subscription {
+    override fun subscribe(subscriber: Log.GroupSubscriber<M>): Log.Subscription {
         val offsets = subscriber.onPartitionsAssigned(listOf(0))
         val nextOffset = offsets[0] ?: 0L
         val subscription = tailAll(subscriber, nextOffset - 1)

--- a/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
+++ b/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Transient
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
 import xtdb.api.log.SourceMessage
+import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.LogOffset
 import xtdb.api.log.ReadOnlyLog
 import xtdb.database.proto.DatabaseConfig
@@ -31,6 +32,9 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
 
         override fun openReadOnlySourceLog(clusters: Map<LogClusterAlias, Log.Cluster>) =
             ReadOnlyLog(openSourceLog(clusters))
+
+        override fun openReplicaLog(clusters: Map<LogClusterAlias, Log.Cluster>) =
+            RecordingLog<ReplicaMessage>(instantSource, emptyList())
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) = Unit
     }

--- a/core/src/main/proto/xtdb/log/proto/log.proto
+++ b/core/src/main/proto/xtdb/log/proto/log.proto
@@ -15,9 +15,13 @@ message SourceLogMessage {
         AttachDatabase attach_database = 3;
         DetachDatabase detach_database = 4;
         BlockUploaded block_uploaded = 5;
-        ResolvedTx resolved_tx = 6;
-        BlockBoundary block_boundary = 7;
     }
+}
+
+message BlockUploaded {
+    int64 block_index = 1;
+    int64 latest_processed_msg_id = 2;
+    int32 storage_epoch = 3;
 }
 
 message FlushBlock {
@@ -69,25 +73,3 @@ message DetachDatabase {
     string db_name = 1;
 }
 
-message ResolvedTx {
-    int64 tx_id = 1;
-    int64 system_time_micros = 2;
-    bool committed = 3;
-    bytes error = 4;
-    map<string, bytes> table_data = 5;
-
-    oneof db_op {
-        AttachDatabase attach_database = 6;
-        DetachDatabase detach_database = 7;
-    }
-}
-
-message BlockBoundary {
-    int64 block_index = 1;
-}
-
-message BlockUploaded {
-    int64 block_index = 1;
-    int64 latest_processed_msg_id = 2;
-    int32 storage_epoch = 3;
-}

--- a/core/src/main/proto/xtdb/log/proto/log.proto
+++ b/core/src/main/proto/xtdb/log/proto/log.proto
@@ -8,7 +8,7 @@ option java_multiple_files = true;
 
 // Behavioural spec: dev/doc/db.allium
 
-message LogMessage {
+message SourceLogMessage {
     oneof message {
         FlushBlock flush_block = 1;
         TriesAdded tries_added = 2;

--- a/core/src/main/proto/xtdb/log/proto/replica-log.proto
+++ b/core/src/main/proto/xtdb/log/proto/replica-log.proto
@@ -1,0 +1,33 @@
+edition = "2023";
+
+package xtdb.log.proto;
+
+import "xtdb/log/proto/log.proto";
+
+option java_multiple_files = true;
+
+message ReplicaLogMessage {
+    oneof message {
+        ResolvedTx resolved_tx = 1;
+        TriesAdded tries_added = 2;
+        BlockBoundary block_boundary = 3;
+        BlockUploaded block_uploaded = 4;
+    }
+}
+
+message ResolvedTx {
+    int64 tx_id = 1;
+    int64 system_time_micros = 2;
+    bool committed = 3;
+    bytes error = 4;
+    map<string, bytes> table_data = 5;
+
+    oneof db_op {
+        AttachDatabase attach_database = 6;
+        DetachDatabase detach_database = 7;
+    }
+}
+
+message BlockBoundary {
+    int64 block_index = 1;
+}

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -17,6 +17,7 @@ import xtdb.SimulationTestUtils.Companion.createTrieCatalog
 import xtdb.SimulationTestUtils.Companion.prefix
 import xtdb.SimulationTestUtils.Companion.setLogLevel
 import xtdb.api.TransactionKey
+import xtdb.api.log.Watchers
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.BlockCatalog.Companion.latestBlock
 import xtdb.compactor.Compactor
@@ -122,7 +123,7 @@ class NodeSimulationTest : SimulationTestBase() {
             val compactor = Compactor.Impl(compactorDriver, null, jobCalculator, false, 2, dispatcher)
             val dbStorage = DatabaseStorage(null, null, sharedBufferPool, null)
             val dbState = DatabaseState("xtdb", blockCatalog, null, trieCatalog)
-            val compactorForDb = compactor.openForDatabase(allocator, dbStorage, dbState)
+            val compactorForDb = compactor.openForDatabase(allocator, dbStorage, dbState, Watchers(-1))
             val garbageCollector = GarbageCollector.Impl(sharedBufferPool, dbState, gcDriver, 2, garbageLifetime, Duration.ofSeconds(30), dispatcher)
             MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, garbageCollector)
         }

--- a/core/src/test/kotlin/xtdb/api/log/InMemoryLogSubscribeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/InMemoryLogSubscribeTest.kt
@@ -17,8 +17,8 @@ class InMemoryLogSubscribeTest {
     fun `assignment callback fires immediately`() = runTest(timeout = 10.seconds) {
         val assignedPartitions = AtomicReference<Collection<Int>>(null)
 
-        val subscriber = object : GroupSubscriber {
-            override fun processRecords(records: List<Record>) {}
+        val subscriber = object : GroupSubscriber<Message> {
+            override fun processRecords(records: List<Record<Message>>) {}
             override fun onPartitionsAssigned(partitions: Collection<Int>): Map<Int, LogOffset> {
                 assignedPartitions.set(partitions)
                 return emptyMap()
@@ -36,10 +36,10 @@ class InMemoryLogSubscribeTest {
 
     @Test
     fun `returned offset determines start position`() = runTest(timeout = 10.seconds) {
-        val receivedRecords = Collections.synchronizedList(mutableListOf<Record>())
+        val receivedRecords = Collections.synchronizedList(mutableListOf<Record<Message>>())
 
-        val subscriber = object : GroupSubscriber {
-            override fun processRecords(records: List<Record>) {
+        val subscriber = object : GroupSubscriber<Message> {
+            override fun processRecords(records: List<Record<Message>>) {
                 receivedRecords.addAll(records)
             }
             override fun onPartitionsAssigned(partitions: Collection<Int>): Map<Int, LogOffset> {
@@ -70,8 +70,8 @@ class InMemoryLogSubscribeTest {
     fun `revocation callback fires on close`() {
         val revokedPartitions = AtomicReference<Collection<Int>>(null)
 
-        val subscriber = object : GroupSubscriber {
-            override fun processRecords(records: List<Record>) {}
+        val subscriber = object : GroupSubscriber<Message> {
+            override fun processRecords(records: List<Record<Message>>) {}
             override fun onPartitionsAssigned(partitions: Collection<Int>): Map<Int, LogOffset> {
                 return emptyMap()
             }

--- a/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
@@ -5,11 +5,11 @@ import org.junit.jupiter.api.Test
 
 class InMemoryLogTest {
 
-    private fun txMessage(id: Byte) = Log.Message.Tx(byteArrayOf(-1, id))
+    private fun txMessage(id: Byte) = SourceMessage.Tx(byteArrayOf(-1, id))
 
     @Test
     fun `readLastMessage always returns null`() {
-        val log = InMemoryLog.Factory().openLog(emptyMap())
+        val log = InMemoryLog.Factory().openSourceLog(emptyMap())
         log.use {
             assertNull(log.readLastMessage())
 

--- a/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
@@ -22,10 +22,10 @@ class LocalLogTest {
         val log = LocalLog.Factory(tempDir.resolve("log")).openLog(emptyMap())
 
         // Create a subscription
-        val receivedRecords = mutableListOf<Record>()
+        val receivedRecords = mutableListOf<Record<Message>>()
         val subscription = log.tailAll(
-            object : Log.Subscriber {
-                override fun processRecords(records: List<Record>) {
+            object : Log.Subscriber<Message> {
+                override fun processRecords(records: List<Record<Message>>) {
                     records.forEach { receivedRecords.add(it) }
                 }
             },

--- a/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import xtdb.api.log.Log.Message
 import xtdb.api.log.Log.Record
 import java.nio.file.Path
 import kotlin.time.Duration.Companion.seconds
@@ -19,31 +18,31 @@ class LocalLogTest {
     @Tag("integration")
     @RepeatedTest(5000)
     fun `close should cancel all subscription coroutines without leaking`() = runTest(timeout = 10.seconds) {
-        val log = LocalLog.Factory(tempDir.resolve("log")).openLog(emptyMap())
+        val log = LocalLog.Factory(tempDir.resolve("log")).openSourceLog(emptyMap())
 
         // Create a subscription
-        val receivedRecords = mutableListOf<Record<Message>>()
+        val receivedRecords = mutableListOf<Record<SourceMessage>>()
         val subscription = log.tailAll(
-            object : Log.Subscriber<Message> {
-                override fun processRecords(records: List<Record<Message>>) {
+            object : Log.Subscriber<SourceMessage> {
+                override fun processRecords(records: List<Record<SourceMessage>>) {
                     records.forEach { receivedRecords.add(it) }
                 }
             },
             -1
         )
 
-        log.appendMessage(Message.FlushBlock(1))
+        log.appendMessage(SourceMessage.FlushBlock(1))
 
         subscription.close()
 
         log.close()
     }
 
-    private fun txMessage(id: Byte) = Message.Tx(byteArrayOf(-1, id))
+    private fun txMessage(id: Byte) = SourceMessage.Tx(byteArrayOf(-1, id))
 
     @Test
     fun `readLastMessage returns null when log is empty`() {
-        val log = LocalLog.Factory(tempDir.resolve("log")).openLog(emptyMap())
+        val log = LocalLog.Factory(tempDir.resolve("log")).openSourceLog(emptyMap())
         log.use {
             assertNull(log.readLastMessage())
         }
@@ -51,20 +50,20 @@ class LocalLogTest {
 
     @Test
     fun `readLastMessage returns the message after appending one`() {
-        val log = LocalLog.Factory(tempDir.resolve("log")).openLog(emptyMap())
+        val log = LocalLog.Factory(tempDir.resolve("log")).openSourceLog(emptyMap())
         log.use {
             log.appendMessage(txMessage(1)).get()
 
             val lastMessage = log.readLastMessage()
             assertNotNull(lastMessage)
-            assertTrue(lastMessage is Message.Tx)
-            assertArrayEquals(byteArrayOf(-1, 1), (lastMessage as Message.Tx).payload)
+            assertTrue(lastMessage is SourceMessage.Tx)
+            assertArrayEquals(byteArrayOf(-1, 1), (lastMessage as SourceMessage.Tx).payload)
         }
     }
 
     @Test
     fun `readLastMessage returns the last message after appending multiple`() {
-        val log = LocalLog.Factory(tempDir.resolve("log")).openLog(emptyMap())
+        val log = LocalLog.Factory(tempDir.resolve("log")).openSourceLog(emptyMap())
         log.use {
             log.appendMessage(txMessage(1)).get()
             log.appendMessage(txMessage(2)).get()
@@ -72,8 +71,8 @@ class LocalLogTest {
 
             val lastMessage = log.readLastMessage()
             assertNotNull(lastMessage)
-            assertTrue(lastMessage is Message.Tx)
-            assertArrayEquals(byteArrayOf(-1, 3), (lastMessage as Message.Tx).payload)
+            assertTrue(lastMessage is SourceMessage.Tx)
+            assertArrayEquals(byteArrayOf(-1, 3), (lastMessage as SourceMessage.Tx).payload)
         }
     }
 }

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -22,8 +22,8 @@ import xtdb.SimulationTestUtils.Companion.createTrieCatalog
 import xtdb.SimulationTestUtils.Companion.prefix
 import xtdb.SimulationTestUtils.Companion.setLogLevel
 import xtdb.WithSeed
-import xtdb.api.log.Log
 import xtdb.api.log.Log.Message.TriesAdded
+import xtdb.api.log.Watchers
 import xtdb.api.storage.Storage
 import xtdb.compactor.Compactor.Driver
 import xtdb.compactor.Compactor.Driver.Factory
@@ -94,7 +94,7 @@ class CompactorMockDriver(
     val sharedFlow = MutableSharedFlow<AppendMessage>(extraBufferCapacity = Int.MAX_VALUE)
     var nextSystemId = 0
 
-    override fun create(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState): Driver {
+    override fun create(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers): Driver {
         val systemId = nextSystemId++
         return ForDatabase(dbStorage, dbState, systemId)
     }
@@ -207,15 +207,18 @@ class CompactorMockDriver(
             return result
         }
 
-        var logOffset = 0L
-
-        override suspend fun appendMessage(triesAdded: TriesAdded): Log.MessageMetadata {
-            LOGGER.debug("[appendMessage started] systemId=$systemId offset=$logOffset tries=${triesAdded.tries.map { it.trieKey }}")
-            yield() // Force suspension after appendMessage started
+        override suspend fun publishTries(triesAdded: TriesAdded) {
+            LOGGER.debug("[publishTries started] systemId=$systemId tries=${triesAdded.tries.map { it.trieKey }}")
+            yield()
             val logTimestamp = Instant.now()
             sharedFlow.emit(AppendMessage(triesAdded, logTimestamp, systemId))
-            LOGGER.debug("[appendMessage completed] systemId=$systemId offset=$logOffset sent to channel")
-            return Log.MessageMetadata(logOffset++, logTimestamp)
+            yield()
+            triesAdded.tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
+                val tableRef = TableRef.parse(dbState.name, tableName)
+                addTriesToBufferPool(bufferPool, tableRef, tries)
+                trieCatalog.addTries(tableRef, tries, logTimestamp)
+            }
+            LOGGER.debug("[publishTries completed] systemId=$systemId")
         }
 
         override fun close() {
@@ -333,7 +336,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         val l0Trie = buildTrieDetails(docsTable.tableName, L0TrieKeys.first())
         val db = dbs[0]
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState).use {
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(-1)).use {
             seedTries(docsTable, listOf(l0Trie))
             it.compactAllSync(null)
         }
@@ -349,7 +352,6 @@ class CompactorSimulationTest : SimulationTestBase() {
     }
 
     @Test
-    @WithSeed(-1748393987)
     fun singleL0CompactionNotHanging() {
         singleL0Compaction(0)
     }
@@ -360,7 +362,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         val table = TableRef("xtdb", "public", "docs")
         val db = dbs[0]
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState).use {
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(-1)).use {
             // Round 1: Add 3 L0 tries and compact
             seedTries(
                 table,
@@ -414,7 +416,6 @@ class CompactorSimulationTest : SimulationTestBase() {
     }
 
     @Test
-    @WithSeed(-1754611144)
     fun multipleL0ToL1CompactionIssue() {
         multipleL0ToL1Compaction(0)
     }
@@ -427,15 +428,15 @@ class CompactorSimulationTest : SimulationTestBase() {
         val l0tries = L0TrieKeys.take(100).map { buildTrieDetails(docsTable.tableName, it, 10L * 1024L * 1024L) }
         val db = dbs[0]
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState).use {
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(-1)).use { c ->
             seedTries(docsTable, l0tries.toList())
-            it.compactAllSync(null)
+            c.compactAllSync(null)
             val liveTries = db.trieCatalog.listLiveAndNascentTrieKeys(docsTable)
             val garbageTries = db.trieCatalog.listAllGarbageTrieKeys(docsTable)
             assertEquals(0, liveTries.prefix("l00-rc-").size)
             assertTrue(garbageTries.any { it.startsWith("l00-rc-") }, "L0s should be in garbage")
-            assertTrue(liveTries.prefix("l01-rc-").size > 0, "Some L1Cs should be live")
-            assertTrue(liveTries.prefix("l02-rc-").size > 0, "Some L2Cs should be live")
+            assertTrue(liveTries.prefix("l01-rc-").isNotEmpty(), "Some L1Cs should be live")
+            assertTrue(liveTries.prefix("l02-rc-").isNotEmpty(), "Some L2Cs should be live")
         }
     }
 
@@ -450,7 +451,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
         val l1Tries = L1TrieKeys.take(4).map { buildTrieDetails(docsTable.tableName, it, defaultFileTarget) }
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState).use {
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(-1)).use {
             seedTries(docsTable, l1Tries.toList())
 
             it.compactAllSync(null)
@@ -488,7 +489,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
         val missingPartitions = (0..3).filterNot { it in existingPartitions }
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState).use {
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(-1)).use {
             seedTries(docsTable, l1Tries.toList() + existingL2Tries)
 
             it.compactAllSync(null)
@@ -535,7 +536,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         l2tries.add(buildTrieDetails(docsTable.tableName, "l02-rc-p3-b03", defaultFileTarget))
         l2tries.add(buildTrieDetails(docsTable.tableName, "l02-rc-p3-b07", defaultFileTarget))
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState).use {
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(-1)).use {
             seedTries(docsTable, l1Tries.toList() + l2tries)
 
             it.compactAllSync(null)
@@ -569,7 +570,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         seedTries(ordersTable, ordersTries.toList())
 
         dbs.safeMap { db ->
-            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState)
+            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(-1))
         }.useAll { compactorsForDb ->
             runBlocking {
                 compactorsForDb.shuffled(rand).map { c -> async { c.compactAll() } }.awaitAll()
@@ -618,7 +619,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         seedTries(docsTable, listOf(l0Trie))
 
         dbs.safeMap { db ->
-            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState)
+            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(-1))
         }.useAll { compactorsForDb ->
             runBlocking {
                 compactorsForDb.shuffled(rand).map { c -> async { c.compactAll() } }.awaitAll()
@@ -651,7 +652,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         seedTries(docsTable, l0tries.toList())
 
         dbs.safeMap { db ->
-            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState)
+            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(-1))
         }.useAll { compactorsForDb ->
             runBlocking {
                 compactorsForDb.shuffled(rand).map { c -> async { c.compactAll() } }.awaitAll()

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -22,7 +22,8 @@ import xtdb.SimulationTestUtils.Companion.createTrieCatalog
 import xtdb.SimulationTestUtils.Companion.prefix
 import xtdb.SimulationTestUtils.Companion.setLogLevel
 import xtdb.WithSeed
-import xtdb.api.log.Log.Message.TriesAdded
+import xtdb.api.log.Log
+import xtdb.api.log.SourceMessage.TriesAdded
 import xtdb.api.log.Watchers
 import xtdb.api.storage.Storage
 import xtdb.compactor.Compactor.Driver
@@ -41,7 +42,6 @@ import xtdb.table.TableRef
 import xtdb.time.InstantUtil.asMicros
 import xtdb.trie.Trie
 import xtdb.trie.TrieCatalog
-import xtdb.trie.TrieKey
 import xtdb.util.logger
 import xtdb.util.safeMap
 import xtdb.util.useAll

--- a/core/src/test/kotlin/xtdb/indexer/ReplicaLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/ReplicaLogProcessorTest.kt
@@ -85,7 +85,7 @@ class ReplicaLogProcessorTest {
         val blockCatalog = BlockCatalog("test", null)
         val liveIndex = mockk<LiveIndex>(relaxed = true)
 
-        val dbStorage = DatabaseStorage(log, log, BufferPool.UNUSED, null)
+        val dbStorage = DatabaseStorage(log, null, BufferPool.UNUSED, null)
         val dbState = DatabaseState(
             "test", blockCatalog,
             mockk<TableCatalog>(relaxed = true), mockk<TrieCatalog>(relaxed = true),
@@ -139,7 +139,7 @@ class ReplicaLogProcessorTest {
         }
 
         RootAllocator().use { allocator ->
-            val dbStorage = DatabaseStorage(log, log, bufferPool, null)
+            val dbStorage = DatabaseStorage(log, null, bufferPool, null)
             val dbState = DatabaseState(
                 "test", blockCatalog,
                 mockk<TableCatalog>(relaxed = true), mockk<TrieCatalog>(relaxed = true),

--- a/core/src/test/kotlin/xtdb/indexer/ReplicaLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/ReplicaLogProcessorTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import xtdb.api.log.InMemoryLog
 import xtdb.api.log.Log
+import xtdb.api.log.Watchers
 import xtdb.api.storage.ObjectStore
 import xtdb.block.proto.block
 import xtdb.catalog.BlockCatalog
@@ -96,6 +97,7 @@ class ReplicaLogProcessorTest {
                 liveIndex,
                 mockk<Compactor.ForDatabase>(relaxed = true),
                 emptySet(),
+                watchers = Watchers(-1),
                 maxBufferedRecords = 2
             )
 
@@ -148,6 +150,7 @@ class ReplicaLogProcessorTest {
                 liveIndex,
                 mockk<Compactor.ForDatabase>(relaxed = true),
                 emptySet(),
+                watchers = Watchers(-1),
             )
 
             val now = Instant.now()

--- a/core/src/test/kotlin/xtdb/indexer/ReplicaLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/ReplicaLogProcessorTest.kt
@@ -79,7 +79,7 @@ class ReplicaLogProcessorTest {
 
     @Test
     fun `buffer overflow stops ingestion`() {
-        val log = InMemoryLog(InstantSource.system(), 0)
+        val log = InMemoryLog<Log.Message>(InstantSource.system(), 0)
         val blockCatalog = BlockCatalog("test", null)
         val liveIndex = mockk<LiveIndex>(relaxed = true)
 
@@ -118,7 +118,7 @@ class ReplicaLogProcessorTest {
 
     @Test
     fun `replay handles block transitions during replay`() {
-        val log = InMemoryLog(InstantSource.system(), 0)
+        val log = InMemoryLog<Log.Message>(InstantSource.system(), 0)
         val blockCatalog = BlockCatalog("test", null)
         val liveIndex = mockk<LiveIndex>(relaxed = true)
 

--- a/core/src/test/kotlin/xtdb/test/log/RecordingLogTest.kt
+++ b/core/src/test/kotlin/xtdb/test/log/RecordingLogTest.kt
@@ -2,33 +2,33 @@ package xtdb.test.log
 
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import xtdb.api.log.Log.Message
+import xtdb.api.log.SourceMessage
 
 class RecordingLogTest {
 
-    private fun txMessage(id: Byte) = Message.Tx(byteArrayOf(-1, id))
+    private fun txMessage(id: Byte) = SourceMessage.Tx(byteArrayOf(-1, id))
 
     @Test
     fun `readLastMessage returns null when log is empty`() {
-        val log = RecordingLog.Factory().openLog(emptyMap())
+        val log = RecordingLog.Factory().openSourceLog(emptyMap())
         assertNull(log.readLastMessage())
     }
 
     @Test
     fun `readLastMessage returns the message after appending one`() {
-        val log = RecordingLog.Factory().openLog(emptyMap())
+        val log = RecordingLog.Factory().openSourceLog(emptyMap())
 
         log.appendMessage(txMessage(1)).get()
 
         val lastMessage = log.readLastMessage()
         assertNotNull(lastMessage)
-        assertTrue(lastMessage is Message.Tx)
-        assertArrayEquals(byteArrayOf(-1, 1), (lastMessage as Message.Tx).payload)
+        assertTrue(lastMessage is SourceMessage.Tx)
+        assertArrayEquals(byteArrayOf(-1, 1), (lastMessage as SourceMessage.Tx).payload)
     }
 
     @Test
     fun `readLastMessage returns the last message after appending multiple`() {
-        val log = RecordingLog.Factory().openLog(emptyMap())
+        val log = RecordingLog.Factory().openSourceLog(emptyMap())
 
         log.appendMessage(txMessage(1)).get()
         log.appendMessage(txMessage(2)).get()
@@ -36,19 +36,19 @@ class RecordingLogTest {
 
         val lastMessage = log.readLastMessage()
         assertNotNull(lastMessage)
-        assertTrue(lastMessage is Message.Tx)
-        assertArrayEquals(byteArrayOf(-1, 3), (lastMessage as Message.Tx).payload)
+        assertTrue(lastMessage is SourceMessage.Tx)
+        assertArrayEquals(byteArrayOf(-1, 3), (lastMessage as SourceMessage.Tx).payload)
     }
 
     @Test
     fun `factory can be initialized with messages`() {
         val log = RecordingLog.Factory()
             .messages(listOf(txMessage(1), txMessage(2), txMessage(3)))
-            .openLog(emptyMap())
+            .openSourceLog(emptyMap())
 
         val lastMessage = log.readLastMessage()
         assertNotNull(lastMessage)
-        assertTrue(lastMessage is Message.Tx)
-        assertArrayEquals(byteArrayOf(-1, 3), (lastMessage as Message.Tx).payload)
+        assertTrue(lastMessage is SourceMessage.Tx)
+        assertArrayEquals(byteArrayOf(-1, 3), (lastMessage as SourceMessage.Tx).payload)
     }
 }

--- a/dev/doc/db-5188.allium
+++ b/dev/doc/db-5188.allium
@@ -158,7 +158,7 @@ entity SourceMessage {
 
 variant TxMessage : SourceMessage {
     -- Client-submitted transaction operations.
-    -- See: tx/TxWriter.kt, api/log/Log.kt (Log$Message$Tx)
+    -- See: tx/TxWriter.kt, api/log/Log.kt, api/log/SourceMessage. (SourceMessage$Tx) — serialised via TxWriter, not proto.
     system_time: Instant?
     default_tz: String?
     user: String?

--- a/dev/doc/db-5188.allium
+++ b/dev/doc/db-5188.allium
@@ -1,0 +1,607 @@
+-- db-5188.allium
+--
+-- The processing model of a single database within an XTDB node
+-- after source/replica log decoupling (#5188).
+--
+-- Key changes from db.allium:
+-- 1. Source and replica are always separate logs (invariant, not just convention).
+-- 2. The single LogProcessor is split into SourceProcessor (leader) and ReplicaProcessor (all nodes).
+-- 3. The source processor resolves messages and writes to the replica log.
+-- 4. The replica processor subscribes independently to the replica log (not driven in-process).
+-- 5. Read-only nodes skip the source system entirely.
+-- 6. The compactor writes L1+ to the source log; the source processor forwards to replica.
+--    The compactor does not eagerly register tries — the job is complete when the
+--    TriesAdded round-trips through source → replica → trie catalog.
+--
+-- Compaction job selection and algorithm: compaction.allium (unchanged).
+
+use "./trie-cat.allium" as trie_cat
+use "./compaction.allium" as compaction
+
+------------------------------------------------------------
+-- Context
+------------------------------------------------------------
+
+context {
+    database: Database
+    source_processor: SourceProcessor       -- leader only
+    replica_processor: ReplicaProcessor     -- all nodes
+    source_live_index: LiveIndex            -- leader's live index
+    replica_live_index: LiveIndex           -- replica's live index (all nodes)
+    block_catalog: BlockCatalog
+    table_catalog: TableCatalog
+}
+
+------------------------------------------------------------
+-- External Entities
+------------------------------------------------------------
+
+external entity Client {
+    -- The party submitting transactions.
+}
+
+external entity Log {
+    -- An ordered, append-only message stream.
+    -- Two separate instances per database: source_log and replica_log.
+    -- They MUST be distinct logs (not aliases for the same underlying log).
+    -- See: api/log/Log.kt
+}
+
+external entity ObjectStore {
+    -- Durable key-value storage for blocks, tries, table-blocks.
+}
+
+------------------------------------------------------------
+-- Entities
+------------------------------------------------------------
+
+entity LiveIndex {
+    -- See: indexer/LiveIndex.kt
+    latest_completed_tx: TransactionKey?
+    is_full: Boolean
+
+    -- Derived
+    has_data: latest_completed_tx != null
+}
+
+entity Database {
+    -- See: indexer/Indexer.kt
+    mode: read_write | read_only
+    source_log: Log
+    replica_log: Log
+
+    invariant: source_log != replica_log
+        -- Source and replica are always distinct logs.
+}
+
+entity BlockCatalog {
+    -- See: catalog/BlockCatalog.kt
+    latest_block: Block?
+
+    -- Derived
+    current_block_index: latest_block?.block_index
+}
+
+entity TableCatalog {
+    -- See: catalog/TableCatalog.kt, table_catalog.clj
+    table_metadata: Map<trie_cat/TableRef, TableMetadata>
+}
+
+entity SourceProcessor {
+    -- See: indexer/SourceLogProcessor.kt
+    -- Leader-only. Subscribes to the source log, resolves messages,
+    -- writes resolved output to the replica log.
+    -- Also owns block finishing: writes tries, table blocks, block files to storage.
+    latest_processed_msg_id: MessageId
+    last_flush_check: Instant
+}
+
+entity ReplicaProcessor {
+    -- See: indexer/ReplicaLogProcessor.kt
+    -- All nodes. Subscribes independently to the replica log.
+    -- Applies resolved transactions, handles block transitions, updates catalogs.
+    latest_processed_msg_id: MessageId
+    pending_block_index: Long?
+
+    -- Watchers: clients await by source-log tx id (the id returned by submit-tx).
+    -- ResolvedTxMessage carries the source tx_id for this mapping.
+}
+
+external value current_storage_version: Int   -- See: storage/Storage.kt (VERSION)
+external value current_storage_epoch: Int     -- See: buffer_pool/BufferPool.kt (epoch)
+
+------------------------------------------------------------
+-- Values
+------------------------------------------------------------
+
+value MessageId {
+    -- Epoch + offset packed into a long.
+    -- See: util/MsgIdUtil.kt
+    epoch: Int
+    offset: Int
+}
+
+value TransactionKey {
+    -- See: block/proto/block.proto (TxKey)
+    tx_id: Long
+    system_time: Instant
+}
+
+value Block {
+    -- A persisted block in the object store.
+    block_index: Long
+    latest_completed_tx: TransactionKey
+    latest_processed_msg_id: MessageId
+}
+
+value Snapshot {
+    as_of: TransactionKey
+}
+
+value TableMetadata {
+    row_count: Long?
+}
+
+------------------------------------------------------------
+-- Source Log Messages
+------------------------------------------------------------
+
+-- Messages on the source log. Written by clients, the leader (FlushBlock),
+-- and the compactor (TriesAdded L1+).
+-- See: log/proto/log.proto (LogMessage oneof)
+
+entity SourceMessage {
+    msg_id: MessageId
+    log_timestamp: Instant
+    kind: TxMessage | FlushBlockMessage | TriesAddedMessage | AttachDbMessage | DetachDbMessage
+}
+
+variant TxMessage : SourceMessage {
+    -- Client-submitted transaction operations.
+    -- See: tx/TxWriter.kt, api/log/Log.kt (Log$Message$Tx)
+    system_time: Instant?
+    default_tz: String?
+    user: String?
+}
+
+variant FlushBlockMessage : SourceMessage {
+    -- Leader self-sends to trigger block flush on timeout.
+    -- See: log/proto/log.proto (FlushBlock)
+    expected_block_idx: Long?
+}
+
+variant TriesAddedMessage : SourceMessage {
+    -- L1+ compaction results written by the compactor.
+    -- The source processor forwards these to the replica log.
+    -- See: log/proto/log.proto (TriesAdded)
+    storage_version: Int
+    storage_epoch: Int
+    tries: List<trie_cat/TrieDetails>
+}
+
+variant AttachDbMessage : SourceMessage {
+    -- See: log/proto/log.proto (AttachDatabase)
+    db_name: String
+}
+
+variant DetachDbMessage : SourceMessage {
+    -- See: log/proto/log.proto (DetachDatabase)
+    db_name: String
+}
+
+------------------------------------------------------------
+-- Replica Log Messages
+------------------------------------------------------------
+
+-- Messages on the replica log. Written exclusively by the leader (source processor).
+-- Consumed by all nodes (including the leader's own replica processor).
+
+entity ReplicaMessage {
+    msg_id: MessageId
+    log_timestamp: Instant
+    kind: ResolvedTxMessage | BlockBoundaryMessage | BlockUploadedMessage | TriesAddedMessage
+}
+
+variant ResolvedTxMessage : ReplicaMessage {
+    -- A resolved transaction: put/delete/erase events that require no database reads.
+    -- Carries the source tx_id so watchers can correlate with submit-tx responses.
+    -- Attach/detach results are encoded as a dbOp field within the resolved tx.
+    -- See: api/log/Log.kt (Message.ResolvedTx)
+    tx_id: MessageId            -- source-log msg id of the original Tx/Attach/Detach
+    committed: Boolean
+    db_op: DbOp?               -- Attach or Detach side-effect, if any
+}
+
+variant BlockBoundaryMessage : ReplicaMessage {
+    -- Leader signals that a block boundary has been reached.
+    -- L0 TriesAdded is written before this message on the replica log,
+    -- so L0 tries are in the trie catalog before the pending-block gate fires.
+    -- Followers enter pending mode and buffer subsequent messages until BlockUploaded.
+    -- See: log/proto/log.proto (BlockBoundary)
+    block_index: Long
+    latest_completed_tx: TransactionKey
+}
+
+variant BlockUploadedMessage : ReplicaMessage {
+    -- Block has been written to the object store.
+    -- Followers refresh catalogs and transition.
+    -- See: log/proto/log.proto (BlockUploaded)
+    block_index: Long
+    latest_processed_msg_id: MessageId
+    storage_epoch: Int
+}
+
+variant TriesAddedMessage : ReplicaMessage {
+    -- New tries available.
+    -- L0 tries: written by the leader during block finishing (before BlockBoundary).
+    -- L1+ tries: forwarded by the leader from the source log (compactor writes).
+    -- See: log/proto/log.proto (TriesAdded)
+    storage_version: Int
+    storage_epoch: Int
+    tries: List<trie_cat/TrieDetails>
+}
+
+------------------------------------------------------------
+-- Config
+------------------------------------------------------------
+
+config {
+    flush_timeout: Duration = 4.hours
+    max_block_rows: Integer = 102400
+}
+
+------------------------------------------------------------
+-- Rules: Transaction Submission
+------------------------------------------------------------
+
+rule ClientSubmitsTransaction {
+    when: ClientSubmitsTx(client, database, tx_ops, opts)
+
+    requires: database.mode == read_write
+
+    ensures:
+        let msg = TxMessage.created(
+            system_time: opts.system_time,
+            default_tz: opts.default_tz,
+            user: opts.user
+        )
+        msg appended to database.source_log
+}
+
+------------------------------------------------------------
+-- Rules: Source Processor (leader only)
+------------------------------------------------------------
+
+-- The source processor subscribes to the source log.
+-- It resolves each message and writes the result to the replica log.
+-- Read-only nodes do not run the source processor.
+
+rule SourceProcessesTx {
+    when: msg: TxMessage consumed from database.source_log
+
+    requires: msg.msg_id > source_processor.latest_processed_msg_id
+
+    ensures:
+        let resolved = IndexTransaction(msg)
+        ResolvedTxMessage.created(
+            tx_id: msg.msg_id,
+            committed: resolved.committed,
+            db_op: resolved.db_op
+        ) appended to database.replica_log
+
+        source_processor.latest_processed_msg_id = msg.msg_id
+
+        if source_live_index.is_full:
+            SourceBlockFlushNeeded(msg.log_timestamp)
+}
+
+rule SourceProcessesAttachDb {
+    when: msg: AttachDbMessage consumed from database.source_log
+
+    requires: msg.msg_id > source_processor.latest_processed_msg_id
+
+    ensures:
+        let resolved = ResolveAttach(msg)
+        ResolvedTxMessage.created(
+            tx_id: msg.msg_id,
+            committed: resolved.committed,
+            db_op: resolved.db_op
+        ) appended to database.replica_log
+
+        source_processor.latest_processed_msg_id = msg.msg_id
+}
+
+rule SourceProcessesDetachDb {
+    when: msg: DetachDbMessage consumed from database.source_log
+
+    requires: msg.msg_id > source_processor.latest_processed_msg_id
+
+    ensures:
+        let resolved = ResolveDetach(msg)
+        ResolvedTxMessage.created(
+            tx_id: msg.msg_id,
+            committed: resolved.committed,
+            db_op: resolved.db_op
+        ) appended to database.replica_log
+
+        source_processor.latest_processed_msg_id = msg.msg_id
+}
+
+rule SourceProcessesFlushBlock {
+    when: msg: FlushBlockMessage consumed from database.source_log
+
+    requires: msg.msg_id > source_processor.latest_processed_msg_id
+    requires: msg.expected_block_idx == block_catalog.current_block_index
+
+    ensures:
+        source_processor.latest_processed_msg_id = msg.msg_id
+        SourceBlockFlushNeeded(msg.log_timestamp)
+}
+
+rule SourceProcessesTriesAdded {
+    -- L1+ from compactor. The source processor needs these in its trie catalog
+    -- for correct partition info at block time, and forwards them to the replica log.
+    when: msg: TriesAddedMessage consumed from database.source_log
+
+    requires: msg.msg_id > source_processor.latest_processed_msg_id
+    requires: msg.storage_version == current_storage_version
+    requires: msg.storage_epoch == current_storage_epoch
+
+    ensures:
+        -- Update the source's trie catalog (needed for finishBlock partition info).
+        trie_cat/trie_catalog.addTries(msg.tries, msg.log_timestamp)
+
+        -- Forward to replica log so followers see L1+ tries.
+        TriesAddedMessage.created(
+            storage_version: msg.storage_version,
+            storage_epoch: msg.storage_epoch,
+            tries: msg.tries
+        ) appended to database.replica_log
+
+        source_processor.latest_processed_msg_id = msg.msg_id
+}
+
+------------------------------------------------------------
+-- Rules: Source Block Finishing
+------------------------------------------------------------
+
+-- The source processor finishes blocks: writes storage, then signals the replica log.
+
+rule SourceFinishesBlock {
+    -- log_timestamp is the log timestamp of the message that triggered the flush
+    -- (either the transaction that filled the block, or a FlushBlock message).
+    -- This becomes the as_of for trie registration, used later by GC to determine
+    -- deletion eligibility. The 24-hour garbage_lifetime grace period absorbs
+    -- any practical difference between these two sources.
+    when: SourceBlockFlushNeeded(log_timestamp)
+
+    let block_index = (block_catalog.current_block_index ?? -1) + 1
+    let finished_tables = source_live_index.finishBlock(block_index)
+    let tries = finished_tables.collectTries()
+
+    ensures:
+        -- Write L0 tries-added to replica log.
+        TriesAddedMessage.created(tries: tries) appended to database.replica_log
+
+        -- Register L0 tries in the source's trie catalog.
+        trie_cat/trie_catalog.addTries(tries, log_timestamp)
+
+        -- Update table catalog.
+        table_catalog.finishBlock(finished_tables)
+
+        -- Persist block to object store.
+        let block = Block.created(
+            block_index: block_index,
+            latest_completed_tx: source_live_index.latest_completed_tx,
+            latest_processed_msg_id: source_processor.latest_processed_msg_id
+        )
+        block_catalog.refresh(block)
+
+        -- Signal replica: block boundary, then block uploaded.
+        BlockBoundaryMessage.created(
+            block_index: block_index,
+            latest_completed_tx: source_live_index.latest_completed_tx
+        ) appended to database.replica_log
+
+        BlockUploadedMessage.created(
+            block_index: block_index,
+            latest_processed_msg_id: source_processor.latest_processed_msg_id,
+            storage_epoch: current_storage_epoch
+        ) appended to database.replica_log
+
+        -- Reset for next block.
+        source_live_index.nextBlock()
+}
+
+------------------------------------------------------------
+-- Rules: Source Flush Timeout
+------------------------------------------------------------
+
+rule SourceFlushTimeout {
+    when: source_processor.last_flush_check + config.flush_timeout <= now
+
+    requires: source_live_index.has_data
+    requires: block_catalog.current_block_index unchanged since source_processor.last_flush_check
+
+    ensures:
+        FlushBlockMessage.created(
+            expected_block_idx: block_catalog.current_block_index
+        ) appended to database.source_log
+}
+
+------------------------------------------------------------
+-- Rules: Replica Processor (all nodes)
+------------------------------------------------------------
+
+-- The replica processor subscribes independently to the replica log.
+-- Both leader nodes and read-only nodes run this processor.
+
+rule ReplicaProcessesResolvedTx {
+    when: msg: ResolvedTxMessage consumed from database.replica_log
+
+    ensures:
+        replica_live_index.importTx(msg)
+
+        -- Handle attach/detach catalog side-effects.
+        if msg.db_op is Attach:
+            database.catalog.attach(msg.db_op.db_name, msg.db_op.config)
+        if msg.db_op is Detach:
+            database.catalog.detach(msg.db_op.db_name)
+
+        -- Notify watchers using the source-log tx id.
+        replica_processor.latest_processed_msg_id = msg.tx_id
+        NotifyWatchers(msg.tx_id, result)
+}
+
+rule ReplicaProcessesTriesAdded {
+    -- Both L0 (from block finishing) and L1+ (forwarded from source).
+    when: msg: TriesAddedMessage consumed from database.replica_log
+
+    requires: msg.storage_version == current_storage_version
+    requires: msg.storage_epoch == current_storage_epoch
+
+    ensures:
+        trie_cat/trie_catalog.addTries(msg.tries, msg.log_timestamp)
+}
+
+rule ReplicaProcessesBlockBoundary {
+    -- The leader has signalled a block boundary.
+    -- Enter pending mode: buffer subsequent records until BlockUploaded.
+    when: msg: BlockBoundaryMessage consumed from database.replica_log
+
+    ensures:
+        replica_processor.pending_block_index = msg.block_index
+        -- All subsequent messages are buffered until BlockUploaded arrives.
+}
+
+rule ReplicaProcessesBlockUploaded {
+    -- Block is available in storage. Refresh catalogs and transition.
+    when: msg: BlockUploadedMessage consumed from database.replica_log
+
+    requires: msg.storage_epoch == current_storage_epoch
+    requires: msg.block_index == (block_catalog.current_block_index ?? -1) + 1
+
+    ensures:
+        block_catalog.refresh(msg.block_index)
+        table_catalog.refresh()
+        trie_cat/trie_catalog.refresh()
+        replica_live_index.nextBlock()
+
+        -- Wake up compaction.
+        CompactorSignalled()
+
+        -- Replay any buffered messages.
+        replica_processor.pending_block_index = null
+        ReplayBuffered()
+}
+
+------------------------------------------------------------
+-- Rules: Compaction Orchestration
+------------------------------------------------------------
+
+-- The compactor runs asynchronously, triggered after block flushes.
+-- Job selection and the merge algorithm are specified in compaction.allium.
+-- The compactor writes L1+ TriesAdded to the source log (not the replica log).
+-- The job is not complete until the message round-trips through
+-- source → replica → trie catalog.
+
+rule CompactorWakesUp {
+    when: CompactorSignalled()
+
+    let jobs = compaction/available_jobs(trie_cat/trie_catalog)
+
+    ensures:
+        for each job in jobs:
+            StartCompactionJob(job)
+}
+
+rule CompactionJobWritesOutput {
+    when: StartCompactionJob(job)
+
+    ensures:
+        -- Data file uploaded first; meta file presence is the completion marker.
+
+        -- Write TriesAdded to the source log.
+        -- The source processor will forward to the replica log.
+        TriesAddedMessage.created(tries: job.output_tries) appended to database.source_log
+
+        -- Job is NOT complete yet — awaiting round-trip confirmation.
+}
+
+rule CompactionJobConfirmed {
+    -- The TriesAdded has round-tripped through the log and is now in the trie catalog.
+    -- Job selection naturally sees the updated catalog for the next cycle.
+    when: job.output_tries visible in trie_cat/trie_catalog
+}
+
+------------------------------------------------------------
+-- Rules: Query Serving
+------------------------------------------------------------
+
+rule ClientOpensSnapshot {
+    when: ClientOpensSnapshot(client, database)
+
+    ensures:
+        Snapshot.created(
+            as_of: replica_live_index.latest_completed_tx
+        )
+}
+
+------------------------------------------------------------
+-- Rules: Error Handling
+------------------------------------------------------------
+
+rule ProcessingErrorHaltsNode {
+    when: ProcessingError(msg_id, error)
+
+    ensures:
+        NodeMarkedUnhealthy()
+}
+
+------------------------------------------------------------
+-- Surfaces
+------------------------------------------------------------
+
+actor Client {
+    identified_by: external session
+}
+
+surface TransactionSubmission {
+    for caller: Client
+
+    context db: Database
+
+    provides:
+        ClientSubmitsTx(caller, db, tx_ops, opts)
+            when db.mode == read_write
+
+    invariant: OrderedProcessing
+        -- Transactions are processed in the order they appear in the source log.
+}
+
+surface QueryAccess {
+    for caller: Client
+
+    context db: Database
+
+    provides:
+        ClientOpensSnapshot(caller, db)
+
+    invariant: SnapshotIsolation
+        -- A snapshot sees a consistent point-in-time view.
+        -- It includes all transactions up to latest_completed_tx.
+}
+
+------------------------------------------------------------
+-- Deferred Specifications
+------------------------------------------------------------
+
+deferred IndexTransaction           -- transaction resolution (put/delete/erase logic)
+deferred ResolveAttach              -- attach database resolution
+deferred ResolveDetach              -- detach database resolution
+
+------------------------------------------------------------
+-- Open Questions
+------------------------------------------------------------
+
+open_question "Replica log offset tracking: currently always replays from beginning. Persist offset in block file?"

--- a/dev/doc/db-5188.allium
+++ b/dev/doc/db-5188.allium
@@ -28,6 +28,7 @@ context {
     replica_processor: ReplicaProcessor     -- all nodes
     source_live_index: LiveIndex            -- leader's live index
     replica_live_index: LiveIndex           -- replica's live index (all nodes)
+    watchers: Watchers                     -- correlates submit-tx with replica processing
     block_catalog: BlockCatalog
     table_catalog: TableCatalog
 }
@@ -102,9 +103,14 @@ entity ReplicaProcessor {
     -- Applies resolved transactions, handles block transitions, updates catalogs.
     latest_processed_msg_id: MessageId
     pending_block_index: Long?
+}
 
-    -- Watchers: clients await by source-log tx id (the id returned by submit-tx).
-    -- ResolvedTxMessage carries the source tx_id for this mapping.
+entity Watchers {
+    -- Correlates source-log message IDs with client futures.
+    -- Clients receive the source-log msg_id from submit-tx;
+    -- Watchers notifies them when ReplicaProcessor processes the corresponding ResolvedTx.
+    -- See: api/log/Watchers.kt
+    current_msg_id: MessageId
 }
 
 external value current_storage_version: Int   -- See: storage/Storage.kt (VERSION)
@@ -140,6 +146,21 @@ value Snapshot {
 
 value TableMetadata {
     row_count: Long?
+}
+
+value DbOp {
+    -- A database-level side-effect carried within a ResolvedTx.
+    -- See: api/log/DbOp.kt
+    kind: Attach | Detach
+}
+
+variant Attach : DbOp {
+    db_name: String
+    config: DatabaseConfig
+}
+
+variant Detach : DbOp {
+    db_name: String
 }
 
 ------------------------------------------------------------
@@ -206,10 +227,11 @@ variant ResolvedTxMessage : ReplicaMessage {
     -- A resolved transaction: put/delete/erase events that require no database reads.
     -- Carries the source tx_id so watchers can correlate with submit-tx responses.
     -- Attach/detach results are encoded as a dbOp field within the resolved tx.
-    -- See: api/log/Log.kt (Message.ResolvedTx)
+    -- See: api/log/Log.kt (Message.ResolvedTx), api/log/ReplicaMessage.kt (ResolvedTx)
     tx_id: MessageId            -- source-log msg id of the original Tx/Attach/Detach
     committed: Boolean
     db_op: DbOp?               -- Attach or Detach side-effect, if any
+    table_data: Map<String, Bytes>  -- resolved row data per table, serialized; imported by replica processor
 }
 
 variant BlockBoundaryMessage : ReplicaMessage {
@@ -450,7 +472,7 @@ rule ReplicaProcessesResolvedTx {
 
         -- Notify watchers using the source-log tx id.
         replica_processor.latest_processed_msg_id = msg.tx_id
-        NotifyWatchers(msg.tx_id, result)
+        watchers.notify(msg.tx_id, result)
 }
 
 rule ReplicaProcessesTriesAdded {

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -145,7 +145,7 @@ entity Message {
 
 variant TxMessage : Message {
     -- Client-submitted transaction operations.
-    -- See: tx/TxWriter.kt, api/log/Log.kt (Log$Message$Tx) — serialised via TxWriter, not proto.
+    -- See: tx/TxWriter.kt, api/log/Log.kt, api/log/SourceMessage.kt (SourceMessage$Tx) — serialised via TxWriter, not proto.
     system_time: Instant?
     default_tz: String?
     user: String?

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -376,12 +376,9 @@ rule CompactionJobCompletes {
 
     ensures:
         -- Data file uploaded first; meta file presence is the completion marker.
-        -- Append tries-added to replica-log.
+        -- Append tries-added to source-log; source processor will forward to replica.
         let tries_added = TriesAddedMessage.created(tries: job.output_tries)
-        tries_added appended to database.replica_log
-
-        -- Eagerly register in trie catalog (idempotent).
-        trie_cat/trie_catalog.addTries(job.output_tries, tries_added.log_timestamp)
+        tries_added appended to database.source_log
 }
 
 

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -137,13 +137,13 @@ value TableMetadata {
 -- The LogProcessor dispatches on message kind.
 -- See: log/proto/log.proto (LogMessage oneof)
 
-entity Message {
+entity SourceMessage {
     msg_id: MessageId
     log_timestamp: Instant
-    kind: TxMessage | FlushBlockMessage | TriesAddedMessage | BlockUploadedMessage | AttachDbMessage | DetachDbMessage
+    kind: TxMessage | FlushBlockMessage | TriesAddedMessage | AttachDbMessage | DetachDbMessage
 }
 
-variant TxMessage : Message {
+variant TxMessage : SourceMessage {
     -- Client-submitted transaction operations.
     -- See: tx/TxWriter.kt, api/log/Log.kt, api/log/SourceMessage.kt (SourceMessage$Tx) — serialised via TxWriter, not proto.
     system_time: Instant?
@@ -151,13 +151,13 @@ variant TxMessage : Message {
     user: String?
 }
 
-variant FlushBlockMessage : Message {
+variant FlushBlockMessage : SourceMessage {
     -- Request to finish the current block.
     -- See: log/proto/log.proto (FlushBlock)
     expected_block_idx: Long?
 }
 
-variant TriesAddedMessage : Message {
+variant TriesAddedMessage : SourceMessage {
     -- Notification that new tries exist (from block flush or compaction).
     -- See: log/proto/log.proto (TriesAdded)
     storage_version: Int
@@ -165,21 +165,12 @@ variant TriesAddedMessage : Message {
     tries: List<trie_cat/TrieDetails>
 }
 
-variant BlockUploadedMessage : Message {
-    -- Notification that a block has been written to the object store.
-    -- Sent by the writer after finishBlock(); consumed by read-only nodes to refresh catalogs without polling.
-    -- See: log/proto/log.proto (BlockUploaded)
-    block_index: Long
-    latest_processed_msg_id: MessageId
-    storage_epoch: Int
-}
-
-variant AttachDbMessage : Message {
+variant AttachDbMessage : SourceMessage {
     -- See: log/proto/log.proto (AttachDatabase)
     db_name: String
 }
 
-variant DetachDbMessage : Message {
+variant DetachDbMessage : SourceMessage {
     -- See: log/proto/log.proto (DetachDatabase)
     db_name: String
 }

--- a/modules/kafka/src/main/clojure/xtdb/kafka.clj
+++ b/modules/kafka/src/main/clojure/xtdb/kafka.clj
@@ -11,6 +11,10 @@
     properties-map (.propertiesMap properties-map)
     properties-file (.propertiesFile (util/->path properties-file))))
 
-(defmethod log/->log-factory ::kafka [_ {:keys [cluster topic epoch] :as opts}]
-  (cond-> (KafkaCluster$LogFactory. (str (symbol cluster)) topic (boolean (:create-topic? opts true)))
-    epoch (.epoch epoch)))
+(defmethod log/->log-factory ::kafka [_ {:keys [cluster topic replica-cluster replica-topic epoch] :as opts}]
+  (let [cluster-str (str (symbol cluster))]
+    (cond-> (KafkaCluster$LogFactory. cluster-str topic
+                                      (or replica-cluster cluster-str)
+                                      (or replica-topic (str topic "-replica"))
+                                      (boolean (:create-topic? opts true)))
+      epoch (.epoch epoch))))

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -370,7 +370,7 @@ class KafkaCluster(
         fun epoch(epoch: Int) = apply { this.epoch = epoch }
         fun groupId(groupId: String) = apply { this.groupId = groupId }
 
-        override fun openLog(clusters: Map<LogClusterAlias, Cluster>): Log<Message> {
+        override fun openSourceLog(clusters: Map<LogClusterAlias, Cluster>): Log<SourceMessage> {
             val clusterAlias = this.cluster
             val cluster = requireNotNull(clusters[clusterAlias] as? KafkaCluster) {
                 "missing Kafka cluster: '$clusterAlias'"
@@ -382,11 +382,11 @@ class KafkaCluster(
                 admin.ensureTopicExists(topic, autoCreateTopic)
             }
 
-            return cluster.KafkaLog(Message.Codec, clusterAlias, topic, epoch, groupId)
+            return cluster.KafkaLog(SourceMessage.Codec, clusterAlias, topic, epoch, groupId)
         }
 
-        override fun openReadOnlyLog(clusters: Map<LogClusterAlias, Cluster>) =
-            ReadOnlyLog(openLog(clusters))
+        override fun openReadOnlySourceLog(clusters: Map<LogClusterAlias, Cluster>) =
+            ReadOnlyLog(openSourceLog(clusters))
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.setOtherLog(ProtoAny.pack(kafkaLogConfig {

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -151,12 +151,13 @@ class KafkaCluster(
         override fun open(): KafkaCluster = KafkaCluster(configMap, pollDuration, coroutineContext)
     }
 
-    private inner class KafkaLog(
+    private inner class KafkaLog<M>(
+        private val codec: MessageCodec<M>,
         private val clusterAlias: LogClusterAlias,
         private val topic: String,
         override val epoch: Int,
         private val groupId: String?
-    ) : Log {
+    ) : Log<M> {
 
         private fun readLatestSubmittedMessage(kafkaConfigMap: KafkaConfigMap): LogOffset =
             kafkaConfigMap.openConsumer().use { c ->
@@ -167,12 +168,12 @@ class KafkaCluster(
         private val latestSubmittedOffset0 = AtomicLong(readLatestSubmittedMessage(kafkaConfigMap))
         override val latestSubmittedOffset get() = latestSubmittedOffset0.get()
 
-        override fun appendMessage(message: Message): CompletableFuture<MessageMetadata> =
+        override fun appendMessage(message: M): CompletableFuture<MessageMetadata> =
             scope.future {
                 CompletableDeferred<MessageMetadata>()
                     .also { res ->
                         producer.send(
-                            ProducerRecord(topic, null, Unit, message.encode())
+                            ProducerRecord(topic, null, Unit, codec.encode(message))
                         ) { recordMetadata, e ->
                             if (e == null) res.complete(
                                 MessageMetadata(
@@ -186,7 +187,7 @@ class KafkaCluster(
                     .also { messageMetadata -> latestSubmittedOffset0.updateAndGet { it.coerceAtLeast(messageMetadata.logOffset) } }
             }
 
-        override fun readLastMessage(): Message? =
+        override fun readLastMessage(): M? =
             kafkaConfigMap.openConsumer().use { c ->
                 val tp = TopicPartition(topic, 0)
                 val lastOffset = c.endOffsets(listOf(tp))[tp]?.minus(1)?.takeIf { it >= 0 } ?: return null
@@ -194,10 +195,10 @@ class KafkaCluster(
                 c.seek(tp, lastOffset)
 
                 val records = c.poll(pollDuration).records(topic)
-                records.firstOrNull()?.let { record -> Message.parse(record.value()) }
+                records.firstOrNull()?.let { record -> codec.decode(record.value()) }
             }
 
-        override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer {
+        override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer<M> {
             private val producer = KafkaProducer(
                 mapOf(
                     "enable.idempotence" to "true",
@@ -209,18 +210,18 @@ class KafkaCluster(
                 ByteArraySerializer()
             ).also { it.initTransactions() }
 
-            override fun openTx(): AtomicProducer.Tx {
+            override fun openTx(): AtomicProducer.Tx<M> {
                 producer.beginTransaction()
 
-                return object : AtomicProducer.Tx {
+                return object : AtomicProducer.Tx<M> {
                     private val futures = mutableListOf<CompletableFuture<MessageMetadata>>()
                     private var isOpen = true
 
-                    override fun appendMessage(message: Message): CompletableFuture<MessageMetadata> {
+                    override fun appendMessage(message: M): CompletableFuture<MessageMetadata> {
                         check(isOpen) { "Transaction already closed" }
                         val future = CompletableFuture<MessageMetadata>()
                         futures.add(future)
-                        producer.send(ProducerRecord(topic, null, Unit, message.encode())) { recordMetadata, e ->
+                        producer.send(ProducerRecord(topic, null, Unit, codec.encode(message))) { recordMetadata, e ->
                             if (e == null) {
                                 future.complete(
                                     MessageMetadata(
@@ -262,7 +263,7 @@ class KafkaCluster(
             }
         }
 
-        override fun tailAll(subscriber: Subscriber, latestProcessedOffset: LogOffset): Subscription {
+        override fun tailAll(subscriber: Subscriber<M>, latestProcessedOffset: LogOffset): Subscription {
             val job = scope.launch {
                 kafkaConfigMap.openConsumer().use { c ->
                     TopicPartition(topic, 0).also { tp ->
@@ -280,7 +281,7 @@ class KafkaCluster(
 
                             subscriber.processRecords(
                                 records.mapNotNull { record ->
-                                    Message.parse(record.value())
+                                    codec.decode(record.value())
                                         ?.let { msg ->
                                             Record(
                                                 record.offset(),
@@ -298,7 +299,7 @@ class KafkaCluster(
             return Subscription { runBlocking { withTimeout(5.seconds) { job.cancelAndJoin() } } }
         }
 
-        override fun subscribe(subscriber: GroupSubscriber): Subscription {
+        override fun subscribe(subscriber: GroupSubscriber<M>): Subscription {
             val groupId = requireNotNull(groupId) { "groupId must be configured to use subscribe" }
 
             val consumerConfig = kafkaConfigMap + mapOf("group.id" to groupId)
@@ -334,7 +335,7 @@ class KafkaCluster(
 
                             subscriber.processRecords(
                                 records.mapNotNull { record ->
-                                    Message.parse(record.value())
+                                    codec.decode(record.value())
                                         ?.let { msg ->
                                             Record(
                                                 record.offset(),
@@ -369,7 +370,7 @@ class KafkaCluster(
         fun epoch(epoch: Int) = apply { this.epoch = epoch }
         fun groupId(groupId: String) = apply { this.groupId = groupId }
 
-        override fun openLog(clusters: Map<LogClusterAlias, Cluster>): Log {
+        override fun openLog(clusters: Map<LogClusterAlias, Cluster>): Log<Message> {
             val clusterAlias = this.cluster
             val cluster = requireNotNull(clusters[clusterAlias] as? KafkaCluster) {
                 "missing Kafka cluster: '$clusterAlias'"
@@ -381,7 +382,7 @@ class KafkaCluster(
                 admin.ensureTopicExists(topic, autoCreateTopic)
             }
 
-            return cluster.KafkaLog(clusterAlias, topic, epoch, groupId)
+            return cluster.KafkaLog(Message.Codec, clusterAlias, topic, epoch, groupId)
         }
 
         override fun openReadOnlyLog(clusters: Map<LogClusterAlias, Cluster>) =

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
@@ -34,14 +34,14 @@ class KafkaAtomicProducerTest {
         }
     }
 
-    private fun txMessage(id: Byte) = Message.Tx(byteArrayOf(-1, id))
+    private fun txMessage(id: Byte) = SourceMessage.Tx(byteArrayOf(-1, id))
 
     @Test
     fun `committed transaction messages are visible to subscribers`() = runTest(timeout = 60.seconds) {
         val topicName = "test-topic-${UUID.randomUUID()}"
-        val msgs = synchronizedList(mutableListOf<List<Record<Message>>>())
+        val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
 
-        val subscriber = mockk<Subscriber<Message>> {
+        val subscriber = mockk<Subscriber<SourceMessage>> {
             every { processRecords(capture(msgs)) } returns Unit
         }
 
@@ -49,7 +49,7 @@ class KafkaAtomicProducerTest {
             .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         log.tailAll(subscriber, -1).use {
                             log.openAtomicProducer("tx-producer-1").use { producer ->
@@ -69,11 +69,11 @@ class KafkaAtomicProducerTest {
         assertEquals(2, allMsgs.size)
 
         allMsgs[0].message.let {
-            check(it is Message.Tx)
+            check(it is SourceMessage.Tx)
             assertArrayEquals(byteArrayOf(-1, 1), it.payload)
         }
         allMsgs[1].message.let {
-            check(it is Message.Tx)
+            check(it is SourceMessage.Tx)
             assertArrayEquals(byteArrayOf(-1, 2), it.payload)
         }
     }
@@ -81,9 +81,9 @@ class KafkaAtomicProducerTest {
     @Test
     fun `aborted transaction messages are not visible to subscribers`() = runTest(timeout = 60.seconds) {
         val topicName = "test-topic-${UUID.randomUUID()}"
-        val msgs = synchronizedList(mutableListOf<List<Record<Message>>>())
+        val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
 
-        val subscriber = mockk<Subscriber<Message>> {
+        val subscriber = mockk<Subscriber<SourceMessage>> {
             every { processRecords(capture(msgs)) } returns Unit
         }
 
@@ -91,7 +91,7 @@ class KafkaAtomicProducerTest {
             .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         log.tailAll(subscriber, -1).use {
                             log.openAtomicProducer("tx-producer-1").use { producer ->
@@ -121,7 +121,7 @@ class KafkaAtomicProducerTest {
         assertEquals(1, allMsgs.size)
 
         allMsgs[0].message.let {
-            check(it is Message.Tx)
+            check(it is SourceMessage.Tx)
             assertArrayEquals(byteArrayOf(-1, 3), it.payload)
         }
     }
@@ -129,9 +129,9 @@ class KafkaAtomicProducerTest {
     @Test
     fun `multiple sequential transactions on same producer`() = runTest(timeout = 60.seconds) {
         val topicName = "test-topic-${UUID.randomUUID()}"
-        val msgs = synchronizedList(mutableListOf<List<Record<Message>>>())
+        val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
 
-        val subscriber = mockk<Subscriber<Message>> {
+        val subscriber = mockk<Subscriber<SourceMessage>> {
             every { processRecords(capture(msgs)) } returns Unit
         }
 
@@ -139,7 +139,7 @@ class KafkaAtomicProducerTest {
             .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         log.tailAll(subscriber, -1).use {
                             log.openAtomicProducer("tx-producer-1").use { producer ->
@@ -171,16 +171,16 @@ class KafkaAtomicProducerTest {
         val allMsgs = synchronized(msgs) { msgs.flatten() }
         assertEquals(4, allMsgs.size)
 
-        val payloads = allMsgs.map { (it.message as Message.Tx).payload[1] }
+        val payloads = allMsgs.map { (it.message as SourceMessage.Tx).payload[1] }
         assertEquals(listOf<Byte>(1, 2, 3, 4), payloads)
     }
 
     @Test
     fun `uncommitted transaction messages not visible until commit`() = runTest(timeout = 60.seconds) {
         val topicName = "test-topic-${UUID.randomUUID()}"
-        val msgs = synchronizedList(mutableListOf<List<Record<Message>>>())
+        val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
 
-        val subscriber = mockk<Subscriber<Message>> {
+        val subscriber = mockk<Subscriber<SourceMessage>> {
             every { processRecords(capture(msgs)) } returns Unit
         }
 
@@ -188,7 +188,7 @@ class KafkaAtomicProducerTest {
             .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         log.tailAll(subscriber, -1).use {
                             log.openAtomicProducer("tx-producer-1").use { producer ->

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
@@ -39,9 +39,9 @@ class KafkaAtomicProducerTest {
     @Test
     fun `committed transaction messages are visible to subscribers`() = runTest(timeout = 60.seconds) {
         val topicName = "test-topic-${UUID.randomUUID()}"
-        val msgs = synchronizedList(mutableListOf<List<Record>>())
+        val msgs = synchronizedList(mutableListOf<List<Record<Message>>>())
 
-        val subscriber = mockk<Subscriber> {
+        val subscriber = mockk<Subscriber<Message>> {
             every { processRecords(capture(msgs)) } returns Unit
         }
 
@@ -81,9 +81,9 @@ class KafkaAtomicProducerTest {
     @Test
     fun `aborted transaction messages are not visible to subscribers`() = runTest(timeout = 60.seconds) {
         val topicName = "test-topic-${UUID.randomUUID()}"
-        val msgs = synchronizedList(mutableListOf<List<Record>>())
+        val msgs = synchronizedList(mutableListOf<List<Record<Message>>>())
 
-        val subscriber = mockk<Subscriber> {
+        val subscriber = mockk<Subscriber<Message>> {
             every { processRecords(capture(msgs)) } returns Unit
         }
 
@@ -129,9 +129,9 @@ class KafkaAtomicProducerTest {
     @Test
     fun `multiple sequential transactions on same producer`() = runTest(timeout = 60.seconds) {
         val topicName = "test-topic-${UUID.randomUUID()}"
-        val msgs = synchronizedList(mutableListOf<List<Record>>())
+        val msgs = synchronizedList(mutableListOf<List<Record<Message>>>())
 
-        val subscriber = mockk<Subscriber> {
+        val subscriber = mockk<Subscriber<Message>> {
             every { processRecords(capture(msgs)) } returns Unit
         }
 
@@ -178,9 +178,9 @@ class KafkaAtomicProducerTest {
     @Test
     fun `uncommitted transaction messages not visible until commit`() = runTest(timeout = 60.seconds) {
         val topicName = "test-topic-${UUID.randomUUID()}"
-        val msgs = synchronizedList(mutableListOf<List<Record>>())
+        val msgs = synchronizedList(mutableListOf<List<Record<Message>>>())
 
-        val subscriber = mockk<Subscriber> {
+        val subscriber = mockk<Subscriber<Message>> {
             every { processRecords(capture(msgs)) } returns Unit
         }
 

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -43,9 +43,9 @@ class KafkaClusterTest {
 
     @Test
     fun `round-trips messages`() = runTest(timeout = 30.seconds) {
-        val msgs = synchronizedList(mutableListOf<List<Record>>())
+        val msgs = synchronizedList(mutableListOf<List<Record<Message>>>())
 
-        val subscriber = mockk<Subscriber> {
+        val subscriber = mockk<Subscriber<Message>> {
             every { processRecords(capture(msgs)) } returns Unit
         }
 

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -43,9 +43,9 @@ class KafkaClusterTest {
 
     @Test
     fun `round-trips messages`() = runTest(timeout = 30.seconds) {
-        val msgs = synchronizedList(mutableListOf<List<Record<Message>>>())
+        val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
 
-        val subscriber = mockk<Subscriber<Message>> {
+        val subscriber = mockk<Subscriber<SourceMessage>> {
             every { processRecords(capture(msgs)) } returns Unit
         }
 
@@ -67,17 +67,17 @@ class KafkaClusterTest {
             .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         log.tailAll(subscriber, -1).use { _ ->
                             val txPayload = ByteBuffer.allocate(9).put(-1).putLong(42).flip().array()
-                            log.appendMessage(Message.Tx(txPayload)).await()
+                            log.appendMessage(SourceMessage.Tx(txPayload)).await()
 
-                            log.appendMessage(Message.FlushBlock(12)).await()
+                            log.appendMessage(SourceMessage.FlushBlock(12)).await()
 
-                            log.appendMessage(Message.TriesAdded(Storage.VERSION, 0, addedTrieDetails)).await()
+                            log.appendMessage(SourceMessage.TriesAdded(Storage.VERSION, 0, addedTrieDetails)).await()
 
-                            log.appendMessage(Message.AttachDatabase("foo", databaseConfig))
+                            log.appendMessage(SourceMessage.AttachDatabase("foo", databaseConfig))
 
                             while (synchronized(msgs) { msgs.flatten().size } < 4) delay(100)
                         }
@@ -89,28 +89,28 @@ class KafkaClusterTest {
         assertEquals(4, allMsgs.size)
 
         allMsgs[0].message.let {
-            check(it is Message.Tx)
+            check(it is SourceMessage.Tx)
             assertEquals(42, ByteBuffer.wrap(it.payload).getLong(1))
         }
 
         allMsgs[1].message.let {
-            check(it is Message.FlushBlock)
+            check(it is SourceMessage.FlushBlock)
             assertEquals(12, it.expectedBlockIdx)
         }
 
         allMsgs[2].message.let {
-            check(it is Message.TriesAdded)
+            check(it is SourceMessage.TriesAdded)
             assertEquals(addedTrieDetails, it.tries)
         }
 
         allMsgs[3].message.let {
-            check(it is Message.AttachDatabase)
+            check(it is SourceMessage.AttachDatabase)
             assertEquals("foo", it.dbName)
             assertEquals(databaseConfig, it.config)
         }
     }
 
-    private fun txMessage(id: Byte) = Message.Tx(byteArrayOf(-1, id))
+    private fun txMessage(id: Byte) = SourceMessage.Tx(byteArrayOf(-1, id))
 
     @Test
     fun `readLastMessage returns null when topic is empty`() = runTest(timeout = 30.seconds)  {
@@ -120,7 +120,7 @@ class KafkaClusterTest {
             .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         assertEquals(null, log.readLastMessage())
                     }
@@ -135,12 +135,12 @@ class KafkaClusterTest {
             .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         log.appendMessage(txMessage(1)).await()
 
                         val lastMessage = log.readLastMessage()
-                        check(lastMessage is Message.Tx)
+                        check(lastMessage is SourceMessage.Tx)
                         assertArrayEquals(byteArrayOf(-1, 1), lastMessage.payload)
                     }
             }
@@ -154,14 +154,14 @@ class KafkaClusterTest {
             .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         log.appendMessage(txMessage(1)).await()
                         log.appendMessage(txMessage(2)).await()
                         log.appendMessage(txMessage(3)).await()
 
                         val lastMessage = log.readLastMessage()
-                        check(lastMessage is Message.Tx)
+                        check(lastMessage is SourceMessage.Tx)
                         assertArrayEquals(byteArrayOf(-1, 3), lastMessage.payload)
                     }
             }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaSubscribeTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaSubscribeTest.kt
@@ -35,7 +35,7 @@ class KafkaSubscribeTest {
         }
     }
 
-    private fun txMessage(id: Byte) = Message.Tx(byteArrayOf(-1, id))
+    private fun txMessage(id: Byte) = SourceMessage.Tx(byteArrayOf(-1, id))
 
     @Test
     fun `assignment callback fires on subscribe`() = runTest(timeout = 30.seconds) {
@@ -44,8 +44,8 @@ class KafkaSubscribeTest {
 
         val assignedPartitions = AtomicReference<Collection<Int>>(null)
 
-        val subscriber = object : GroupSubscriber<Message> {
-            override fun processRecords(records: List<Record<Message>>) {}
+        val subscriber = object : GroupSubscriber<SourceMessage> {
+            override fun processRecords(records: List<Record<SourceMessage>>) {}
             override fun onPartitionsAssigned(partitions: Collection<Int>): Map<Int, LogOffset> {
                 assignedPartitions.set(partitions)
                 return emptyMap()
@@ -58,7 +58,7 @@ class KafkaSubscribeTest {
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .groupId(groupId)
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         log.subscribe(subscriber).use {
                             while (assignedPartitions.get() == null) delay(50)
@@ -74,10 +74,10 @@ class KafkaSubscribeTest {
         val topicName = "test-topic-${UUID.randomUUID()}"
         val groupId = "test-group-${UUID.randomUUID()}"
 
-        val receivedRecords = Collections.synchronizedList(mutableListOf<Record<Message>>())
+        val receivedRecords = Collections.synchronizedList(mutableListOf<Record<SourceMessage>>())
 
-        val subscriber = object : GroupSubscriber<Message> {
-            override fun processRecords(records: List<Record<Message>>) {
+        val subscriber = object : GroupSubscriber<SourceMessage> {
+            override fun processRecords(records: List<Record<SourceMessage>>) {
                 receivedRecords.addAll(records)
             }
             override fun onPartitionsAssigned(partitions: Collection<Int>): Map<Int, LogOffset> {
@@ -91,7 +91,7 @@ class KafkaSubscribeTest {
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .groupId(groupId)
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         // Append some messages first
                         log.appendMessage(txMessage(0)).await()
@@ -119,8 +119,8 @@ class KafkaSubscribeTest {
         val revokedPartitions = AtomicReference<Collection<Int>>(null)
         val assigned = AtomicBoolean(false)
 
-        val subscriber = object : GroupSubscriber<Message> {
-            override fun processRecords(records: List<Record<Message>>) {}
+        val subscriber = object : GroupSubscriber<SourceMessage> {
+            override fun processRecords(records: List<Record<SourceMessage>>) {}
             override fun onPartitionsAssigned(partitions: Collection<Int>): Map<Int, LogOffset> {
                 assigned.set(true)
                 return emptyMap()
@@ -135,7 +135,7 @@ class KafkaSubscribeTest {
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .groupId(groupId)
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         log.subscribe(subscriber).use {
                             while (!assigned.get()) delay(50)
@@ -150,14 +150,14 @@ class KafkaSubscribeTest {
     fun `subscribe without groupId throws`() {
         val topicName = "test-topic-${UUID.randomUUID()}"
 
-        val subscriber = mockk<GroupSubscriber<Message>>()
+        val subscriber = mockk<GroupSubscriber<SourceMessage>>()
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
             .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     // no groupId set
-                    .openLog(mapOf("my-cluster" to cluster))
+                    .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
                         val ex = assertThrows(IllegalArgumentException::class.java) {
                             log.subscribe(subscriber)

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaSubscribeTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaSubscribeTest.kt
@@ -44,8 +44,8 @@ class KafkaSubscribeTest {
 
         val assignedPartitions = AtomicReference<Collection<Int>>(null)
 
-        val subscriber = object : GroupSubscriber {
-            override fun processRecords(records: List<Record>) {}
+        val subscriber = object : GroupSubscriber<Message> {
+            override fun processRecords(records: List<Record<Message>>) {}
             override fun onPartitionsAssigned(partitions: Collection<Int>): Map<Int, LogOffset> {
                 assignedPartitions.set(partitions)
                 return emptyMap()
@@ -74,10 +74,10 @@ class KafkaSubscribeTest {
         val topicName = "test-topic-${UUID.randomUUID()}"
         val groupId = "test-group-${UUID.randomUUID()}"
 
-        val receivedRecords = Collections.synchronizedList(mutableListOf<Record>())
+        val receivedRecords = Collections.synchronizedList(mutableListOf<Record<Message>>())
 
-        val subscriber = object : GroupSubscriber {
-            override fun processRecords(records: List<Record>) {
+        val subscriber = object : GroupSubscriber<Message> {
+            override fun processRecords(records: List<Record<Message>>) {
                 receivedRecords.addAll(records)
             }
             override fun onPartitionsAssigned(partitions: Collection<Int>): Map<Int, LogOffset> {
@@ -119,8 +119,8 @@ class KafkaSubscribeTest {
         val revokedPartitions = AtomicReference<Collection<Int>>(null)
         val assigned = AtomicBoolean(false)
 
-        val subscriber = object : GroupSubscriber {
-            override fun processRecords(records: List<Record>) {}
+        val subscriber = object : GroupSubscriber<Message> {
+            override fun processRecords(records: List<Record<Message>>) {}
             override fun onPartitionsAssigned(partitions: Collection<Int>): Map<Int, LogOffset> {
                 assigned.set(true)
                 return emptyMap()
@@ -150,7 +150,7 @@ class KafkaSubscribeTest {
     fun `subscribe without groupId throws`() {
         val topicName = "test-topic-${UUID.randomUUID()}"
 
-        val subscriber = mockk<GroupSubscriber>()
+        val subscriber = mockk<GroupSubscriber<Message>>()
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
             .pollDuration(Duration.ofMillis(100))

--- a/src/dev/clojure/dev.clj
+++ b/src/dev/clojure/dev.clj
@@ -23,7 +23,7 @@
            (xtdb.block.proto TableBlock)
            (xtdb.log.proto TrieDetails)
            (xtdb.trie ArrowHashTrie ArrowHashTrie$IidBranch ArrowHashTrie$Leaf ArrowHashTrie$Node)
-           [xtdb.api.log Log$Message]))
+           [xtdb.api.log SourceMessage]))
 
 #_{:clj-kondo/ignore [:unused-namespace :unused-referred-var]}
 (require '[xtdb.logging :refer [set-log-level!]])
@@ -190,7 +190,7 @@
 
 (defn byte-array->txs [^bytes ba]
   (with-open [al (RootAllocator.)
-              r (Relation/openFromArrowStream al (.getPayload (Log$Message/parse ba)))]
+              r (Relation/openFromArrowStream al (.getPayload (SourceMessage/parse ba)))]
     (vec
       (for [op (-> r .getAsMaps first :tx-ops)]
         (let [{:keys [query args]} (.getValue op)]

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -31,7 +31,7 @@
            (xtdb.pgwire PgType)
            (xtdb JsonSerde JsonLdSerde)
            (xtdb.api DataSource$ConnectionBuilder)
-           xtdb.api.log.Log$Message$FlushBlock
+           xtdb.api.log.SourceMessage$FlushBlock
            xtdb.pgwire.Server))
 
 (set! *warn-on-reflection* false) ; gagh! lazy. don't do this.
@@ -2994,7 +2994,7 @@ ORDER BY 1,2;")
     (xt/execute-tx conn [[:put-docs :foo {:xt/id 1}]])
     (t/is (= [{:xt/id 1}] (xt/q conn "SELECT * FROM foo")))
     (doto (.getSourceLog (db/primary-db tu/*node*))
-      (.appendMessage (Log$Message$FlushBlock. 1)))
+      (.appendMessage (SourceMessage$FlushBlock. 1)))
     (t/is (= [{:xt/id 1}] (xt/q conn "SELECT * FROM foo")))))
 
 (t/deftest test-database-metadata

--- a/src/test/clojure/xtdb/tx_source_test.clj
+++ b/src/test/clojure/xtdb/tx_source_test.clj
@@ -14,7 +14,7 @@
             [xtdb.log :as xt-log]
             [xtdb.trie-catalog :as trie-cat]
             [xtdb.tx-source :as tx-source])
-  (:import [xtdb.api.log Log$Message]
+  (:import [xtdb.api.log SourceMessage]
            [xtdb.table TableRef]
            [xtdb.test.log RecordingLog]))
 
@@ -25,7 +25,7 @@
 
 (defn decode-record
   ([msg] (decode-record msg :json))
-  ([msg fmt] (-> msg Log$Message/.encode (xtdb.serde/read-transit fmt))))
+  ([msg fmt] (-> msg SourceMessage/.encode (xtdb.serde/read-transit fmt))))
 
 (t/deftest test-tx-source-output
   (with-open [node (xtn/start-node (merge tu/*node-opts*


### PR DESCRIPTION
Chalk: #5212

## ⚠️ Breaking change

**Kafka installations** will need to create a replica topic alongside their existing source topic.

## Why

The target architecture (#5188) requires source and replica to be distinct logs with distinct message types.
This PR lays the groundwork: tidy-first equivalence changes that widen our options, plus the first behavioural steps toward the split.

The most important behavioural change: **the compactor no longer eagerly calls `addTries` on its own local trie catalog.**
It writes `TriesAdded` to the source log and waits for the message to round-trip through source → replica → trie catalog.
This eliminates a class of state divergence where the compactor's view of available tries could differ from what the log processors see.

## What's here

**Equivalence changes (tidy-first):**
- Genericise `Log<M>` over message type — preparation for typed source/replica logs
- Rename `Log.Message` → `SourceMessage` — names now match their role
- Extract `Watchers` as standalone integrant component — decouples client notification from log processing
- Remove `latestSubmittedMsgId` from `LogProcessor` interface — unused

**Behavioural changes:**
- Create `ReplicaMessage` sealed interface (`ResolvedTx`, `TriesAdded`, `BlockBoundary`, `BlockUploaded`) — enforces at the type level what can appear on each log
- Wire `ReplicaLogProcessor` to handle `ReplicaMessage` instead of `SourceMessage`
- Add `Log.Factory.openReplicaLog` — source and replica are now distinct log instances
- Compactor writes `TriesAdded` to source log, awaits round-trip confirmation

**Spec:**
- Add `db-5188.allium` describing the target source/replica architecture
- Update `db.allium` to match current codebase (SourceMessage rename, remove stale BlockUploaded variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)