### PR TITLE
feat(sql): support expressions and SELECT aliases in GROUP BY

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -584,7 +584,7 @@ whereClause : 'WHERE' searchCondition ;
 groupByClause : 'GROUP' 'BY' (setQuantifier)? groupingElement (',' groupingElement)* ;
 
 groupingElement
-    : columnReference # OrdinaryGroupingSet
+    : expr # ExpressionGroupingSet
     | '(' ')' # EmptyGroupingSet
     ;
 

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -532,20 +532,90 @@
   PlanError
   (error-string [_] (format "Missing grouping columns: %s" missing-grouping-cols)))
 
-(defrecord GroupInvariantColsTracker [env scope, ^Set !implied-gicrs ^Set !unresolved-cr]
+(defrecord GroupInvariantColsTracker [env scope, ^Set !implied-gicrs ^Set !unresolved-cr
+                                     !projected-cols !group-by-in-projs]
   SqlVisitor
   (visitSelectClause [this ctx] (.accept (.getParent ctx) this))
 
   (visitGroupByClause [_ gbc]
-    (let [grouping-cols (vec (for [^ParserRuleContext grp-el (.groupingElement gbc)]
-                               (.accept grp-el
-                                        (reify SqlVisitor
-                                          (visitOrdinaryGroupingSet [_ ctx]
-                                            (.accept (.columnReference ctx)
-                                                     (map->ExprPlanVisitor {:env env :scope scope
-                                                                            :!unresolved-cr !unresolved-cr})))))))]
+    (let [;; build alias map from SELECT projected-cols (FROM-first precedence for GROUP BY)
+          alias-cols (->> @!projected-cols
+                          (into {} (mapcat (fn [{:keys [col-sym]}]
+                                            [[(symbol (name col-sym)) col-sym]
+                                             [col-sym col-sym]]))))
 
-      (if-let [missing-grouping-cols (not-empty (set/difference (set !implied-gicrs) (set grouping-cols)))]
+          gb-scope (reify Scope
+                     (available-cols [_]
+                       (set/union (available-cols scope) (set (keys alias-cols))))
+                     (-find-cols [_ [col-name :as chain] excl-cols]
+                       (or (find-cols scope chain excl-cols)
+                           (when (= 1 (count chain))
+                             (when-let [sym (get alias-cols col-name)]
+                               (when-not (contains? excl-cols col-name)
+                                 [sym]))))))
+
+          ;; map from SELECT expressions to their col-syms (for dedup)
+          select-expr-to-col (into {} (for [{:keys [projection col-sym]} @!projected-cols
+                                            :when (map? projection)
+                                            :let [[_ expr] (first projection)]]
+                                        [expr col-sym]))
+
+          ;; reverse map: col-sym -> expr (for alias resolution)
+          select-col-to-expr (into {} (for [{:keys [projection col-sym]} @!projected-cols
+                                            :when (map? projection)
+                                            :let [[_ expr] (first projection)]]
+                                        [col-sym expr]))
+
+          gb-expr-visitor (map->ExprPlanVisitor {:env env :scope gb-scope :!unresolved-cr !unresolved-cr})
+
+          grouping-elements (vec (for [^ParserRuleContext grp-el (.groupingElement gbc)]
+                                  (.accept grp-el
+                                           (reify SqlVisitor
+                                             (visitExpressionGroupingSet [_ ctx]
+                                               (let [expr (.accept (.expr ctx) gb-expr-visitor)]
+                                                 (cond
+                                                   ;; alias resolved to a SELECT col-sym with a complex expression
+                                                   (and (lp/column? expr) (contains? select-col-to-expr expr))
+                                                   {:col-sym expr :expr (get select-col-to-expr expr) :replace-in-projected-cols? true}
+
+                                                   ;; simple column ref from FROM - use as-is
+                                                   (lp/column? expr)
+                                                   {:col-sym expr}
+
+                                                   ;; matches a SELECT expression - reuse col-sym, pre-project it
+                                                   (contains? select-expr-to-col expr)
+                                                   {:col-sym (get select-expr-to-col expr) :expr expr :replace-in-projected-cols? true}
+
+                                                   ;; new expression - create synthetic col
+                                                   :else
+                                                   (let [gb-sym (->col-sym (str "_gb" (swap! (:!id-count env) inc)))]
+                                                     {:col-sym gb-sym :expr expr}))))
+
+                                             (visitEmptyGroupingSet [_ _ctx])))))
+
+          _ (doseq [{:keys [col-sym expr replace-in-projected-cols?]} grouping-elements
+                     :when expr]
+              (swap! !group-by-in-projs conj {col-sym expr})
+              (when replace-in-projected-cols?
+                (swap! !projected-cols
+                       (fn [pcs] (mapv (fn [pc]
+                                         (if (= (:col-sym pc) col-sym)
+                                           (assoc pc :projection col-sym)
+                                           pc))
+                                       pcs)))))
+
+          grouping-cols (mapv :col-sym grouping-elements)
+
+          ;; collect raw columns referenced by GROUP BY expressions (for permissive validation)
+          gb-referenced-cols (into #{}
+                                   (comp (mapcat (comp vals))
+                                         (mapcat #(tree-seq coll? seq %))
+                                         (filter lp/column?)
+                                         (filter namespace))
+                                   @!group-by-in-projs)]
+
+      (if-let [missing-grouping-cols (not-empty (set/difference (set !implied-gicrs)
+                                                                (set/union (set grouping-cols) gb-referenced-cols)))]
         (add-err! env (->MissingGroupingColumns missing-grouping-cols))
         grouping-cols)))
 
@@ -558,8 +628,10 @@
         (some-> !implied-gicrs (.add sym))
         sym))))
 
-(defn- wrap-aggs [plan aggs group-invariant-cols]
-  (let [in-projs (not-empty (into [] (keep (comp :projection :in-projection)) (vals aggs)))]
+(defn- wrap-aggs [plan aggs group-invariant-cols group-by-in-projs]
+  (let [in-projs (not-empty (into (vec group-by-in-projs)
+                                  (keep (comp :projection :in-projection))
+                                  (vals aggs)))]
     (as-> plan plan
       (if in-projs
         [:map {:projections in-projs} plan]
@@ -2389,7 +2461,10 @@
                         order-by-clause]
   (let [!unresolved-cr (HashSet.)
         !implied-gicrs (HashSet.)
-        group-invar-col-tracker (->GroupInvariantColsTracker env scope !implied-gicrs !unresolved-cr)
+        !projected-cols (atom nil)
+        !group-by-in-projs (atom [])
+        group-invar-col-tracker (->GroupInvariantColsTracker env scope !implied-gicrs !unresolved-cr
+                                                             !projected-cols !group-by-in-projs)
 
         having-plan (when having-clause
                       (let [!subqs (HashMap.)
@@ -2400,7 +2475,9 @@
                          :aggs (not-empty (into {} !aggs))}))
 
 
-        {:keys [projected-cols windows agg-subqs] :as select-plan} (.accept select-clause (->SelectClauseProjectedCols env group-invar-col-tracker))
+        {:keys [windows agg-subqs] :as select-plan} (.accept select-clause (->SelectClauseProjectedCols env group-invar-col-tracker))
+        _ (reset! !projected-cols (:projected-cols select-plan))
+
         aggs (not-empty (merge (:aggs select-plan) (:aggs having-plan)))
         grouped-table? (boolean (or aggs group-by-clause))
         group-invariant-cols (when grouped-table?
@@ -2408,6 +2485,9 @@
                                  (.accept group-by-clause group-invar-col-tracker)
                                  (for [col-ref !implied-gicrs]
                                    col-ref)))
+
+        ;; use potentially-rewritten projected-cols (GROUP BY dedup may have changed projections)
+        projected-cols @!projected-cols
 
         ob-plan (some-> order-by-clause
                         (plan-order-by env scope
@@ -2443,7 +2523,7 @@
             agg-subqs (apply-sqs agg-subqs))
 
           (cond-> plan
-            grouped-table? (wrap-aggs aggs group-invariant-cols))
+            grouped-table? (wrap-aggs aggs group-invariant-cols @!group-by-in-projs))
 
           (if-let [{:keys [predicate subqs]} having-plan]
             (-> plan

--- a/src/test/clojure/xtdb/pgwire/pg2_test.clj
+++ b/src/test/clojure/xtdb/pgwire/pg2_test.clj
@@ -245,7 +245,7 @@
       (pg/execute conn "SELECT 2 AS b FROM docs GROUP BY b")
       ;; the fn-notice runs in a separate executor pool
       (Thread/sleep 100)
-      (t/is (= #{"Table not found: docs" "Column not found: b"}
+      (t/is (= #{"Table not found: docs"}
                (set @warns))))))
 
 (deftest test-time

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2040,7 +2040,7 @@ ORDER BY t.oid DESC LIMIT 1"
               stmt (.prepareStatement conn "SELECT 2 AS b FROM docs GROUP BY b")]
     (.execute stmt)
 
-    (t/is (= #{"Table not found: docs" "Column not found: b"}
+    (t/is (= #{"Table not found: docs"}
              (set (map #(.getMessage ^SQLWarning %) (stmt->warnings stmt)))))))
 
 (deftest test-ignore-returning-keys-3668

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -894,6 +894,62 @@
             FROM foo "
           {:table-info {#xt/table foo #{"a"}}}))))
 
+(t/deftest test-group-by-expression
+  (t/testing "expression grouping"
+    (t/is (=plan-file
+           "test-group-by-expression"
+           (sql/plan "SELECT UPPER(category) AS cat, COUNT(*) AS cnt FROM products GROUP BY UPPER(category)"
+                     {:table-info {#xt/table products #{"category"}}}))))
+
+  (t/testing "alias grouping"
+    (t/is (=plan-file
+           "test-group-by-alias"
+           (sql/plan "SELECT UPPER(category) AS cat, COUNT(*) AS cnt FROM products GROUP BY cat"
+                     {:table-info {#xt/table products #{"category"}}}))))
+
+  (t/testing "mixed expression and column grouping"
+    (t/is (=plan-file
+           "test-group-by-mixed"
+           (sql/plan "SELECT a, UPPER(b) AS ub, COUNT(*) AS cnt FROM t GROUP BY a, UPPER(b)"
+                     {:table-info {#xt/table t #{"a" "b"}}}))))
+
+  (t/testing "expression grouping (not in SELECT)"
+    (t/is (=plan-file
+           "test-group-by-expr-not-in-select"
+           (sql/plan "SELECT COUNT(*) AS cnt FROM products GROUP BY UPPER(category)"
+                     {:table-info {#xt/table products #{"category"}}}))))
+
+  (t/testing "FROM column takes precedence over alias on name conflict"
+    ;; GROUP BY b resolves to FROM column b, not the alias b (which maps to a).
+    ;; So 'a' is not covered by GROUP BY, producing a planning error.
+    (t/is (thrown-with-msg? Exception #"Missing grouping columns"
+           (sql/plan "SELECT a AS b, COUNT(*) AS cnt FROM t GROUP BY b"
+                     {:table-info {#xt/table t #{"a" "b"}}}))))
+
+  (t/testing "ungrouped column with expression GROUP BY"
+    (t/is (thrown-with-msg? Exception #"Missing grouping columns"
+           (sql/plan "SELECT a, COUNT(*) AS cnt FROM t GROUP BY UPPER(b)"
+                     {:table-info {#xt/table t #{"a" "b"}}}))))
+
+  (t/testing "execution"
+    (xt/submit-tx tu/*node* [[:put-docs :products {:xt/id 1 :category "food"}]
+                              [:put-docs :products {:xt/id 2 :category "food"}]
+                              [:put-docs :products {:xt/id 3 :category "drink"}]])
+    (t/is (= #{{:cat "FOOD" :cnt 2} {:cat "DRINK" :cnt 1}}
+             (set (xt/q tu/*node* "SELECT UPPER(category) AS cat, COUNT(*) AS cnt FROM products GROUP BY UPPER(category)"))))
+    (t/is (= #{{:cat "FOOD" :cnt 2} {:cat "DRINK" :cnt 1}}
+             (set (xt/q tu/*node* "SELECT UPPER(category) AS cat, COUNT(*) AS cnt FROM products GROUP BY cat")))
+          "GROUP BY alias")
+    (t/is (= #{{:cnt 2} {:cnt 1}}
+             (set (xt/q tu/*node* "SELECT COUNT(*) AS cnt FROM products GROUP BY UPPER(category)")))
+          "GROUP BY expression not in SELECT")
+
+    ;; gb-referenced-cols permits this at plan time because category appears inside UPPER(category),
+    ;; but it fails at runtime because category doesn't survive the :group-by node.
+    ;; TODO: stricter plan-time validation would reject this (as PostgreSQL does).
+    (t/is (thrown? Exception
+             (xt/q tu/*node* "SELECT category, COUNT(*) AS cnt FROM products GROUP BY UPPER(category)")))))
+
 (t/deftest test-ordered-set-aggregates
   (t/is (=plan-file
          "test-percentile-cont"

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-alias.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-alias.edn
@@ -1,0 +1,9 @@
+[:project
+ {:projections [{cat cat} {cnt _row_count_2}]}
+ [:group-by
+  {:columns [cat {_row_count_2 (row-count)}]}
+  [:map
+   {:projections [{cat (upper products.1/category)}]}
+   [:rename
+    {:prefix products.1}
+    [:scan {:table #xt/table products, :columns [category]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-not-in-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-not-in-select.edn
@@ -1,0 +1,5 @@
+[:project {:projections [{cnt _row_count_2}]}
+ [:group-by {:columns [_gb3 {_row_count_2 (row-count)}]}
+  [:map {:projections [{_gb3 (upper products.1/category)}]}
+   [:rename {:prefix products.1}
+    [:scan {:table #xt/table products, :columns [category]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expression.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expression.edn
@@ -1,0 +1,9 @@
+[:project
+ {:projections [{cat cat} {cnt _row_count_2}]}
+ [:group-by
+  {:columns [cat {_row_count_2 (row-count)}]}
+  [:map
+   {:projections [{cat (upper products.1/category)}]}
+   [:rename
+    {:prefix products.1}
+    [:scan {:table #xt/table products, :columns [category]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-mixed.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-mixed.edn
@@ -1,0 +1,9 @@
+[:project
+ {:projections [{a t.1/a} {ub ub} {cnt _row_count_2}]}
+ [:group-by
+  {:columns [t.1/a ub {_row_count_2 (row-count)}]}
+  [:map
+   {:projections [{ub (upper t.1/b)}]}
+   [:rename
+    {:prefix t.1}
+    [:scan {:table #xt/table t, :columns [a b]}]]]]]


### PR DESCRIPTION
GROUP BY previously only accepted column references. This adds support for arbitrary expressions (`GROUP BY UPPER(category)`) and SELECT alias references (`GROUP BY cat`).

GROUP BY resolves names through its own scope rather than the GroupInvariantColsTracker scope used by SELECT/HAVING. This prevents GROUP BY's internal column references from polluting !implied-gicrs — routing resolution through the tracker was a category error since GROUP BY defines what's grouped, it doesn't need observing.

Alias precedence follows PostgreSQL/DuckDB: FROM columns first, SELECT aliases as fallback for unqualified names.

When a GROUP BY expression matches a SELECT expression, the planner reuses the SELECT col-sym and pre-projects via a :map node below :group-by, rewriting the SELECT projection to a pass-through.

The !implied-gicrs validation uses a permissive gb-referenced-cols check — columns appearing inside GROUP BY expressions are considered covered.
This over-accepts some edge cases that PostgreSQL would reject (e.g. SELECT b ... GROUP BY UPPER(b) where b is not functionally determined). Strict expression-level validation is left as future work.