### PR TITLE
fix(sql): ORDER BY alias expressions and SELECT expression dedup

### DIFF
--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -2246,18 +2246,21 @@
         plan))))
 
 (defn- wrap-integrated-ob [plan projected-cols ob-specs]
-  (let [in-projs (not-empty (into [] (keep :in-projection) ob-specs))]
+  (let [in-projs (not-empty (into [] (keep :in-projection) ob-specs))
+        extend-projs (not-empty (into [] (filter map?) (map :projection projected-cols)))]
     (as-> plan plan
-      [:project {:projections (into (mapv :projection projected-cols)
-                      in-projs)}
-       plan]
+      (if extend-projs
+        [:map {:projections extend-projs} plan]
+        plan)
+
+      (if in-projs
+        [:map {:projections in-projs} plan]
+        plan)
 
       [:order-by {:order-specs (mapv :order-by-spec ob-specs)}
        plan]
 
-      (if in-projs
-        [:project {:projections (mapv :col-sym projected-cols)} plan]
-        plan))))
+      [:project {:projections (mapv :col-sym projected-cols)} plan])))
 
 (defn- wrap-windows [plan windows]
   (when (> (count windows) 1)

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -2177,7 +2177,8 @@
 
 (defn- plan-sort-specification-list [^Sql$SortSpecificationListContext ctx
                                      {:keys [!id-count] :as env} inner-scope outer-col-syms
-                                     & {:keys [gb-expr-to-col] :or {gb-expr-to-col {}}}]
+                                     & {:keys [gb-expr-to-col select-expr-to-col]
+                                        :or {gb-expr-to-col {}, select-expr-to-col {}}}]
   (let [outer-cols (->> outer-col-syms
                         (into {} (mapcat (juxt (juxt identity identity)
                                                (juxt (comp symbol name) identity)))))
@@ -2223,6 +2224,8 @@
                                            (add-err! env (->InvalidOrderByOrdinal outer-col-syms expr)))
 
                          (contains? outer-cols expr) {:order-by-spec [expr ob-opts]}
+
+                         (get select-expr-to-col expr) {:order-by-spec [(get select-expr-to-col expr) ob-opts]}
 
                          :else (let [in-sym (->col-sym (str "_ob" (swap! !id-count inc)))]
                                  {:order-by-spec [in-sym ob-opts]
@@ -2508,10 +2511,16 @@
                                 (w/postwalk #(get gb-expr-to-col % %) pred)))
                       having-plan)
 
+        ob-select-expr-to-col (into {} (for [{:keys [projection col-sym]} projected-cols
+                                           :when (map? projection)
+                                           :let [[_ expr] (first projection)]]
+                                       [expr col-sym]))
+
         ob-plan (some-> order-by-clause
                         (plan-order-by env scope
                                        (mapv :col-sym projected-cols)
-                                       :gb-expr-to-col gb-expr-to-col))]
+                                       :gb-expr-to-col gb-expr-to-col
+                                       :select-expr-to-col ob-select-expr-to-col))]
 
     (when-let [dup-cols (not-empty (dups (mapv :col-sym projected-cols)))]
       (doseq [col dup-cols]

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -931,6 +931,12 @@
            (sql/plan "SELECT a, COUNT(*) AS cnt FROM t GROUP BY UPPER(b)"
                      {:table-info {#xt/table t #{"a" "b"}}}))))
 
+  (t/testing "alias within GROUP BY expression - invalid as cat is not a grouping col"
+    ;; could produce a better error here by rejecting alias refences in group by expressions during planning
+    (t/is (thrown-with-msg? Exception #"Missing grouping columns:.*category"
+           (sql/plan "SELECT UPPER(category) AS cat, COUNT(*) AS cnt FROM products GROUP BY cat + 1"
+                     {:table-info {#xt/table products #{"category"}}}))))
+
   (t/testing "execution"
     (xt/submit-tx tu/*node* [[:put-docs :products {:xt/id 1 :category "food"}]
                               [:put-docs :products {:xt/id 2 :category "food"}]

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -994,6 +994,29 @@
     (t/is (= [{:x 1.0 :cnt 1} {:x 2.0 :cnt 1} {:x 3.0 :cnt 1}]
              (xt/q tu/*node* "SELECT (FLOOR((_id - 1.0) / 1.0)) * 1.0 + 1.0 AS x, COUNT(*) AS cnt FROM orders GROUP BY (FLOOR((_id - 1.0) / 1.0)) * 1.0 + 1.0 ORDER BY (FLOOR((_id - 1.0) / 1.0)) * 1.0 + 1.0 ASC")))))
 
+(t/deftest test-order-by-alias
+  (t/testing "alias within expression - plan"
+    (t/is (=plan-file
+           "test-order-by-alias-in-expr"
+           (sql/plan "SELECT x + 1 AS y FROM t ORDER BY y * 2 ASC"
+                     {:table-info {#xt/table t #{"x"}}}))))
+
+  (xt/submit-tx tu/*node* [[:put-docs :t {:xt/id 1 :x 10}]
+                           [:put-docs :t {:xt/id 2 :x 20}]
+                           [:put-docs :t {:xt/id 3 :x 30}]])
+
+  (t/testing "bare alias reference"
+    (t/is (= [{:y 31} {:y 21} {:y 11}]
+             (xt/q tu/*node* "SELECT x + 1 AS y FROM t ORDER BY y DESC"))))
+
+  (t/testing "alias within expression"
+    (t/is (= [{:y 11} {:y 21} {:y 31}]
+             (xt/q tu/*node* "SELECT x + 1 AS y FROM t ORDER BY y * 2 ASC"))))
+
+  (t/testing "subquery in ORDER BY - not yet supported"
+    (t/is (thrown-with-msg? Exception #"Subqueries are not allowed in this context"
+             (xt/q tu/*node* "SELECT x + 1 AS y FROM t ORDER BY (SELECT 1)")))))
+
 (t/deftest test-ordered-set-aggregates
   (t/is (=plan-file
          "test-percentile-cont"

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-27.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-27.edn
@@ -2,8 +2,8 @@
  {:projections [{movie_title si.1/movie_title}]}
  [:order-by
   {:order-specs [[_ob2 {:direction :asc, :null-ordering :nulls-last}]]}
-  [:project
-   {:projections [si.1/movie_title {_ob2 si.1/year}]}
+  [:map
+   {:projections [{_ob2 si.1/year}]}
    [:rename
     {:prefix si.1}
     [:scan {:table #xt/table stars_in, :columns [year movie_title]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
@@ -2,9 +2,10 @@
  {:projections [{_column_1 _column_1}]}
  [:order-by
   {:order-specs [[_ob2 {:direction :asc, :null-ordering :nulls-last}]]}
-  [:project
-   {:projections
-    [{_column_1 (== si.1/year "foo")} {_ob2 (== si.1/year "foo")}]}
-   [:rename
-    {:prefix si.1}
-    [:scan {:table #xt/table stars_in, :columns [year]}]]]]]
+  [:map
+   {:projections [{_ob2 (== si.1/year "foo")}]}
+   [:map
+    {:projections [{_column_1 (== si.1/year "foo")}]}
+    [:rename
+     {:prefix si.1}
+     [:scan {:table #xt/table stars_in, :columns [year]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
@@ -1,11 +1,9 @@
 [:project
  {:projections [{_column_1 _column_1}]}
  [:order-by
-  {:order-specs [[_ob2 {:direction :asc, :null-ordering :nulls-last}]]}
+  {:order-specs [[_column_1 {:direction :asc, :null-ordering :nulls-last}]]}
   [:map
-   {:projections [{_ob2 (== si.1/year "foo")}]}
-   [:map
-    {:projections [{_column_1 (== si.1/year "foo")}]}
-    [:rename
-     {:prefix si.1}
-     [:scan {:table #xt/table stars_in, :columns [year]}]]]]]]
+   {:projections [{_column_1 (== si.1/year "foo")}]}
+   [:rename
+    {:prefix si.1}
+    [:scan {:table #xt/table stars_in, :columns [year]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-having-non-pushable.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-having-non-pushable.edn
@@ -5,7 +5,8 @@
   [:select
    {:predicate (> _row_count_2 1)}
    [:group-by
-    {:columns [cat {_row_count_3 (row-count)} {_row_count_2 (row-count)}]}
+    {:columns
+     [cat {_row_count_3 (row-count)} {_row_count_2 (row-count)}]}
     [:map
      {:projections [{cat (upper products.1/category)}]}
      [:rename

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-not-in-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-not-in-select.edn
@@ -1,5 +1,9 @@
-[:project {:projections [{cnt _row_count_2}]}
- [:group-by {:columns [_gb3 {_row_count_2 (row-count)}]}
-  [:map {:projections [{_gb3 (upper products.1/category)}]}
-   [:rename {:prefix products.1}
+[:project
+ {:projections [{cnt _row_count_2}]}
+ [:group-by
+  {:columns [_gb3 {_row_count_2 (row-count)}]}
+  [:map
+   {:projections [{_gb3 (upper products.1/category)}]}
+   [:rename
+    {:prefix products.1}
     [:scan {:table #xt/table products, :columns [category]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-order-by.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-order-by.edn
@@ -1,11 +1,13 @@
-[:order-by
- {:order-specs [[cat {:direction :asc, :null-ordering :nulls-last}]]}
- [:project
-  {:projections [cat {cnt _row_count_2}]}
-  [:group-by
-   {:columns [cat {_row_count_2 (row-count)}]}
-   [:map
-    {:projections [{cat (upper products.1/category)}]}
-    [:rename
-     {:prefix products.1}
-     [:scan {:table #xt/table products, :columns [category]}]]]]]]
+[:project
+ {:projections [{cat cat} {cnt cnt}]}
+ [:order-by
+  {:order-specs [[cat {:direction :asc, :null-ordering :nulls-last}]]}
+  [:map
+   {:projections [{cnt _row_count_2}]}
+   [:group-by
+    {:columns [cat {_row_count_2 (row-count)}]}
+    [:map
+     {:projections [{cat (upper products.1/category)}]}
+     [:rename
+      {:prefix products.1}
+      [:scan {:table #xt/table products, :columns [category]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-order-by-alias-in-expr.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-order-by-alias-in-expr.edn
@@ -1,0 +1,11 @@
+[:project
+ {:projections [{y y}]}
+ [:order-by
+  {:order-specs [[_ob2 {:direction :asc, :null-ordering :nulls-last}]]}
+  [:map
+   {:projections [{_ob2 (* y 2)}]}
+   [:map
+    {:projections [{y (+ t.1/x 1)}]}
+    [:rename
+     {:prefix t.1}
+     [:scan {:table #xt/table t, :columns [x]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-percentile-cont.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-percentile-cont.edn
@@ -3,9 +3,7 @@
  [:group-by
   {:columns
    [{_percentile_cont_out_2
-     (percentile_cont
-      0.5
-      [t.1/amount {:direction :asc}])}]}
+     (percentile_cont 0.5 [t.1/amount {:direction :asc}])}]}
   [:rename
    {:prefix t.1}
    [:scan {:table #xt/table t, :columns [amount]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-percentile-disc-desc.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-percentile-disc-desc.edn
@@ -3,9 +3,7 @@
  [:group-by
   {:columns
    [{_percentile_disc_out_2
-     (percentile_disc
-      0.5
-      [t.1/amount {:direction :desc}])}]}
+     (percentile_disc 0.5 [t.1/amount {:direction :desc}])}]}
   [:rename
    {:prefix t.1}
    [:scan {:table #xt/table t, :columns [amount]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q01.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q01.edn
@@ -1,55 +1,62 @@
 [:project
- {:projections [{l_returnflag l.1/l_returnflag}
-  {l_linestatus l.1/l_linestatus}
-  sum_qty
-  sum_base_price
-  sum_disc_price
-  sum_charge
-  avg_qty
-  avg_price
-  avg_disc
-  count_order]}
+ {:projections
+  [{l_returnflag l.1/l_returnflag}
+   {l_linestatus l.1/l_linestatus}
+   {sum_qty sum_qty}
+   {sum_base_price sum_base_price}
+   {sum_disc_price sum_disc_price}
+   {sum_charge sum_charge}
+   {avg_qty avg_qty}
+   {avg_price avg_price}
+   {avg_disc avg_disc}
+   {count_order count_order}]}
  [:order-by
-  {:order-specs [[l.1/l_returnflag {:direction :asc, :null-ordering :nulls-last}]
-   [l.1/l_linestatus {:direction :asc, :null-ordering :nulls-last}]]}
-  [:project
-   {:projections [l.1/l_returnflag
-    l.1/l_linestatus
-    {sum_qty _sum_out_2}
-    {sum_base_price _sum_out_3}
-    {sum_disc_price _sum_out_4}
-    {sum_charge _sum_out_6}
-    {avg_qty _avg_out_8}
-    {avg_price _avg_out_9}
-    {avg_disc _avg_out_10}
-    {count_order _row_count_11}]}
+  {:order-specs
+   [[l.1/l_returnflag {:direction :asc, :null-ordering :nulls-last}]
+    [l.1/l_linestatus {:direction :asc, :null-ordering :nulls-last}]]}
+  [:map
+   {:projections
+    [{sum_qty _sum_out_2}
+     {sum_base_price _sum_out_3}
+     {sum_disc_price _sum_out_4}
+     {sum_charge _sum_out_6}
+     {avg_qty _avg_out_8}
+     {avg_price _avg_out_9}
+     {avg_disc _avg_out_10}
+     {count_order _row_count_11}]}
    [:group-by
-    {:columns [l.1/l_returnflag
-     l.1/l_linestatus
-     {_avg_out_10 (avg l.1/l_discount)}
-     {_avg_out_8 (avg l.1/l_quantity)}
-     {_row_count_11 (row-count)}
-     {_sum_out_6 (sum _sum_in_7)}
-     {_sum_out_4 (sum _sum_in_5)}
-     {_sum_out_2 (sum l.1/l_quantity)}
-     {_sum_out_3 (sum l.1/l_extendedprice)}
-     {_avg_out_9 (avg l.1/l_extendedprice)}]}
+    {:columns
+     [l.1/l_returnflag
+      l.1/l_linestatus
+      {_avg_out_10 (avg l.1/l_discount)}
+      {_avg_out_8 (avg l.1/l_quantity)}
+      {_row_count_11 (row-count)}
+      {_sum_out_6 (sum _sum_in_7)}
+      {_sum_out_4 (sum _sum_in_5)}
+      {_sum_out_2 (sum l.1/l_quantity)}
+      {_sum_out_3 (sum l.1/l_extendedprice)}
+      {_avg_out_9 (avg l.1/l_extendedprice)}]}
     [:map
-     {:projections [{_sum_in_7
-       (*
-        (* l.1/l_extendedprice (- 1 l.1/l_discount))
-        (+ 1 l.1/l_tax))}
-      {_sum_in_5 (* l.1/l_extendedprice (- 1 l.1/l_discount))}]}
-     [:rename {:prefix l.1} [:scan
-       {:table #xt/table lineitem, :columns [l_linestatus
-        l_tax
-        {l_shipdate
-         (<=
-          l_shipdate
-          (-
-           #xt/date "1998-12-01"
-           (single-field-interval "90" "DAY" 2 6)))}
-        l_returnflag
-        l_extendedprice
-        l_quantity
-        l_discount]}]]]]]]]
+     {:projections
+      [{_sum_in_7
+        (*
+         (* l.1/l_extendedprice (- 1 l.1/l_discount))
+         (+ 1 l.1/l_tax))}
+       {_sum_in_5 (* l.1/l_extendedprice (- 1 l.1/l_discount))}]}
+     [:rename
+      {:prefix l.1}
+      [:scan
+       {:table #xt/table lineitem,
+        :columns
+        [l_linestatus
+         l_tax
+         {l_shipdate
+          (<=
+           l_shipdate
+           (-
+            #xt/date "1998-12-01"
+            (single-field-interval "90" "DAY" 2 6)))}
+         l_returnflag
+         l_extendedprice
+         l_quantity
+         l_discount]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
@@ -15,105 +15,103 @@
     [[s.2/s_acctbal {:direction :desc, :null-ordering :nulls-first}]
      [n.4/n_name {:direction :asc, :null-ordering :nulls-last}]
      [s.2/s_name {:direction :asc, :null-ordering :nulls-last}]
-     [_ob13 {:direction :asc, :null-ordering :nulls-last}]]}
+     [p_partkey {:direction :asc, :null-ordering :nulls-last}]]}
    [:map
-    {:projections [{_ob13 p.1/_id}]}
+    {:projections [{p_partkey p.1/_id}]}
     [:map
-     {:projections [{p_partkey p.1/_id}]}
-     [:map
-      {:projections [{_sq_6 _min_out_12}]}
-      [:select
-       {:predicate (== ps.3/ps_supplycost _min_out_12)}
-       [:group-by
-        {:columns
-         [p.1/_id
-          p.1/p_size
-          p.1/p_mfgr
-          p.1/p_type
-          s.2/s_comment
-          s.2/s_name
-          s.2/s_address
-          s.2/s_phone
-          s.2/_id
-          s.2/s_acctbal
-          s.2/s_nationkey
-          ps.3/ps_partkey
-          ps.3/ps_supplycost
-          ps.3/ps_suppkey
-          n.4/_id
-          n.4/n_name
-          n.4/n_regionkey
-          r.5/_id
-          r.5/r_name
-          _row_number_0
-          {_min_out_12 (min ps.7/ps_supplycost)}]}
-        [:left-outer-join
-         {:conditions [{p.1/_id ps.7/ps_partkey}]}
-         [:map
-          {:projections [{_row_number_0 (row-number)}]}
-          [:mega-join
-           {:conditions
-            [{n.4/n_regionkey r.5/_id}
-             {s.2/s_nationkey n.4/_id}
-             {p.1/_id ps.3/ps_partkey}
-             {s.2/_id ps.3/ps_suppkey}]}
-           [[:rename
-             {:prefix r.5}
-             [:scan
-              {:table #xt/table region,
-               :columns [_id {r_name (== r_name "EUROPE")}]}]]
-            [:rename
-             {:prefix n.4}
-             [:scan
-              {:table #xt/table nation,
-               :columns [_id n_name n_regionkey]}]]
-            [:rename
-             {:prefix ps.3}
-             [:scan
-              {:table #xt/table partsupp,
-               :columns [ps_partkey ps_supplycost ps_suppkey]}]]
-            [:rename
-             {:prefix p.1}
-             [:scan
-              {:table #xt/table part,
-               :columns
-               [_id
-                {p_size (== p_size 15)}
-                p_mfgr
-                {p_type (like p_type "%BRASS")}]}]]
-            [:rename
-             {:prefix s.2}
-             [:scan
-              {:table #xt/table supplier,
-               :columns
-               [s_comment
-                s_name
-                s_address
-                s_phone
-                _id
-                s_acctbal
-                s_nationkey]}]]]]]
+     {:projections [{_sq_6 _min_out_12}]}
+     [:select
+      {:predicate (== ps.3/ps_supplycost _min_out_12)}
+      [:group-by
+       {:columns
+        [p.1/_id
+         p.1/p_size
+         p.1/p_mfgr
+         p.1/p_type
+         s.2/s_comment
+         s.2/s_name
+         s.2/s_address
+         s.2/s_phone
+         s.2/_id
+         s.2/s_acctbal
+         s.2/s_nationkey
+         ps.3/ps_partkey
+         ps.3/ps_supplycost
+         ps.3/ps_suppkey
+         n.4/_id
+         n.4/n_name
+         n.4/n_regionkey
+         r.5/_id
+         r.5/r_name
+         _row_number_0
+         {_min_out_12 (min ps.7/ps_supplycost)}]}
+       [:left-outer-join
+        {:conditions [{p.1/_id ps.7/ps_partkey}]}
+        [:map
+         {:projections [{_row_number_0 (row-number)}]}
          [:mega-join
           {:conditions
-           [{n.9/n_regionkey r.10/_id}
-            {s.8/s_nationkey n.9/_id}
-            {ps.7/ps_suppkey s.8/_id}]}
+           [{n.4/n_regionkey r.5/_id}
+            {s.2/s_nationkey n.4/_id}
+            {p.1/_id ps.3/ps_partkey}
+            {s.2/_id ps.3/ps_suppkey}]}
           [[:rename
-            {:prefix r.10}
+            {:prefix r.5}
             [:scan
              {:table #xt/table region,
               :columns [_id {r_name (== r_name "EUROPE")}]}]]
            [:rename
-            {:prefix n.9}
+            {:prefix n.4}
             [:scan
-             {:table #xt/table nation, :columns [_id n_regionkey]}]]
+             {:table #xt/table nation,
+              :columns [_id n_name n_regionkey]}]]
            [:rename
-            {:prefix ps.7}
+            {:prefix ps.3}
             [:scan
              {:table #xt/table partsupp,
               :columns [ps_partkey ps_supplycost ps_suppkey]}]]
            [:rename
-            {:prefix s.8}
+            {:prefix p.1}
+            [:scan
+             {:table #xt/table part,
+              :columns
+              [_id
+               {p_size (== p_size 15)}
+               p_mfgr
+               {p_type (like p_type "%BRASS")}]}]]
+           [:rename
+            {:prefix s.2}
             [:scan
              {:table #xt/table supplier,
-              :columns [_id s_nationkey]}]]]]]]]]]]]]]
+              :columns
+              [s_comment
+               s_name
+               s_address
+               s_phone
+               _id
+               s_acctbal
+               s_nationkey]}]]]]]
+        [:mega-join
+         {:conditions
+          [{n.9/n_regionkey r.10/_id}
+           {s.8/s_nationkey n.9/_id}
+           {ps.7/ps_suppkey s.8/_id}]}
+         [[:rename
+           {:prefix r.10}
+           [:scan
+            {:table #xt/table region,
+             :columns [_id {r_name (== r_name "EUROPE")}]}]]
+          [:rename
+           {:prefix n.9}
+           [:scan
+            {:table #xt/table nation, :columns [_id n_regionkey]}]]
+          [:rename
+           {:prefix ps.7}
+           [:scan
+            {:table #xt/table partsupp,
+             :columns [ps_partkey ps_supplycost ps_suppkey]}]]
+          [:rename
+           {:prefix s.8}
+           [:scan
+            {:table #xt/table supplier,
+             :columns [_id s_nationkey]}]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
@@ -1,90 +1,119 @@
 [:top
  {:skip nil, :limit 100}
  [:project
-  {:projections [{s_acctbal s.2/s_acctbal}
-   {s_name s.2/s_name}
-   {n_name n.4/n_name}
-   {p_partkey p_partkey}
-   {p_mfgr p.1/p_mfgr}
-   {s_address s.2/s_address}
-   {s_phone s.2/s_phone}
-   {s_comment s.2/s_comment}]}
+  {:projections
+   [{s_acctbal s.2/s_acctbal}
+    {s_name s.2/s_name}
+    {n_name n.4/n_name}
+    {p_partkey p_partkey}
+    {p_mfgr p.1/p_mfgr}
+    {s_address s.2/s_address}
+    {s_phone s.2/s_phone}
+    {s_comment s.2/s_comment}]}
   [:order-by
-   {:order-specs [[s.2/s_acctbal {:direction :desc, :null-ordering :nulls-first}]
-    [n.4/n_name {:direction :asc, :null-ordering :nulls-last}]
-    [s.2/s_name {:direction :asc, :null-ordering :nulls-last}]
-    [_ob13 {:direction :asc, :null-ordering :nulls-last}]]}
-   [:project
-    {:projections [s.2/s_acctbal
-     s.2/s_name
-     n.4/n_name
-     {p_partkey p.1/_id}
-     p.1/p_mfgr
-     s.2/s_address
-     s.2/s_phone
-     s.2/s_comment
-     {_ob13 p.1/_id}]}
+   {:order-specs
+    [[s.2/s_acctbal {:direction :desc, :null-ordering :nulls-first}]
+     [n.4/n_name {:direction :asc, :null-ordering :nulls-last}]
+     [s.2/s_name {:direction :asc, :null-ordering :nulls-last}]
+     [_ob13 {:direction :asc, :null-ordering :nulls-last}]]}
+   [:map
+    {:projections [{_ob13 p.1/_id}]}
     [:map
-     {:projections [{_sq_6 _min_out_12}]}
-     [:select
-      {:predicate (== ps.3/ps_supplycost _min_out_12)}
-      [:group-by
-       {:columns [p.1/_id
-        p.1/p_size
-        p.1/p_mfgr
-        p.1/p_type
-        s.2/s_comment
-        s.2/s_name
-        s.2/s_address
-        s.2/s_phone
-        s.2/_id
-        s.2/s_acctbal
-        s.2/s_nationkey
-        ps.3/ps_partkey
-        ps.3/ps_supplycost
-        ps.3/ps_suppkey
-        n.4/_id
-        n.4/n_name
-        n.4/n_regionkey
-        r.5/_id
-        r.5/r_name
-        _row_number_0
-        {_min_out_12 (min ps.7/ps_supplycost)}]}
-       [:left-outer-join
-        {:conditions [{p.1/_id ps.7/ps_partkey}]}
-        [:map
-         {:projections [{_row_number_0 (row-number)}]}
+     {:projections [{p_partkey p.1/_id}]}
+     [:map
+      {:projections [{_sq_6 _min_out_12}]}
+      [:select
+       {:predicate (== ps.3/ps_supplycost _min_out_12)}
+       [:group-by
+        {:columns
+         [p.1/_id
+          p.1/p_size
+          p.1/p_mfgr
+          p.1/p_type
+          s.2/s_comment
+          s.2/s_name
+          s.2/s_address
+          s.2/s_phone
+          s.2/_id
+          s.2/s_acctbal
+          s.2/s_nationkey
+          ps.3/ps_partkey
+          ps.3/ps_supplycost
+          ps.3/ps_suppkey
+          n.4/_id
+          n.4/n_name
+          n.4/n_regionkey
+          r.5/_id
+          r.5/r_name
+          _row_number_0
+          {_min_out_12 (min ps.7/ps_supplycost)}]}
+        [:left-outer-join
+         {:conditions [{p.1/_id ps.7/ps_partkey}]}
+         [:map
+          {:projections [{_row_number_0 (row-number)}]}
+          [:mega-join
+           {:conditions
+            [{n.4/n_regionkey r.5/_id}
+             {s.2/s_nationkey n.4/_id}
+             {p.1/_id ps.3/ps_partkey}
+             {s.2/_id ps.3/ps_suppkey}]}
+           [[:rename
+             {:prefix r.5}
+             [:scan
+              {:table #xt/table region,
+               :columns [_id {r_name (== r_name "EUROPE")}]}]]
+            [:rename
+             {:prefix n.4}
+             [:scan
+              {:table #xt/table nation,
+               :columns [_id n_name n_regionkey]}]]
+            [:rename
+             {:prefix ps.3}
+             [:scan
+              {:table #xt/table partsupp,
+               :columns [ps_partkey ps_supplycost ps_suppkey]}]]
+            [:rename
+             {:prefix p.1}
+             [:scan
+              {:table #xt/table part,
+               :columns
+               [_id
+                {p_size (== p_size 15)}
+                p_mfgr
+                {p_type (like p_type "%BRASS")}]}]]
+            [:rename
+             {:prefix s.2}
+             [:scan
+              {:table #xt/table supplier,
+               :columns
+               [s_comment
+                s_name
+                s_address
+                s_phone
+                _id
+                s_acctbal
+                s_nationkey]}]]]]]
          [:mega-join
-          {:conditions [{n.4/n_regionkey r.5/_id}
-           {s.2/s_nationkey n.4/_id}
-           {p.1/_id ps.3/ps_partkey}
-           {s.2/_id ps.3/ps_suppkey}]}
-          [[:rename {:prefix r.5} [:scan
-             {:table #xt/table region, :columns [_id {r_name (== r_name "EUROPE")}]}]]
-           [:rename {:prefix n.4} [:scan {:table #xt/table nation, :columns [_id n_name n_regionkey]}]]
-           [:rename {:prefix ps.3} [:scan
-             {:table #xt/table partsupp, :columns [ps_partkey ps_supplycost ps_suppkey]}]]
-           [:rename {:prefix p.1} [:scan
-             {:table #xt/table part, :columns [_id
-              {p_size (== p_size 15)}
-              p_mfgr
-              {p_type (like p_type "%BRASS")}]}]]
-           [:rename {:prefix s.2} [:scan
-             {:table #xt/table supplier, :columns [s_comment
-              s_name
-              s_address
-              s_phone
-              _id
-              s_acctbal
-              s_nationkey]}]]]]]
-        [:mega-join
-         {:conditions [{n.9/n_regionkey r.10/_id}
-          {s.8/s_nationkey n.9/_id}
-          {ps.7/ps_suppkey s.8/_id}]}
-         [[:rename {:prefix r.10} [:scan
-            {:table #xt/table region, :columns [_id {r_name (== r_name "EUROPE")}]}]]
-          [:rename {:prefix n.9} [:scan {:table #xt/table nation, :columns [_id n_regionkey]}]]
-          [:rename {:prefix ps.7} [:scan
-            {:table #xt/table partsupp, :columns [ps_partkey ps_supplycost ps_suppkey]}]]
-          [:rename {:prefix s.8} [:scan
-            {:table #xt/table supplier, :columns [_id s_nationkey]}]]]]]]]]]]]]
+          {:conditions
+           [{n.9/n_regionkey r.10/_id}
+            {s.8/s_nationkey n.9/_id}
+            {ps.7/ps_suppkey s.8/_id}]}
+          [[:rename
+            {:prefix r.10}
+            [:scan
+             {:table #xt/table region,
+              :columns [_id {r_name (== r_name "EUROPE")}]}]]
+           [:rename
+            {:prefix n.9}
+            [:scan
+             {:table #xt/table nation, :columns [_id n_regionkey]}]]
+           [:rename
+            {:prefix ps.7}
+            [:scan
+             {:table #xt/table partsupp,
+              :columns [ps_partkey ps_supplycost ps_suppkey]}]]
+           [:rename
+            {:prefix s.8}
+            [:scan
+             {:table #xt/table supplier,
+              :columns [_id s_nationkey]}]]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q03.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q03.edn
@@ -1,36 +1,49 @@
 [:top
  {:skip nil, :limit 10}
  [:project
-  {:projections [{l_orderkey l.3/l_orderkey}
-   revenue
-   {o_orderdate o.2/o_orderdate}
-   {o_shippriority o.2/o_shippriority}]}
+  {:projections
+   [{l_orderkey l.3/l_orderkey}
+    {revenue revenue}
+    {o_orderdate o.2/o_orderdate}
+    {o_shippriority o.2/o_shippriority}]}
   [:order-by
-   {:order-specs [[revenue {:direction :desc, :null-ordering :nulls-first}]
-    [o.2/o_orderdate {:direction :asc, :null-ordering :nulls-last}]]}
-   [:project
-    {:projections [l.3/l_orderkey
-     {revenue _sum_out_4}
-     o.2/o_orderdate
-     o.2/o_shippriority]}
+   {:order-specs
+    [[revenue {:direction :desc, :null-ordering :nulls-first}]
+     [o.2/o_orderdate {:direction :asc, :null-ordering :nulls-last}]]}
+   [:map
+    {:projections [{revenue _sum_out_4}]}
     [:group-by
-     {:columns [l.3/l_orderkey
-      o.2/o_orderdate
-      o.2/o_shippriority
-      {_sum_out_4 (sum _sum_in_5)}]}
+     {:columns
+      [l.3/l_orderkey
+       o.2/o_orderdate
+       o.2/o_shippriority
+       {_sum_out_4 (sum _sum_in_5)}]}
      [:map
-      {:projections [{_sum_in_5 (* l.3/l_extendedprice (- 1 l.3/l_discount))}]}
+      {:projections
+       [{_sum_in_5 (* l.3/l_extendedprice (- 1 l.3/l_discount))}]}
       [:mega-join
        {:conditions [{o.2/_id l.3/l_orderkey} {c.1/_id o.2/o_custkey}]}
-       [[:rename {:prefix l.3} [:scan
-          {:table #xt/table lineitem, :columns [l_orderkey
-           {l_shipdate (> l_shipdate #xt/date "1995-03-15")}
-           l_extendedprice
-           l_discount]}]]
-        [:rename {:prefix c.1} [:scan
-          {:table #xt/table customer, :columns [_id {c_mktsegment (== c_mktsegment "BUILDING")}]}]]
-        [:rename {:prefix o.2} [:scan
-          {:table #xt/table orders, :columns [_id
-           {o_orderdate (< o_orderdate #xt/date "1995-03-15")}
-           o_shippriority
-           o_custkey]}]]]]]]]]]]
+       [[:rename
+         {:prefix l.3}
+         [:scan
+          {:table #xt/table lineitem,
+           :columns
+           [l_orderkey
+            {l_shipdate (> l_shipdate #xt/date "1995-03-15")}
+            l_extendedprice
+            l_discount]}]]
+        [:rename
+         {:prefix c.1}
+         [:scan
+          {:table #xt/table customer,
+           :columns
+           [_id {c_mktsegment (== c_mktsegment "BUILDING")}]}]]
+        [:rename
+         {:prefix o.2}
+         [:scan
+          {:table #xt/table orders,
+           :columns
+           [_id
+            {o_orderdate (< o_orderdate #xt/date "1995-03-15")}
+            o_shippriority
+            o_custkey]}]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q04.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q04.edn
@@ -1,61 +1,73 @@
 [:project
- {:projections [{o_orderpriority o.1/o_orderpriority} order_count]}
+ {:projections
+  [{o_orderpriority o.1/o_orderpriority} {order_count order_count}]}
  [:order-by
-  {:order-specs [[o.1/o_orderpriority {:direction :asc, :null-ordering :nulls-last}]]}
-  [:project
-   {:projections [o.1/o_orderpriority {order_count _row_count_5}]}
+  {:order-specs
+   [[o.1/o_orderpriority
+     {:direction :asc, :null-ordering :nulls-last}]]}
+  [:map
+   {:projections [{order_count _row_count_5}]}
    [:group-by
     {:columns [o.1/o_orderpriority {_row_count_5 (row-count)}]}
     [:map
      {:projections [{_sq_2 true}]}
      [:semi-join
       {:conditions [{o.1/_id l_orderkey}]}
-      [:rename {:prefix o.1} [:scan
-        {:table #xt/table orders, :columns [o_orderpriority
-         _id
-         {o_orderdate
-          (and
-           (<
-            o_orderdate
-            (+
-             #xt/date "1993-07-01"
-             (single-field-interval "3" "MONTH" 2 6)))
-           (>= o_orderdate #xt/date "1993-07-01"))}]}]]
+      [:rename
+       {:prefix o.1}
+       [:scan
+        {:table #xt/table orders,
+         :columns
+         [o_orderpriority
+          _id
+          {o_orderdate
+           (and
+            (<
+             o_orderdate
+             (+
+              #xt/date "1993-07-01"
+              (single-field-interval "3" "MONTH" 2 6)))
+            (>= o_orderdate #xt/date "1993-07-01"))}]}]]
       [:project
-       {:projections [{_id l.3/_id}
-        {l_comment l.3/l_comment}
-        {l_commitdate l.3/l_commitdate}
-        {l_discount l.3/l_discount}
-        {l_extendedprice l.3/l_extendedprice}
-        {l_linenumber l.3/l_linenumber}
-        {l_linestatus l.3/l_linestatus}
-        {l_orderkey l.3/l_orderkey}
-        {l_partkey l.3/l_partkey}
-        {l_quantity l.3/l_quantity}
-        {l_receiptdate l.3/l_receiptdate}
-        {l_returnflag l.3/l_returnflag}
-        {l_shipdate l.3/l_shipdate}
-        {l_shipinstruct l.3/l_shipinstruct}
-        {l_shipmode l.3/l_shipmode}
-        {l_suppkey l.3/l_suppkey}
-        {l_tax l.3/l_tax}]}
-       [:rename {:prefix l.3} [:select
+       {:projections
+        [{_id l.3/_id}
+         {l_comment l.3/l_comment}
+         {l_commitdate l.3/l_commitdate}
+         {l_discount l.3/l_discount}
+         {l_extendedprice l.3/l_extendedprice}
+         {l_linenumber l.3/l_linenumber}
+         {l_linestatus l.3/l_linestatus}
+         {l_orderkey l.3/l_orderkey}
+         {l_partkey l.3/l_partkey}
+         {l_quantity l.3/l_quantity}
+         {l_receiptdate l.3/l_receiptdate}
+         {l_returnflag l.3/l_returnflag}
+         {l_shipdate l.3/l_shipdate}
+         {l_shipinstruct l.3/l_shipinstruct}
+         {l_shipmode l.3/l_shipmode}
+         {l_suppkey l.3/l_suppkey}
+         {l_tax l.3/l_tax}]}
+       [:rename
+        {:prefix l.3}
+        [:select
          {:predicate (< l_commitdate l_receiptdate)}
          [:scan
-          {:table #xt/table lineitem, :columns [l_linestatus
-           l_receiptdate
-           l_commitdate
-           l_tax
-           l_orderkey
-           l_shipdate
-           l_comment
-           _id
-           l_returnflag
-           l_extendedprice
-           l_linenumber
-           l_quantity
-           l_shipinstruct
-           l_suppkey
-           l_shipmode
-           l_discount
-           l_partkey]}]]]]]]]]]]
+          {:table #xt/table lineitem,
+           :columns
+           [l_linestatus
+            l_receiptdate
+            l_commitdate
+            l_tax
+            l_orderkey
+            l_shipdate
+            l_comment
+            _id
+            l_returnflag
+            l_extendedprice
+            l_linenumber
+            l_quantity
+            l_shipinstruct
+            l_suppkey
+            l_shipmode
+            l_discount
+            l_partkey]}]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q05.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q05.edn
@@ -1,35 +1,57 @@
 [:project
- {:projections [{n_name n.5/n_name} revenue]}
+ {:projections [{n_name n.5/n_name} {revenue revenue}]}
  [:order-by
-  {:order-specs [[revenue {:direction :desc, :null-ordering :nulls-first}]]}
-  [:project
-   {:projections [n.5/n_name {revenue _sum_out_7}]}
+  {:order-specs
+   [[revenue {:direction :desc, :null-ordering :nulls-first}]]}
+  [:map
+   {:projections [{revenue _sum_out_7}]}
    [:group-by
     {:columns [n.5/n_name {_sum_out_7 (sum _sum_in_8)}]}
     [:map
-     {:projections [{_sum_in_8 (* l.3/l_extendedprice (- 1 l.3/l_discount))}]}
+     {:projections
+      [{_sum_in_8 (* l.3/l_extendedprice (- 1 l.3/l_discount))}]}
      [:mega-join
-      {:conditions [{n.5/n_regionkey r.6/_id}
-       {s.4/s_nationkey n.5/_id}
-       {l.3/l_suppkey s.4/_id}
-       {c.1/c_nationkey s.4/s_nationkey}
-       {o.2/_id l.3/l_orderkey}
-       {c.1/_id o.2/o_custkey}]}
-      [[:rename {:prefix r.6} [:scan
-         {:table #xt/table region, :columns [_id {r_name (== r_name "ASIA")}]}]]
-       [:rename {:prefix n.5} [:scan {:table #xt/table nation, :columns [_id n_name n_regionkey]}]]
-       [:rename {:prefix s.4} [:scan {:table #xt/table supplier, :columns [_id s_nationkey]}]]
-       [:rename {:prefix l.3} [:scan
-         {:table #xt/table lineitem, :columns [l_orderkey l_extendedprice l_suppkey l_discount]}]]
-       [:rename {:prefix c.1} [:scan {:table #xt/table customer, :columns [c_nationkey _id]}]]
-       [:rename {:prefix o.2} [:scan
-         {:table #xt/table orders, :columns [_id
-          {o_orderdate
-           (and
-            (<
-             o_orderdate
-             (+
-              #xt/date "1994-01-01"
-              (single-field-interval "1" "YEAR" 2 6)))
-            (>= o_orderdate #xt/date "1994-01-01"))}
-          o_custkey]}]]]]]]]]]
+      {:conditions
+       [{n.5/n_regionkey r.6/_id}
+        {s.4/s_nationkey n.5/_id}
+        {l.3/l_suppkey s.4/_id}
+        {c.1/c_nationkey s.4/s_nationkey}
+        {o.2/_id l.3/l_orderkey}
+        {c.1/_id o.2/o_custkey}]}
+      [[:rename
+        {:prefix r.6}
+        [:scan
+         {:table #xt/table region,
+          :columns [_id {r_name (== r_name "ASIA")}]}]]
+       [:rename
+        {:prefix n.5}
+        [:scan
+         {:table #xt/table nation, :columns [_id n_name n_regionkey]}]]
+       [:rename
+        {:prefix s.4}
+        [:scan
+         {:table #xt/table supplier, :columns [_id s_nationkey]}]]
+       [:rename
+        {:prefix l.3}
+        [:scan
+         {:table #xt/table lineitem,
+          :columns [l_orderkey l_extendedprice l_suppkey l_discount]}]]
+       [:rename
+        {:prefix c.1}
+        [:scan
+         {:table #xt/table customer, :columns [c_nationkey _id]}]]
+       [:rename
+        {:prefix o.2}
+        [:scan
+         {:table #xt/table orders,
+          :columns
+          [_id
+           {o_orderdate
+            (and
+             (<
+              o_orderdate
+              (+
+               #xt/date "1994-01-01"
+               (single-field-interval "1" "YEAR" 2 6)))
+             (>= o_orderdate #xt/date "1994-01-01"))}
+           o_custkey]}]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q06.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q06.edn
@@ -4,15 +4,19 @@
   {:columns [{_sum_out_2 (sum _sum_in_3)}]}
   [:map
    {:projections [{_sum_in_3 (* l.1/l_extendedprice l.1/l_discount)}]}
-   [:rename {:prefix l.1} [:scan
-     {:table #xt/table lineitem, :columns [{l_shipdate
-       (and
-        (<
-         l_shipdate
-         (+
-          #xt/date "1994-01-01"
-          (single-field-interval "1" "YEAR" 2 6)))
-        (>= l_shipdate #xt/date "1994-01-01"))}
-      l_extendedprice
-      {l_quantity (< l_quantity 24)}
-      {l_discount (between l_discount 0.05 0.07)}]}]]]]]
+   [:rename
+    {:prefix l.1}
+    [:scan
+     {:table #xt/table lineitem,
+      :columns
+      [{l_shipdate
+        (and
+         (<
+          l_shipdate
+          (+
+           #xt/date "1994-01-01"
+           (single-field-interval "1" "YEAR" 2 6)))
+         (>= l_shipdate #xt/date "1994-01-01"))}
+       l_extendedprice
+       {l_quantity (< l_quantity 24)}
+       {l_discount (between l_discount 0.05 0.07)}]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q07.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q07.edn
@@ -1,50 +1,70 @@
 [:project
- {:projections [{supp_nation shipping.7/supp_nation}
-  {cust_nation shipping.7/cust_nation}
-  {l_year shipping.7/l_year}
-  revenue]}
+ {:projections
+  [{supp_nation shipping.7/supp_nation}
+   {cust_nation shipping.7/cust_nation}
+   {l_year shipping.7/l_year}
+   {revenue revenue}]}
  [:order-by
-  {:order-specs [[shipping.7/supp_nation
-    {:direction :asc, :null-ordering :nulls-last}]
-   [shipping.7/cust_nation
-    {:direction :asc, :null-ordering :nulls-last}]
-   [shipping.7/l_year {:direction :asc, :null-ordering :nulls-last}]]}
-  [:project
-   {:projections [shipping.7/supp_nation
-    shipping.7/cust_nation
-    shipping.7/l_year
-    {revenue _sum_out_8}]}
+  {:order-specs
+   [[shipping.7/supp_nation
+     {:direction :asc, :null-ordering :nulls-last}]
+    [shipping.7/cust_nation
+     {:direction :asc, :null-ordering :nulls-last}]
+    [shipping.7/l_year {:direction :asc, :null-ordering :nulls-last}]]}
+  [:map
+   {:projections [{revenue _sum_out_8}]}
    [:group-by
-    {:columns [shipping.7/supp_nation
-     shipping.7/cust_nation
-     shipping.7/l_year
-     {_sum_out_8 (sum shipping.7/volume)}]}
-    [:rename {:prefix shipping.7} [:project
-      {:projections [{supp_nation n1.5/n_name}
-       {cust_nation n2.6/n_name}
-       {l_year (extract "YEAR" l.2/l_shipdate)}
-       {volume (* l.2/l_extendedprice (- 1 l.2/l_discount))}]}
+    {:columns
+     [shipping.7/supp_nation
+      shipping.7/cust_nation
+      shipping.7/l_year
+      {_sum_out_8 (sum shipping.7/volume)}]}
+    [:rename
+     {:prefix shipping.7}
+     [:project
+      {:projections
+       [{supp_nation n1.5/n_name}
+        {cust_nation n2.6/n_name}
+        {l_year (extract "YEAR" l.2/l_shipdate)}
+        {volume (* l.2/l_extendedprice (- 1 l.2/l_discount))}]}
       [:mega-join
-       {:conditions [{c.4/c_nationkey n2.6/_id}
-        (or
-         (and (== n1.5/n_name "FRANCE") (== n2.6/n_name "GERMANY"))
-         (and (== n1.5/n_name "GERMANY") (== n2.6/n_name "FRANCE")))
-        {s.1/s_nationkey n1.5/_id}
-        {o.3/o_custkey c.4/_id}
-        {l.2/l_orderkey o.3/_id}
-        {s.1/_id l.2/l_suppkey}]}
-       [[:rename {:prefix n2.6} [:scan {:table #xt/table nation, :columns [_id n_name]}]]
-        [:rename {:prefix n1.5} [:scan {:table #xt/table nation, :columns [_id n_name]}]]
-        [:rename {:prefix c.4} [:scan {:table #xt/table customer, :columns [c_nationkey _id]}]]
-        [:rename {:prefix o.3} [:scan {:table #xt/table orders, :columns [_id o_custkey]}]]
-        [:rename {:prefix s.1} [:scan {:table #xt/table supplier, :columns [_id s_nationkey]}]]
-        [:rename {:prefix l.2} [:scan
-          {:table #xt/table lineitem, :columns [l_orderkey
-           {l_shipdate
-            (between
-             l_shipdate
-             #xt/date "1995-01-01"
-             #xt/date "1996-12-31")}
-           l_extendedprice
-           l_suppkey
-           l_discount]}]]]]]]]]]]
+       {:conditions
+        [{c.4/c_nationkey n2.6/_id}
+         (or
+          (and (== n1.5/n_name "FRANCE") (== n2.6/n_name "GERMANY"))
+          (and (== n1.5/n_name "GERMANY") (== n2.6/n_name "FRANCE")))
+         {s.1/s_nationkey n1.5/_id}
+         {o.3/o_custkey c.4/_id}
+         {l.2/l_orderkey o.3/_id}
+         {s.1/_id l.2/l_suppkey}]}
+       [[:rename
+         {:prefix n2.6}
+         [:scan {:table #xt/table nation, :columns [_id n_name]}]]
+        [:rename
+         {:prefix n1.5}
+         [:scan {:table #xt/table nation, :columns [_id n_name]}]]
+        [:rename
+         {:prefix c.4}
+         [:scan
+          {:table #xt/table customer, :columns [c_nationkey _id]}]]
+        [:rename
+         {:prefix o.3}
+         [:scan {:table #xt/table orders, :columns [_id o_custkey]}]]
+        [:rename
+         {:prefix s.1}
+         [:scan
+          {:table #xt/table supplier, :columns [_id s_nationkey]}]]
+        [:rename
+         {:prefix l.2}
+         [:scan
+          {:table #xt/table lineitem,
+           :columns
+           [l_orderkey
+            {l_shipdate
+             (between
+              l_shipdate
+              #xt/date "1995-01-01"
+              #xt/date "1996-12-31")}
+            l_extendedprice
+            l_suppkey
+            l_discount]}]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q08.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q08.edn
@@ -1,52 +1,85 @@
 [:project
- {:projections [{o_year all_nations.9/o_year} mkt_share]}
+ {:projections [{o_year all_nations.9/o_year} {mkt_share mkt_share}]}
  [:order-by
-  {:order-specs [[all_nations.9/o_year
-    {:direction :asc, :null-ordering :nulls-last}]]}
-  [:project
-   {:projections [all_nations.9/o_year {mkt_share (/ _sum_out_10 _sum_out_12)}]}
+  {:order-specs
+   [[all_nations.9/o_year
+     {:direction :asc, :null-ordering :nulls-last}]]}
+  [:map
+   {:projections [{mkt_share (/ _sum_out_10 _sum_out_12)}]}
    [:group-by
-    {:columns [all_nations.9/o_year
-     {_sum_out_10 (sum _sum_in_11)}
-     {_sum_out_12 (sum all_nations.9/volume)}]}
+    {:columns
+     [all_nations.9/o_year
+      {_sum_out_10 (sum _sum_in_11)}
+      {_sum_out_12 (sum all_nations.9/volume)}]}
     [:map
-     {:projections [{_sum_in_11
-       (cond
-        (== all_nations.9/nation "BRAZIL")
-        all_nations.9/volume
-        0)}]}
-     [:rename {:prefix all_nations.9} [:project
-       {:projections [{o_year (extract "YEAR" o.4/o_orderdate)}
-        {volume (* l.3/l_extendedprice (- 1 l.3/l_discount))}
-        {nation n2.7/n_name}]}
+     {:projections
+      [{_sum_in_11
+        (cond
+         (== all_nations.9/nation "BRAZIL")
+         all_nations.9/volume
+         0)}]}
+     [:rename
+      {:prefix all_nations.9}
+      [:project
+       {:projections
+        [{o_year (extract "YEAR" o.4/o_orderdate)}
+         {volume (* l.3/l_extendedprice (- 1 l.3/l_discount))}
+         {nation n2.7/n_name}]}
        [:mega-join
-        {:conditions [{n1.6/n_regionkey r.8/_id}
-         {s.2/s_nationkey n2.7/_id}
-         {c.5/c_nationkey n1.6/_id}
-         {o.4/o_custkey c.5/_id}
-         {l.3/l_orderkey o.4/_id}
-         {p.1/_id l.3/l_partkey}
-         {s.2/_id l.3/l_suppkey}]}
-        [[:rename {:prefix r.8} [:scan
-           {:table #xt/table region, :columns [_id {r_name (== r_name "AMERICA")}]}]]
-         [:rename {:prefix n2.7} [:scan {:table #xt/table nation, :columns [_id n_name]}]]
-         [:rename {:prefix n1.6} [:scan {:table #xt/table nation, :columns [_id n_regionkey]}]]
-         [:rename {:prefix c.5} [:scan {:table #xt/table customer, :columns [c_nationkey _id]}]]
-         [:rename {:prefix o.4} [:scan
-           {:table #xt/table orders, :columns [_id
-            {o_orderdate
-             (between
-              o_orderdate
-              #xt/date "1995-01-01"
-              #xt/date "1996-12-31")}
-            o_custkey]}]]
-         [:rename {:prefix l.3} [:scan
-           {:table #xt/table lineitem, :columns [l_orderkey
-            l_extendedprice
-            l_suppkey
-            l_discount
-            l_partkey]}]]
-         [:rename {:prefix p.1} [:scan
-           {:table #xt/table part, :columns [_id {p_type (== p_type "ECONOMY ANODIZED STEEL")}]}]]
-         [:rename {:prefix s.2} [:scan
-           {:table #xt/table supplier, :columns [_id s_nationkey]}]]]]]]]]]]]
+        {:conditions
+         [{n1.6/n_regionkey r.8/_id}
+          {s.2/s_nationkey n2.7/_id}
+          {c.5/c_nationkey n1.6/_id}
+          {o.4/o_custkey c.5/_id}
+          {l.3/l_orderkey o.4/_id}
+          {p.1/_id l.3/l_partkey}
+          {s.2/_id l.3/l_suppkey}]}
+        [[:rename
+          {:prefix r.8}
+          [:scan
+           {:table #xt/table region,
+            :columns [_id {r_name (== r_name "AMERICA")}]}]]
+         [:rename
+          {:prefix n2.7}
+          [:scan {:table #xt/table nation, :columns [_id n_name]}]]
+         [:rename
+          {:prefix n1.6}
+          [:scan
+           {:table #xt/table nation, :columns [_id n_regionkey]}]]
+         [:rename
+          {:prefix c.5}
+          [:scan
+           {:table #xt/table customer, :columns [c_nationkey _id]}]]
+         [:rename
+          {:prefix o.4}
+          [:scan
+           {:table #xt/table orders,
+            :columns
+            [_id
+             {o_orderdate
+              (between
+               o_orderdate
+               #xt/date "1995-01-01"
+               #xt/date "1996-12-31")}
+             o_custkey]}]]
+         [:rename
+          {:prefix l.3}
+          [:scan
+           {:table #xt/table lineitem,
+            :columns
+            [l_orderkey
+             l_extendedprice
+             l_suppkey
+             l_discount
+             l_partkey]}]]
+         [:rename
+          {:prefix p.1}
+          [:scan
+           {:table #xt/table part,
+            :columns
+            [_id {p_type (== p_type "ECONOMY ANODIZED STEEL")}]}]]
+         [:rename
+          {:prefix s.2}
+          [:scan
+           {:table #xt/table supplier,
+            :columns [_id s_nationkey]}]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q09.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q09.edn
@@ -1,39 +1,66 @@
 [:project
- {:projections [{nation profit.7/nation} {o_year profit.7/o_year} sum_profit]}
+ {:projections
+  [{nation profit.7/nation}
+   {o_year profit.7/o_year}
+   {sum_profit sum_profit}]}
  [:order-by
-  {:order-specs [[profit.7/nation {:direction :asc, :null-ordering :nulls-last}]
-   [profit.7/o_year {:direction :desc, :null-ordering :nulls-first}]]}
-  [:project
-   {:projections [profit.7/nation profit.7/o_year {sum_profit _sum_out_8}]}
+  {:order-specs
+   [[profit.7/nation {:direction :asc, :null-ordering :nulls-last}]
+    [profit.7/o_year {:direction :desc, :null-ordering :nulls-first}]]}
+  [:map
+   {:projections [{sum_profit _sum_out_8}]}
    [:group-by
-    {:columns [profit.7/nation
-     profit.7/o_year
-     {_sum_out_8 (sum profit.7/amount)}]}
-    [:rename {:prefix profit.7} [:project
-      {:projections [{nation n.6/n_name}
-       {o_year (extract "YEAR" o.5/o_orderdate)}
-       {amount
-        (-
-         (* l.3/l_extendedprice (- 1 l.3/l_discount))
-         (* ps.4/ps_supplycost l.3/l_quantity))}]}
+    {:columns
+     [profit.7/nation
+      profit.7/o_year
+      {_sum_out_8 (sum profit.7/amount)}]}
+    [:rename
+     {:prefix profit.7}
+     [:project
+      {:projections
+       [{nation n.6/n_name}
+        {o_year (extract "YEAR" o.5/o_orderdate)}
+        {amount
+         (-
+          (* l.3/l_extendedprice (- 1 l.3/l_discount))
+          (* ps.4/ps_supplycost l.3/l_quantity))}]}
       [:mega-join
-       {:conditions [{s.2/s_nationkey n.6/_id}
-        {l.3/l_orderkey o.5/_id}
-        {l.3/l_suppkey ps.4/ps_suppkey}
-        {l.3/l_partkey ps.4/ps_partkey}
-        {s.2/_id l.3/l_suppkey}
-        {p.1/_id l.3/l_partkey}]}
-       [[:rename {:prefix n.6} [:scan {:table #xt/table nation, :columns [_id n_name]}]]
-        [:rename {:prefix o.5} [:scan {:table #xt/table orders, :columns [_id o_orderdate]}]]
-        [:rename {:prefix ps.4} [:scan
-          {:table #xt/table partsupp, :columns [ps_partkey ps_supplycost ps_suppkey]}]]
-        [:rename {:prefix l.3} [:scan
-          {:table #xt/table lineitem, :columns [l_orderkey
-           l_extendedprice
-           l_quantity
-           l_suppkey
-           l_discount
-           l_partkey]}]]
-        [:rename {:prefix p.1} [:scan
-          {:table #xt/table part, :columns [_id {p_name (like p_name "%green%")}]}]]
-        [:rename {:prefix s.2} [:scan {:table #xt/table supplier, :columns [_id s_nationkey]}]]]]]]]]]]
+       {:conditions
+        [{s.2/s_nationkey n.6/_id}
+         {l.3/l_orderkey o.5/_id}
+         {l.3/l_suppkey ps.4/ps_suppkey}
+         {l.3/l_partkey ps.4/ps_partkey}
+         {s.2/_id l.3/l_suppkey}
+         {p.1/_id l.3/l_partkey}]}
+       [[:rename
+         {:prefix n.6}
+         [:scan {:table #xt/table nation, :columns [_id n_name]}]]
+        [:rename
+         {:prefix o.5}
+         [:scan {:table #xt/table orders, :columns [_id o_orderdate]}]]
+        [:rename
+         {:prefix ps.4}
+         [:scan
+          {:table #xt/table partsupp,
+           :columns [ps_partkey ps_supplycost ps_suppkey]}]]
+        [:rename
+         {:prefix l.3}
+         [:scan
+          {:table #xt/table lineitem,
+           :columns
+           [l_orderkey
+            l_extendedprice
+            l_quantity
+            l_suppkey
+            l_discount
+            l_partkey]}]]
+        [:rename
+         {:prefix p.1}
+         [:scan
+          {:table #xt/table part,
+           :columns [_id {p_name (like p_name "%green%")}]}]]
+        [:rename
+         {:prefix s.2}
+         [:scan
+          {:table #xt/table supplier,
+           :columns [_id s_nationkey]}]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q10.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q10.edn
@@ -1,62 +1,74 @@
 [:top
  {:skip nil, :limit 20}
  [:project
-  {:projections [c_custkey
-   {c_name c.1/c_name}
-   revenue
-   {c_acctbal c.1/c_acctbal}
-   {n_name n.4/n_name}
-   {c_address c.1/c_address}
-   {c_phone c.1/c_phone}
-   {c_comment c.1/c_comment}]}
+  {:projections
+   [{c_custkey c_custkey}
+    {c_name c.1/c_name}
+    {revenue revenue}
+    {c_acctbal c.1/c_acctbal}
+    {n_name n.4/n_name}
+    {c_address c.1/c_address}
+    {c_phone c.1/c_phone}
+    {c_comment c.1/c_comment}]}
   [:order-by
-   {:order-specs [[revenue {:direction :desc, :null-ordering :nulls-first}]]}
-   [:project
-    {:projections [{c_custkey c.1/_id}
-     c.1/c_name
-     {revenue _sum_out_5}
-     c.1/c_acctbal
-     n.4/n_name
-     c.1/c_address
-     c.1/c_phone
-     c.1/c_comment]}
+   {:order-specs
+    [[revenue {:direction :desc, :null-ordering :nulls-first}]]}
+   [:map
+    {:projections [{c_custkey c.1/_id} {revenue _sum_out_5}]}
     [:group-by
-     {:columns [n.4/n_name
-      c.1/_id
-      c.1/c_comment
-      c.1/c_acctbal
-      c.1/c_phone
-      c.1/c_name
-      c.1/c_address
-      {_sum_out_5 (sum _sum_in_6)}]}
+     {:columns
+      [n.4/n_name
+       c.1/_id
+       c.1/c_comment
+       c.1/c_acctbal
+       c.1/c_phone
+       c.1/c_name
+       c.1/c_address
+       {_sum_out_5 (sum _sum_in_6)}]}
      [:map
-      {:projections [{_sum_in_6 (* l.3/l_extendedprice (- 1 l.3/l_discount))}]}
+      {:projections
+       [{_sum_in_6 (* l.3/l_extendedprice (- 1 l.3/l_discount))}]}
       [:mega-join
-       {:conditions [{c.1/c_nationkey n.4/_id}
-        {o.2/_id l.3/l_orderkey}
-        {c.1/_id o.2/o_custkey}]}
-       [[:rename {:prefix n.4} [:scan {:table #xt/table nation, :columns [_id n_name]}]]
-        [:rename {:prefix l.3} [:scan
-          {:table #xt/table lineitem, :columns [l_orderkey
-           {l_returnflag (== l_returnflag "R")}
-           l_extendedprice
-           l_discount]}]]
-        [:rename {:prefix c.1} [:scan
-          {:table #xt/table customer, :columns [c_phone
-           c_acctbal
-           c_address
-           c_nationkey
-           _id
-           c_comment
-           c_name]}]]
-        [:rename {:prefix o.2} [:scan
-          {:table #xt/table orders, :columns [_id
-           {o_orderdate
-            (and
-             (<
-              o_orderdate
-              (+
-               #xt/date "1993-10-01"
-               (single-field-interval "3" "MONTH" 2 6)))
-             (>= o_orderdate #xt/date "1993-10-01"))}
-           o_custkey]}]]]]]]]]]]
+       {:conditions
+        [{c.1/c_nationkey n.4/_id}
+         {o.2/_id l.3/l_orderkey}
+         {c.1/_id o.2/o_custkey}]}
+       [[:rename
+         {:prefix n.4}
+         [:scan {:table #xt/table nation, :columns [_id n_name]}]]
+        [:rename
+         {:prefix l.3}
+         [:scan
+          {:table #xt/table lineitem,
+           :columns
+           [l_orderkey
+            {l_returnflag (== l_returnflag "R")}
+            l_extendedprice
+            l_discount]}]]
+        [:rename
+         {:prefix c.1}
+         [:scan
+          {:table #xt/table customer,
+           :columns
+           [c_phone
+            c_acctbal
+            c_address
+            c_nationkey
+            _id
+            c_comment
+            c_name]}]]
+        [:rename
+         {:prefix o.2}
+         [:scan
+          {:table #xt/table orders,
+           :columns
+           [_id
+            {o_orderdate
+             (and
+              (<
+               o_orderdate
+               (+
+                #xt/date "1993-10-01"
+                (single-field-interval "3" "MONTH" 2 6)))
+              (>= o_orderdate #xt/date "1993-10-01"))}
+            o_custkey]}]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q11.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q11.edn
@@ -1,38 +1,64 @@
 [:project
- {:projections [{ps_partkey ps.1/ps_partkey} value]}
+ {:projections [{ps_partkey ps.1/ps_partkey} {value value}]}
  [:order-by
-  {:order-specs [[value {:direction :desc, :null-ordering :nulls-first}]]}
-  [:project
-   {:projections [ps.1/ps_partkey {value _sum_out_12}]}
+  {:order-specs
+   [[value {:direction :desc, :null-ordering :nulls-first}]]}
+  [:map
+   {:projections [{value _sum_out_12}]}
    [:select
     {:predicate (> _sum_out_4 _sq_6)}
     [:single-join
      {:conditions []}
      [:group-by
-      {:columns [ps.1/ps_partkey
-       {_sum_out_12 (sum _sum_in_13)}
-       {_sum_out_4 (sum _sum_in_5)}]}
+      {:columns
+       [ps.1/ps_partkey
+        {_sum_out_12 (sum _sum_in_13)}
+        {_sum_out_4 (sum _sum_in_5)}]}
       [:map
-       {:projections [{_sum_in_13 (* ps.1/ps_supplycost ps.1/ps_availqty)}
-        {_sum_in_5 (* ps.1/ps_supplycost ps.1/ps_availqty)}]}
+       {:projections
+        [{_sum_in_13 (* ps.1/ps_supplycost ps.1/ps_availqty)}
+         {_sum_in_5 (* ps.1/ps_supplycost ps.1/ps_availqty)}]}
        [:mega-join
-        {:conditions [{s.2/s_nationkey n.3/_id} {ps.1/ps_suppkey s.2/_id}]}
-        [[:rename {:prefix n.3} [:scan
-           {:table #xt/table nation, :columns [_id {n_name (== n_name "GERMANY")}]}]]
-         [:rename {:prefix ps.1} [:scan
-           {:table #xt/table partsupp, :columns [ps_partkey ps_supplycost ps_availqty ps_suppkey]}]]
-         [:rename {:prefix s.2} [:scan {:table #xt/table supplier, :columns [_id s_nationkey]}]]]]]]
+        {:conditions
+         [{s.2/s_nationkey n.3/_id} {ps.1/ps_suppkey s.2/_id}]}
+        [[:rename
+          {:prefix n.3}
+          [:scan
+           {:table #xt/table nation,
+            :columns [_id {n_name (== n_name "GERMANY")}]}]]
+         [:rename
+          {:prefix ps.1}
+          [:scan
+           {:table #xt/table partsupp,
+            :columns
+            [ps_partkey ps_supplycost ps_availqty ps_suppkey]}]]
+         [:rename
+          {:prefix s.2}
+          [:scan
+           {:table #xt/table supplier,
+            :columns [_id s_nationkey]}]]]]]]
      [:project
       {:projections [{_sq_6 (* _sum_out_10 1.0E-4)}]}
       [:group-by
        {:columns [{_sum_out_10 (sum _sum_in_11)}]}
        [:map
-        {:projections [{_sum_in_11 (* ps.7/ps_supplycost ps.7/ps_availqty)}]}
+        {:projections
+         [{_sum_in_11 (* ps.7/ps_supplycost ps.7/ps_availqty)}]}
         [:mega-join
-         {:conditions [{s.8/s_nationkey n.9/_id} {ps.7/ps_suppkey s.8/_id}]}
-         [[:rename {:prefix n.9} [:scan
-            {:table #xt/table nation, :columns [_id {n_name (== n_name "GERMANY")}]}]]
-          [:rename {:prefix ps.7} [:scan
-            {:table #xt/table partsupp, :columns [ps_supplycost ps_availqty ps_suppkey]}]]
-          [:rename {:prefix s.8} [:scan
-            {:table #xt/table supplier, :columns [_id s_nationkey]}]]]]]]]]]]]]
+         {:conditions
+          [{s.8/s_nationkey n.9/_id} {ps.7/ps_suppkey s.8/_id}]}
+         [[:rename
+           {:prefix n.9}
+           [:scan
+            {:table #xt/table nation,
+             :columns [_id {n_name (== n_name "GERMANY")}]}]]
+          [:rename
+           {:prefix ps.7}
+           [:scan
+            {:table #xt/table partsupp,
+             :columns [ps_supplycost ps_availqty ps_suppkey]}]]
+          [:rename
+           {:prefix s.8}
+           [:scan
+            {:table #xt/table supplier,
+             :columns [_id s_nationkey]}]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q12.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q12.edn
@@ -1,52 +1,69 @@
 [:project
- {:projections [{l_shipmode l.2/l_shipmode} high_line_count low_line_count]}
+ {:projections
+  [{l_shipmode l.2/l_shipmode}
+   {high_line_count high_line_count}
+   {low_line_count low_line_count}]}
  [:order-by
-  {:order-specs [[l.2/l_shipmode {:direction :asc, :null-ordering :nulls-last}]]}
-  [:project
-   {:projections [l.2/l_shipmode
-    {high_line_count _sum_out_5}
-    {low_line_count _sum_out_7}]}
+  {:order-specs
+   [[l.2/l_shipmode {:direction :asc, :null-ordering :nulls-last}]]}
+  [:map
+   {:projections
+    [{high_line_count _sum_out_5} {low_line_count _sum_out_7}]}
    [:group-by
-    {:columns [l.2/l_shipmode
-     {_sum_out_7 (sum _sum_in_8)}
-     {_sum_out_5 (sum _sum_in_6)}]}
+    {:columns
+     [l.2/l_shipmode
+      {_sum_out_7 (sum _sum_in_8)}
+      {_sum_out_5 (sum _sum_in_6)}]}
     [:map
-     {:projections [{_sum_in_8
-       (cond
-        (and
-         (<> o.1/o_orderpriority "1-URGENT")
-         (<> o.1/o_orderpriority "2-HIGH"))
-        1
-        0)}
-      {_sum_in_6
-       (cond
-        (or
-         (== o.1/o_orderpriority "1-URGENT")
-         (== o.1/o_orderpriority "2-HIGH"))
-        1
-        0)}]}
+     {:projections
+      [{_sum_in_8
+        (cond
+         (and
+          (<> o.1/o_orderpriority "1-URGENT")
+          (<> o.1/o_orderpriority "2-HIGH"))
+         1
+         0)}
+       {_sum_in_6
+        (cond
+         (or
+          (== o.1/o_orderpriority "1-URGENT")
+          (== o.1/o_orderpriority "2-HIGH"))
+         1
+         0)}]}
      [:map
       {:projections [{_sq_3 true}]}
       [:mega-join
        {:conditions [{o.1/_id l.2/l_orderkey}]}
-       [[:rename {:prefix o.1} [:scan {:table #xt/table orders, :columns [o_orderpriority _id]}]]
+       [[:rename
+         {:prefix o.1}
+         [:scan
+          {:table #xt/table orders, :columns [o_orderpriority _id]}]]
         [:semi-join
          {:conditions [{l.2/l_shipmode xt.values.4/_column_1}]}
-         [:rename {:prefix l.2} [:select
-           {:predicate (and
-                        (< l_commitdate l_receiptdate)
-                        (< l_shipdate l_commitdate))}
+         [:rename
+          {:prefix l.2}
+          [:select
+           {:predicate
+            (and
+             (< l_commitdate l_receiptdate)
+             (< l_shipdate l_commitdate))}
            [:scan
-            {:table #xt/table lineitem, :columns [{l_receiptdate
-              (and
-               (<
-                l_receiptdate
-                (+
-                 #xt/date "1994-01-01"
-                 (single-field-interval "1" "YEAR" 2 6)))
-               (>= l_receiptdate #xt/date "1994-01-01"))}
-             l_commitdate
-             l_orderkey
-             l_shipdate
-             l_shipmode]}]]]
-         [:rename {:prefix xt.values.4} [:table {:output-cols [_column_1], :rows [{:_column_1 "MAIL"} {:_column_1 "SHIP"}]}]]]]]]]]]]]
+            {:table #xt/table lineitem,
+             :columns
+             [{l_receiptdate
+               (and
+                (<
+                 l_receiptdate
+                 (+
+                  #xt/date "1994-01-01"
+                  (single-field-interval "1" "YEAR" 2 6)))
+                (>= l_receiptdate #xt/date "1994-01-01"))}
+              l_commitdate
+              l_orderkey
+              l_shipdate
+              l_shipmode]}]]]
+         [:rename
+          {:prefix xt.values.4}
+          [:table
+           {:output-cols [_column_1],
+            :rows [{:_column_1 "MAIL"} {:_column_1 "SHIP"}]}]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q13.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q13.edn
@@ -1,17 +1,26 @@
-[:order-by
- {:order-specs [[custdist {:direction :desc, :null-ordering :nulls-first}]
-  [c_count {:direction :desc, :null-ordering :nulls-first}]]}
- [:project
-  {:projections [c_count {custdist _row_count_4}]}
-  [:group-by
-   {:columns [c_count {_row_count_4 (row-count)}]}
-   [:project
-    {:projections [{c_custkey c.1/_id} {c_count _count_out_3}]}
-    [:group-by
-     {:columns [c.1/_id {_count_out_3 (count o.2/_id)}]}
-     [:left-outer-join
-      {:conditions [{c.1/_id o.2/o_custkey}
-       (not (like o.2/o_comment "%special%requests%"))]}
-      [:rename {:prefix c.1} [:scan {:table #xt/table customer, :columns [_id]}]]
-      [:rename {:prefix o.2} [:scan
-        {:table #xt/table orders, :columns [_id o_comment o_custkey]}]]]]]]]]
+[:project
+ {:projections [{c_count c_count} {custdist custdist}]}
+ [:order-by
+  {:order-specs
+   [[custdist {:direction :desc, :null-ordering :nulls-first}]
+    [c_count {:direction :desc, :null-ordering :nulls-first}]]}
+  [:map
+   {:projections [{custdist _row_count_4}]}
+   [:group-by
+    {:columns [c_count {_row_count_4 (row-count)}]}
+    [:project
+     {:projections [{c_custkey c.1/_id} {c_count _count_out_3}]}
+     [:group-by
+      {:columns [c.1/_id {_count_out_3 (count o.2/_id)}]}
+      [:left-outer-join
+       {:conditions
+        [{c.1/_id o.2/o_custkey}
+         (not (like o.2/o_comment "%special%requests%"))]}
+       [:rename
+        {:prefix c.1}
+        [:scan {:table #xt/table customer, :columns [_id]}]]
+       [:rename
+        {:prefix o.2}
+        [:scan
+         {:table #xt/table orders,
+          :columns [_id o_comment o_custkey]}]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q14.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q14.edn
@@ -1,26 +1,34 @@
 [:project
  {:projections [{promo_revenue (/ (* 100.0 _sum_out_3) _sum_out_5)}]}
  [:group-by
-  {:columns [{_sum_out_5 (sum _sum_in_6)} {_sum_out_3 (sum _sum_in_4)}]}
+  {:columns
+   [{_sum_out_5 (sum _sum_in_6)} {_sum_out_3 (sum _sum_in_4)}]}
   [:map
-   {:projections [{_sum_in_6 (* l.1/l_extendedprice (- 1 l.1/l_discount))}
-    {_sum_in_4
-     (cond
-      (like p.2/p_type "PROMO%")
-      (* l.1/l_extendedprice (- 1 l.1/l_discount))
-      0)}]}
+   {:projections
+    [{_sum_in_6 (* l.1/l_extendedprice (- 1 l.1/l_discount))}
+     {_sum_in_4
+      (cond
+       (like p.2/p_type "PROMO%")
+       (* l.1/l_extendedprice (- 1 l.1/l_discount))
+       0)}]}
    [:mega-join
     {:conditions [{l.1/l_partkey p.2/_id}]}
-    [[:rename {:prefix l.1} [:scan
-       {:table #xt/table lineitem, :columns [{l_shipdate
-         (and
-          (<
-           l_shipdate
-           (+
-            #xt/date "1995-09-01"
-            (single-field-interval "1" "MONTH" 2 6)))
-          (>= l_shipdate #xt/date "1995-09-01"))}
-        l_extendedprice
-        l_discount
-        l_partkey]}]]
-     [:rename {:prefix p.2} [:scan {:table #xt/table part, :columns [_id p_type]}]]]]]]]
+    [[:rename
+      {:prefix l.1}
+      [:scan
+       {:table #xt/table lineitem,
+        :columns
+        [{l_shipdate
+          (and
+           (<
+            l_shipdate
+            (+
+             #xt/date "1995-09-01"
+             (single-field-interval "1" "MONTH" 2 6)))
+           (>= l_shipdate #xt/date "1995-09-01"))}
+         l_extendedprice
+         l_discount
+         l_partkey]}]]
+     [:rename
+      {:prefix p.2}
+      [:scan {:table #xt/table part, :columns [_id p_type]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q15.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q15.edn
@@ -33,33 +33,31 @@
     {total_revenue revenue.6/total_revenue}]}
   [:order-by
    {:order-specs
-    [[_ob10 {:direction :asc, :null-ordering :nulls-last}]]}
+    [[s_suppkey {:direction :asc, :null-ordering :nulls-last}]]}
    [:map
-    {:projections [{_ob10 s.5/_id}]}
-    [:map
-     {:projections [{s_suppkey s.5/_id}]}
-     [:select
-      {:predicate (== revenue.6/total_revenue _sq_7)}
-      [:single-join
-       {:conditions []}
-       [:mega-join
-        {:conditions [{s.5/_id revenue.6/supplier_no}]}
-        [[:rename
-          {:prefix s.5}
-          [:scan
-           {:table #xt/table supplier,
-            :columns [s_name s_address s_phone _id]}]]
-         [:rename
-          {:prefix revenue.6}
-          [:relation
-           {:cte-id revenue.4,
-            :col-names [supplier_no total_revenue]}]]]]
-       [:project
-        {:projections [{_sq_7 _max_out_9}]}
-        [:group-by
-         {:columns [{_max_out_9 (max revenue.8/total_revenue)}]}
-         [:rename
-          {:prefix revenue.8}
-          [:relation
-           {:cte-id revenue.4,
-            :col-names [supplier_no total_revenue]}]]]]]]]]]]]
+    {:projections [{s_suppkey s.5/_id}]}
+    [:select
+     {:predicate (== revenue.6/total_revenue _sq_7)}
+     [:single-join
+      {:conditions []}
+      [:mega-join
+       {:conditions [{s.5/_id revenue.6/supplier_no}]}
+       [[:rename
+         {:prefix s.5}
+         [:scan
+          {:table #xt/table supplier,
+           :columns [s_name s_address s_phone _id]}]]
+        [:rename
+         {:prefix revenue.6}
+         [:relation
+          {:cte-id revenue.4,
+           :col-names [supplier_no total_revenue]}]]]]
+      [:project
+       {:projections [{_sq_7 _max_out_9}]}
+       [:group-by
+        {:columns [{_max_out_9 (max revenue.8/total_revenue)}]}
+        [:rename
+         {:prefix revenue.8}
+         [:relation
+          {:cte-id revenue.4,
+           :col-names [supplier_no total_revenue]}]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q15.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q15.edn
@@ -1,49 +1,65 @@
 [:let
  {:binding-sym revenue.4}
  [:project
-  {:projections [{supplier_no l.1/l_suppkey} {total_revenue _sum_out_2}]}
+  {:projections
+   [{supplier_no l.1/l_suppkey} {total_revenue _sum_out_2}]}
   [:group-by
    {:columns [l.1/l_suppkey {_sum_out_2 (sum _sum_in_3)}]}
    [:map
-    {:projections [{_sum_in_3 (* l.1/l_extendedprice (- 1 l.1/l_discount))}]}
-    [:rename {:prefix l.1} [:scan
-      {:table #xt/table lineitem, :columns [{l_shipdate
-        (and
-         (<
-          l_shipdate
-          (+
-           #xt/date "1996-01-01"
-           (single-field-interval "3" "MONTH" 2 6)))
-         (>= l_shipdate #xt/date "1996-01-01"))}
-       l_extendedprice
-       l_suppkey
-       l_discount]}]]]]]
+    {:projections
+     [{_sum_in_3 (* l.1/l_extendedprice (- 1 l.1/l_discount))}]}
+    [:rename
+     {:prefix l.1}
+     [:scan
+      {:table #xt/table lineitem,
+       :columns
+       [{l_shipdate
+         (and
+          (<
+           l_shipdate
+           (+
+            #xt/date "1996-01-01"
+            (single-field-interval "3" "MONTH" 2 6)))
+          (>= l_shipdate #xt/date "1996-01-01"))}
+        l_extendedprice
+        l_suppkey
+        l_discount]}]]]]]
  [:project
-  {:projections [{s_suppkey s_suppkey}
-   {s_name s.5/s_name}
-   {s_address s.5/s_address}
-   {s_phone s.5/s_phone}
-   {total_revenue revenue.6/total_revenue}]}
+  {:projections
+   [{s_suppkey s_suppkey}
+    {s_name s.5/s_name}
+    {s_address s.5/s_address}
+    {s_phone s.5/s_phone}
+    {total_revenue revenue.6/total_revenue}]}
   [:order-by
-   {:order-specs [[_ob10 {:direction :asc, :null-ordering :nulls-last}]]}
-   [:project
-    {:projections [{s_suppkey s.5/_id}
-     s.5/s_name
-     s.5/s_address
-     s.5/s_phone
-     revenue.6/total_revenue
-     {_ob10 s.5/_id}]}
-    [:select
-     {:predicate (== revenue.6/total_revenue _sq_7)}
-     [:single-join
-      {:conditions []}
-      [:mega-join
-       {:conditions [{s.5/_id revenue.6/supplier_no}]}
-       [[:rename {:prefix s.5} [:scan
-          {:table #xt/table supplier, :columns [s_name s_address s_phone _id]}]]
-        [:rename {:prefix revenue.6} [:relation {:cte-id revenue.4 :col-names [supplier_no total_revenue]}]]]]
-      [:project
-       {:projections [{_sq_7 _max_out_9}]}
-       [:group-by
-        {:columns [{_max_out_9 (max revenue.8/total_revenue)}]}
-        [:rename {:prefix revenue.8} [:relation {:cte-id revenue.4 :col-names [supplier_no total_revenue]}]]]]]]]]]]
+   {:order-specs
+    [[_ob10 {:direction :asc, :null-ordering :nulls-last}]]}
+   [:map
+    {:projections [{_ob10 s.5/_id}]}
+    [:map
+     {:projections [{s_suppkey s.5/_id}]}
+     [:select
+      {:predicate (== revenue.6/total_revenue _sq_7)}
+      [:single-join
+       {:conditions []}
+       [:mega-join
+        {:conditions [{s.5/_id revenue.6/supplier_no}]}
+        [[:rename
+          {:prefix s.5}
+          [:scan
+           {:table #xt/table supplier,
+            :columns [s_name s_address s_phone _id]}]]
+         [:rename
+          {:prefix revenue.6}
+          [:relation
+           {:cte-id revenue.4,
+            :col-names [supplier_no total_revenue]}]]]]
+       [:project
+        {:projections [{_sq_7 _max_out_9}]}
+        [:group-by
+         {:columns [{_max_out_9 (max revenue.8/total_revenue)}]}
+         [:rename
+          {:prefix revenue.8}
+          [:relation
+           {:cte-id revenue.4,
+            :col-names [supplier_no total_revenue]}]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q16.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q16.edn
@@ -1,23 +1,23 @@
 [:project
- {:projections [{p_brand p.2/p_brand}
-  {p_type p.2/p_type}
-  {p_size p.2/p_size}
-  supplier_cnt]}
+ {:projections
+  [{p_brand p.2/p_brand}
+   {p_type p.2/p_type}
+   {p_size p.2/p_size}
+   {supplier_cnt supplier_cnt}]}
  [:order-by
-  {:order-specs [[supplier_cnt {:direction :desc, :null-ordering :nulls-first}]
-   [p.2/p_brand {:direction :asc, :null-ordering :nulls-last}]
-   [p.2/p_type {:direction :asc, :null-ordering :nulls-last}]
-   [p.2/p_size {:direction :asc, :null-ordering :nulls-last}]]}
-  [:project
-   {:projections [p.2/p_brand
-    p.2/p_type
-    p.2/p_size
-    {supplier_cnt _count_distinct_out_7}]}
+  {:order-specs
+   [[supplier_cnt {:direction :desc, :null-ordering :nulls-first}]
+    [p.2/p_brand {:direction :asc, :null-ordering :nulls-last}]
+    [p.2/p_type {:direction :asc, :null-ordering :nulls-last}]
+    [p.2/p_size {:direction :asc, :null-ordering :nulls-last}]]}
+  [:map
+   {:projections [{supplier_cnt _count_distinct_out_7}]}
    [:group-by
-    {:columns [p.2/p_brand
-     p.2/p_type
-     p.2/p_size
-     {_count_distinct_out_7 (count_distinct ps.1/ps_suppkey)}]}
+    {:columns
+     [p.2/p_brand
+      p.2/p_type
+      p.2/p_size
+      {_count_distinct_out_7 (count_distinct ps.1/ps_suppkey)}]}
     [:map
      {:projections [{_sq_5 true}]}
      [:map
@@ -26,17 +26,41 @@
        {:conditions [{ps.1/ps_partkey p.2/_id}]}
        [[:anti-join
          {:conditions [{ps.1/ps_suppkey _id}]}
-         [:rename {:prefix ps.1} [:scan {:table #xt/table partsupp, :columns [ps_partkey ps_suppkey]}]]
+         [:rename
+          {:prefix ps.1}
+          [:scan
+           {:table #xt/table partsupp,
+            :columns [ps_partkey ps_suppkey]}]]
          [:project
           {:projections [{_id s.6/_id}]}
-          [:rename {:prefix s.6} [:scan
-            {:table #xt/table supplier, :columns [{s_comment (like s_comment "%Customer%Complaints%")}
-             _id]}]]]]
+          [:rename
+           {:prefix s.6}
+           [:scan
+            {:table #xt/table supplier,
+             :columns
+             [{s_comment (like s_comment "%Customer%Complaints%")}
+              _id]}]]]]
         [:semi-join
          {:conditions [{p.2/p_size xt.values.4/_column_1}]}
-         [:rename {:prefix p.2} [:scan
-           {:table #xt/table part, :columns [_id
-            {p_brand (<> p_brand "Brand#45")}
-            p_size
-            {p_type (not (like p_type "MEDIUM POLISHED%"))}]}]]
-         [:rename {:prefix xt.values.4} [:table {:output-cols [_column_1], :rows [{:_column_1 49} {:_column_1 14} {:_column_1 23} {:_column_1 45} {:_column_1 19} {:_column_1 3} {:_column_1 36} {:_column_1 9}]}]]]]]]]]]]]
+         [:rename
+          {:prefix p.2}
+          [:scan
+           {:table #xt/table part,
+            :columns
+            [_id
+             {p_brand (<> p_brand "Brand#45")}
+             p_size
+             {p_type (not (like p_type "MEDIUM POLISHED%"))}]}]]
+         [:rename
+          {:prefix xt.values.4}
+          [:table
+           {:output-cols [_column_1],
+            :rows
+            [{:_column_1 49}
+             {:_column_1 14}
+             {:_column_1 23}
+             {:_column_1 45}
+             {:_column_1 19}
+             {:_column_1 3}
+             {:_column_1 36}
+             {:_column_1 9}]}]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
@@ -7,24 +7,36 @@
    [:map
     {:projections [{_sq_3 (* 0.2 _avg_out_6)}]}
     [:group-by
-     {:columns [l.1/l_extendedprice
-      l.1/l_quantity
-      l.1/l_partkey
-      p.2/_id
-      p.2/p_brand
-      p.2/p_container
-      _row_number_0
-      {_avg_out_6 (avg l.4/l_quantity)}]}
+     {:columns
+      [l.1/l_extendedprice
+       l.1/l_quantity
+       l.1/l_partkey
+       p.2/_id
+       p.2/p_brand
+       p.2/p_container
+       _row_number_0
+       {_avg_out_6 (avg l.4/l_quantity)}]}
      [:left-outer-join
       {:conditions [{p.2/_id l.4/l_partkey}]}
       [:map
        {:projections [{_row_number_0 (row-number)}]}
        [:mega-join
         {:conditions [{l.1/l_partkey p.2/_id}]}
-        [[:rename {:prefix l.1} [:scan
-           {:table #xt/table lineitem, :columns [l_extendedprice l_quantity l_partkey]}]]
-         [:rename {:prefix p.2} [:scan
-           {:table #xt/table part, :columns [_id
-            {p_brand (== p_brand "Brand#23")}
-            {p_container (== p_container "MED BOX")}]}]]]]]
-      [:rename {:prefix l.4} [:scan {:table #xt/table lineitem, :columns [l_quantity l_partkey]}]]]]]]]]
+        [[:rename
+          {:prefix l.1}
+          [:scan
+           {:table #xt/table lineitem,
+            :columns [l_extendedprice l_quantity l_partkey]}]]
+         [:rename
+          {:prefix p.2}
+          [:scan
+           {:table #xt/table part,
+            :columns
+            [_id
+             {p_brand (== p_brand "Brand#23")}
+             {p_container (== p_container "MED BOX")}]}]]]]]
+      [:rename
+       {:prefix l.4}
+       [:scan
+        {:table #xt/table lineitem,
+         :columns [l_quantity l_partkey]}]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q18.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q18.edn
@@ -1,44 +1,56 @@
 [:top
  {:skip nil, :limit 100}
  [:project
-  {:projections [{c_name c.1/c_name}
-   c_custkey
-   o_orderkey
-   {o_orderdate o.2/o_orderdate}
-   {o_totalprice o.2/o_totalprice}
-   sum_qty]}
+  {:projections
+   [{c_name c.1/c_name}
+    {c_custkey c_custkey}
+    {o_orderkey o_orderkey}
+    {o_orderdate o.2/o_orderdate}
+    {o_totalprice o.2/o_totalprice}
+    {sum_qty sum_qty}]}
   [:order-by
-   {:order-specs [[o.2/o_totalprice {:direction :desc, :null-ordering :nulls-first}]
-    [o.2/o_orderdate {:direction :asc, :null-ordering :nulls-last}]]}
-   [:project
-    {:projections [c.1/c_name
-     {c_custkey c.1/_id}
-     {o_orderkey o.2/_id}
-     o.2/o_orderdate
-     o.2/o_totalprice
-     {sum_qty _sum_out_7}]}
+   {:order-specs
+    [[o.2/o_totalprice {:direction :desc, :null-ordering :nulls-first}]
+     [o.2/o_orderdate {:direction :asc, :null-ordering :nulls-last}]]}
+   [:map
+    {:projections
+     [{c_custkey c.1/_id} {o_orderkey o.2/_id} {sum_qty _sum_out_7}]}
     [:group-by
-     {:columns [c.1/c_name
-      c.1/_id
-      o.2/_id
-      o.2/o_orderdate
-      o.2/o_totalprice
-      {_sum_out_7 (sum l.3/l_quantity)}]}
+     {:columns
+      [c.1/c_name
+       c.1/_id
+       o.2/_id
+       o.2/o_orderdate
+       o.2/o_totalprice
+       {_sum_out_7 (sum l.3/l_quantity)}]}
      [:map
       {:projections [{_sq_4 true}]}
       [:mega-join
        {:conditions [{o.2/_id l.3/l_orderkey} {c.1/_id o.2/o_custkey}]}
-       [[:rename {:prefix l.3} [:scan {:table #xt/table lineitem, :columns [l_orderkey l_quantity]}]]
-        [:rename {:prefix c.1} [:scan {:table #xt/table customer, :columns [_id c_name]}]]
+       [[:rename
+         {:prefix l.3}
+         [:scan
+          {:table #xt/table lineitem,
+           :columns [l_orderkey l_quantity]}]]
+        [:rename
+         {:prefix c.1}
+         [:scan {:table #xt/table customer, :columns [_id c_name]}]]
         [:semi-join
          {:conditions [{o.2/_id l_orderkey}]}
-         [:rename {:prefix o.2} [:scan
-           {:table #xt/table orders, :columns [o_totalprice _id o_orderdate o_custkey]}]]
+         [:rename
+          {:prefix o.2}
+          [:scan
+           {:table #xt/table orders,
+            :columns [o_totalprice _id o_orderdate o_custkey]}]]
          [:project
           {:projections [{l_orderkey l.5/l_orderkey}]}
           [:select
            {:predicate (> _sum_out_6 300)}
            [:group-by
-            {:columns [l.5/l_orderkey {_sum_out_6 (sum l.5/l_quantity)}]}
-            [:rename {:prefix l.5} [:scan
-              {:table #xt/table lineitem, :columns [l_orderkey l_quantity]}]]]]]]]]]]]]]]
+            {:columns
+             [l.5/l_orderkey {_sum_out_6 (sum l.5/l_quantity)}]}
+            [:rename
+             {:prefix l.5}
+             [:scan
+              {:table #xt/table lineitem,
+               :columns [l_orderkey l_quantity]}]]]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q19.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q19.edn
@@ -3,43 +3,45 @@
  [:group-by
   {:columns [{_sum_out_15 (sum _sum_in_16)}]}
   [:map
-   {:projections [{_sum_in_16 (* l.1/l_extendedprice (- 1 l.1/l_discount))}]}
+   {:projections
+    [{_sum_in_16 (* l.1/l_extendedprice (- 1 l.1/l_discount))}]}
    [:select
-    {:predicate (or
-                 (or
-                  (and
-                   (and
-                    (and
-                     (and
-                      (and
-                       (and (== p.2/p_brand "Brand#12") _sq_3)
-                       (>= l.1/l_quantity 1))
-                      (<= l.1/l_quantity (+ 1 10)))
-                     (between p.2/p_size 1 5))
-                    _sq_5)
-                   (== l.1/l_shipinstruct "DELIVER IN PERSON"))
-                  (and
-                   (and
-                    (and
-                     (and
-                      (and
-                       (and (== p.2/p_brand "Brand#23") _sq_7)
-                       (>= l.1/l_quantity 10))
-                      (<= l.1/l_quantity (+ 10 10)))
-                     (between p.2/p_size 1 10))
-                    _sq_9)
-                   (== l.1/l_shipinstruct "DELIVER IN PERSON")))
-                 (and
-                  (and
-                   (and
-                    (and
-                     (and
-                      (and (== p.2/p_brand "Brand#34") _sq_11)
-                      (>= l.1/l_quantity 20))
-                     (<= l.1/l_quantity (+ 20 10)))
-                    (between p.2/p_size 1 15))
-                   _sq_13)
-                  (== l.1/l_shipinstruct "DELIVER IN PERSON")))}
+    {:predicate
+     (or
+      (or
+       (and
+        (and
+         (and
+          (and
+           (and
+            (and (== p.2/p_brand "Brand#12") _sq_3)
+            (>= l.1/l_quantity 1))
+           (<= l.1/l_quantity (+ 1 10)))
+          (between p.2/p_size 1 5))
+         _sq_5)
+        (== l.1/l_shipinstruct "DELIVER IN PERSON"))
+       (and
+        (and
+         (and
+          (and
+           (and
+            (and (== p.2/p_brand "Brand#23") _sq_7)
+            (>= l.1/l_quantity 10))
+           (<= l.1/l_quantity (+ 10 10)))
+          (between p.2/p_size 1 10))
+         _sq_9)
+        (== l.1/l_shipinstruct "DELIVER IN PERSON")))
+      (and
+       (and
+        (and
+         (and
+          (and
+           (and (== p.2/p_brand "Brand#34") _sq_11)
+           (>= l.1/l_quantity 20))
+          (<= l.1/l_quantity (+ 20 10)))
+         (between p.2/p_size 1 15))
+        _sq_13)
+       (== l.1/l_shipinstruct "DELIVER IN PERSON")))}
     [:mark-join
      {:mark-spec {_sq_13 [{l.1/l_shipmode xt.values.14/_column_1}]}}
      [:mark-join
@@ -51,21 +53,65 @@
         [:mark-join
          {:mark-spec {_sq_7 [{p.2/p_container xt.values.8/_column_1}]}}
          [:mark-join
-          {:mark-spec {_sq_9 [{l.1/l_shipmode xt.values.10/_column_1}]}}
+          {:mark-spec
+           {_sq_9 [{l.1/l_shipmode xt.values.10/_column_1}]}}
           [:mega-join
            {:conditions [{l.1/l_partkey p.2/_id}]}
-           [[:rename {:prefix l.1} [:scan
-              {:table #xt/table lineitem, :columns [l_extendedprice
-               l_quantity
-               l_shipinstruct
-               l_shipmode
-               l_discount
-               l_partkey]}]]
-            [:rename {:prefix p.2} [:scan
-              {:table #xt/table part, :columns [_id p_brand p_size p_container]}]]]]
-          [:rename {:prefix xt.values.10} [:table {:output-cols [_column_1], :rows [{:_column_1 "AIR"} {:_column_1 "AIR REG"}]}]]]
-         [:rename {:prefix xt.values.8} [:table {:output-cols [_column_1], :rows [{:_column_1 "MED BAG"} {:_column_1 "MED BOX"} {:_column_1 "MED PKG"} {:_column_1 "MED PACK"}]}]]]
-        [:rename {:prefix xt.values.4} [:table {:output-cols [_column_1], :rows [{:_column_1 "SM CASE"} {:_column_1 "SM BOX"} {:_column_1 "SM PACK"} {:_column_1 "SM PKG"}]}]]]
-       [:rename {:prefix xt.values.6} [:table {:output-cols [_column_1], :rows [{:_column_1 "AIR"} {:_column_1 "AIR REG"}]}]]]
-      [:rename {:prefix xt.values.12} [:table {:output-cols [_column_1], :rows [{:_column_1 "LG CASE"} {:_column_1 "LG BOX"} {:_column_1 "LG PACK"} {:_column_1 "LG PKG"}]}]]]
-     [:rename {:prefix xt.values.14} [:table {:output-cols [_column_1], :rows [{:_column_1 "AIR"} {:_column_1 "AIR REG"}]}]]]]]]]
+           [[:rename
+             {:prefix l.1}
+             [:scan
+              {:table #xt/table lineitem,
+               :columns
+               [l_extendedprice
+                l_quantity
+                l_shipinstruct
+                l_shipmode
+                l_discount
+                l_partkey]}]]
+            [:rename
+             {:prefix p.2}
+             [:scan
+              {:table #xt/table part,
+               :columns [_id p_brand p_size p_container]}]]]]
+          [:rename
+           {:prefix xt.values.10}
+           [:table
+            {:output-cols [_column_1],
+             :rows [{:_column_1 "AIR"} {:_column_1 "AIR REG"}]}]]]
+         [:rename
+          {:prefix xt.values.8}
+          [:table
+           {:output-cols [_column_1],
+            :rows
+            [{:_column_1 "MED BAG"}
+             {:_column_1 "MED BOX"}
+             {:_column_1 "MED PKG"}
+             {:_column_1 "MED PACK"}]}]]]
+        [:rename
+         {:prefix xt.values.4}
+         [:table
+          {:output-cols [_column_1],
+           :rows
+           [{:_column_1 "SM CASE"}
+            {:_column_1 "SM BOX"}
+            {:_column_1 "SM PACK"}
+            {:_column_1 "SM PKG"}]}]]]
+       [:rename
+        {:prefix xt.values.6}
+        [:table
+         {:output-cols [_column_1],
+          :rows [{:_column_1 "AIR"} {:_column_1 "AIR REG"}]}]]]
+      [:rename
+       {:prefix xt.values.12}
+       [:table
+        {:output-cols [_column_1],
+         :rows
+         [{:_column_1 "LG CASE"}
+          {:_column_1 "LG BOX"}
+          {:_column_1 "LG PACK"}
+          {:_column_1 "LG PKG"}]}]]]
+     [:rename
+      {:prefix xt.values.14}
+      [:table
+       {:output-cols [_column_1],
+        :rows [{:_column_1 "AIR"} {:_column_1 "AIR REG"}]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
@@ -1,42 +1,53 @@
 [:project
  {:projections [{s_name s.1/s_name} {s_address s.1/s_address}]}
  [:order-by
-  {:order-specs [[s.1/s_name {:direction :asc, :null-ordering :nulls-last}]]}
-  [:project
-   {:projections [s.1/s_name s.1/s_address]}
-   [:map
-    {:projections [{_sq_3 true}]}
-    [:mega-join
-     {:conditions [{s.1/s_nationkey n.2/_id}]}
-     [[:semi-join
-       {:conditions [{s.1/_id ps_suppkey}]}
-       [:rename {:prefix s.1} [:scan
-         {:table #xt/table supplier, :columns [s_name s_address _id s_nationkey]}]]
-       [:project
-        {:projections [{ps_suppkey ps.4/ps_suppkey}]}
-        [:map
-         {:projections [{_sq_5 true}]}
-         [:semi-join
-          {:conditions [{ps.4/ps_partkey _id}]}
-          [:select
-           {:predicate (> ps.4/ps_availqty _sq_7)}
-           [:map
-            {:projections [{_sq_7 (* 0.5 _sum_out_11)}]}
-            [:group-by
-             {:columns [ps.4/ps_partkey
+  {:order-specs
+   [[s.1/s_name {:direction :asc, :null-ordering :nulls-last}]]}
+  [:map
+   {:projections [{_sq_3 true}]}
+   [:mega-join
+    {:conditions [{s.1/s_nationkey n.2/_id}]}
+    [[:semi-join
+      {:conditions [{s.1/_id ps_suppkey}]}
+      [:rename
+       {:prefix s.1}
+       [:scan
+        {:table #xt/table supplier,
+         :columns [s_name s_address _id s_nationkey]}]]
+      [:project
+       {:projections [{ps_suppkey ps.4/ps_suppkey}]}
+       [:map
+        {:projections [{_sq_5 true}]}
+        [:semi-join
+         {:conditions [{ps.4/ps_partkey _id}]}
+         [:select
+          {:predicate (> ps.4/ps_availqty _sq_7)}
+          [:map
+           {:projections [{_sq_7 (* 0.5 _sum_out_11)}]}
+           [:group-by
+            {:columns
+             [ps.4/ps_partkey
               ps.4/ps_availqty
               ps.4/ps_suppkey
               _row_number_0
               {_sum_out_11 (sum l.8/l_quantity)}]}
-             [:left-outer-join
-              {:conditions [{ps.4/ps_partkey l.8/l_partkey}
+            [:left-outer-join
+             {:conditions
+              [{ps.4/ps_partkey l.8/l_partkey}
                {ps.4/ps_suppkey l.8/l_suppkey}]}
-              [:map
-               {:projections [{_row_number_0 (row-number)}]}
-               [:rename {:prefix ps.4} [:scan
-                 {:table #xt/table partsupp, :columns [ps_partkey ps_availqty ps_suppkey]}]]]
-              [:rename {:prefix l.8} [:scan
-                {:table #xt/table lineitem, :columns [{l_shipdate
+             [:map
+              {:projections [{_row_number_0 (row-number)}]}
+              [:rename
+               {:prefix ps.4}
+               [:scan
+                {:table #xt/table partsupp,
+                 :columns [ps_partkey ps_availqty ps_suppkey]}]]]
+             [:rename
+              {:prefix l.8}
+              [:scan
+               {:table #xt/table lineitem,
+                :columns
+                [{l_shipdate
                   (and
                    (<
                     l_shipdate
@@ -47,9 +58,15 @@
                  l_quantity
                  l_suppkey
                  l_partkey]}]]]]]]
-          [:project
-           {:projections [{_id p.6/_id}]}
-           [:rename {:prefix p.6} [:scan
-             {:table #xt/table part, :columns [_id {p_name (like p_name "forest%")}]}]]]]]]]
-      [:rename {:prefix n.2} [:scan
-        {:table #xt/table nation, :columns [_id {n_name (== n_name "CANADA")}]}]]]]]]]]
+         [:project
+          {:projections [{_id p.6/_id}]}
+          [:rename
+           {:prefix p.6}
+           [:scan
+            {:table #xt/table part,
+             :columns [_id {p_name (like p_name "forest%")}]}]]]]]]]
+     [:rename
+      {:prefix n.2}
+      [:scan
+       {:table #xt/table nation,
+        :columns [_id {n_name (== n_name "CANADA")}]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q21.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q21.edn
@@ -1,12 +1,13 @@
 [:top
  {:skip nil, :limit 100}
  [:project
-  {:projections [{s_name s.1/s_name} numwait]}
+  {:projections [{s_name s.1/s_name} {numwait numwait}]}
   [:order-by
-   {:order-specs [[numwait {:direction :desc, :null-ordering :nulls-first}]
-    [s.1/s_name {:direction :asc, :null-ordering :nulls-last}]]}
-   [:project
-    {:projections [s.1/s_name {numwait _row_count_13}]}
+   {:order-specs
+    [[numwait {:direction :desc, :null-ordering :nulls-first}]
+     [s.1/s_name {:direction :asc, :null-ordering :nulls-last}]]}
+   [:map
+    {:projections [{numwait _row_count_13}]}
     [:group-by
      {:columns [s.1/s_name {_row_count_13 (row-count)}]}
      [:map
@@ -14,93 +15,122 @@
       [:map
        {:projections [{_sq_9 true}]}
        [:mega-join
-        {:conditions [{s.1/s_nationkey n.4/_id}
-         {l1.2/l_orderkey o.3/_id}
-         {s.1/_id l1.2/l_suppkey}]}
-        [[:rename {:prefix n.4} [:scan
-           {:table #xt/table nation, :columns [_id {n_name (== n_name "SAUDI ARABIA")}]}]]
-         [:rename {:prefix o.3} [:scan
-           {:table #xt/table orders, :columns [{o_orderstatus (== o_orderstatus "F")} _id]}]]
-         [:rename {:prefix s.1} [:scan {:table #xt/table supplier, :columns [s_name _id s_nationkey]}]]
+        {:conditions
+         [{s.1/s_nationkey n.4/_id}
+          {l1.2/l_orderkey o.3/_id}
+          {s.1/_id l1.2/l_suppkey}]}
+        [[:rename
+          {:prefix n.4}
+          [:scan
+           {:table #xt/table nation,
+            :columns [_id {n_name (== n_name "SAUDI ARABIA")}]}]]
+         [:rename
+          {:prefix o.3}
+          [:scan
+           {:table #xt/table orders,
+            :columns [{o_orderstatus (== o_orderstatus "F")} _id]}]]
+         [:rename
+          {:prefix s.1}
+          [:scan
+           {:table #xt/table supplier,
+            :columns [s_name _id s_nationkey]}]]
          [:semi-join
-          {:conditions [(<> l_suppkey l1.2/l_suppkey) {l1.2/l_orderkey l_orderkey}]}
+          {:conditions
+           [(<> l_suppkey l1.2/l_suppkey)
+            {l1.2/l_orderkey l_orderkey}]}
           [:anti-join
-           {:conditions [(<> l_suppkey l1.2/l_suppkey) {l1.2/l_orderkey l_orderkey}]}
-           [:rename {:prefix l1.2} [:select
+           {:conditions
+            [(<> l_suppkey l1.2/l_suppkey)
+             {l1.2/l_orderkey l_orderkey}]}
+           [:rename
+            {:prefix l1.2}
+            [:select
              {:predicate (> l_receiptdate l_commitdate)}
              [:scan
-              {:table #xt/table lineitem, :columns [l_receiptdate l_commitdate l_orderkey l_suppkey]}]]]
+              {:table #xt/table lineitem,
+               :columns
+               [l_receiptdate l_commitdate l_orderkey l_suppkey]}]]]
            [:project
-            {:projections [{_id l3.10/_id}
-             {l_comment l3.10/l_comment}
-             {l_commitdate l3.10/l_commitdate}
-             {l_discount l3.10/l_discount}
-             {l_extendedprice l3.10/l_extendedprice}
-             {l_linenumber l3.10/l_linenumber}
-             {l_linestatus l3.10/l_linestatus}
-             {l_orderkey l3.10/l_orderkey}
-             {l_partkey l3.10/l_partkey}
-             {l_quantity l3.10/l_quantity}
-             {l_receiptdate l3.10/l_receiptdate}
-             {l_returnflag l3.10/l_returnflag}
-             {l_shipdate l3.10/l_shipdate}
-             {l_shipinstruct l3.10/l_shipinstruct}
-             {l_shipmode l3.10/l_shipmode}
-             {l_suppkey l3.10/l_suppkey}
-             {l_tax l3.10/l_tax}]}
-            [:rename {:prefix l3.10} [:select
+            {:projections
+             [{_id l3.10/_id}
+              {l_comment l3.10/l_comment}
+              {l_commitdate l3.10/l_commitdate}
+              {l_discount l3.10/l_discount}
+              {l_extendedprice l3.10/l_extendedprice}
+              {l_linenumber l3.10/l_linenumber}
+              {l_linestatus l3.10/l_linestatus}
+              {l_orderkey l3.10/l_orderkey}
+              {l_partkey l3.10/l_partkey}
+              {l_quantity l3.10/l_quantity}
+              {l_receiptdate l3.10/l_receiptdate}
+              {l_returnflag l3.10/l_returnflag}
+              {l_shipdate l3.10/l_shipdate}
+              {l_shipinstruct l3.10/l_shipinstruct}
+              {l_shipmode l3.10/l_shipmode}
+              {l_suppkey l3.10/l_suppkey}
+              {l_tax l3.10/l_tax}]}
+            [:rename
+             {:prefix l3.10}
+             [:select
               {:predicate (> l_receiptdate l_commitdate)}
               [:scan
-               {:table #xt/table lineitem, :columns [l_linestatus
-                l_receiptdate
-                l_commitdate
-                l_tax
-                l_orderkey
-                l_shipdate
-                l_comment
-                _id
-                l_returnflag
-                l_extendedprice
-                l_linenumber
-                l_quantity
-                l_shipinstruct
-                l_suppkey
-                l_shipmode
-                l_discount
-                l_partkey]}]]]]]
+               {:table #xt/table lineitem,
+                :columns
+                [l_linestatus
+                 l_receiptdate
+                 l_commitdate
+                 l_tax
+                 l_orderkey
+                 l_shipdate
+                 l_comment
+                 _id
+                 l_returnflag
+                 l_extendedprice
+                 l_linenumber
+                 l_quantity
+                 l_shipinstruct
+                 l_suppkey
+                 l_shipmode
+                 l_discount
+                 l_partkey]}]]]]]
           [:project
-           {:projections [{_id l2.6/_id}
-            {l_comment l2.6/l_comment}
-            {l_commitdate l2.6/l_commitdate}
-            {l_discount l2.6/l_discount}
-            {l_extendedprice l2.6/l_extendedprice}
-            {l_linenumber l2.6/l_linenumber}
-            {l_linestatus l2.6/l_linestatus}
-            {l_orderkey l2.6/l_orderkey}
-            {l_partkey l2.6/l_partkey}
-            {l_quantity l2.6/l_quantity}
-            {l_receiptdate l2.6/l_receiptdate}
-            {l_returnflag l2.6/l_returnflag}
-            {l_shipdate l2.6/l_shipdate}
-            {l_shipinstruct l2.6/l_shipinstruct}
-            {l_shipmode l2.6/l_shipmode}
-            {l_suppkey l2.6/l_suppkey}
-            {l_tax l2.6/l_tax}]}
-           [:rename {:prefix l2.6} [:scan
-             {:table #xt/table lineitem, :columns [l_linestatus
-              l_receiptdate
-              l_commitdate
-              l_tax
-              l_orderkey
-              l_shipdate
-              l_comment
-              _id
-              l_returnflag
-              l_extendedprice
-              l_linenumber
-              l_quantity
-              l_shipinstruct
-              l_suppkey
-              l_shipmode
-              l_discount
-              l_partkey]}]]]]]]]]]]]]]
+           {:projections
+            [{_id l2.6/_id}
+             {l_comment l2.6/l_comment}
+             {l_commitdate l2.6/l_commitdate}
+             {l_discount l2.6/l_discount}
+             {l_extendedprice l2.6/l_extendedprice}
+             {l_linenumber l2.6/l_linenumber}
+             {l_linestatus l2.6/l_linestatus}
+             {l_orderkey l2.6/l_orderkey}
+             {l_partkey l2.6/l_partkey}
+             {l_quantity l2.6/l_quantity}
+             {l_receiptdate l2.6/l_receiptdate}
+             {l_returnflag l2.6/l_returnflag}
+             {l_shipdate l2.6/l_shipdate}
+             {l_shipinstruct l2.6/l_shipinstruct}
+             {l_shipmode l2.6/l_shipmode}
+             {l_suppkey l2.6/l_suppkey}
+             {l_tax l2.6/l_tax}]}
+           [:rename
+            {:prefix l2.6}
+            [:scan
+             {:table #xt/table lineitem,
+              :columns
+              [l_linestatus
+               l_receiptdate
+               l_commitdate
+               l_tax
+               l_orderkey
+               l_shipdate
+               l_comment
+               _id
+               l_returnflag
+               l_extendedprice
+               l_linenumber
+               l_quantity
+               l_shipinstruct
+               l_suppkey
+               l_shipmode
+               l_discount
+               l_partkey]}]]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q22.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q22.edn
@@ -1,19 +1,25 @@
 [:project
- {:projections [{cntrycode custsale.12/cntrycode} numcust totacctbal]}
+ {:projections
+  [{cntrycode custsale.12/cntrycode}
+   {numcust numcust}
+   {totacctbal totacctbal}]}
  [:order-by
-  {:order-specs [[custsale.12/cntrycode
-    {:direction :asc, :null-ordering :nulls-last}]]}
-  [:project
-   {:projections [custsale.12/cntrycode
-    {numcust _row_count_13}
-    {totacctbal _sum_out_14}]}
+  {:order-specs
+   [[custsale.12/cntrycode
+     {:direction :asc, :null-ordering :nulls-last}]]}
+  [:map
+   {:projections [{numcust _row_count_13} {totacctbal _sum_out_14}]}
    [:group-by
-    {:columns [custsale.12/cntrycode
-     {_row_count_13 (row-count)}
-     {_sum_out_14 (sum custsale.12/c_acctbal)}]}
-    [:rename {:prefix custsale.12} [:project
-      {:projections [{cntrycode (substring c.1/c_phone 1 2)}
-       {c_acctbal c.1/c_acctbal}]}
+    {:columns
+     [custsale.12/cntrycode
+      {_row_count_13 (row-count)}
+      {_sum_out_14 (sum custsale.12/c_acctbal)}]}
+    [:rename
+     {:prefix custsale.12}
+     [:project
+      {:projections
+       [{cntrycode (substring c.1/c_phone 1 2)}
+        {c_acctbal c.1/c_acctbal}]}
       [:select
        {:predicate (> c.1/c_acctbal _sq_4)}
        [:single-join
@@ -28,29 +34,48 @@
             {:projections [{_sq_9 true}]}
             [:anti-join
              {:conditions [{c.1/_id o_custkey}]}
-             [:rename {:prefix c.1} [:scan
-               {:table #xt/table customer, :columns [c_phone c_acctbal _id]}]]
+             [:rename
+              {:prefix c.1}
+              [:scan
+               {:table #xt/table customer,
+                :columns [c_phone c_acctbal _id]}]]
              [:project
-              {:projections [{_id o.10/_id}
-               {o_clerk o.10/o_clerk}
-               {o_comment o.10/o_comment}
-               {o_custkey o.10/o_custkey}
-               {o_orderdate o.10/o_orderdate}
-               {o_orderpriority o.10/o_orderpriority}
-               {o_orderstatus o.10/o_orderstatus}
-               {o_shippriority o.10/o_shippriority}
-               {o_totalprice o.10/o_totalprice}]}
-              [:rename {:prefix o.10} [:scan
-                {:table #xt/table orders, :columns [o_orderpriority
-                 o_clerk
-                 o_orderstatus
-                 o_totalprice
-                 _id
-                 o_orderdate
-                 o_comment
-                 o_shippriority
-                 o_custkey]}]]]]]]
-          [:rename {:prefix xt.values.3} [:table {:output-cols [_column_1], :rows [{:_column_1 "13"} {:_column_1 "31"} {:_column_1 "23"} {:_column_1 "29"} {:_column_1 "30"} {:_column_1 "18"} {:_column_1 "17"}]}]]]]
+              {:projections
+               [{_id o.10/_id}
+                {o_clerk o.10/o_clerk}
+                {o_comment o.10/o_comment}
+                {o_custkey o.10/o_custkey}
+                {o_orderdate o.10/o_orderdate}
+                {o_orderpriority o.10/o_orderpriority}
+                {o_orderstatus o.10/o_orderstatus}
+                {o_shippriority o.10/o_shippriority}
+                {o_totalprice o.10/o_totalprice}]}
+              [:rename
+               {:prefix o.10}
+               [:scan
+                {:table #xt/table orders,
+                 :columns
+                 [o_orderpriority
+                  o_clerk
+                  o_orderstatus
+                  o_totalprice
+                  _id
+                  o_orderdate
+                  o_comment
+                  o_shippriority
+                  o_custkey]}]]]]]]
+          [:rename
+           {:prefix xt.values.3}
+           [:table
+            {:output-cols [_column_1],
+             :rows
+             [{:_column_1 "13"}
+              {:_column_1 "31"}
+              {:_column_1 "23"}
+              {:_column_1 "29"}
+              {:_column_1 "30"}
+              {:_column_1 "18"}
+              {:_column_1 "17"}]}]]]]
         [:project
          {:projections [{_sq_4 _avg_out_8}]}
          [:group-by
@@ -61,6 +86,20 @@
             {:conditions [{_needle xt.values.7/_column_1}]}
             [:map
              {:projections [{_needle (substring c.5/c_phone 1 2)}]}
-             [:rename {:prefix c.5} [:scan
-               {:table #xt/table customer, :columns [c_phone {c_acctbal (> c_acctbal 0.0)}]}]]]
-            [:rename {:prefix xt.values.7} [:table {:output-cols [_column_1], :rows [{:_column_1 "13"} {:_column_1 "31"} {:_column_1 "23"} {:_column_1 "29"} {:_column_1 "30"} {:_column_1 "18"} {:_column_1 "17"}]}]]]]]]]]]]]]]]
+             [:rename
+              {:prefix c.5}
+              [:scan
+               {:table #xt/table customer,
+                :columns [c_phone {c_acctbal (> c_acctbal 0.0)}]}]]]
+            [:rename
+             {:prefix xt.values.7}
+             [:table
+              {:output-cols [_column_1],
+               :rows
+               [{:_column_1 "13"}
+                {:_column_1 "31"}
+                {:_column_1 "23"}
+                {:_column_1 "29"}
+                {:_column_1 "30"}
+                {:_column_1 "18"}
+                {:_column_1 "17"}]}]]]]]]]]]]]]]]


### PR DESCRIPTION
  ## Summary                                                                                                                                              
  - Fix ORDER BY when referencing SELECT aliases inside expressions (e.g. `ORDER BY y * 2` where `y` is a SELECT alias).
    Previously this produced invalid plans with sibling dependencies in a single `:project` node.                                                         
    `wrap-integrated-ob` now layers `:map` nodes — first for computed SELECT expressions, then for ORDER BY in-projections — so each layer can reference  
  the output below it.                                                                                                                                    
  - Avoid redundant ORDER BY in-projections when the ORDER BY expression matches a SELECT expression                                                      
    (e.g. `SELECT year = 'foo' ORDER BY year = 'foo'` no longer computes the expression twice).                                                           
  - Document that alias references within GROUP BY expressions produce the expected "Missing grouping columns" error.