### PR TITLE
feat(sql): allow CURRENT_USER as a column alias

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -156,6 +156,11 @@ identifier
 
 columnName : identifier ;
 
+columnLabel
+    : identifier
+    | 'CURRENT_USER'
+    ;
+
 // §6 Scalar Expressions
 
 /// §6.1 Data Types
@@ -649,7 +654,7 @@ excludeClause
     ;
 
 derivedColumn : expr asClause? ;
-asClause : 'AS'? columnName ;
+asClause : 'AS'? columnLabel ;
 
 /// §7.13 <query expression>
 

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -53,7 +53,12 @@
 (defn identifier-sym [^ParserRuleContext ctx]
   (some-> ctx
           (.accept (reify SqlVisitor
-                     (visitAsClause [this ctx] (-> (.columnName ctx) (.accept this)))
+                     (visitAsClause [this ctx] (-> (.columnLabel ctx) (.accept this)))
+
+                     (visitColumnLabel [this ctx]
+                       (if-let [id (.identifier ctx)]
+                         (.accept id this)
+                         (symbol (util/str->normal-form-str (.getText ctx)))))
 
                      (visitTargetTable [this ctx]
                        (let [tn (-> (.tableName ctx) (.accept this))]
@@ -843,7 +848,7 @@
                                                                               (let [renames (->> (for [^Sql$QualifiedRenameColumnContext rename-pair (some-> (.qualifiedRenameClause ctx)
                                                                                                                                                              (.qualifiedRenameColumn))]
                                                                                                    (let [sym (find-col scope [(identifier-sym (.identifier rename-pair)) table-name])
-                                                                                                         out-col-name (.columnName (.asClause rename-pair))]
+                                                                                                         out-col-name (.columnLabel (.asClause rename-pair))]
                                                                                                      (MapEntry/create sym (->col-sym (identifier-sym out-col-name)))))
                                                                                                  (into {}))]
                                                                                 (->> table-cols
@@ -859,7 +864,7 @@
                                       (let [renames (->> (for [^Sql$RenameColumnContext rename-pair (some-> (.renameClause star-ctx)
                                                                                                             (.renameColumn))]
                                                            (let [chain (rseq (mapv identifier-sym (.identifier (.identifierChain (.columnReference rename-pair)))))
-                                                                 out-col-name (.columnName (.asClause rename-pair))
+                                                                 out-col-name (.columnLabel (.asClause rename-pair))
                                                                  sym (find-col scope chain)]
 
                                                              (MapEntry/create sym (->col-sym (identifier-sym out-col-name)))))

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1531,7 +1531,22 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
            (xt/q tu/*node* "SELECT current_schemas(false) v")))
 
   (t/is (= [{:v ["pg_catalog" "public"]} {:v ["public"]}]
-           (xt/q tu/*node* "SELECT current_schemas(a) v FROM (VALUES (true), (false)) AS x(a)"))))
+           (xt/q tu/*node* "SELECT current_schemas(a) v FROM (VALUES (true), (false)) AS x(a)")))
+
+  (t/is (= [{:current-user 1}]
+           (xt/q tu/*node* "SELECT 1 AS current_user")))
+
+  (t/is (= [{:current-user 1}]
+           (xt/q tu/*node* "SELECT 1 AS current_user ORDER BY current_user || 'x'")))
+
+  (t/is (= [{:current-user 1}]
+           (xt/q tu/*node* "SELECT x.\"current_user\" FROM (SELECT 1 AS current_user) x")))
+
+  (t/is (= [{:xt/column-1 "xtdb"}]
+           (xt/q tu/*node* "SELECT current_user FROM (SELECT 1 AS current_user) x")))
+
+  (t/is (= [{:current-user 1}]
+           (xt/q tu/*node* "SELECT \"current_user\" FROM (SELECT 1 AS current_user) x"))))
 
 (t/deftest test-postgres-access-control-functions
   ;; These current functions should always should return true


### PR DESCRIPTION
`CURRENT_USER` is a niladic function keyword so it's not in the `identifier` grammar rule, which meant `SELECT 1 AS current_user` failed to parse.

Introduces a `columnLabel` rule (superset of `identifier`) that additionally accepts niladic function keywords, and uses it in `asClause`.
This mirrors the PostgreSQL grammar pattern and generalises for future niladic function keywords.

Bare `current_user` in expression position still resolves to the niladic function even when an alias of the same name is in scope.