### PR TITLE
fix(pgwire): use virtual threads for connection pool to prevent glibc arena proliferation

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -1902,7 +1902,7 @@
                                 :port port
                                 :read-only? read-only?
                                 :accept-socket accept-socket
-                                :thread-pool (Executors/newFixedThreadPool num-threads (util/->prefix-thread-factory "pgwire-connection-"))
+                                :thread-pool (Executors/newFixedThreadPool num-threads (-> (Thread/ofVirtual) (.name "pgwire-connection-" 0) (.factory)))
                                 :!closing? (atom false)
                                 ;;TODO use clock from node or at least take clock as a param for testing
                                 :server-state (atom (let [default-clock (Clock/systemDefaultZone)]


### PR DESCRIPTION
pgwire's connection pool used platform threads via newFixedThreadPool. Each new platform thread triggers glibc to create a new malloc arena. Under query load, these arenas fill with ~400-500MB of Arrow/Netty allocations (for large queries), then when freed, tiny pinned allocations (33-2001 bytes) prevent glibc from returning pages to the OS. This causes monotonic anonymous memory growth (~400MB per new connection thread) until cgroup OOM kill.

Virtual threads run on a small fixed pool of carrier threads, so no new OS threads are created regardless of how many connections arrive. This eliminates arena proliferation at the source.

We use newFixedThreadPool with a virtual thread factory rather than newVirtualThreadPerTaskExecutor to preserve the existing num-threads connection limit (default 42).

Confirmed: 10 minutes of query-registration stress (357 queries) completes cleanly at ~3.5GB anon with 54 arenas held flat throughout. Previously this OOM killed at 10GB within minutes with arena count growing +1 per query.