### PR TITLE
Ingestion stopped on leader >follower

### DIFF
--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -83,7 +83,7 @@
                                          :post (fn [{:keys [^Database db]}]
                                                  (try
                                                    (let [flush-msg (SourceMessage$FlushBlock. (or (.getCurrentBlockIndex (.getBlockCatalog db)) -1))
-                                                         msg-id (.appendMessageBlocking (.getSourceLog db) flush-msg)]
+                                                         msg-id @(.appendMessage (.getSourceLog db) flush-msg)]
                                                      {:status 200, :body "Block flush message sent successfully."
                                                       :headers {"X-XTDB-Message-Id" (str msg-id)}})
                                                    (catch Exception e

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -15,7 +15,7 @@
            java.util.concurrent.TimeUnit
            org.apache.arrow.memory.BufferAllocator
            (xtdb.api TransactionKey Xtdb$Config)
-           (xtdb.api.log Log Log$Cluster$Factory Log$Factory SourceMessage$Tx)
+           (xtdb.api.log Log Log$Cluster$Factory Log$Factory SourceMessage$Tx Log$MessageMetadata)
            (xtdb.arrow Relation Vector)
            xtdb.catalog.BlockCatalog
            (xtdb.database Database DatabaseStorage Database$Catalog Database$Mode)
@@ -241,11 +241,11 @@
         log (.getSourceLog db)
         default-tz (:default-tz opts default-tz)]
     (util/rethrowing-cause
-      (let [message-meta (.appendMessageBlocking log
-                                                 (SourceMessage$Tx. (serialize-tx-ops allocator (->TxOps tx-ops)
-                                                                                      (-> (select-keys opts [:authn :default-db])
-                                                                                          (assoc :default-tz (:default-tz opts default-tz)
-                                                                                                 :system-time (some-> system-time time/expect-instant))))))]
+      (let [^Log$MessageMetadata message-meta @(.appendMessage log
+                                                               (SourceMessage$Tx. (serialize-tx-ops allocator (->TxOps tx-ops)
+                                                                                                  (-> (select-keys opts [:authn :default-db])
+                                                                                                      (assoc :default-tz (:default-tz opts default-tz)
+                                                                                                             :system-time (some-> system-time time/expect-instant))))))]
         (.getMsgId message-meta)))))
 
 

--- a/core/src/main/clojure/xtdb/log/processor.clj
+++ b/core/src/main/clojure/xtdb/log/processor.clj
@@ -102,7 +102,8 @@
                                                     replica-producer
                                                     watchers replica-watchers db-catalog)))
 
-          log-processor (LogProcessor. proc-factory db-storage db-state watchers block-finisher meter-registry)]
+          log-processor (LogProcessor. proc-factory db-storage db-state watchers block-finisher
+                                       meter-registry (.getLeaderHandoffTimeout indexer-conf))]
 
       {:log-processor log-processor
        :consumer (when-not (= mode Database$Mode/READ_ONLY)

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -24,7 +24,7 @@
            (xtdb.adbc XtdbConnection XtdbConnection$Node)
            (xtdb.antlr Sql$DirectlyExecutableStatementContext)
            (xtdb.api DataSource TransactionResult Xtdb Xtdb$CompactorNode Xtdb$Config Xtdb$ExecutedTx Xtdb$SubmittedTx Xtdb$XtdbInternal)
-           (xtdb.api.log SourceMessage$Tx)
+           (xtdb.api.log SourceMessage$Tx Log$MessageMetadata)
            xtdb.api.module.XtdbModule$Factory
            (xtdb.database Database Database$Catalog)
            xtdb.error.Anomaly
@@ -173,7 +173,7 @@
             tx-opts (.withFallbackTz tx-opts default-tz)]
         (util/rethrowing-cause
          (let [tx-msg (SourceMessage$Tx. (TxWriter/serializeTxOps tx-ops allocator tx-opts))
-               message-meta (.appendMessageBlocking log tx-msg)]
+               ^Log$MessageMetadata message-meta @(.appendMessage log tx-msg)]
            (Xtdb$SubmittedTx. (.getMsgId message-meta)))))
       (catch Anomaly e
         (when tx-error-counter

--- a/core/src/main/kotlin/xtdb/api/IndexerConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/IndexerConfig.kt
@@ -15,7 +15,8 @@ data class IndexerConfig(
     var rowsPerBlock: Long = 102400L,
     var flushDuration: Duration = Duration.ofHours(4),
     var skipTxs: List<MessageId> = System.getenv("XTDB_SKIP_TXS")?.let(::parseSkipTxsEnv).orEmpty(),
-    var enabled: Boolean = true
+    var enabled: Boolean = true,
+    var leaderHandoffTimeout: Duration = Duration.ofSeconds(30),
 ) {
     fun logLimit(logLimit: Long) = apply { this.logLimit = logLimit }
     fun pageLimit(pageLimit: Long) = apply { this.pageLimit = pageLimit }
@@ -23,6 +24,7 @@ data class IndexerConfig(
     fun flushDuration(flushDuration: Duration) = apply { this.flushDuration = flushDuration }
     fun skipTxs(skipTxs: List<MessageId>) = apply { this.skipTxs = skipTxs.sorted() }
     fun enabled(enabled: Boolean) = apply { this.enabled = enabled }
+    fun leaderHandoffTimeout(leaderHandoffTimeout: Duration) = apply { this.leaderHandoffTimeout = leaderHandoffTimeout }
 
     companion object {
         private fun parseSkipTxsEnv(skipTxs: String): List<MessageId> =

--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -81,27 +81,29 @@ class InMemoryLog<M> @JvmOverloads constructor(
         private set
 
     override fun appendMessage(message: M) =
-        CompletableDeferred<MessageMetadata>()
-            .also { scope.launch { appendCh.send(NewMessage(message, it)) } }
+        scope.future {
+            val res = CompletableDeferred<MessageMetadata>()
+            appendCh.send(NewMessage(message, res))
+            res.await()
+        }
 
     override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer<M> {
         override fun openTx() = object : AtomicProducer.Tx<M> {
-            private val buffer = mutableListOf<Pair<M, CompletableDeferred<MessageMetadata>>>()
+            private val buffer = mutableListOf<Pair<M, CompletableFuture<MessageMetadata>>>()
             private var isOpen = true
 
-            override fun appendMessage(message: M): CompletableDeferred<MessageMetadata> {
+            override fun appendMessage(message: M): CompletableFuture<MessageMetadata> {
                 check(isOpen) { "Transaction already closed" }
-                return CompletableDeferred<MessageMetadata>()
-                    .also { buffer.add(message to it) }
+                val future = CompletableFuture<MessageMetadata>()
+                buffer.add(message to future)
+                return future
             }
 
             override fun commit() {
                 check(isOpen) { "Transaction already closed" }
                 isOpen = false
-                runBlocking {
-                    for ((message, res) in buffer) {
-                        res.complete(this@InMemoryLog.appendMessage(message).await())
-                    }
+                for ((message, future) in buffer) {
+                    future.complete(this@InMemoryLog.appendMessage(message).join())
                 }
             }
 
@@ -145,8 +147,13 @@ class InMemoryLog<M> @JvmOverloads constructor(
                         @OptIn(ExperimentalCoroutinesApi::class)
                         onTimeout(1.minutes) { emptyList() }
                     }
-
-                    processor.processRecords(records)
+                    if (records.isNotEmpty()) runInterruptible {
+                        try {
+                            processor.processRecords(records)
+                        } catch (_: Interrupted) {
+                            throw InterruptedException()
+                        }
+                    }
                 }
             }
 
@@ -157,7 +164,7 @@ class InMemoryLog<M> @JvmOverloads constructor(
     }
 
     override fun openGroupConsumer(listener: SubscriptionListener): Consumer<M> {
-        listener.onPartitionsAssignedSync(listOf(0))
+        listener.onPartitionsAssigned(listOf(0))
         val inner = openConsumer()
         return object : Consumer<M> {
             override fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>) =
@@ -165,7 +172,7 @@ class InMemoryLog<M> @JvmOverloads constructor(
 
             override fun close() {
                 inner.close()
-                listener.onPartitionsRevokedSync(listOf(0))
+                listener.onPartitionsRevoked(listOf(0))
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -3,6 +3,7 @@ package xtdb.api.log
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.future.future
 import kotlinx.coroutines.selects.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -11,9 +12,11 @@ import xtdb.api.log.Log.*
 import xtdb.database.proto.DatabaseConfig
 import xtdb.util.MsgIdUtil
 import xtdb.database.proto.inMemoryLog
+import xtdb.error.Interrupted
 import java.time.Instant
 import java.time.InstantSource
 import java.time.temporal.ChronoUnit.MICROS
+import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -77,7 +80,7 @@ class InMemoryLog<M> @JvmOverloads constructor(
     override var latestSubmittedOffset: LogOffset = -1
         private set
 
-    override fun appendMessage(message: M): Deferred<MessageMetadata> =
+    override fun appendMessage(message: M) =
         CompletableDeferred<MessageMetadata>()
             .also { scope.launch { appendCh.send(NewMessage(message, it)) } }
 

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -198,7 +198,7 @@ class LocalLog<M>(
         }
     }
 
-    override fun appendMessage(message: M): Deferred<MessageMetadata> =
+    override fun appendMessage(message: M) =
         CompletableDeferred<MessageMetadata>()
             .also { res ->
                 scope.launch {

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.future.future
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.SerialName
@@ -29,6 +30,7 @@ import java.nio.file.Path
 import java.nio.file.StandardOpenOption.*
 import java.time.Instant
 import java.time.InstantSource
+import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.CoroutineContext
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.exists
@@ -199,34 +201,30 @@ class LocalLog<M>(
     }
 
     override fun appendMessage(message: M) =
-        CompletableDeferred<MessageMetadata>()
-            .also { res ->
-                scope.launch {
-                    val onCommit = CompletableDeferred<Record<M>>()
-                    appendCh.send(NewMessage(message, onCommit))
-                    val record = onCommit.await()
-                    res.complete(MessageMetadata(epoch, record.logOffset, record.logTimestamp))
-                }
-            }
+        scope.future {
+            val onCommit = CompletableDeferred<Record<M>>()
+            appendCh.send(NewMessage(message, onCommit))
+            val record = onCommit.await()
+            MessageMetadata(epoch, record.logOffset, record.logTimestamp)
+        }
 
     override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer<M> {
         override fun openTx() = object : AtomicProducer.Tx<M> {
-            private val buffer = mutableListOf<Pair<M, CompletableDeferred<MessageMetadata>>>()
+            private val buffer = mutableListOf<Pair<M, CompletableFuture<MessageMetadata>>>()
             private var isOpen = true
 
-            override fun appendMessage(message: M): CompletableDeferred<MessageMetadata> {
+            override fun appendMessage(message: M): CompletableFuture<MessageMetadata> {
                 check(isOpen) { "Transaction already closed" }
-                return CompletableDeferred<MessageMetadata>()
-                    .also { buffer.add(message to it) }
+                val future = CompletableFuture<MessageMetadata>()
+                buffer.add(message to future)
+                return future
             }
 
             override fun commit() {
                 check(isOpen) { "Transaction already closed" }
                 isOpen = false
-                runBlocking {
-                    for ((message, res) in buffer) {
-                        res.complete(this@LocalLog.appendMessage(message).await())
-                    }
+                for ((message, future) in buffer) {
+                    future.complete(this@LocalLog.appendMessage(message).join())
                 }
             }
 
@@ -311,7 +309,7 @@ class LocalLog<M>(
                     val msg = withTimeoutOrNull(1.minutes) {
                         ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
                     }
-                    if (msg != null) processor.processRecords(listOf(msg))
+                    if (msg != null) runInterruptible { processor.processRecords(listOf(msg)) }
                 }
             }
 
@@ -322,15 +320,14 @@ class LocalLog<M>(
     }
 
     override fun openGroupConsumer(listener: SubscriptionListener): Consumer<M> {
-        listener.onPartitionsAssignedSync(listOf(0))
+        listener.onPartitionsAssigned(listOf(0))
         val inner = openConsumer()
         return object : Consumer<M> {
             override fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>) =
                 inner.tailAll(afterMsgId, processor)
-
             override fun close() {
                 inner.close()
-                listener.onPartitionsRevokedSync(listOf(0))
+                listener.onPartitionsRevoked(listOf(0))
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -3,7 +3,6 @@
 package xtdb.api.log
 
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withTimeoutOrNull
@@ -149,7 +148,7 @@ interface Log<M> : AutoCloseable {
         val msgId: MessageId get() = offsetToMsgId(epoch, logOffset)
     }
 
-    fun appendMessage(message: M): Deferred<MessageMetadata>
+    fun appendMessage(message: M): CompletableDeferred<MessageMetadata>
 
     fun appendMessageBlocking(message: M): MessageMetadata = runBlocking { appendMessage(message).await() }
 

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -4,7 +4,6 @@ package xtdb.api.log
 
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.runInterruptible
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.SerializersModule
@@ -21,7 +20,6 @@ import java.nio.file.Path
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.CompletableFuture
-import kotlin.time.Duration.Companion.seconds
 import com.google.protobuf.Any as ProtoAny
 
 
@@ -112,10 +110,7 @@ interface Log<M> : AutoCloseable {
             openConsumer().closeOnCatch { c ->
                 c.tailAll(afterMsgId, processor).closeOnCatch { subs ->
                     Subscription {
-                        runBlocking {
-                            withTimeoutOrNull(5.seconds) { runInterruptible { subs.close() } }
-                        }
-
+                        runBlocking { runInterruptible { subs.close() } }
                         c.close()
                     }
                 }

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -2,7 +2,6 @@
 
 package xtdb.api.log
 
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withTimeoutOrNull
@@ -21,6 +20,7 @@ import xtdb.util.closeOnCatch
 import java.nio.file.Path
 import java.time.Instant
 import java.util.*
+import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.seconds
 import com.google.protobuf.Any as ProtoAny
 
@@ -87,7 +87,7 @@ interface Log<M> : AutoCloseable {
     }
 
     fun interface RecordProcessor<in M> {
-        suspend fun processRecords(records: List<Record<M>>)
+        fun processRecords(records: List<Record<M>>)
     }
 
     interface Consumer<M> : AutoCloseable {
@@ -148,9 +148,7 @@ interface Log<M> : AutoCloseable {
         val msgId: MessageId get() = offsetToMsgId(epoch, logOffset)
     }
 
-    fun appendMessage(message: M): CompletableDeferred<MessageMetadata>
-
-    fun appendMessageBlocking(message: M): MessageMetadata = runBlocking { appendMessage(message).await() }
+    fun appendMessage(message: M): CompletableFuture<MessageMetadata>
 
     /**
      * @param transactionalId uniquely identifies this producer for Kafka's transaction coordinator.
@@ -162,7 +160,7 @@ interface Log<M> : AutoCloseable {
         fun openTx(): Tx<M>
 
         interface Tx<M> : AutoCloseable {
-            fun appendMessage(message: M): CompletableDeferred<MessageMetadata>
+            fun appendMessage(message: M): CompletableFuture<MessageMetadata>
             fun commit()
             fun abort()
         }
@@ -186,12 +184,9 @@ interface Log<M> : AutoCloseable {
     fun openGroupConsumer(listener: SubscriptionListener): Consumer<M>
 
     interface SubscriptionListener {
-        suspend fun onPartitionsAssigned(partitions: Collection<Int>)
-        fun onPartitionsAssignedSync(partitions: Collection<Int>) = runBlocking { onPartitionsAssigned(partitions) }
-        suspend fun onPartitionsRevoked(partitions: Collection<Int>)
-        fun onPartitionsRevokedSync(partitions: Collection<Int>) = runBlocking { onPartitionsRevoked(partitions) }
-        suspend fun onPartitionsLost(partitions: Collection<Int>) = onPartitionsRevoked(partitions)
-        fun onPartitionsLostSync(partitions: Collection<Int>) = runBlocking { onPartitionsLost(partitions) }
+        fun onPartitionsAssigned(partitions: Collection<Int>)
+        fun onPartitionsRevoked(partitions: Collection<Int>)
+        fun onPartitionsLost(partitions: Collection<Int>) = onPartitionsRevoked(partitions)
     }
 
     class Record<out M>(

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
@@ -93,7 +93,7 @@ class ReadOnlyLocalLog<M>(
     override val latestSubmittedOffset: LogOffset
         get() = readLatestSubmittedOffset(logFilePath)
 
-    override fun appendMessage(message: M): Deferred<MessageMetadata> =
+    override fun appendMessage(message: M) =
         throw Incorrect("Cannot append to read-only database log")
 
     override fun openAtomicProducer(transactionalId: String) =

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
@@ -154,7 +154,7 @@ class ReadOnlyLocalLog<M>(
                         val msg = withTimeoutOrNull(1.minutes) {
                             ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
                         }
-                        if (msg != null) processor.processRecords(listOf(msg))
+                        if (msg != null) runInterruptible { processor.processRecords(listOf(msg)) }
                     }
                 } finally {
                     producerJob.cancelAndJoin()
@@ -168,15 +168,14 @@ class ReadOnlyLocalLog<M>(
     }
 
     override fun openGroupConsumer(listener: Log.SubscriptionListener): Log.Consumer<M> {
-        listener.onPartitionsAssignedSync(listOf(0))
+        listener.onPartitionsAssigned(listOf(0))
         val inner = openConsumer()
         return object : Log.Consumer<M> {
             override fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) =
                 inner.tailAll(afterMsgId, processor)
-
             override fun close() {
                 inner.close()
-                listener.onPartitionsRevokedSync(listOf(0))
+                listener.onPartitionsRevoked(listOf(0))
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLog.kt
@@ -1,10 +1,9 @@
 package xtdb.api.log
 
-import kotlinx.coroutines.Deferred
 import xtdb.error.Incorrect
 
 class ReadOnlyLog<M>(private val delegate: Log<M>) : Log<M> by delegate {
-    override fun appendMessage(message: M): Deferred<Log.MessageMetadata> =
+    override fun appendMessage(message: M): Nothing =
         throw Incorrect("Cannot append to read-only database log")
 
     override fun appendMessageBlocking(message: M): Nothing =

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLog.kt
@@ -3,12 +3,9 @@ package xtdb.api.log
 import xtdb.error.Incorrect
 
 class ReadOnlyLog<M>(private val delegate: Log<M>) : Log<M> by delegate {
-    override fun appendMessage(message: M): Nothing =
+    override fun appendMessage(message: M) =
         throw Incorrect("Cannot append to read-only database log")
 
-    override fun appendMessageBlocking(message: M): Nothing =
-        throw Incorrect("Cannot append to read-only database log")
-
-    override fun openAtomicProducer(transactionalId: String): Nothing =
+    override fun openAtomicProducer(transactionalId: String) =
         throw Incorrect("Cannot open atomic producer on read-only database log")
 }

--- a/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
@@ -58,7 +58,7 @@ sealed interface ReplicaMessage {
                         }
 
                         ReplicaLogMessage.MessageCase.TRIES_ADDED -> msg.triesAdded.let {
-                            TriesAdded(it.storageVersion, it.storageEpoch, it.triesList, it.sourceMsgId)
+                            TriesAdded(it.storageVersion, it.storageEpoch, it.triesList)
                         }
 
                         ReplicaLogMessage.MessageCase.BLOCK_BOUNDARY -> msg.blockBoundary.let {
@@ -123,15 +123,13 @@ sealed interface ReplicaMessage {
     }
 
     data class TriesAdded(
-        val storageVersion: Int, val storageEpoch: StorageEpoch, val tries: List<TrieDetails>,
-        val sourceMsgId: MessageId = 0,
+        val storageVersion: Int, val storageEpoch: StorageEpoch, val tries: List<TrieDetails>
     ) : ProtobufMessage() {
         override fun toLogMessage() = replicaLogMessage {
             triesAdded = triesAdded {
                 storageVersion = this@TriesAdded.storageVersion
                 storageEpoch = this@TriesAdded.storageEpoch
                 tries.addAll(this@TriesAdded.tries)
-                sourceMsgId = this@TriesAdded.sourceMsgId
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.time.withTimeout
+import xtdb.api.log.Log
 import xtdb.api.log.SourceMessage.TriesAdded
 import xtdb.api.log.Watchers
 import xtdb.api.storage.Storage

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -28,6 +28,7 @@ import xtdb.trie.ColumnName
 import xtdb.database.proto.DatabaseConfig
 import xtdb.database.proto.DatabaseMode
 import xtdb.compactor.Compactor
+import xtdb.indexer.Indexer
 import xtdb.indexer.LiveIndex
 import xtdb.indexer.Snapshot
 import xtdb.metadata.PageMetadata

--- a/core/src/main/kotlin/xtdb/indexer/BlockFinisher.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockFinisher.kt
@@ -1,6 +1,5 @@
 package xtdb.indexer
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import xtdb.api.log.Log
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.api.log.MessageId
@@ -77,7 +76,6 @@ class BlockFinisher(
         blockCatalog.refresh(block)
 
         // Now signal followers that the block is available.
-        @OptIn(ExperimentalCoroutinesApi::class)
         val uploadedMsgId = replicaProducer.withTx { tx ->
             tx.appendMessage(
                 BlockUploaded(
@@ -86,7 +84,7 @@ class BlockFinisher(
                     addedTries
                 )
             )
-        }.getCompleted().msgId
+        }.get().msgId
 
         LOG.debug("block uploaded b${blockIdx.asLexHex}: source=$latestProcessedMsgId, replica=$uploadedMsgId")
 

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -128,7 +128,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
         }
     }
 
-    override suspend fun processRecords(records: List<Log.Record<ReplicaMessage>>) {
+    override fun processRecords(records: List<Log.Record<ReplicaMessage>>) {
         for (record in records) {
             try {
                 val res = handleRecord(record)

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -106,9 +106,6 @@ class FollowerLogProcessor @JvmOverloads constructor(
             is ReplicaMessage.TriesAdded -> {
                 if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch)
                     addTries(msg.tries, record.logTimestamp)
-
-                sourceWatchers.notify(msg.sourceMsgId, null)
-
                 null
             }
 

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -69,15 +69,15 @@ class LeaderLogProcessor(
 
     private val blockFlusher = BlockFlusher(flushTimeout, blockCatalog)
 
-    private suspend fun maybeFlushBlock() {
+    private fun maybeFlushBlock() {
         if (blockFlusher.checkBlockTimeout(blockCatalog, liveIndex)) {
             val flushMessage = SourceMessage.FlushBlock(blockCatalog.currentBlockIndex ?: -1)
-            blockFlusher.flushedTxId = sourceLog.appendMessage(flushMessage).await().msgId
+            blockFlusher.flushedTxId = sourceLog.appendMessage(flushMessage).get().msgId
         }
     }
 
-    private suspend fun appendToReplica(message: ReplicaMessage): Log.MessageMetadata =
-        replicaProducer.withTx { tx -> tx.appendMessage(message) }.await()
+    private fun appendToReplica(message: ReplicaMessage): Log.MessageMetadata =
+        replicaProducer.withTx { tx -> tx.appendMessage(message) }.get()
 
     private fun resolveTx(
         msgId: MessageId, record: Log.Record<SourceMessage>, msg: SourceMessage.Tx
@@ -128,7 +128,7 @@ class LeaderLogProcessor(
         watchers.notify(txId, result)
     }
 
-    private suspend fun finishBlock(latestProcessedMsgId: MessageId) {
+    private fun finishBlock(latestProcessedMsgId: MessageId) {
         val boundaryMsg = BlockBoundary((blockCatalog.currentBlockIndex ?: -1) + 1, latestProcessedMsgId)
         val boundaryMsgId = appendToReplica(boundaryMsg).msgId
         LOG.debug("block boundary b${boundaryMsg.blockIndex.asLexHex}: source=$latestProcessedMsgId, replica=$boundaryMsgId")
@@ -137,7 +137,7 @@ class LeaderLogProcessor(
         pendingBlock = null
     }
 
-    private suspend fun handleResolvedTx(resolvedTx: ReplicaMessage.ResolvedTx) {
+    private fun handleResolvedTx(resolvedTx: ReplicaMessage.ResolvedTx) {
         val txId = resolvedTx.txId
 
         appendToReplica(resolvedTx)
@@ -147,7 +147,7 @@ class LeaderLogProcessor(
             finishBlock(txId)
     }
 
-    override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+    override fun processRecords(records: List<Log.Record<SourceMessage>>) {
         maybeFlushBlock()
 
         for (record in records) {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -220,7 +220,7 @@ class LeaderLogProcessor(
                                 )
                             }
                         }
-                        appendToReplica(ReplicaMessage.TriesAdded(msg.storageVersion, msg.storageEpoch, msg.tries, sourceMsgId = msgId))
+                        appendToReplica(ReplicaMessage.TriesAdded(msg.storageVersion, msg.storageEpoch, msg.tries))
                         watchers.notify(msgId, null)
                     }
 

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -2,6 +2,7 @@ package xtdb.indexer
 
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.runBlocking
 import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.api.log.Log.Companion.tailAll
@@ -88,7 +89,7 @@ class LogProcessor(
         }
     }
 
-    override suspend fun onPartitionsAssigned(partitions: Collection<Int>) {
+    override fun onPartitionsAssigned(partitions: Collection<Int>) {
         if (partitions != listOf(0)) return
 
         this.sys = when (val oldSys = sys) {
@@ -106,9 +107,9 @@ class LogProcessor(
                     // Send a NoOp to get a known msgId we can await —
                     // we can't use latestSubmittedMsgId because Kafka's endOffsets
                     // includes transaction marker offsets that consumers never deliver.
-                    val replayTarget = replicaProducer.withTx { it.appendMessage(ReplicaMessage.NoOp) }.await().msgId
+                    val replayTarget = replicaProducer.withTx { it.appendMessage(ReplicaMessage.NoOp) }.get().msgId
                     LOG.debug("transition: awaiting replica watcher catch-up to $replayTarget (replica latest: ${replicaLog.latestSubmittedMsgId})")
-                    replicaWatchers.await0(replayTarget)
+                    runBlocking { replicaWatchers.await0(replayTarget) }
                     LOG.debug("transition: replica watchers caught up to $replayTarget")
 
                     val followerProc = oldSys.proc
@@ -129,7 +130,7 @@ class LogProcessor(
                         }
 
                         LOG.debug("transition: syncing watchers")
-                        val latestProcessedMsgId = watchers.sync()
+                        val latestProcessedMsgId = runBlocking { watchers.sync() }
 
                         LOG.debug("transition: opening leader processor")
 
@@ -141,7 +142,7 @@ class LogProcessor(
         }
     }
 
-    override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {
+    override fun onPartitionsRevoked(partitions: Collection<Int>) {
         if (partitions != listOf(0)) return
 
         LOG.debug("partitions revoked: $partitions — transitioning to follower")

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -151,9 +151,9 @@ class LogProcessor(
                 val pendingBlock = oldSys.pendingBlock
                 LOG.debug("revocation: closing leader system (pendingBlock=${pendingBlock != null})")
                 oldSys.close()
-                val latestSubmitted = replicaLog.latestSubmittedMsgId
-                LOG.debug("revocation: opening follower system from $latestSubmitted")
-                openFollowerSystem(latestSubmitted, pendingBlock)
+                val startMsgId = pendingBlock?.boundaryMsgId ?: replicaLog.latestSubmittedMsgId
+                LOG.debug("revocation: opening follower system from $startMsgId (pendingBlock=${pendingBlock != null})")
+                openFollowerSystem(startMsgId, pendingBlock)
             }
 
             is FollowerSystem -> {

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -2,6 +2,7 @@ package xtdb.indexer
 
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
 import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
@@ -14,7 +15,11 @@ import xtdb.util.closeOnCatch
 import xtdb.util.debug
 import xtdb.util.info
 import xtdb.util.logger
+import xtdb.util.warn
+import xtdb.util.runBlockingWithTimeout
+import java.time.Duration
 import kotlin.math.max
+import kotlin.time.Duration.Companion.seconds
 
 private val LOG = LogProcessor::class.logger
 
@@ -25,6 +30,7 @@ class LogProcessor(
     private val watchers: Watchers,
     private val blockFinisher: BlockFinisher,
     meterRegistry: MeterRegistry? = null,
+    private val leaderHandoffTimeout: Duration = Duration.ofMinutes(4),
 ) : Log.SubscriptionListener, AutoCloseable {
 
     interface LeaderProcessor : Log.RecordProcessor<SourceMessage>, AutoCloseable
@@ -115,7 +121,7 @@ class LogProcessor(
                     val followerProc = oldSys.proc
                     val pendingBlock = followerProc.pendingBlock
                     LOG.debug("transition: closing follower system (pendingBlock=${pendingBlock != null})")
-                    oldSys.close()
+                    runBlockingWithTimeout(leaderHandoffTimeout) { oldSys.close() }
 
                     procFactory.openTransition(replicaProducer, replicaWatchers).use { transition ->
                         if (pendingBlock != null) {
@@ -151,7 +157,7 @@ class LogProcessor(
                 LOG.info("partitions revoked: $partitions — was leader, transitioning to follower")
                 val pendingBlock = oldSys.pendingBlock
                 LOG.debug("revocation: closing leader system (pendingBlock=${pendingBlock != null})")
-                oldSys.close()
+                runBlockingWithTimeout(leaderHandoffTimeout) { oldSys.close() }
                 val startMsgId = pendingBlock?.boundaryMsgId ?: replicaLog.latestSubmittedMsgId
                 LOG.debug("revocation: opening follower system from $startMsgId (pendingBlock=${pendingBlock != null})")
                 openFollowerSystem(startMsgId, pendingBlock)
@@ -165,7 +171,11 @@ class LogProcessor(
     }
 
     override fun close() {
-        sys.close()
+        try {
+            runBlockingWithTimeout(10.seconds) { sys.close() }
+        } catch (e: TimeoutCancellationException) {
+            LOG.warn(e, "close timed out")
+        }
         replicaWatchers.close()
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
@@ -220,10 +220,10 @@ class SourceLogProcessor(
         LOG.debug("read-only: waiting for block 'b${blockIdx.asLexHex}' via BlockUploaded...")
     }
 
-    override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+    override fun processRecords(records: List<Log.Record<SourceMessage>>) {
         if (!readOnly && flusher.checkBlockTimeout(blockCatalog, liveIndex)) {
             val flushMessage = SourceMessage.FlushBlock(blockCatalog.currentBlockIndex ?: -1)
-            flusher.flushedTxId = log.appendMessage(flushMessage).await().msgId
+            flusher.flushedTxId = log.appendMessage(flushMessage).get().msgId
         }
 
         var lastMsgId: MessageId = latestProcessedMsgId

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -72,7 +72,6 @@ class TransitionLogProcessor(
                                 )
                             }
                         }
-                        sourceWatchers.notify(msg.sourceMsgId, null)
                         null
                     }
 

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -34,7 +34,7 @@ class TransitionLogProcessor(
 
     private val allocator = allocator.newChildAllocator("transition-log-processor", 0, Long.MAX_VALUE)
 
-    override suspend fun processRecords(records: List<Log.Record<ReplicaMessage>>) {
+    override fun processRecords(records: List<Log.Record<ReplicaMessage>>) {
         LOG.debug("transition: processing ${records.size} records")
 
         for (record in records) {

--- a/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
+++ b/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
@@ -11,7 +11,6 @@ import xtdb.api.log.LogOffset
 import xtdb.api.log.ReadOnlyLog
 import xtdb.database.proto.DatabaseConfig
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.runBlocking
 import java.time.Instant
 import java.time.InstantSource
@@ -48,7 +47,7 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
     override var latestSubmittedOffset: LogOffset = -1
         private set
 
-    override fun appendMessage(message: M): Deferred<Log.MessageMetadata> {
+    override fun appendMessage(message: M): CompletableDeferred<Log.MessageMetadata> {
         messages.add(message)
 
         val ts = if (message is SourceMessage.Tx) instantSource.instant() else Instant.now()

--- a/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
+++ b/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
@@ -10,11 +10,10 @@ import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.LogOffset
 import xtdb.api.log.ReadOnlyLog
 import xtdb.database.proto.DatabaseConfig
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.runBlocking
 import java.time.Instant
 import java.time.InstantSource
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.CompletableFuture
 
 class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M>) : Log<M> {
     override val epoch = 0
@@ -47,12 +46,12 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
     override var latestSubmittedOffset: LogOffset = -1
         private set
 
-    override fun appendMessage(message: M): CompletableDeferred<Log.MessageMetadata> {
+    override fun appendMessage(message: M): CompletableFuture<Log.MessageMetadata> {
         messages.add(message)
 
         val ts = if (message is SourceMessage.Tx) instantSource.instant() else Instant.now()
 
-        return CompletableDeferred(
+        return CompletableFuture.completedFuture(
             Log.MessageMetadata(
                 epoch,
                 ++latestSubmittedOffset,
@@ -65,22 +64,21 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
 
     override fun openAtomicProducer(transactionalId: String) = object : Log.AtomicProducer<M> {
         override fun openTx() = object : Log.AtomicProducer.Tx<M> {
-            private val buffer = mutableListOf<Pair<M, CompletableDeferred<Log.MessageMetadata>>>()
+            private val buffer = mutableListOf<Pair<M, CompletableFuture<Log.MessageMetadata>>>()
             private var isOpen = true
 
-            override fun appendMessage(message: M): CompletableDeferred<Log.MessageMetadata> {
+            override fun appendMessage(message: M): CompletableFuture<Log.MessageMetadata> {
                 check(isOpen) { "Transaction already closed" }
-                return CompletableDeferred<Log.MessageMetadata>()
-                    .also { buffer.add(message to it) }
+                val future = CompletableFuture<Log.MessageMetadata>()
+                buffer.add(message to future)
+                return future
             }
 
             override fun commit() {
                 check(isOpen) { "Transaction already closed" }
                 isOpen = false
-                runBlocking {
-                    for ((message, res) in buffer) {
-                        res.complete(this@RecordingLog.appendMessage(message).await())
-                    }
+                for ((message, future) in buffer) {
+                    future.complete(this@RecordingLog.appendMessage(message).join())
                 }
             }
 

--- a/core/src/main/proto/xtdb/log/proto/log.proto
+++ b/core/src/main/proto/xtdb/log/proto/log.proto
@@ -34,7 +34,6 @@ message TriesAdded {
     int32 storage_version = 2;
     int32 storage_epoch = 3;
     repeated TrieDetails tries = 1;
-    int64 source_msg_id = 4;
 }
 
 message TemporalMetadata {

--- a/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
@@ -1,6 +1,5 @@
 package xtdb.api.log
 
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -9,12 +8,12 @@ class InMemoryLogTest {
     private fun txMessage(id: Byte) = SourceMessage.Tx(byteArrayOf(-1, id))
 
     @Test
-    fun `readLastMessage always returns null`() = runTest {
+    fun `readLastMessage always returns null`() {
         val log = InMemoryLog.Factory().openSourceLog(emptyMap())
         log.use {
             assertNull(log.readLastMessage())
 
-            log.appendMessage(txMessage(1)).await()
+            log.appendMessage(txMessage(1)).get()
 
             // Still null because InMemoryLog has no persistence
             assertNull(log.readLastMessage())

--- a/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
@@ -26,7 +26,7 @@ class LocalLogTest {
         val subscription = log.tailAll(
             -1L,
             object : Log.RecordProcessor<SourceMessage> {
-                override suspend fun processRecords(records: List<Record<SourceMessage>>) {
+                override fun processRecords(records: List<Record<SourceMessage>>) {
                     records.forEach { receivedRecords.add(it) }
                 }
             }
@@ -50,10 +50,10 @@ class LocalLogTest {
     }
 
     @Test
-    fun `readLastMessage returns the message after appending one`() = runTest {
+    fun `readLastMessage returns the message after appending one`() {
         val log = LocalLog.Factory(tempDir.resolve("log")).openSourceLog(emptyMap())
         log.use {
-            log.appendMessage(txMessage(1)).await()
+            log.appendMessage(txMessage(1)).get()
 
             val lastMessage = log.readLastMessage()
             assertNotNull(lastMessage)
@@ -63,12 +63,12 @@ class LocalLogTest {
     }
 
     @Test
-    fun `readLastMessage returns the last message after appending multiple`() = runTest {
+    fun `readLastMessage returns the last message after appending multiple`() {
         val log = LocalLog.Factory(tempDir.resolve("log")).openSourceLog(emptyMap())
         log.use {
-            log.appendMessage(txMessage(1)).await()
-            log.appendMessage(txMessage(2)).await()
-            log.appendMessage(txMessage(3)).await()
+            log.appendMessage(txMessage(1)).get()
+            log.appendMessage(txMessage(2)).get()
+            log.appendMessage(txMessage(3)).get()
 
             val lastMessage = log.readLastMessage()
             assertNotNull(lastMessage)

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -4,7 +4,6 @@ import io.mockk.*
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import xtdb.api.TransactionKey
@@ -66,7 +65,7 @@ class FollowerLogProcessorTest {
         Log.Record(0, offset, Instant.now(), message)
 
     @Test
-    fun `buffer overflow stops ingestion`() = runTest {
+    fun `buffer overflow stops ingestion`() {
         val proc = makeProcessor(maxBufferedRecords = 2)
 
         val records = listOf(
@@ -81,7 +80,7 @@ class FollowerLogProcessorTest {
     }
 
     @Test
-    fun `ResolvedTx skips already-applied transactions`() = runTest {
+    fun `ResolvedTx skips already-applied transactions`() {
         every { liveIndex.latestCompletedTx } returns TransactionKey(42, Instant.now())
 
         val proc = makeProcessor()

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.apache.arrow.memory.RootAllocator
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import xtdb.api.log.InMemoryLog
@@ -54,7 +53,7 @@ class LeaderLogProcessorTest {
     }
 
     @Test
-    fun `TriesAdded forwarded to replica log`() = runTest {
+    fun `TriesAdded forwarded to replica log`() {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val trieCatalog = mockk<TrieCatalog>(relaxed = true)
         val lp = leaderProc(replicaLog = replicaLog, trieCatalog = trieCatalog)
@@ -78,7 +77,7 @@ class LeaderLogProcessorTest {
     }
 
     @Test
-    fun `FlushBlock triggers block finish when CAS matches`() = runTest {
+    fun `FlushBlock triggers block finish when CAS matches`() {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val liveIndex = mockk<LiveIndex>(relaxed = true) {
             every { finishBlock(any()) } returns emptyMap()
@@ -117,7 +116,7 @@ class LeaderLogProcessorTest {
     }
 
     @Test
-    fun `FlushBlock ignored when CAS does not match`() = runTest {
+    fun `FlushBlock ignored when CAS does not match`() {
         val liveIndex = mockk<LiveIndex>(relaxed = true)
         val lp = leaderProc(liveIndex = liveIndex)
 
@@ -130,7 +129,7 @@ class LeaderLogProcessorTest {
     }
 
     @Test
-    fun `block finishing writes BlockBoundary + BlockUploaded to replica log`() = runTest {
+    fun `block finishing writes BlockBoundary + BlockUploaded to replica log`() {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val finishedBlock = LiveTable.FinishedBlock(
             vecTypes = emptyMap(),

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -3,14 +3,21 @@ package xtdb.indexer
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.test.runTest
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
-import xtdb.api.log.*
+import xtdb.api.log.InMemoryLog
+import xtdb.api.log.Log
 import xtdb.api.log.Log.Companion.tailAll
+import xtdb.api.log.ReplicaMessage
+import xtdb.api.log.SourceMessage
+import xtdb.api.log.MessageId
+import xtdb.util.closeOnCatch
+import xtdb.api.log.Watchers
+import xtdb.api.storage.Storage
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
@@ -18,7 +25,6 @@ import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
 import xtdb.storage.BufferPool
 import xtdb.trie.TrieCatalog
-import xtdb.util.closeOnCatch
 import java.time.InstantSource
 import java.util.concurrent.TimeUnit
 
@@ -49,17 +55,9 @@ class LogProcessorTest {
             liveIndex
         )
 
-    private fun procFactory(
-        allocator: RootAllocator,
-        bufferPool: BufferPool,
-        dbState: DatabaseState,
-        dbStorage: DatabaseStorage
-    ) =
+    private fun procFactory(allocator: RootAllocator, bufferPool: BufferPool, dbState: DatabaseState, dbStorage: DatabaseStorage) =
         object : LogProcessor.ProcessorFactory {
-            override fun openLeaderSystem(
-                replicaProducer: Log.AtomicProducer<ReplicaMessage>,
-                afterMsgId: MessageId
-            ): LogProcessor.LeaderSystem {
+            override fun openLeaderSystem(replicaProducer: Log.AtomicProducer<ReplicaMessage>, afterMsgId: MessageId): LogProcessor.LeaderSystem {
                 val watchers = Watchers(-1)
                 val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
                 val blockFinisher = BlockFinisher(dbStorage, dbState, compactor, null)
@@ -145,7 +143,7 @@ class LogProcessorTest {
     }
 
     @Test
-    fun `leader replays existing replica messages during transition`() = runTest {
+    fun `leader replays existing replica messages during transition`() {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val bufferPool = mockBufferPool()
@@ -159,7 +157,10 @@ class LogProcessorTest {
 
         // Pre-populate the replica log with a transaction
         val replicaProducer = replicaLog.openAtomicProducer("setup")
-        replicaLog.appendMessage(ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap())).await()
+        val future = replicaLog.appendMessage(
+            ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap())
+        )
+        future.get()
         replicaProducer.close()
 
         val logProc = LogProcessor(
@@ -180,7 +181,7 @@ class LogProcessorTest {
     }
 
     @Test
-    fun `leader replays existing replica messages with non-zero epoch`() = runTest {
+    fun `leader replays existing replica messages with non-zero epoch`() {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 1)
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 1)
         val bufferPool = mockBufferPool(epoch = 1)
@@ -193,7 +194,10 @@ class LogProcessorTest {
         val blockFinisher = BlockFinisher(dbStorage, dbState, mockk(relaxed = true), null)
 
         // Pre-populate the replica log
-        replicaLog.appendMessage(ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap())).await()
+        val future = replicaLog.appendMessage(
+            ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap())
+        )
+        future.get()
 
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage),

--- a/core/src/test/kotlin/xtdb/test/log/RecordingLogTest.kt
+++ b/core/src/test/kotlin/xtdb/test/log/RecordingLogTest.kt
@@ -1,6 +1,5 @@
 package xtdb.test.log
 
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import xtdb.api.log.SourceMessage
@@ -16,10 +15,10 @@ class RecordingLogTest {
     }
 
     @Test
-    fun `readLastMessage returns the message after appending one`() = runTest {
+    fun `readLastMessage returns the message after appending one`() {
         val log = RecordingLog.Factory().openSourceLog(emptyMap())
 
-        log.appendMessage(txMessage(1)).await()
+        log.appendMessage(txMessage(1)).get()
 
         val lastMessage = log.readLastMessage()
         assertNotNull(lastMessage)
@@ -28,12 +27,12 @@ class RecordingLogTest {
     }
 
     @Test
-    fun `readLastMessage returns the last message after appending multiple`() = runTest {
+    fun `readLastMessage returns the last message after appending multiple`() {
         val log = RecordingLog.Factory().openSourceLog(emptyMap())
 
-        log.appendMessage(txMessage(1)).await()
-        log.appendMessage(txMessage(2)).await()
-        log.appendMessage(txMessage(3)).await()
+        log.appendMessage(txMessage(1)).get()
+        log.appendMessage(txMessage(2)).get()
+        log.appendMessage(txMessage(3)).get()
 
         val lastMessage = log.readLastMessage()
         assertNotNull(lastMessage)

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
@@ -15,6 +15,7 @@ import xtdb.api.log.SourceMessage
 import xtdb.util.MsgIdUtil
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.seconds
 
@@ -41,7 +42,7 @@ class DebeziumLog @JvmOverloads constructor(
     override val latestSubmittedOffset: Long get() = -1
     override val epoch: Int get() = 0
 
-    override fun appendMessage(message: SourceMessage): Nothing =
+    override fun appendMessage(message: SourceMessage): CompletableFuture<MessageMetadata> =
         throw UnsupportedOperationException("CDC log is read-only")
 
     override fun openAtomicProducer(transactionalId: String): AtomicProducer<SourceMessage> =
@@ -56,9 +57,11 @@ class DebeziumLog @JvmOverloads constructor(
         override fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<SourceMessage>): Log.Subscription {
             val afterOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
-            val job = scope.launch {
+            val producerJob = scope.launch {
                 KafkaConsumer(
-                    kafkaConfig.plus(mapOf(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false")),
+                    kafkaConfig + mapOf(
+                        ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false",
+                    ),
                     UnitDeserializer,
                     ByteArrayDeserializer()
                 ).use { c ->
@@ -67,8 +70,8 @@ class DebeziumLog @JvmOverloads constructor(
                         c.seek(tp, afterOffset + 1)
                     }
                     while (isActive) {
-                        val records = runInterruptible(Dispatchers.IO) {
-                            try {
+                        runInterruptible(Dispatchers.IO) {
+                            val records = try {
                                 c.poll(pollDuration).records(topic).mapNotNull { record ->
                                     record.value()?.let { value ->
                                         Log.Record(
@@ -82,14 +85,14 @@ class DebeziumLog @JvmOverloads constructor(
                             } catch (_: InterruptException) {
                                 throw InterruptedException()
                             }
-                        }
 
-                        processor.processRecords(records)
+                            processor.processRecords(records)
+                        }
                     }
                 }
             }
 
-            return Log.Subscription { runBlocking { withTimeout(5.seconds) { job.cancelAndJoin() } } }
+            return Log.Subscription { runBlocking { withTimeout(5.seconds) { producerJob.cancelAndJoin() } } }
         }
 
         override fun close() {}

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
@@ -69,8 +69,8 @@ class DebeziumLog @JvmOverloads constructor(
                         c.assign(listOf(tp))
                         c.seek(tp, afterOffset + 1)
                     }
-                    while (isActive) {
-                        runInterruptible(Dispatchers.IO) {
+                    runInterruptible(Dispatchers.IO) {
+                        while (true) {
                             val records = try {
                                 c.poll(pollDuration).records(topic).mapNotNull { record ->
                                     record.value()?.let { value ->

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
@@ -41,7 +41,7 @@ class DebeziumLog @JvmOverloads constructor(
     override val latestSubmittedOffset: Long get() = -1
     override val epoch: Int get() = 0
 
-    override fun appendMessage(message: SourceMessage): Deferred<MessageMetadata> =
+    override fun appendMessage(message: SourceMessage): Nothing =
         throw UnsupportedOperationException("CDC log is read-only")
 
     override fun openAtomicProducer(transactionalId: String): AtomicProducer<SourceMessage> =

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
@@ -56,6 +56,7 @@ class DebeziumLog @JvmOverloads constructor(
     override fun openConsumer(): Log.Consumer<SourceMessage> = object : Log.Consumer<SourceMessage> {
         override fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<SourceMessage>): Log.Subscription {
             val afterOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
+            val ch = kotlinx.coroutines.channels.Channel<List<Log.Record<SourceMessage>>>(10)
 
             val producerJob = scope.launch {
                 KafkaConsumer(
@@ -72,7 +73,13 @@ class DebeziumLog @JvmOverloads constructor(
                     runInterruptible(Dispatchers.IO) {
                         while (true) {
                             val records = try {
-                                c.poll(pollDuration).records(topic).mapNotNull { record ->
+                                c.poll(pollDuration).records(topic)
+                            } catch (_: InterruptException) {
+                                throw InterruptedException()
+                            }
+
+                            ch.trySend(
+                                records.mapNotNull { record ->
                                     record.value()?.let { value ->
                                         Log.Record(
                                             epoch,
@@ -82,17 +89,24 @@ class DebeziumLog @JvmOverloads constructor(
                                         )
                                     }
                                 }
-                            } catch (_: InterruptException) {
-                                throw InterruptedException()
-                            }
-
-                            processor.processRecords(records)
+                            )
                         }
                     }
                 }
             }
 
-            return Log.Subscription { runBlocking { withTimeout(5.seconds) { producerJob.cancelAndJoin() } } }
+            val consumerJob = scope.launch {
+                try {
+                    while (isActive) {
+                        val records = ch.receive()
+                        if (records.isNotEmpty()) runInterruptible { processor.processRecords(records) }
+                    }
+                } finally {
+                    producerJob.cancelAndJoin()
+                }
+            }
+
+            return Log.Subscription { runBlocking { withTimeout(5.seconds) { consumerJob.cancelAndJoin() } } }
         }
 
         override fun close() {}

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumProcessor.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumProcessor.kt
@@ -16,7 +16,7 @@ class DebeziumProcessor(
     private val allocator: BufferAllocator,
 ) : Log.RecordProcessor<SourceMessage>, AutoCloseable {
 
-    override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+    override fun processRecords(records: List<Log.Record<SourceMessage>>) {
         for (record in records) {
             try {
                 val event = CdcEvent.fromJson((record.message as SourceMessage.Tx).payload)

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
@@ -306,7 +306,7 @@ class DebeziumIntegrationTest {
             val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
 
             val capturing = object : Log.RecordProcessor<SourceMessage> {
-                override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
                     processor.processRecords(records)
                     received.addAll(records)
                 }
@@ -371,7 +371,7 @@ class DebeziumIntegrationTest {
             val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
 
             val capturing = object : Log.RecordProcessor<SourceMessage> {
-                override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
                     processor.processRecords(records)
                     received.addAll(records)
                 }
@@ -433,7 +433,7 @@ class DebeziumIntegrationTest {
             val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
 
             val capturing = object : Log.RecordProcessor<SourceMessage> {
-                override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
                     processor.processRecords(records)
                     received.addAll(records)
                 }
@@ -515,7 +515,7 @@ class DebeziumIntegrationTest {
             val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
 
             val capturing = object : Log.RecordProcessor<SourceMessage> {
-                override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
                     processor.processRecords(records)
                     received.addAll(records)
                 }
@@ -577,7 +577,7 @@ class DebeziumIntegrationTest {
             val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
 
             val capturing = object : Log.RecordProcessor<SourceMessage> {
-                override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
                     processor.processRecords(records)
                     received.addAll(records)
                 }
@@ -642,7 +642,7 @@ class DebeziumIntegrationTest {
             val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
 
             val capturing = object : Log.RecordProcessor<SourceMessage> {
-                override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
                     processor.processRecords(records)
                     received.addAll(records)
                 }
@@ -692,7 +692,7 @@ class DebeziumIntegrationTest {
             val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
 
             val capturing = object : Log.RecordProcessor<SourceMessage> {
-                override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
                     processor.processRecords(records)
                     received.addAll(records)
                 }
@@ -750,7 +750,7 @@ class DebeziumIntegrationTest {
             val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
 
             val capturing = object : Log.RecordProcessor<SourceMessage> {
-                override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+                override fun processRecords(records: List<Log.Record<SourceMessage>>) {
                     processor.processRecords(records)
                     received.addAll(records)
                 }

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumLogTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumLogTest.kt
@@ -77,7 +77,7 @@ class DebeziumLogTest {
 
         val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
         val subscriber = object : Log.RecordProcessor<SourceMessage> {
-            override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+            override fun processRecords(records: List<Log.Record<SourceMessage>>) {
                 received.addAll(records)
             }
         }
@@ -113,7 +113,7 @@ class DebeziumLogTest {
 
         val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
         val subscriber = object : Log.RecordProcessor<SourceMessage> {
-            override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+            override fun processRecords(records: List<Log.Record<SourceMessage>>) {
                 received.addAll(records)
             }
         }
@@ -139,7 +139,7 @@ class DebeziumLogTest {
 
         val received = Collections.synchronizedList(mutableListOf<Log.Record<SourceMessage>>())
         val subscriber = object : Log.RecordProcessor<SourceMessage> {
-            override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+            override fun processRecords(records: List<Log.Record<SourceMessage>>) {
                 received.addAll(records)
             }
         }

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumProcessorTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumProcessorTest.kt
@@ -1,15 +1,12 @@
 package xtdb.debezium
 
-import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
-import kotlinx.serialization.json.putJsonObject
+import kotlinx.serialization.json.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import xtdb.api.Xtdb
+import xtdb.api.log.Log
 import xtdb.api.log.Log.Record
 import xtdb.api.log.SourceMessage
 import java.time.Instant
@@ -89,8 +86,7 @@ class DebeziumProcessorTest {
         }
     }
 
-    private fun dlqTxs(node: Xtdb): List<Map<String, Any?>> = xtQuery(
-        node,
+    private fun dlqTxs(node: Xtdb): List<Map<String, Any?>> = xtQuery(node,
         """SELECT (user_metadata).error, (user_metadata).kafka_offset
            FROM xt.txs
            WHERE (user_metadata).source = 'debezium'
@@ -99,7 +95,7 @@ class DebeziumProcessorTest {
     )
 
     @Test
-    fun `invalid JSON goes to DLQ`() = runTest {
+    fun `invalid JSON goes to DLQ`() {
         Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
             val processor = DebeziumProcessor(node, "xtdb", node.allocator)
 
@@ -114,7 +110,7 @@ class DebeziumProcessorTest {
     }
 
     @Test
-    fun `JSON array goes to DLQ`() = runTest {
+    fun `JSON array goes to DLQ`() {
         Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
             val processor = DebeziumProcessor(node, "xtdb", node.allocator)
 
@@ -128,7 +124,7 @@ class DebeziumProcessorTest {
     }
 
     @Test
-    fun `unknown op goes to DLQ`() = runTest {
+    fun `unknown op goes to DLQ`() {
         Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
             val processor = DebeziumProcessor(node, "xtdb", node.allocator)
 
@@ -150,7 +146,7 @@ class DebeziumProcessorTest {
     }
 
     @Test
-    fun `missing _id goes to DLQ`() = runTest {
+    fun `missing _id goes to DLQ`() {
         Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
             val processor = DebeziumProcessor(node, "xtdb", node.allocator)
 
@@ -172,7 +168,7 @@ class DebeziumProcessorTest {
     }
 
     @Test
-    fun `empty record list is a no-op`() = runTest {
+    fun `empty record list is a no-op`() {
         Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
             val processor = DebeziumProcessor(node, "xtdb", node.allocator)
 
@@ -184,7 +180,7 @@ class DebeziumProcessorTest {
     }
 
     @Test
-    fun `valid records in batch still processed when others fail`() = runTest {
+    fun `valid records in batch still processed when others fail`() {
         Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
             val processor = DebeziumProcessor(node, "xtdb", node.allocator)
 
@@ -213,7 +209,7 @@ class DebeziumProcessorTest {
     }
 
     @Test
-    fun `node failure propagates out of processRecords`() = runTest {
+    fun `node failure propagates out of processRecords`() {
         val node = Xtdb.openNode { server { port = 0 }; flightSql = null }
         val processor = DebeziumProcessor(node, "xtdb", node.allocator)
 
@@ -229,7 +225,7 @@ class DebeziumProcessorTest {
     }
 
     @Test
-    fun `batch of mixed ops processes all records`() = runTest {
+    fun `batch of mixed ops processes all records`() {
         Xtdb.openNode { server { port = 0 }; flightSql = null }.use { node ->
             val processor = DebeziumProcessor(node, "xtdb", node.allocator)
 
@@ -244,8 +240,7 @@ class DebeziumProcessorTest {
 
             awaitTxs(node, 4)
 
-            val rows = xtQuery(
-                node,
+            val rows = xtQuery(node,
                 """SELECT _id, name, _valid_from, _valid_to
                    FROM public.test
                    FOR ALL VALID_TIME

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -173,7 +173,7 @@ class KafkaCluster(
         private val latestSubmittedOffset0 = AtomicLong(readLatestSubmittedMessage(kafkaConfigMap))
         override val latestSubmittedOffset get() = latestSubmittedOffset0.get()
 
-        override fun appendMessage(message: M): Deferred<Log.MessageMetadata> =
+        override fun appendMessage(message: M): CompletableDeferred<Log.MessageMetadata> =
             CompletableDeferred<Log.MessageMetadata>()
                 .also { res ->
                     producer.send(

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -9,6 +9,7 @@ package xtdb.api.log
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.future.future
 import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
 import kotlinx.serialization.SerialName
@@ -42,6 +43,7 @@ import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant.ofEpochMilli
 import java.util.*
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.CoroutineContext
@@ -173,23 +175,25 @@ class KafkaCluster(
         private val latestSubmittedOffset0 = AtomicLong(readLatestSubmittedMessage(kafkaConfigMap))
         override val latestSubmittedOffset get() = latestSubmittedOffset0.get()
 
-        override fun appendMessage(message: M): CompletableDeferred<Log.MessageMetadata> =
-            CompletableDeferred<Log.MessageMetadata>()
-                .also { res ->
-                    producer.send(
-                        ProducerRecord(topic, null, Unit, codec.encode(message))
-                    ) { recordMetadata, e ->
-                        if (e == null) {
-                            val metadata = Log.MessageMetadata(
-                                epoch,
-                                recordMetadata.offset(),
-                                ofEpochMilli(recordMetadata.timestamp())
-                            )
-                            latestSubmittedOffset0.updateAndGet { it.coerceAtLeast(metadata.logOffset) }
-                            res.complete(metadata)
-                        } else res.completeExceptionally(e)
+        override fun appendMessage(message: M): CompletableFuture<Log.MessageMetadata> =
+            scope.future {
+                CompletableDeferred<Log.MessageMetadata>()
+                    .also { res ->
+                        producer.send(
+                            ProducerRecord(topic, null, Unit, codec.encode(message))
+                        ) { recordMetadata, e ->
+                            if (e == null) res.complete(
+                                Log.MessageMetadata(
+                                    epoch,
+                                    recordMetadata.offset(),
+                                    ofEpochMilli(recordMetadata.timestamp())
+                                )
+                            ) else res.completeExceptionally(e)
+                        }
                     }
-                }
+                    .await()
+                    .also { messageMetadata -> latestSubmittedOffset0.updateAndGet { it.coerceAtLeast(messageMetadata.logOffset) } }
+            }
 
         override fun readLastMessage(): M? =
             kafkaConfigMap.openConsumer().use { c ->
@@ -218,16 +222,16 @@ class KafkaCluster(
                 producer.beginTransaction()
 
                 return object : Log.AtomicProducer.Tx<M> {
-                    private val futures = mutableListOf<CompletableDeferred<Log.MessageMetadata>>()
+                    private val futures = mutableListOf<CompletableFuture<Log.MessageMetadata>>()
                     private var isOpen = true
 
-                    override fun appendMessage(message: M): CompletableDeferred<Log.MessageMetadata> {
+                    override fun appendMessage(message: M): CompletableFuture<Log.MessageMetadata> {
                         check(isOpen) { "Transaction already closed" }
-                        val deferred = CompletableDeferred<Log.MessageMetadata>()
-                        futures.add(deferred)
+                        val future = CompletableFuture<Log.MessageMetadata>()
+                        futures.add(future)
                         producer.send(ProducerRecord(topic, null, Unit, codec.encode(message))) { recordMetadata, e ->
                             if (e == null) {
-                                deferred.complete(
+                                future.complete(
                                     Log.MessageMetadata(
                                         epoch,
                                         recordMetadata.offset(),
@@ -235,20 +239,19 @@ class KafkaCluster(
                                     )
                                 )
                             } else {
-                                deferred.completeExceptionally(e)
+                                future.completeExceptionally(e)
                             }
                         }
-                        return deferred
+                        return future
                     }
 
-                    @OptIn(ExperimentalCoroutinesApi::class)
                     override fun commit() {
                         check(isOpen) { "Transaction already closed" }
                         isOpen = false
-                        // commitTransaction flushes all pending sends, so deferreds are already complete
+                        // commitTransaction flushes all pending sends, so futures are already complete
                         producer.commitTransaction()
                         futures.forEach {
-                            latestSubmittedOffset0.updateAndGet { prev -> prev.coerceAtLeast(it.getCompleted().logOffset) }
+                            latestSubmittedOffset0.updateAndGet { prev -> prev.coerceAtLeast(it.join().logOffset) }
                         }
                     }
 
@@ -299,8 +302,8 @@ class KafkaCluster(
                         controlChannel.onReceive { msg -> handleControl(msg) }
 
                         onTimeout(0) {
-                            val records = runInterruptible {
-                                try {
+                            runInterruptible {
+                                val records = try {
                                     c.poll(pollDuration).records(topic)
                                         .mapNotNull { rec ->
                                             val msg = codec.decode(rec.value()) ?: return@mapNotNull null
@@ -310,9 +313,9 @@ class KafkaCluster(
                                 } catch (_: InterruptException) {
                                     throw InterruptedException()
                                 }
-                            }
 
-                            currentProcessor?.processRecords(records)
+                                currentProcessor?.processRecords(records)
+                            }
                         }
                     }
                 }
@@ -356,14 +359,14 @@ class KafkaCluster(
                         // onPartitionsAssigned is called from the poll thread, so pause is safe here
                         override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) {
                             c.pause(partitions)
-                            listener.onPartitionsAssignedSync(partitions.map { it.partition() })
+                            listener.onPartitionsAssigned(partitions.map { it.partition() })
                         }
 
                         override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) =
-                            listener.onPartitionsRevokedSync(partitions.map { it.partition() })
+                            listener.onPartitionsRevoked(partitions.map { it.partition() })
 
                         override fun onPartitionsLost(partitions: Collection<TopicPartition>) =
-                            listener.onPartitionsLostSync(partitions.map { it.partition() })
+                            listener.onPartitionsLost(partitions.map { it.partition() })
                     })
 
                     PollingConsumer(c)

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
@@ -1,6 +1,5 @@
 package xtdb.api.log
 
-import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.delay
@@ -47,7 +46,7 @@ class KafkaAtomicProducerTest {
         val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
 
         val subscriber = mockk<RecordProcessor<SourceMessage>> {
-            coEvery { processRecords(capture(msgs)) } returns Unit
+            every { processRecords(capture(msgs)) } returns Unit
         }
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
@@ -87,7 +86,7 @@ class KafkaAtomicProducerTest {
         val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
 
         val subscriber = mockk<RecordProcessor<SourceMessage>> {
-            coEvery { processRecords(capture(msgs)) } returns Unit
+            every { processRecords(capture(msgs)) } returns Unit
         }
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
@@ -134,7 +133,7 @@ class KafkaAtomicProducerTest {
         val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
 
         val subscriber = mockk<RecordProcessor<SourceMessage>> {
-            coEvery { processRecords(capture(msgs)) } returns Unit
+            every { processRecords(capture(msgs)) } returns Unit
         }
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
@@ -171,7 +170,7 @@ class KafkaAtomicProducerTest {
         val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
 
         val subscriber = mockk<RecordProcessor<SourceMessage>> {
-            coEvery { processRecords(capture(msgs)) } returns Unit
+            every { processRecords(capture(msgs)) } returns Unit
         }
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -1,8 +1,10 @@
 package xtdb.api.log
 
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertArrayEquals

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -1,6 +1,5 @@
 package xtdb.api.log
 
-import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.delay
@@ -48,7 +47,7 @@ class KafkaClusterTest {
         val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
 
         val subscriber = mockk<RecordProcessor<SourceMessage>> {
-            coEvery { processRecords(capture(msgs)) } returns Unit
+            every { processRecords(capture(msgs)) } returns Unit
         }
 
         fun trieDetails(key: String, size: Long) =


### PR DESCRIPTION
fixes #5340 

The issue above happens when there is a leader->follower transition during a long processRecords.

The leader subsystem will close its log subscription `Log.kt:L113`, which, after trying to end it cooperatively (for 5 seconds),  it closes the consumer, which effectively interrupts processRecords.

Ingestion-stopped is actually the right reaction, because the node shouldn't be processing any further messages after interrupting, as it will be left in an indeterminate state.

The changes proposed are around:

- Setting an explicit timeout for leader->follower and follower->leader switchovers. Making it longer than 5 seconds would reduce the probabilty of encountering the issue. (Timeout for closing the log subscription on shutdown is kept shorter).
- Ensure that those timeouts are thrown as exceptions in onPartitionsAssigned/Revoked, as we need to prevent further action. In this case it seems the ingestion-stopped was enough to prevent it, but still.

I'm unsure about these changes, would appreciate a review.