### PR TITLE
fix(pgwire): disallow !Env in ATTACH DATABASE config

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -903,7 +903,11 @@
                                            :db-config (try
                                                         (or (some-> (.configYaml ctx)
                                                                     (sql/plan-expr env)
-                                                                    (Database$Config/fromYaml))
+                                                                    (as-> yaml
+                                                                      (do (when (re-find #"!Env\b" yaml)
+                                                                            (throw (IllegalArgumentException.
+                                                                                     "!Env is not supported in ATTACH DATABASE - environment variables are resolved at submission time and baked into the log, use literal values instead")))
+                                                                          (Database$Config/fromYaml yaml))))
                                                             (Database$Config.))
                                                         (catch Exception e
                                                           (throw (err/incorrect :xtdb/invalid-database-config

--- a/src/test/clojure/xtdb/database_test.clj
+++ b/src/test/clojure/xtdb/database_test.clj
@@ -159,3 +159,13 @@
       (t/is (= [{:xt/id "xtdb", :version 2}] (xt/q xtdb-conn '(from :foo [xt/id version]))))
 
       (t/is (= [{:xt/id "new-db"}] (xt/q new-db-conn '(from :foo [xt/id])))))))
+
+(t/deftest test-attach-db-rejects-env-tag-5311
+  (with-open [node (xtn/start-node)
+              conn (.build (.createConnectionBuilder node))]
+    (t/is (thrown-with-msg?
+             Exception #"!Env is not supported in ATTACH DATABASE"
+             (jdbc/execute! conn ["ATTACH DATABASE my_db WITH $$
+                                     log: !Local
+                                       path: !Env MY_LOG_PATH
+                                   $$"])))))


### PR DESCRIPTION
!Env tags are resolved at submission time on the submitting node, then the resolved value is baked into the source log via protobuf. Other nodes (or the same node after restart) use whatever was resolved at attach time, not their own environment — making !Env misleading.

Reject !Env in the YAML string before parsing, with a clear error message directing users to use literal values instead.

resolves #5311