### PR TITLE
Debezium CDC: Phase 1

### DIFF
--- a/docker/aws/build.gradle.kts
+++ b/docker/aws/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation(project(":xtdb-main"))
     implementation(project(":modules:xtdb-kafka"))
     implementation(project(":modules:xtdb-aws"))
+    implementation(project(":modules:xtdb-debezium"))
 
     runtimeOnly(libs.logback.classic)
     runtimeOnly(libs.slf4j.jpl)

--- a/docker/azure/build.gradle.kts
+++ b/docker/azure/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation(project(":xtdb-main"))
     implementation(project(":modules:xtdb-kafka"))
     implementation(project(":modules:xtdb-azure"))
+    implementation(project(":modules:xtdb-debezium"))
 
     runtimeOnly(libs.logback.classic)
     runtimeOnly(libs.slf4j.jpl)

--- a/docker/google-cloud/build.gradle.kts
+++ b/docker/google-cloud/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation(project(":xtdb-main"))
     implementation(project(":modules:xtdb-kafka"))
     implementation(project(":modules:xtdb-google-cloud"))
+    implementation(project(":modules:xtdb-debezium"))
 
     runtimeOnly(libs.logback.classic)
     runtimeOnly(libs.slf4j.jpl)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,6 +106,7 @@ jetty-alpn-server = { group = "org.eclipse.jetty", name = "jetty-alpn-server", v
 testcontainers = { group = "org.testcontainers", name = "testcontainers", version.ref = "testcontainers" }
 testcontainers-kafka = { group = "org.testcontainers", name = "testcontainers-kafka", version.ref = "testcontainers" }
 testcontainers-minio = { group = "org.testcontainers", name = "testcontainers-minio", version.ref = "testcontainers" }
+testcontainers-postgresql = { group = "org.testcontainers", name = "testcontainers-postgresql", version.ref = "testcontainers" }
 testcontainers-keycloak = { group = "com.github.dasniko", name = "testcontainers-keycloak", version = "4.1.1" }
 
 micrometer-core = { group = "io.micrometer", name = "micrometer-core", version.ref = "micrometer" }

--- a/main/src/main/clojure/xtdb/main.clj
+++ b/main/src/main/clojure/xtdb/main.clj
@@ -22,6 +22,7 @@
   (println " * `reset-compactor <db-name>`: resets the compacted files on the given node.")
   (println " * `export-snapshot <db-name>`: exports a consistent snapshot of object storage for the given database.")
   (println " * `tx-source`: runs a node which replicates the transaction log to an external log")
+  (println " * `debezium-cdc`: starts a node with Debezium CDC ingestion from Kafka")
   (newline)
   (println "For more information about any command, run `<command> --help`, e.g. `playground --help`"))
 
@@ -261,6 +262,32 @@
           (println "Usage: `read-table-block-file <file>`")
           (System/exit 2))))))
 
+(def debezium-cdc-cli-spec
+  [config-file-opt
+   ["-b" "--bootstrap-servers SERVERS" "Kafka bootstrap servers"
+    :id :bootstrap-servers]
+   ["-t" "--topic TOPIC" "Kafka topic to consume CDC events from"
+    :id :topic]
+   ["-d" "--db-name DB_NAME" "XTDB database name"
+    :id :db-name
+    :default "xtdb"]
+   ["-h" "--help"]])
+
+(defn- start-debezium-cdc [args]
+  (let [{{:keys [file bootstrap-servers topic db-name]} :options}
+        (-> (parse-args args debezium-cdc-cli-spec)
+            (handling-arg-errors-or-help))]
+    (when-not (and bootstrap-servers topic)
+      (binding [*out* *err*]
+        (println "Required: --bootstrap-servers and --topic")
+        (System/exit 2)))
+    (util/with-open [_cdc ((requiring-resolve 'xtdb.debezium/start!)
+                           (file->node-opts file)
+                           {:bootstrap-servers bootstrap-servers
+                            :topic topic
+                            :db-name db-name})]
+      @(shutdown-hook-promise))))
+
 (defn -main [& args]
   (binding [*out* *err*]
     (println (str "Starting " (util/xtdb-version-string) " ...")))
@@ -279,6 +306,8 @@
         "reset-compactor" (do
                             (reset-compactor! more-args)
                             (System/exit 0))
+
+        "debezium-cdc" (start-debezium-cdc more-args)
 
         "tx-source" (do
                       (tx-source! more-args)

--- a/modules/debezium/build.gradle.kts
+++ b/modules/debezium/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    `java-library`
+    alias(libs.plugins.clojurephant)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+dependencies {
+    api(project(":xtdb-api"))
+    api(project(":xtdb-core"))
+    api(project(":modules:xtdb-kafka"))
+
+    api(kotlin("stdlib"))
+    api(libs.kotlinx.serialization.json)
+
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.pgjdbc)
+}

--- a/modules/debezium/src/main/clojure/xtdb/debezium.clj
+++ b/modules/debezium/src/main/clojure/xtdb/debezium.clj
@@ -1,0 +1,27 @@
+(ns xtdb.debezium
+  (:require [clojure.tools.logging :as log]
+            [xtdb.node :as xtn]
+            [xtdb.util :as util])
+  (:import (xtdb.debezium DebeziumLog DebeziumProcessor)))
+
+(defn start!
+  "Starts a CDC ingestion node. Returns an AutoCloseable that tears down
+   the subscription, processor, log and node on close."
+  [node-opts {:keys [bootstrap-servers topic db-name]}]
+  (let [node (let [config (doto (xtn/->config node-opts)
+                            (-> (.getCompactor) (.threads 0))
+                            (.setServer nil)
+                            (.setFlightSql nil))]
+               (.open config))
+        log (DebeziumLog. bootstrap-servers topic)
+        processor (DebeziumProcessor. node db-name (.allocator node))
+        subscription (.tailAll log processor -1)]
+    (log/info "Debezium CDC node started"
+              {:bootstrap-servers bootstrap-servers
+               :topic topic :db-name db-name})
+    (reify java.lang.AutoCloseable
+      (close [_]
+        (util/close subscription)
+        (util/close processor)
+        (util/close log)
+        (util/close node)))))

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/CdcEvent.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/CdcEvent.kt
@@ -1,0 +1,128 @@
+package xtdb.debezium
+
+import kotlinx.serialization.json.*
+import org.apache.arrow.memory.BufferAllocator
+import xtdb.arrow.Relation
+import xtdb.arrow.Vector
+import xtdb.error.Incorrect
+import xtdb.tx.TxOp
+import java.time.DateTimeException
+import java.time.Instant
+
+internal fun JsonElement.toJvmValue(): Any? = when (this) {
+    is JsonNull -> null
+    is JsonPrimitive -> if (isString) content else booleanOrNull ?: longOrNull ?: doubleOrNull ?: content
+    is JsonArray -> map { it.toJvmValue() }
+    is JsonObject -> toJvmMap()
+}
+
+internal fun JsonObject.toJvmMap(): Map<String, Any?> =
+    entries.associate { (k, v) -> k to v.toJvmValue() }
+
+sealed class CdcEvent {
+    abstract val schema: String
+    abstract val table: String
+    abstract val lsn: Long?
+    abstract val txId: Long?
+
+    abstract fun toTxOp(allocator: BufferAllocator): TxOp
+
+    val metadata: Map<String, Any?>
+        get() = buildMap {
+            put("source", "debezium")
+            lsn?.let { put("lsn", it) }
+            txId?.let { put("tx_id", it) }
+        }
+
+    data class Put(
+        override val schema: String,
+        override val table: String,
+        override val lsn: Long?,
+        override val txId: Long?,
+        val doc: Map<String, Any?>,
+        val validFrom: Instant? = null,
+        val validTo: Instant? = null,
+    ) : CdcEvent() {
+        override fun toTxOp(allocator: BufferAllocator): TxOp {
+            val rel = Relation.openFromRows(allocator, listOf(doc))
+            return TxOp.PutDocs(schema, table, validFrom, validTo, rel)
+        }
+    }
+
+    data class Delete(
+        override val schema: String,
+        override val table: String,
+        override val lsn: Long?,
+        override val txId: Long?,
+        val id: Any,
+    ) : CdcEvent() {
+        override fun toTxOp(allocator: BufferAllocator): TxOp {
+            val ids = Vector.fromList(allocator, "_id", listOf(id))
+            return TxOp.DeleteDocs(schema, table, null, null, ids)
+        }
+    }
+
+    companion object {
+        private fun parseValidTime(value: Any?, field: String): Instant? = when (value) {
+            null -> null
+            is String -> try {
+                Instant.parse(value)
+            } catch (e: DateTimeException) {
+                throw Incorrect("Invalid ISO-8601 timestamp for '$field': $value")
+            }
+            else -> throw Incorrect("'$field' must be a TIMESTAMPTZ string, got ${value::class.simpleName}")
+        }
+
+        fun fromJson(envelope: JsonObject): CdcEvent {
+            val payload = envelope["payload"]?.jsonObject
+                ?: throw Incorrect("Missing 'payload' in CDC message")
+
+            val op = payload["op"]?.jsonPrimitive?.content
+                ?: throw Incorrect("Missing 'op' in payload")
+
+            val source = payload["source"]?.jsonObject
+                ?: throw Incorrect("Missing 'source' in payload")
+            val schema = source["schema"]?.jsonPrimitive?.content
+                ?: throw Incorrect("Missing 'source.schema' in payload")
+            val table = source["table"]?.jsonPrimitive?.content
+                ?: throw Incorrect("Missing 'source.table' in payload")
+            val lsn = source["lsn"]?.jsonPrimitive?.longOrNull
+            val txId = source["txId"]?.jsonPrimitive?.longOrNull
+
+            return when (op) {
+                "c", "r", "u" -> {
+                    val after = payload["after"]?.jsonObject
+                        ?: throw Incorrect("Missing 'after' for put op")
+
+                    val docMap = after.toJvmMap().toMutableMap()
+
+                    if ("_id" !in docMap) {
+                        throw Incorrect("Missing '_id' in document")
+                    }
+
+                    // Debezium sends TIMESTAMPTZ as ISO-8601 strings
+                    val validFrom = parseValidTime(docMap.remove("_valid_from"), "_valid_from")
+                    val validTo = parseValidTime(docMap.remove("_valid_to"), "_valid_to")
+
+                    if (validTo != null && validFrom == null) {
+                        throw Incorrect("'_valid_to' requires '_valid_from'")
+                    }
+
+                    Put(schema, table, lsn, txId, docMap, validFrom, validTo)
+                }
+
+                "d" -> {
+                    val before = payload["before"]?.takeUnless { it is JsonNull }?.jsonObject
+                        ?: throw Incorrect("Missing 'before' for delete — check REPLICA IDENTITY on source table")
+
+                    val id = before["_id"]?.toJvmValue()
+                        ?: throw Incorrect("Missing '_id' in 'before' for delete")
+
+                    Delete(schema, table, lsn, txId, id)
+                }
+
+                else -> throw Incorrect("Unknown CDC op: '$op'")
+            }
+        }
+    }
+}

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
@@ -1,0 +1,93 @@
+package xtdb.debezium
+
+import kotlinx.coroutines.*
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.InterruptException
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.slf4j.LoggerFactory
+import xtdb.api.log.Log
+import xtdb.api.log.Log.*
+import xtdb.api.log.SourceMessage
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.seconds
+
+private val logger = LoggerFactory.getLogger(DebeziumLog::class.java)
+
+class DebeziumLog @JvmOverloads constructor(
+    private val bootstrapServers: String,
+    private val topic: String,
+    private val pollDuration: Duration = Duration.ofSeconds(1),
+    coroutineContext: CoroutineContext = Dispatchers.Default,
+) : Log<SourceMessage> {
+
+    // TODO: non-deterministic failures (e.g. node down) currently kill this coroutine silently.
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        logger.error("Fatal error in CDC ingestion — ingestion has stopped", throwable)
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + coroutineContext + exceptionHandler)
+
+    override val latestSubmittedOffset: Long get() = -1
+    override val epoch: Int get() = 0
+
+    override fun appendMessage(message: SourceMessage): CompletableFuture<MessageMetadata> =
+        throw UnsupportedOperationException("CDC log is read-only")
+
+    override fun openAtomicProducer(transactionalId: String): AtomicProducer<SourceMessage> =
+        throw UnsupportedOperationException("CDC log is read-only")
+
+    override fun subscribe(subscriber: GroupSubscriber<SourceMessage>): Subscription =
+        throw UnsupportedOperationException("CDC log does not support group subscription")
+
+    override fun readLastMessage(): SourceMessage? = null
+
+    override fun tailAll(subscriber: Subscriber<SourceMessage>, latestProcessedOffset: Long): Subscription {
+        val job = scope.launch {
+            KafkaConsumer<String, String>(
+                mapOf(
+                    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServers,
+                    ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false",
+                    ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java.name,
+                    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java.name,
+                )
+            ).use { c ->
+                TopicPartition(topic, 0).also { tp ->
+                    c.assign(listOf(tp))
+                    c.seek(tp, latestProcessedOffset + 1)
+                }
+                runInterruptible(Dispatchers.IO) {
+                    while (true) {
+                        val records = try {
+                            c.poll(pollDuration).records(topic)
+                        } catch (_: InterruptException) {
+                            throw InterruptedException()
+                        }
+
+                        subscriber.processRecords(
+                            records.mapNotNull { record ->
+                                record.value()?.let { value ->
+                                    Record(
+                                        record.offset(),
+                                        Instant.ofEpochMilli(record.timestamp()),
+                                        SourceMessage.Tx(value.toByteArray()),
+                                    )
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        return Subscription { runBlocking { withTimeout(5.seconds) { job.cancelAndJoin() } } }
+    }
+
+    override fun close() {
+        runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
+    }
+}

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumProcessor.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumProcessor.kt
@@ -1,0 +1,61 @@
+package xtdb.debezium
+
+import kotlinx.serialization.json.*
+import org.apache.arrow.memory.BufferAllocator
+import org.slf4j.LoggerFactory
+import xtdb.api.Xtdb
+import xtdb.api.log.Log
+import xtdb.api.log.SourceMessage
+import xtdb.error.Incorrect
+import xtdb.tx.TxOpts
+
+private val logger = LoggerFactory.getLogger(DebeziumProcessor::class.java)
+
+class DebeziumProcessor(
+    private val node: Xtdb,
+    private val dbName: String,
+    private val allocator: BufferAllocator,
+) : Log.Subscriber<SourceMessage>, AutoCloseable {
+
+    override fun processRecords(records: List<Log.Record<SourceMessage>>) {
+        for (record in records) {
+            try {
+                val json = String((record.message as SourceMessage.Tx).payload)
+
+                val event = try {
+                    val envelope = Json.parseToJsonElement(json).jsonObject
+                    CdcEvent.fromJson(envelope)
+                } catch (e: IllegalArgumentException) {
+                    // Covers JsonDecodingException (malformed JSON) and .jsonObject on non-objects
+                    throw Incorrect("Invalid CDC message: ${e.message}", cause = e)
+                }
+
+                event.toTxOp(allocator).use { txOp ->
+                    val metadata = event.metadata + ("kafka_offset" to record.logOffset)
+                    val result = node.submitTx(dbName, listOf(txOp), TxOpts(userMetadata = metadata))
+                    logger.debug("Submitted tx {} at offset {}", result.txId, record.logOffset)
+                }
+            } catch (e: Incorrect) {
+                logger.error("Failed to process CDC record at offset {}: {}", record.logOffset, e.message, e)
+                submitDlq(e.message ?: "Unknown error", record.logOffset)
+            }
+        }
+    }
+
+    // TODO: Currently: DLQ txs have committed=true and error in the user metadata.
+    //       In the future we will fail somewhere in the indexer so that the error shows there.
+    private fun submitDlq(errorMessage: String, logOffset: Long) {
+        node.submitTx(
+            dbName, emptyList(),
+            TxOpts(
+                userMetadata = mapOf(
+                    "source" to "debezium",
+                    "error" to errorMessage,
+                    "kafka_offset" to logOffset,
+                )
+            )
+        )
+    }
+
+    override fun close() {}
+}

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/CdcEventTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/CdcEventTest.kt
@@ -1,0 +1,295 @@
+package xtdb.debezium
+
+import kotlinx.serialization.json.*
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import xtdb.error.Incorrect
+import xtdb.tx.TxOp
+import java.time.Instant
+
+class CdcEventTest {
+
+    private lateinit var allocator: RootAllocator
+
+    @BeforeEach
+    fun setUp() {
+        allocator = RootAllocator()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        allocator.close()
+    }
+
+    private fun cdcEnvelope(
+        op: String,
+        before: JsonObject? = null,
+        after: JsonObject? = null,
+        schema: String = "public",
+        table: String = "test_items",
+        tsNs: Long = 1700000000000000000L,
+        lsn: Long = 12345L,
+    ): JsonObject = buildJsonObject {
+        putJsonObject("payload") {
+            put("op", op)
+            if (before != null) put("before", before) else put("before", JsonNull)
+            if (after != null) put("after", after) else put("after", JsonNull)
+            putJsonObject("source") {
+                put("schema", schema)
+                put("table", table)
+                put("ts_ns", tsNs)
+                put("lsn", lsn)
+            }
+        }
+    }
+
+    // -- JSON conversion tests --
+
+    @Test
+    fun `toJvmMap converts primitives correctly`() {
+        val obj = buildJsonObject {
+            put("str", "hello")
+            put("int", 42)
+            put("long", 9999999999L)
+            put("double", 3.14)
+            put("bool", true)
+            put("nil", JsonNull)
+        }
+        val map = obj.toJvmMap()
+
+        assertEquals("hello", map["str"])
+        assertEquals(42L, map["int"])
+        assertEquals(9999999999L, map["long"])
+        assertEquals(3.14, map["double"])
+        assertEquals(true, map["bool"])
+        assertNull(map["nil"])
+    }
+
+    @Test
+    fun `toJvmMap converts nested structures`() {
+        val obj = buildJsonObject {
+            putJsonArray("tags") { add("a"); add("b"); add(1) }
+            putJsonObject("address") {
+                put("city", "London")
+                put("zip", 12345)
+            }
+            putJsonArray("matrix") {
+                addJsonArray { add(1); add(2) }
+                addJsonArray { add(3); add(4) }
+            }
+        }
+        val map = obj.toJvmMap()
+
+        assertEquals(listOf("a", "b", 1L), map["tags"])
+        assertEquals(mapOf("city" to "London", "zip" to 12345L), map["address"])
+        assertEquals(listOf(listOf(1L, 2L), listOf(3L, 4L)), map["matrix"])
+    }
+
+    // -- CdcEvent parsing tests --
+
+    @ParameterizedTest
+    @ValueSource(strings = ["c", "r", "u"])
+    fun `create, read and update ops produce Put event`(op: String) {
+        val after = buildJsonObject { put("_id", 1); put("name", "Alice") }
+        val event = CdcEvent.fromJson(cdcEnvelope(op, after = after))
+
+        assertInstanceOf(CdcEvent.Put::class.java, event)
+        event as CdcEvent.Put
+        assertEquals("public", event.schema)
+        assertEquals("test_items", event.table)
+        assertEquals(12345L, event.lsn)
+        assertEquals(1L, event.doc["_id"])
+        assertEquals("Alice", event.doc["name"])
+        assertNull(event.validFrom)
+        assertNull(event.validTo)
+    }
+
+    @Test
+    fun `delete op produces Delete event`() {
+        val before = buildJsonObject { put("_id", 3); put("name", "to-delete") }
+        val event = CdcEvent.fromJson(cdcEnvelope("d", before = before))
+
+        assertInstanceOf(CdcEvent.Delete::class.java, event)
+        event as CdcEvent.Delete
+        assertEquals("test_items", event.table)
+        assertEquals(3L, event.id)
+    }
+
+    @Test
+    fun `unknown op throws`() {
+        val after = buildJsonObject { put("_id", 1) }
+        val envelope = cdcEnvelope("x", after = after)
+
+        val ex = assertThrows(Incorrect::class.java) {
+            CdcEvent.fromJson(envelope)
+        }
+        assertTrue(ex.message!!.contains("Unknown CDC op"))
+    }
+
+    @Test
+    fun `missing _id in after throws`() {
+        val after = buildJsonObject { put("name", "no-id") }
+        val envelope = cdcEnvelope("c", after = after)
+
+        val ex = assertThrows(Incorrect::class.java) {
+            CdcEvent.fromJson(envelope)
+        }
+        assertTrue(ex.message!!.contains("_id"))
+    }
+
+    @Test
+    fun `missing source schema throws`() {
+        val envelope = buildJsonObject {
+            putJsonObject("payload") {
+                put("op", "c")
+                putJsonObject("after") { put("_id", 1) }
+                putJsonObject("source") { put("table", "t") }
+            }
+        }
+        val ex = assertThrows(Incorrect::class.java) {
+            CdcEvent.fromJson(envelope)
+        }
+        assertTrue(ex.message!!.contains("source.schema"))
+    }
+
+    @Test
+    fun `missing source table throws`() {
+        val envelope = buildJsonObject {
+            putJsonObject("payload") {
+                put("op", "c")
+                putJsonObject("after") { put("_id", 1) }
+                putJsonObject("source") { put("schema", "public") }
+            }
+        }
+        val ex = assertThrows(Incorrect::class.java) {
+            CdcEvent.fromJson(envelope)
+        }
+        assertTrue(ex.message!!.contains("source.table"))
+    }
+
+    @Test
+    fun `delete with null before throws`() {
+        val envelope = cdcEnvelope("d")
+
+        val ex = assertThrows(Incorrect::class.java) {
+            CdcEvent.fromJson(envelope)
+        }
+        assertTrue(ex.message!!.contains("before"))
+    }
+
+    @Test
+    fun `_valid_from absent defaults to null`() {
+        val after = buildJsonObject { put("_id", 1); put("name", "no-vf") }
+        val event = CdcEvent.fromJson(cdcEnvelope("c", after = after)) as CdcEvent.Put
+        assertNull(event.validFrom)
+    }
+
+    @Test
+    fun `_valid_from and _valid_to extracted from ISO strings`() {
+        val after = buildJsonObject {
+            put("_id", 1); put("name", "bounded")
+            put("_valid_from", "2024-01-01T00:00:00Z")
+            put("_valid_to", "2025-01-01T00:00:00Z")
+        }
+        val event = CdcEvent.fromJson(cdcEnvelope("c", after = after)) as CdcEvent.Put
+        assertEquals(Instant.parse("2024-01-01T00:00:00Z"), event.validFrom)
+        assertEquals(Instant.parse("2025-01-01T00:00:00Z"), event.validTo)
+    }
+
+    @Test
+    fun `_valid_to without _valid_from throws`() {
+        val after = buildJsonObject {
+            put("_id", 1); put("name", "end-only")
+            put("_valid_to", "2025-01-01T00:00:00Z")
+        }
+        val ex = assertThrows(Incorrect::class.java) {
+            CdcEvent.fromJson(cdcEnvelope("c", after = after))
+        }
+        assertTrue(ex.message!!.contains("_valid_from"))
+    }
+
+    @Test
+    fun `non-string _valid_from throws`() {
+        val after = buildJsonObject {
+            put("_id", 1); put("_valid_from", 1704067200000000L)
+        }
+        val ex = assertThrows(Incorrect::class.java) {
+            CdcEvent.fromJson(cdcEnvelope("c", after = after))
+        }
+        assertTrue(ex.message!!.contains("TIMESTAMPTZ"))
+    }
+
+    @Test
+    fun `malformed _valid_from string throws`() {
+        val after = buildJsonObject {
+            put("_id", 1); put("_valid_from", "not-a-date")
+        }
+        val ex = assertThrows(Incorrect::class.java) {
+            CdcEvent.fromJson(cdcEnvelope("c", after = after))
+        }
+        assertTrue(ex.message!!.contains("ISO-8601"))
+    }
+
+    @Test
+    fun `schema and table come from source`() {
+        val after = buildJsonObject { put("_id", 1) }
+        val event = CdcEvent.fromJson(cdcEnvelope("c", after = after, schema = "myschema", table = "users"))
+
+        event as CdcEvent.Put
+        assertEquals("myschema", event.schema)
+        assertEquals("users", event.table)
+    }
+
+    // -- TxOp conversion tests --
+
+    @Test
+    fun `Put toTxOp produces PutDocs`() {
+        val after = buildJsonObject { put("_id", 1); put("name", "Alice") }
+        val event = CdcEvent.fromJson(cdcEnvelope("c", after = after)) as CdcEvent.Put
+
+        event.toTxOp(allocator).use { op ->
+            assertInstanceOf(TxOp.PutDocs::class.java, op)
+            op as TxOp.PutDocs
+            assertEquals("public", op.schema)
+            assertEquals("test_items", op.table)
+            assertNull(op.validFrom)
+            assertNull(op.validTo)
+            assertEquals(1, op.docs.rowCount)
+        }
+    }
+
+    @Test
+    fun `Delete toTxOp produces DeleteDocs`() {
+        val before = buildJsonObject { put("_id", 3); put("name", "to-delete") }
+        val event = CdcEvent.fromJson(cdcEnvelope("d", before = before)) as CdcEvent.Delete
+
+        event.toTxOp(allocator).use { op ->
+            assertInstanceOf(TxOp.DeleteDocs::class.java, op)
+            op as TxOp.DeleteDocs
+            assertEquals("test_items", op.table)
+            assertEquals(1, op.ids.valueCount)
+        }
+    }
+
+    @Test
+    fun `Put with validFrom produces PutDocs with validFrom`() {
+        val after = buildJsonObject {
+            put("_id", 1); put("name", "timed"); put("_valid_from", "2024-01-01T00:00:00Z")
+        }
+        val event = CdcEvent.fromJson(cdcEnvelope("c", after = after)) as CdcEvent.Put
+
+        event.toTxOp(allocator).use { op ->
+            op as TxOp.PutDocs
+            assertEquals(Instant.parse("2024-01-01T00:00:00Z"), op.validFrom)
+        }
+    }
+}

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
@@ -195,4 +195,70 @@ class DebeziumIntegrationTest {
         assertCdcEvent(messages[2], "u", after = buildJsonObject { put("id", 2); put("name", "updated") })
         assertCdcEvent(messages[3], "d")
     }
+
+    @Test
+    fun `debezium type mapping for PG temporal and structural types`() = runTest(timeout = 120.seconds) {
+        pgExecute(
+            """CREATE TABLE IF NOT EXISTS type_probe (
+                _id INT PRIMARY KEY,
+                ts TIMESTAMP,
+                tstz TIMESTAMPTZ,
+                d DATE,
+                t TIME,
+                b BOOLEAN,
+                i INT,
+                bi BIGINT,
+                f FLOAT,
+                dp DOUBLE PRECISION,
+                txt TEXT,
+                j JSON,
+                jb JSONB
+            )""",
+        )
+
+        registerConnectorAndAwait()
+
+        pgExecute(
+            """INSERT INTO type_probe (_id, ts, tstz, d, t, b, i, bi, f, dp, txt, j, jb)
+               VALUES (
+                   1,
+                   '2024-01-01 00:00:00',
+                   '2024-01-01 00:00:00+00',
+                   '2024-01-01',
+                   '12:30:00',
+                   true,
+                   42,
+                   9999999999,
+                   3.14,
+                   2.718281828,
+                   'hello',
+                   '{"key": "val"}',
+                   '{"key": "val"}'
+               )""",
+        )
+
+        val messages = pollMessages("testdb.public.type_probe", expected = 1)
+        val after = messages[0].payload()["after"]!!.jsonObject
+
+        // Temporal types — TIMESTAMP is epoch micros, TIMESTAMPTZ is ISO string
+        assertEquals(1704067200000000L, after["ts"]!!.jsonPrimitive.longOrNull, "TIMESTAMP should be epoch micros")
+        assertTrue(after["tstz"]!!.jsonPrimitive.isString, "TIMESTAMPTZ should be a string")
+        assertTrue(after["tstz"]!!.jsonPrimitive.content.endsWith("Z"), "TIMESTAMPTZ should be ISO-8601 UTC")
+        assertEquals(19723L, after["d"]!!.jsonPrimitive.longOrNull, "DATE should be days since epoch")
+        assertEquals(45000000000L, after["t"]!!.jsonPrimitive.longOrNull, "TIME should be nanos since midnight")
+
+        // Numeric types
+        assertEquals(42L, after["i"]!!.jsonPrimitive.longOrNull, "INT should be a long")
+        assertEquals(9999999999L, after["bi"]!!.jsonPrimitive.longOrNull, "BIGINT should be a long")
+        assertEquals(3.14, after["f"]!!.jsonPrimitive.doubleOrNull, "FLOAT should be a double")
+        assertEquals(2.718281828, after["dp"]!!.jsonPrimitive.doubleOrNull, "DOUBLE should be a double")
+
+        // Text/JSON types — both JSON and JSONB come through as strings
+        assertEquals("hello", after["txt"]!!.jsonPrimitive.content)
+        assertTrue(after["j"]!!.jsonPrimitive.isString, "JSON should be a string")
+        assertTrue(after["jb"]!!.jsonPrimitive.isString, "JSONB should be a string")
+
+        // Boolean
+        assertEquals(true, after["b"]!!.jsonPrimitive.booleanOrNull, "BOOLEAN should be a boolean")
+    }
 }

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
@@ -17,12 +17,16 @@ import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.kafka.ConfluentKafkaContainer
 import org.testcontainers.lifecycle.Startables
 import org.testcontainers.postgresql.PostgreSQLContainer
+import xtdb.api.Xtdb
+import xtdb.api.log.Log
+import xtdb.api.log.SourceMessage
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.sql.DriverManager
 import java.time.Duration
+import java.util.Collections
 import kotlin.time.Duration.Companion.seconds
 
 @Tag("integration")
@@ -77,7 +81,7 @@ class DebeziumIntegrationTest {
     private fun connectUrl() =
         "http://${debeziumConnect.host}:${debeziumConnect.getMappedPort(8083)}"
 
-    private suspend fun registerConnectorAndAwait() {
+    private suspend fun registerConnectorAndAwait(schemas: String = "public") {
         fun isConnectorRunning(): Boolean {
             try {
                 val resp = httpClient.send(
@@ -108,7 +112,7 @@ class DebeziumIntegrationTest {
                 put("database.password", "testpass")
                 put("database.dbname", "testdb")
                 put("topic.prefix", "testdb")
-                put("schema.include.list", "public")
+                put("schema.include.list", schemas)
                 put("plugin.name", "pgoutput")
             }
         }
@@ -133,6 +137,22 @@ class DebeziumIntegrationTest {
         }
     }
 
+    private fun xtQuery(node: Xtdb, sql: String): List<Map<String, Any?>> {
+        return node.getConnection().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeQuery(sql).use { rs ->
+                    val metadata = rs.metaData
+                    val cols = (1..metadata.columnCount).map { metadata.getColumnName(it) }
+                    buildList {
+                        while (rs.next()) {
+                            add(cols.associateWith { rs.getObject(it) })
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private suspend fun pollMessages(topic: String, expected: Int): List<JsonObject> {
         val props = mapOf(
             ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to kafka.bootstrapServers,
@@ -150,7 +170,6 @@ class DebeziumIntegrationTest {
             while (messages.size < expected) {
                 val records = consumer.poll(Duration.ofSeconds(1))
                 for (record in records) {
-                    // Debezium sends tombstone records (null value) after deletes for log compaction
                     val value = record.value() ?: continue
                     messages.add(Json.parseToJsonElement(value).jsonObject)
                 }
@@ -260,5 +279,391 @@ class DebeziumIntegrationTest {
 
         // Boolean
         assertEquals(true, after["b"]!!.jsonPrimitive.booleanOrNull, "BOOLEAN should be a boolean")
+    }
+
+    @Test
+    fun `CDC events are ingested into XTDB`() = runTest(timeout = 120.seconds) {
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS cdc_users (_id INT PRIMARY KEY, name TEXT, email TEXT)",
+            "INSERT INTO cdc_users (_id, name, email) VALUES (1, 'Alice', 'alice@example.com')",
+        )
+
+        registerConnectorAndAwait()
+
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val log = DebeziumLog(kafka.bootstrapServers, "testdb.public.cdc_users")
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+            val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
+
+            val capturing = object : Log.Subscriber<SourceMessage> {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                    processor.processRecords(records)
+                    received.addAll(records)
+                }
+            }
+
+            log.use {
+                log.tailAll(capturing, -1).use {
+                    pgExecute(
+                        "INSERT INTO cdc_users (_id, name, email) VALUES (2, 'Bob', 'bob@example.com')",
+                        "UPDATE cdc_users SET email = 'alice-new@example.com' WHERE _id = 1",
+                        "DELETE FROM cdc_users WHERE _id = 2",
+                    )
+
+                    // snapshot(Alice) + insert(Bob) + update(Alice) + delete(Bob)
+                    while (received.size < 4) delay(100)
+
+                    // Allow indexing to complete
+                    delay(2000)
+                }
+            }
+
+            val history = xtQuery(node,
+                """SELECT _id, name, email, _valid_from, _valid_to
+                   FROM public.cdc_users
+                   FOR ALL VALID_TIME
+                   ORDER BY _id, _valid_from"""
+            )
+
+            assertEquals(3, history.size, "Expected 3 history rows (2 Alice + 1 Bob)")
+
+            // Alice: snapshot row then updated row
+            assertEquals(1L, (history[0]["_id"] as Number).toLong())
+            assertEquals("alice@example.com", history[0]["email"])
+            assertTrue(history[0]["_valid_to"] != null, "Snapshot row should be superseded")
+
+            assertEquals(1L, (history[1]["_id"] as Number).toLong())
+            assertEquals("alice-new@example.com", history[1]["email"])
+            assertNull(history[1]["_valid_to"], "Updated row should be current")
+
+            // Bob: inserted then deleted — valid_to proves DELETE op worked
+            assertEquals(2L, (history[2]["_id"] as Number).toLong())
+            assertEquals("bob@example.com", history[2]["email"])
+            assertTrue(history[2]["_valid_to"] != null, "Bob should have valid_to from DELETE")
+        }
+    }
+
+    @Test
+    fun `valid_from and valid_to columns are used as valid time bounds`() = runTest(timeout = 120.seconds) {
+        pgExecute(
+            """CREATE TABLE IF NOT EXISTS timed_docs (
+                _id INT PRIMARY KEY,
+                name TEXT,
+                _valid_from TIMESTAMPTZ,
+                _valid_to TIMESTAMPTZ
+            )""",
+        )
+
+        registerConnectorAndAwait()
+
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val log = DebeziumLog(kafka.bootstrapServers, "testdb.public.timed_docs")
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+            val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
+
+            val capturing = object : Log.Subscriber<SourceMessage> {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                    processor.processRecords(records)
+                    received.addAll(records)
+                }
+            }
+
+            log.use {
+                log.tailAll(capturing, -1).use {
+                    pgExecute(
+                        """INSERT INTO timed_docs (_id, name, _valid_from, _valid_to)
+                           VALUES (1, 'bounded', '2024-01-01T00:00:00Z', '2025-01-01T00:00:00Z')""",
+                        """INSERT INTO timed_docs (_id, name, _valid_from)
+                           VALUES (2, 'from-only', '2024-06-01T00:00:00Z')""",
+                        """INSERT INTO timed_docs (_id, name, _valid_to)
+                           VALUES (3, 'to-only', '2025-06-01T00:00:00Z')""",
+                        """INSERT INTO timed_docs (_id, name)
+                           VALUES (4, 'neither')""",
+                    )
+
+                    while (received.size < 4) delay(100)
+                    delay(2000)
+                }
+            }
+
+            val rows = xtQuery(node,
+                """SELECT _id, name, _valid_from, _valid_to
+                   FROM public.timed_docs
+                   FOR ALL VALID_TIME
+                   ORDER BY _id"""
+            )
+
+            // 3 rows ingested — _id=3 (to-only) rejected to DLQ
+            assertEquals(3, rows.size)
+
+            // Both bounds set
+            assertEquals(1L, (rows[0]["_id"] as Number).toLong())
+            assertEquals("bounded", rows[0]["name"])
+            assertTrue(rows[0]["_valid_from"] != null, "Should have valid_from")
+            assertTrue(rows[0]["_valid_to"] != null, "Should have valid_to")
+
+            // Only valid_from
+            assertEquals(2L, (rows[1]["_id"] as Number).toLong())
+            assertEquals("from-only", rows[1]["name"])
+            assertTrue(rows[1]["_valid_from"] != null, "Should have valid_from")
+            assertNull(rows[1]["_valid_to"], "Should have no valid_to")
+
+            // Neither — system-assigned valid_from, no valid_to
+            assertEquals(4L, (rows[2]["_id"] as Number).toLong())
+            assertEquals("neither", rows[2]["name"])
+            assertTrue(rows[2]["_valid_from"] != null, "Should have system-assigned valid_from")
+            assertNull(rows[2]["_valid_to"], "Should have no valid_to")
+
+            // _valid_to without _valid_from → DLQ
+            val dlqTxs = xtQuery(node,
+                """SELECT (user_metadata).error
+                   FROM xt.txs
+                   WHERE (user_metadata).source = 'debezium'
+                     AND (user_metadata).error IS NOT NULL"""
+            )
+            assertEquals(1, dlqTxs.size, "Expected 1 DLQ transaction for to-only record")
+            assertTrue(
+                (dlqTxs[0]["error"] as String).contains("_valid_from"),
+                "DLQ error should mention _valid_from"
+            )
+        }
+    }
+
+    @Test
+    fun `table without _id column sends records to DLQ`() = runTest(timeout = 120.seconds) {
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS no_id_table (id INT PRIMARY KEY, name TEXT)",
+            "INSERT INTO no_id_table (id, name) VALUES (1, 'pre-existing')",
+        )
+
+        registerConnectorAndAwait()
+
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val log = DebeziumLog(kafka.bootstrapServers, "testdb.public.no_id_table")
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+            val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
+
+            val capturing = object : Log.Subscriber<SourceMessage> {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                    processor.processRecords(records)
+                    received.addAll(records)
+                }
+            }
+
+            log.use {
+                log.tailAll(capturing, -1).use {
+                    pgExecute(
+                        "INSERT INTO no_id_table (id, name) VALUES (2, 'also-no-_id')",
+                    )
+
+                    // snapshot + insert = 2 records, both should fail and go to DLQ
+                    while (received.size < 2) delay(100)
+                    delay(2000)
+                }
+            }
+
+            // No rows should be ingested — all went to DLQ
+            val rows = xtQuery(node,
+                "SELECT * FROM public.no_id_table FOR ALL VALID_TIME"
+            )
+            assertEquals(0, rows.size, "No rows should be ingested — all records lack _id")
+
+            // DLQ txs have source=debezium and error in user_metadata
+            val dlqTxs = xtQuery(node,
+                """SELECT _id, (user_metadata).source, (user_metadata).error
+                   FROM xt.txs
+                   WHERE (user_metadata).source = 'debezium'
+                     AND (user_metadata).error IS NOT NULL
+                   ORDER BY _id"""
+            )
+            assertEquals(2, dlqTxs.size, "Expected 2 DLQ transactions, got ${dlqTxs.size}")
+            assertTrue(
+                (dlqTxs[0]["error"] as String).contains("_id"),
+                "DLQ error should mention missing _id"
+            )
+        }
+    }
+
+    @Test
+    fun `various PG types are ingested correctly`() = runTest(timeout = 120.seconds) {
+        pgExecute(
+            """CREATE TABLE IF NOT EXISTS typed_docs (
+                _id INT PRIMARY KEY,
+                name TEXT,
+                score DOUBLE PRECISION,
+                active BOOLEAN,
+                metadata JSONB,
+                tags TEXT[],
+                notes TEXT
+            )""",
+        )
+
+        registerConnectorAndAwait()
+
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val log = DebeziumLog(kafka.bootstrapServers, "testdb.public.typed_docs")
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+            val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
+
+            val capturing = object : Log.Subscriber<SourceMessage> {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                    processor.processRecords(records)
+                    received.addAll(records)
+                }
+            }
+
+            log.use {
+                log.tailAll(capturing, -1).use {
+                    pgExecute(
+                        """INSERT INTO typed_docs (_id, name, score, active, metadata, tags, notes)
+                           VALUES (1, 'Alice', 3.14, true, '{"city": "London", "nested": {"deep": true}}',
+                                   ARRAY['admin', 'user'], NULL)""",
+                        """INSERT INTO typed_docs (_id, name, score, active, metadata, tags, notes)
+                           VALUES (2, 'Bob', NULL, false, NULL, NULL, 'some notes')""",
+                    )
+
+                    while (received.size < 2) delay(100)
+                    delay(2000)
+                }
+            }
+
+            val rows = xtQuery(node,
+                """SELECT _id, name, score, active, metadata, tags, notes
+                   FROM public.typed_docs
+                   ORDER BY _id"""
+            )
+
+            assertEquals(2, rows.size)
+
+            // Alice: all fields populated
+            val alice = rows[0]
+            assertEquals(1L, (alice["_id"] as Number).toLong())
+            assertEquals("Alice", alice["name"])
+            assertEquals(3.14, (alice["score"] as Number).toDouble(), 0.001)
+            assertEquals(true, alice["active"])
+            // JSONB comes through Debezium as a string
+            assertTrue(alice["metadata"] is String, "JSONB should arrive as a string, got: ${alice["metadata"]?.javaClass}")
+            assertNull(alice["notes"], "NULL column should be null")
+
+            // Bob: sparse row with NULLs
+            val bob = rows[1]
+            assertEquals(2L, (bob["_id"] as Number).toLong())
+            assertEquals("Bob", bob["name"])
+            assertNull(bob["score"], "NULL double should be null")
+            assertEquals(false, bob["active"])
+            assertNull(bob["metadata"], "NULL JSONB should be null")
+            assertEquals("some notes", bob["notes"])
+        }
+    }
+
+    @Test
+    fun `non-public schema is preserved in XTDB`() = runTest(timeout = 120.seconds) {
+        pgExecute(
+            "CREATE SCHEMA IF NOT EXISTS inventory",
+            "CREATE TABLE IF NOT EXISTS inventory.products (_id INT PRIMARY KEY, name TEXT, qty INT)",
+        )
+
+        registerConnectorAndAwait(schemas = "inventory")
+
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val log = DebeziumLog(kafka.bootstrapServers, "testdb.inventory.products")
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+            val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
+
+            val capturing = object : Log.Subscriber<SourceMessage> {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                    processor.processRecords(records)
+                    received.addAll(records)
+                }
+            }
+
+            log.use {
+                log.tailAll(capturing, -1).use {
+                    pgExecute(
+                        "INSERT INTO inventory.products (_id, name, qty) VALUES (1, 'Widget', 100)",
+                    )
+
+                    while (received.size < 1) delay(100)
+                    delay(2000)
+                }
+            }
+
+            val rows = xtQuery(node,
+                "SELECT _id, name, qty FROM inventory.products"
+            )
+
+            assertEquals(1, rows.size)
+            assertEquals(1L, (rows[0]["_id"] as Number).toLong())
+            assertEquals("Widget", rows[0]["name"])
+            assertEquals(100L, (rows[0]["qty"] as Number).toLong())
+        }
+    }
+
+    @Test
+    fun `non-TIMESTAMPTZ _valid_from goes to DLQ`() = runTest(timeout = 120.seconds) {
+        pgExecute(
+            """CREATE TABLE IF NOT EXISTS bad_times (
+                _id INT PRIMARY KEY,
+                name TEXT,
+                _valid_from TIMESTAMP,
+                _valid_to TEXT
+            )""",
+        )
+
+        registerConnectorAndAwait()
+
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val log = DebeziumLog(kafka.bootstrapServers, "testdb.public.bad_times")
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+            val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
+
+            val capturing = object : Log.Subscriber<SourceMessage> {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                    processor.processRecords(records)
+                    received.addAll(records)
+                }
+            }
+
+            log.use {
+                log.tailAll(capturing, -1).use {
+                    // TIMESTAMP (no tz) → Debezium sends as Long, not a string
+                    pgExecute(
+                        """INSERT INTO bad_times (_id, name, _valid_from)
+                           VALUES (1, 'wrong-type', '2024-01-01 00:00:00')""",
+                    )
+                    // TEXT with non-ISO content → string that won't parse
+                    pgExecute(
+                        """INSERT INTO bad_times (_id, name, _valid_to)
+                           VALUES (2, 'bad-string', 'not-a-date')""",
+                    )
+
+                    while (received.size < 2) delay(100)
+                    delay(2000)
+                }
+            }
+
+            // Neither row should be ingested
+            val rows = xtQuery(node,
+                "SELECT * FROM public.bad_times FOR ALL VALID_TIME"
+            )
+            assertEquals(0, rows.size, "No rows should be ingested — both have invalid valid time")
+
+            val dlqTxs = xtQuery(node,
+                """SELECT (user_metadata).error
+                   FROM xt.txs
+                   WHERE (user_metadata).source = 'debezium'
+                     AND (user_metadata).error IS NOT NULL
+                   ORDER BY _id"""
+            )
+            assertEquals(2, dlqTxs.size, "Expected 2 DLQ transactions")
+            assertTrue(
+                (dlqTxs[0]["error"] as String).contains("_valid_from"),
+                "First DLQ should mention _valid_from"
+            )
+            assertTrue(
+                (dlqTxs[1]["error"] as String).contains("_valid_to"),
+                "Second DLQ should mention _valid_to"
+            )
+        }
     }
 }

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
@@ -1,0 +1,198 @@
+package xtdb.debezium
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.*
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.lifecycle.Startables
+import org.testcontainers.postgresql.PostgreSQLContainer
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.sql.DriverManager
+import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@Tag("integration")
+class DebeziumIntegrationTest {
+
+    private lateinit var network: Network
+    private lateinit var kafka: ConfluentKafkaContainer
+    private lateinit var debeziumConnect: GenericContainer<*>
+    private lateinit var postgres: PostgreSQLContainer
+
+    private val httpClient: HttpClient = HttpClient.newHttpClient()
+
+    @BeforeEach
+    fun setUp() {
+        network = Network.newNetwork()
+
+        postgres = PostgreSQLContainer("postgres:17-alpine")
+            .withNetwork(network)
+            .withNetworkAliases("postgres")
+            .withDatabaseName("testdb")
+            .withUsername("testuser")
+            .withPassword("testpass")
+            .withCommand("postgres", "-c", "wal_level=logical")
+
+        kafka = ConfluentKafkaContainer("confluentinc/cp-kafka:7.8.0")
+            .withNetwork(network)
+            .withNetworkAliases("kafka")
+            .withListener("kafka:19092")
+
+        debeziumConnect = GenericContainer("quay.io/debezium/connect:3.0")
+            .withNetwork(network)
+            .withExposedPorts(8083)
+            .withEnv("BOOTSTRAP_SERVERS", "kafka:19092")
+            .withEnv("GROUP_ID", "debezium-connect")
+            .withEnv("CONFIG_STORAGE_TOPIC", "debezium_configs")
+            .withEnv("OFFSET_STORAGE_TOPIC", "debezium_offsets")
+            .withEnv("STATUS_STORAGE_TOPIC", "debezium_statuses")
+            .waitingFor(Wait.forHttp("/connectors").forPort(8083).forStatusCode(200))
+            .dependsOn(kafka)
+
+        Startables.deepStart(postgres, kafka, debeziumConnect).join()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        debeziumConnect.stop()
+        kafka.stop()
+        postgres.stop()
+        network.close()
+    }
+
+    private fun connectUrl() =
+        "http://${debeziumConnect.host}:${debeziumConnect.getMappedPort(8083)}"
+
+    private suspend fun registerConnectorAndAwait() {
+        fun isConnectorRunning(): Boolean {
+            try {
+                val resp = httpClient.send(
+                    HttpRequest.newBuilder()
+                        .uri(URI.create("${connectUrl()}/connectors/test-connector/status"))
+                        .GET()
+                        .build(),
+                    HttpResponse.BodyHandlers.ofString()
+                )
+                if (resp.statusCode() != 200) return false
+                val status = Json.parseToJsonElement(resp.body()).jsonObject
+                val connectorState = status["connector"]?.jsonObject?.get("state")?.jsonPrimitive?.content
+                val taskState = status["tasks"]?.jsonArray?.firstOrNull()?.jsonObject?.get("state")?.jsonPrimitive?.content
+                return connectorState == "RUNNING" && taskState == "RUNNING"
+            } catch (_: Exception) {
+                return false
+            }
+        }
+
+        val connectorConfig = buildJsonObject {
+            put("name", "test-connector")
+            putJsonObject("config") {
+                put("connector.class", "io.debezium.connector.postgresql.PostgresConnector")
+                put("tasks.max", "1")
+                put("database.hostname", "postgres")
+                put("database.port", "5432")
+                put("database.user", "testuser")
+                put("database.password", "testpass")
+                put("database.dbname", "testdb")
+                put("topic.prefix", "testdb")
+                put("schema.include.list", "public")
+                put("plugin.name", "pgoutput")
+            }
+        }
+
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("${connectUrl()}/connectors"))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(connectorConfig.toString()))
+            .build()
+
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        assertTrue(response.statusCode() in 200..201, "Failed to register connector: ${response.body()}")
+
+        while (!isConnectorRunning()) delay(500)
+    }
+
+    private fun pgExecute(vararg statements: String) {
+        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { conn ->
+            conn.createStatement().use { stmt ->
+                for (sql in statements) stmt.execute(sql)
+            }
+        }
+    }
+
+    private suspend fun pollMessages(topic: String, expected: Int): List<JsonObject> {
+        val props = mapOf(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to kafka.bootstrapServers,
+            ConsumerConfig.GROUP_ID_CONFIG to "test-consumer",
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java.name,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java.name,
+        )
+
+        return KafkaConsumer<String, String>(props).use { consumer ->
+            consumer.subscribe(listOf(topic))
+
+            val messages = mutableListOf<JsonObject>()
+
+            while (messages.size < expected) {
+                val records = consumer.poll(Duration.ofSeconds(1))
+                for (record in records) {
+                    // Debezium sends tombstone records (null value) after deletes for log compaction
+                    val value = record.value() ?: continue
+                    messages.add(Json.parseToJsonElement(value).jsonObject)
+                }
+                delay(100)
+            }
+
+            assertEquals(expected, messages.size, "Expected $expected CDC messages on $topic, got ${messages.size}")
+            messages
+        }
+    }
+
+    private fun JsonObject.payload(): JsonObject =
+        this["payload"]?.jsonObject ?: fail("Expected 'payload' key in message")
+
+    @Test
+    fun `debezium captures full CDC lifecycle`() = runTest(timeout = 120.seconds) {
+        fun assertCdcEvent(message: JsonObject, expectedOp: String, after: JsonObject? = null) {
+            val payload = message.payload()
+            assertEquals(expectedOp, payload["op"]?.jsonPrimitive?.content)
+            assertEquals(after, payload["after"]?.takeUnless { it is JsonNull }?.jsonObject)
+        }
+
+        // Initial (s)napshot
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS test_items (id INT PRIMARY KEY, name TEXT)",
+            "INSERT INTO test_items (id, name) VALUES (1, 'snapshot-row')",
+        )
+
+        registerConnectorAndAwait()
+
+        // (c)reate, (u)pdate, (d)elete events
+        pgExecute(
+            "INSERT INTO test_items (id, name) VALUES (2, 'inserted')",
+            "UPDATE test_items SET name = 'updated' WHERE id = 2",
+            "DELETE FROM test_items WHERE id = 2",
+        )
+
+        val messages = pollMessages("testdb.public.test_items", expected = 4)
+
+        assertCdcEvent(messages[0], "r", after = buildJsonObject { put("id", 1); put("name", "snapshot-row") })
+        assertCdcEvent(messages[1], "c", after = buildJsonObject { put("id", 2); put("name", "inserted") })
+        assertCdcEvent(messages[2], "u", after = buildJsonObject { put("id", 2); put("name", "updated") })
+        assertCdcEvent(messages[3], "d")
+    }
+}

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumLogTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumLogTest.kt
@@ -1,0 +1,162 @@
+package xtdb.debezium
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.*
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.StringSerializer
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import xtdb.api.log.Log
+import xtdb.api.log.SourceMessage
+import java.util.Collections
+import kotlin.time.Duration.Companion.seconds
+
+@Tag("integration")
+class DebeziumLogTest {
+
+    private lateinit var kafka: ConfluentKafkaContainer
+
+    @BeforeEach
+    fun setUp() {
+        kafka = ConfluentKafkaContainer("confluentinc/cp-kafka:7.8.0")
+        kafka.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        kafka.stop()
+    }
+
+    private fun cdcMessage(op: String, id: Int, name: String): String {
+        return buildJsonObject {
+            putJsonObject("payload") {
+                put("op", op)
+                putJsonObject("after") { put("_id", id); put("name", name) }
+                put("before", JsonNull)
+                putJsonObject("source") {
+                    put("schema", "public")
+                    put("table", "test")
+                    put("lsn", 100)
+                }
+            }
+        }.toString()
+    }
+
+    private fun produceMessages(topic: String, messages: List<String>) {
+        KafkaProducer<String, String>(
+            mapOf(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to kafka.bootstrapServers,
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java.name,
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java.name,
+            )
+        ).use { producer ->
+            for (msg in messages) {
+                producer.send(ProducerRecord(topic, null, msg)).get()
+            }
+        }
+    }
+
+    @Test
+    fun `tailAll resumes from offset`() = runTest(timeout = 30.seconds) {
+        val topic = "test-resume"
+        val messages = listOf(
+            cdcMessage("c", 1, "Alice"),
+            cdcMessage("c", 2, "Bob"),
+            cdcMessage("c", 3, "Charlie"),
+            cdcMessage("c", 4, "Dave"),
+        )
+        produceMessages(topic, messages)
+
+        val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
+        val subscriber = object : Log.Subscriber<SourceMessage> {
+            override fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                received.addAll(records)
+            }
+        }
+
+        val log = DebeziumLog(kafka.bootstrapServers, topic)
+        log.use {
+            // Resume from offset 1 — should skip records 0 and 1, receive 2 and 3
+            log.tailAll(subscriber, 1).use {
+                while (received.size < 2) delay(100)
+            }
+        }
+
+        assertEquals(2, received.size, "Should receive only records after offset 1")
+        assertEquals(2L, received[0].logOffset)
+        assertEquals(3L, received[1].logOffset)
+
+        // Verify message contents match Charlie and Dave
+        val charlie = Json.parseToJsonElement(
+            String((received[0].message as SourceMessage.Tx).payload)
+        ).jsonObject
+        assertEquals("Charlie", charlie["payload"]!!.jsonObject["after"]!!.jsonObject["name"]!!.jsonPrimitive.content)
+
+        val dave = Json.parseToJsonElement(
+            String((received[1].message as SourceMessage.Tx).payload)
+        ).jsonObject
+        assertEquals("Dave", dave["payload"]!!.jsonObject["after"]!!.jsonObject["name"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `subscription close cancels cleanly`() = runTest(timeout = 10.seconds) {
+        val topic = "test-close"
+        produceMessages(topic, listOf(cdcMessage("c", 1, "Alice")))
+
+        val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
+        val subscriber = object : Log.Subscriber<SourceMessage> {
+            override fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                received.addAll(records)
+            }
+        }
+
+        val log = DebeziumLog(kafka.bootstrapServers, topic)
+        log.use {
+            log.tailAll(subscriber, -1).use {
+                while (received.isEmpty()) delay(100)
+            }
+            // Subscription closed — produce more messages
+            produceMessages(topic, listOf(cdcMessage("c", 2, "Bob")))
+            delay(500)
+        }
+
+        // Should only have the first message — subscription was closed before Bob
+        assertEquals(1, received.size, "Should not receive messages after subscription close")
+    }
+
+    @Test
+    fun `log close cancels all subscriptions`() = runTest(timeout = 10.seconds) {
+        val topic = "test-log-close"
+        produceMessages(topic, listOf(cdcMessage("c", 1, "Alice")))
+
+        val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
+        val subscriber = object : Log.Subscriber<SourceMessage> {
+            override fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                received.addAll(records)
+            }
+        }
+
+        val log = DebeziumLog(kafka.bootstrapServers, topic)
+
+        val subscription = log.tailAll(subscriber, -1)
+        while (received.isEmpty()) delay(100)
+
+        assertEquals(1, received.size, "Should have received Alice before closing")
+
+        // Close log directly (not via subscription) — should cancel the poll coroutine
+        log.close()
+
+        produceMessages(topic, listOf(cdcMessage("c", 2, "Bob")))
+        delay(500)
+
+        assertEquals(1, received.size, "Should not receive messages after log close")
+
+        // Closing subscription after log close should not throw
+        subscription.close()
+    }
+}

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumProcessorTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumProcessorTest.kt
@@ -1,0 +1,265 @@
+package xtdb.debezium
+
+import kotlinx.serialization.json.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import xtdb.api.Xtdb
+import xtdb.api.log.Log
+import xtdb.api.log.Log.Record
+import xtdb.api.log.SourceMessage
+import java.time.Instant
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+class DebeziumProcessorTest {
+
+    private fun putRecord(
+        id: Int,
+        name: String,
+        op: String = "c",
+        offset: Long = 0,
+        table: String = "test",
+    ): Record<SourceMessage> {
+        val envelope = buildJsonObject {
+            putJsonObject("payload") {
+                put("op", op)
+                putJsonObject("after") { put("_id", id); put("name", name) }
+                put("before", JsonNull)
+                putJsonObject("source") {
+                    put("schema", "public")
+                    put("table", table)
+                    put("lsn", 100)
+                }
+            }
+        }
+        return Record(offset, Instant.now(), SourceMessage.Tx(envelope.toString().toByteArray()))
+    }
+
+    private fun deleteRecord(
+        id: Int,
+        offset: Long = 0,
+        table: String = "test",
+    ): Record<SourceMessage> {
+        val envelope = buildJsonObject {
+            putJsonObject("payload") {
+                put("op", "d")
+                put("after", JsonNull)
+                putJsonObject("before") { put("_id", id) }
+                putJsonObject("source") {
+                    put("schema", "public")
+                    put("table", table)
+                    put("lsn", 100)
+                }
+            }
+        }
+        return Record(offset, Instant.now(), SourceMessage.Tx(envelope.toString().toByteArray()))
+    }
+
+    private fun xtQuery(node: Xtdb, sql: String): List<Map<String, Any?>> {
+        return node.getConnection().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeQuery(sql).use { rs ->
+                    val metadata = rs.metaData
+                    val cols = (1..metadata.columnCount).map { metadata.getColumnName(it) }
+                    buildList {
+                        while (rs.next()) {
+                            add(cols.associateWith { rs.getObject(it) })
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun rawRecord(payload: String, offset: Long = 0): Record<SourceMessage> =
+        Record(offset, Instant.now(), SourceMessage.Tx(payload.toByteArray()))
+
+    private fun awaitTxs(node: Xtdb, expected: Int, timeout: kotlin.time.Duration = 10.seconds) {
+        val start = TimeSource.Monotonic.markNow()
+        while (true) {
+            val count = xtQuery(node, "SELECT count(*) AS cnt FROM xt.txs")[0]["cnt"] as Long
+            if (count >= expected) return
+            check(start.elapsedNow() < timeout) { "Timed out waiting for $expected txs (got $count)" }
+            Thread.sleep(50)
+        }
+    }
+
+    private fun dlqTxs(node: Xtdb): List<Map<String, Any?>> = xtQuery(node,
+        """SELECT (user_metadata).error, (user_metadata).kafka_offset
+           FROM xt.txs
+           WHERE (user_metadata).source = 'debezium'
+             AND (user_metadata).error IS NOT NULL
+           ORDER BY _id"""
+    )
+
+    @Test
+    fun `invalid JSON goes to DLQ`() {
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+
+            processor.processRecords(listOf(rawRecord("not json at all", offset = 42)))
+
+            awaitTxs(node, 1)
+
+            val dlq = dlqTxs(node)
+            assertEquals(1, dlq.size)
+            assertEquals(42L, (dlq[0]["kafka_offset"] as Number).toLong())
+        }
+    }
+
+    @Test
+    fun `JSON array goes to DLQ`() {
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+
+            processor.processRecords(listOf(rawRecord("[1, 2, 3]")))
+
+            awaitTxs(node, 1)
+
+            val dlq = dlqTxs(node)
+            assertEquals(1, dlq.size)
+        }
+    }
+
+    @Test
+    fun `unknown op goes to DLQ`() {
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+
+            val envelope = buildJsonObject {
+                putJsonObject("payload") {
+                    put("op", "x")
+                    putJsonObject("after") { put("_id", 1) }
+                    putJsonObject("source") { put("schema", "public"); put("table", "t") }
+                }
+            }
+            processor.processRecords(listOf(rawRecord(envelope.toString())))
+
+            awaitTxs(node, 1)
+
+            val dlq = dlqTxs(node)
+            assertEquals(1, dlq.size)
+            assertTrue((dlq[0]["error"] as String).contains("Unknown CDC op"))
+        }
+    }
+
+    @Test
+    fun `missing _id goes to DLQ`() {
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+
+            val envelope = buildJsonObject {
+                putJsonObject("payload") {
+                    put("op", "c")
+                    putJsonObject("after") { put("name", "no id") }
+                    putJsonObject("source") { put("schema", "public"); put("table", "t") }
+                }
+            }
+            processor.processRecords(listOf(rawRecord(envelope.toString())))
+
+            awaitTxs(node, 1)
+
+            val dlq = dlqTxs(node)
+            assertEquals(1, dlq.size)
+            assertTrue((dlq[0]["error"] as String).contains("_id"))
+        }
+    }
+
+    @Test
+    fun `empty record list is a no-op`() {
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+
+            processor.processRecords(emptyList())
+
+            val txs = xtQuery(node, "SELECT * FROM xt.txs")
+            assertEquals(0, txs.size)
+        }
+    }
+
+    @Test
+    fun `valid records in batch still processed when others fail`() {
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+
+            val batch = listOf(
+                putRecord(1, "Alice", offset = 0),
+                rawRecord("not json", offset = 1),
+                putRecord(2, "Bob", offset = 2),
+            )
+
+            processor.processRecords(batch)
+
+            // 3 txs: Alice, DLQ for invalid, Bob
+            awaitTxs(node, 3)
+
+            // Alice and Bob should be ingested
+            val rows = xtQuery(node, "SELECT _id, name FROM public.test ORDER BY _id")
+            assertEquals(2, rows.size)
+            assertEquals("Alice", rows[0]["name"])
+            assertEquals("Bob", rows[1]["name"])
+
+            // Invalid record should be in DLQ
+            val dlq = dlqTxs(node)
+            assertEquals(1, dlq.size)
+            assertEquals(1L, (dlq[0]["kafka_offset"] as Number).toLong())
+        }
+    }
+
+    @Test
+    fun `node failure propagates out of processRecords`() {
+        val node = Xtdb.openNode { server { port = 0 }; flightSql = null }
+        val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+
+        // Close the node — submitTx will now fail
+        node.close()
+
+        val record = putRecord(1, "Alice")
+
+        // Infrastructure error should propagate, NOT be caught by DLQ handler
+        assertThrows<Exception> {
+            processor.processRecords(listOf(record))
+        }
+    }
+
+    @Test
+    fun `batch of mixed ops processes all records`() {
+        Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
+            val processor = DebeziumProcessor(node, "xtdb", node.allocator)
+
+            val batch = listOf(
+                putRecord(1, "Alice", op = "c", offset = 0),
+                putRecord(2, "Bob", op = "c", offset = 1),
+                putRecord(1, "Alice Updated", op = "u", offset = 2),
+                deleteRecord(2, offset = 3),
+            )
+
+            processor.processRecords(batch)
+
+            awaitTxs(node, 4)
+
+            val rows = xtQuery(node,
+                """SELECT _id, name, _valid_from, _valid_to
+                   FROM public.test
+                   FOR ALL VALID_TIME
+                   ORDER BY _id, _valid_from"""
+            )
+
+            // Alice: created then updated = 2 rows
+            // Bob: created then deleted = 1 row with valid_to
+            assertEquals(3, rows.size, "Expected 3 history rows")
+
+            assertEquals(1L, (rows[0]["_id"] as Number).toLong())
+            assertEquals("Alice", rows[0]["name"])
+
+            assertEquals(1L, (rows[1]["_id"] as Number).toLong())
+            assertEquals("Alice Updated", rows[1]["name"])
+
+            assertEquals(2L, (rows[2]["_id"] as Number).toLong())
+            assertEquals("Bob", rows[2]["name"])
+            assertTrue(rows[2]["_valid_to"] != null)
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,9 +12,10 @@ project(":lang:test-harness").name = "test-harness"
 
 include("docker:standalone", "docker:aws", "docker:azure", "docker:google-cloud")
 
-include("modules:kafka", "modules:kafka-connect", "modules:aws", "modules:azure", "modules:google-cloud")
+include("modules:kafka", "modules:kafka-connect", "modules:debezium", "modules:aws", "modules:azure", "modules:google-cloud")
 project(":modules:kafka").name = "xtdb-kafka"
 project(":modules:kafka-connect").name = "xtdb-kafka-connect"
+project(":modules:debezium").name = "xtdb-debezium"
 project(":modules:aws").name = "xtdb-aws"
 project(":modules:azure").name = "xtdb-azure"
 project(":modules:google-cloud").name = "xtdb-google-cloud"


### PR DESCRIPTION
## Summary

Adds:
- `xtdb-debezium` module which reads Debezium change events into an xtdb node
- `debezium-cdc` CLI command

Features:
- Requires `_id` to be present
- Handles snapshots + regular operations (create, update, delete)
- Supports `_valid_from` & `_valid_to` fields
- Events that fail to parse are put into a "DLQ" (i.e. they have an entry in xt.txs with no associated operations)
- Upstream metadata is included in user_metadata
  - `{"source": "debezium", "lsn": 12345, "txId": 678, "kafka_offset": 42}`
  - Errors additionally have an `error` key in the user_metadata

Limitations:
- JSON format only
- Single topic with a single partition only
- Submits directly to an existing XTDB database, not an independent on
- Valid times only support TIMESTAMPTZ or ISO-8601 string
- Does not default schema to 'public' if source.schema is not present
- Errors still count as successful transactions

Parent: #5130

## Demo

On the left is postgres, on the right is XTDB.
We have debezium setup to sync tables from postgres & XTDB setup to sync from the given kafka topic.

https://github.com/user-attachments/assets/0d28a043-abca-4bb5-94e9-0949516aa72d

## Usage

```
debezium-cdc -b <bootstrap-servers> -t <topic> [-f <config.yaml>] [-d <db-name>]
```

Starts an XTDB node with the provided config (for log + storage), then tails the Debezium topic.
Disables pgwire, FlightSQL, and compactor — matching the `tx-source` pattern.

## Test plan

- Unit tests for JSON envelope parsing, op mapping, valid time extraction, and error cases
- Unit tests for Kafka consumer offset seeking and tombstone filtering
- Unit tests for tx submission and DLQ handling
- Integration test: Postgres → Debezium → Kafka → XTDB (insert, update, delete, snapshot, valid time, type mapping, DLQ)


Closes: #5202