### PR TITLE
fix: inherit parent allocator limit in Kotlin child allocators

### DIFF
--- a/core/src/main/kotlin/xtdb/util/ArrowUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/ArrowUtil.kt
@@ -6,7 +6,7 @@ import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.complex.UnionVector
 
 internal fun BufferAllocator.openChildAllocator(name: String) =
-    newChildAllocator(name, 0, Long.MAX_VALUE)
+    newChildAllocator(name, 0, limit)
 
 fun ValueVector.openSlice(offset: Int = 0, len: Int = valueCount): ValueVector =
     when {


### PR DESCRIPTION
The Kotlin `openChildAllocator` was using `Long.MAX_VALUE` as the limit, allowing child allocators (buffer pool, compactor, metadata manager, all storage impls) to allocate without bound.
The Clojure equivalent (`->child-allocator`) already correctly inherits the parent's limit via `.getLimit`.

Spotted whilst looking into fusion oom kill.