### PR TITLE
fix(log-proc): block could be tried to be finished twice

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -112,9 +112,9 @@ class LogProcessor(
                     LOG.debug("transition: replica watchers caught up to $replayTarget")
 
                     val followerProc = oldSys.proc
-                    val pendingBlock = followerProc.pendingBlock
-                    LOG.debug("transition: closing follower system (pendingBlock=${pendingBlock != null})")
+                    LOG.debug("transition: closing follower system")
                     oldSys.close()
+                    val pendingBlock = followerProc.pendingBlock
 
                     procFactory.openTransition(replicaProducer, replicaWatchers).use { transition ->
                         if (pendingBlock != null) {


### PR DESCRIPTION
Now collecting the pendingBlock info after the follower is closed, as the follower may still process some messages before closing that change the pendingBlock state.