### PR TITLE
fix(docker): add gcompat

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ LABEL usage="Example docker-run options for custom logging configuration: \
 --volume .:/config --env JDK_JAVA_OPTIONS='-Dlogback.configurationFile=/config/logback.xml'"
 
 # For healthcheck
-RUN apk add --no-cache wget
+RUN apk add --no-cache wget gcompat
 
 COPY --from=jlink /build/build/custom-jre /opt/java
 ENV PATH="/opt/java/bin:$PATH"


### PR DESCRIPTION
Snappy (used by Kafka for compression) ships a native .so compiled against glibc, which requires ld-linux-x86-64.so.2 at runtime. Alpine uses musl, so this linker isn't present, causing UnsatisfiedLinkError when consuming snappy-compressed Kafka messages.

gcompat provides a glibc compatibility shim (~338KB) that forwards glibc symbols to musl, fixing native library loading without switching base image.