### PR TITLE
tidy: add safelyOpening to flatten nested closeOnCatch chains

### DIFF
--- a/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
@@ -13,9 +13,8 @@ import xtdb.arrow.metadata.MetadataFlavour
 import xtdb.error.Unsupported
 import xtdb.kw
 import xtdb.util.Hasher
-import xtdb.util.closeAllOnCatch
-import xtdb.util.closeOnCatch
 import xtdb.util.safeMap
+import xtdb.util.safelyOpening
 import java.nio.ByteBuffer
 import org.apache.arrow.vector.complex.DenseUnionVector as ArrowDenseUnionVector
 
@@ -113,14 +112,12 @@ class DenseUnionVector private constructor(
         override fun select(startIdx: Int, len: Int): VectorReader =
             select(IntArray(len) { startIdx + it })
 
-        override fun openSlice(al: BufferAllocator): VectorReader =
-            typeBuffer.openSlice(al).closeOnCatch { typeBuffer ->
-                offsetBuffer.openSlice(al).closeOnCatch { offsetBuffer ->
-                    inner.openSlice(al).closeOnCatch { inner ->
-                        LegReader(valueCount, typeBuffer, offsetBuffer, true, typeId, inner, nested)
-                    }
-                }
-            }
+        override fun openSlice(al: BufferAllocator): VectorReader = safelyOpening {
+            val typeSlice = open { typeBuffer.openSlice(al) }
+            val offsetSlice = open { offsetBuffer.openSlice(al) }
+            val innerSlice = open { inner.openSlice(al) }
+            LegReader(valueCount, typeSlice, offsetSlice, true, typeId, innerSlice, nested)
+        }
 
         override val metadataFlavours get() = inner.metadataFlavours
 
@@ -427,18 +424,12 @@ class DenseUnionVector private constructor(
         valueCount = vc
     }
 
-    override fun openSlice(al: BufferAllocator) =
-        legVectors.safeMap { it.openSlice(al) }.closeAllOnCatch { legSlices ->
-            typeBuffer.openSlice(al).closeOnCatch { typeSlice ->
-                offsetBuffer.openSlice(al).closeOnCatch { offsetSlice ->
-                    DenseUnionVector(
-                        al, name, legSlices,
-                        typeSlice, offsetSlice,
-                        valueCount
-                    )
-                }
-            }
-        }
+    override fun openSlice(al: BufferAllocator) = safelyOpening {
+        val legSlices = openAll { legVectors.safeMap { it.openSlice(al) } }
+        val typeSlice = open { typeBuffer.openSlice(al) }
+        val offsetSlice = open { offsetBuffer.openSlice(al) }
+        DenseUnionVector(al, name, legSlices.toList(), typeSlice, offsetSlice, valueCount)
+    }
 
     override fun maybePromote(al: BufferAllocator, targetType: ArrowType, targetNullable: Boolean) = apply {
         if (targetType != arrowType)

--- a/core/src/main/kotlin/xtdb/operator/join/Shuffle.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/Shuffle.kt
@@ -10,9 +10,7 @@ import xtdb.expression.map.IndexHasher.Companion.hasher
 import xtdb.trie.ColumnName
 import xtdb.arrow.VectorType.Companion.I32
 import xtdb.arrow.VectorType.Companion.ofType
-import xtdb.util.closeOnCatch
-import xtdb.util.deleteOnCatch
-import java.nio.file.Files.createTempFile
+import xtdb.util.safelyOpening
 import java.nio.file.Path
 import kotlin.io.path.deleteIfExists
 
@@ -115,34 +113,24 @@ class Shuffle private constructor(
     }
 
     companion object {
-        // my kingdom for `util/with-close-on-catch` in Kotlin
-        // y'all need macros. or monads.
-
         fun open(
             al: BufferAllocator, inDataRel: Relation, hashColNames: List<ColumnName>,
             rowCount: Long, blockCount: Int, minParts: Int = 1
-        ): Shuffle =
-            createTempFile("xtdb-build-side-shuffle-", ".arrow").deleteOnCatch { dataFile ->
-                Relation(al, inDataRel.schema).closeOnCatch { outDataRel ->
-                    outDataRel.startUnload(dataFile).closeOnCatch { dataUnloader ->
+        ): Shuffle = safelyOpening {
+            val dataFile = openTempFile("xtdb-build-side-shuffle-", ".arrow")
+            val outDataRel = open { Relation(al, inDataRel.schema) }
+            val dataUnloader = open { outDataRel.startUnload(dataFile) }
 
-                        createTempFile("xtdb-build-side-shuffle-hash-", ".arrow").deleteOnCatch { hashFile ->
-                            Relation(al, HASH_COL_NAME ofType I32).closeOnCatch { outHashRel ->
-                                outHashRel.startUnload(hashFile).closeOnCatch { hashUnloader ->
+            val hashFile = openTempFile("xtdb-build-side-shuffle-hash-", ".arrow")
+            val outHashRel = open { Relation(al, HASH_COL_NAME ofType I32) }
+            val hashUnloader = open { outHashRel.startUnload(hashFile) }
 
-                                    Shuffle(
-                                        al, inDataRel, hashColNames,
-                                        dataFile, outDataRel, dataUnloader,
-                                        hashFile, outHashRel, hashUnloader,
-                                        rowCount, blockCount, minParts
-                                    )
-
-                                }
-                            }
-                        }
-
-                    }
-                }
-            }
+            Shuffle(
+                al, inDataRel, hashColNames,
+                dataFile, outDataRel, dataUnloader,
+                hashFile, outHashRel, hashUnloader,
+                rowCount, blockCount, minParts
+            )
+        }
     }
 }

--- a/core/src/main/kotlin/xtdb/operator/join/Spill.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/Spill.kt
@@ -2,8 +2,7 @@ package xtdb.operator.join
 
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.arrow.Relation
-import xtdb.util.closeOnCatch
-import xtdb.util.deleteOnCatch
+import xtdb.util.safelyOpening
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -47,11 +46,10 @@ internal class Spill(
     }
 
     companion object {
-        fun open(al: BufferAllocator, dataRel: Relation): Spill =
-            Files.createTempFile("xtdb-build-side-", ".arrow").deleteOnCatch { dataPath ->
-                dataRel.startUnload(dataPath).closeOnCatch { dataUnloader ->
-                    Spill(al, dataRel, dataPath, dataUnloader)
-                }
-            }
+        fun open(al: BufferAllocator, dataRel: Relation): Spill = safelyOpening {
+            val dataPath = openTempFile("xtdb-build-side-", ".arrow")
+            val dataUnloader = open { dataRel.startUnload(dataPath) }
+            Spill(al, dataRel, dataPath, dataUnloader)
+        }
     }
 }

--- a/core/src/main/kotlin/xtdb/util/IOUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/IOUtil.kt
@@ -1,7 +1,6 @@
 package xtdb.util
 
 import java.nio.channels.FileChannel
-import java.nio.channels.SeekableByteChannel
 import java.nio.channels.WritableByteChannel
 import java.nio.file.Files
 import java.nio.file.Path
@@ -14,15 +13,6 @@ import kotlin.io.path.deleteIfExists
 
 internal fun Path.openReadableChannel(): FileChannel = FileChannel.open(this, READ)
 internal fun Path.openWritableChannel(): WritableByteChannel = Files.newByteChannel(this, WRITE, CREATE)
-
-internal fun <R> useTempFile(prefix: String, suffix: String, block: (Path) -> R): R =
-    createTempFile(prefix, suffix).let {
-        try {
-            block(it)
-        } finally {
-            it.deleteIfExists()
-        }
-    }
 
 val String.asPath: Path
     get() = Path.of(this)
@@ -95,3 +85,28 @@ inline fun <C, L : Iterable<C>, R : AutoCloseable?> L.safeMapIndexed(block: (Int
 
         els
     }
+
+@PublishedApi
+internal class SafelyOpeningScope {
+    @PublishedApi
+    internal val openedResources = mutableListOf<AutoCloseable>()
+
+    fun <C : AutoCloseable?> open(block: () -> C): C =
+        block().also { if (it != null) openedResources.add(it) }
+
+    fun <C : AutoCloseable> openAll(block: () -> Iterable<C>): Iterable<C> =
+        block().also { openedResources.addAll(it) }
+
+    fun <K, C : AutoCloseable> openAllMap(block: () -> Map<K, C>): Map<K, C> =
+        block().also { openedResources.addAll(it.values) }
+}
+
+inline fun <R> safelyOpening(block: SafelyOpeningScope.() -> R): R {
+    val scope = SafelyOpeningScope()
+    return try {
+        scope.block()
+    } catch (e: Throwable) {
+        scope.openedResources.closeAll()
+        throw e
+    }
+}

--- a/core/src/main/kotlin/xtdb/util/IOUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/IOUtil.kt
@@ -86,10 +86,8 @@ inline fun <C, L : Iterable<C>, R : AutoCloseable?> L.safeMapIndexed(block: (Int
         els
     }
 
-@PublishedApi
-internal class SafelyOpeningScope {
-    @PublishedApi
-    internal val openedResources = mutableListOf<AutoCloseable>()
+class SafelyOpeningScope {
+    val openedResources = mutableListOf<AutoCloseable>()
 
     fun <C : AutoCloseable?> open(block: () -> C): C =
         block().also { if (it != null) openedResources.add(it) }
@@ -99,6 +97,11 @@ internal class SafelyOpeningScope {
 
     fun <K, C : AutoCloseable> openAllMap(block: () -> Map<K, C>): Map<K, C> =
         block().also { openedResources.addAll(it.values) }
+
+    fun openTempFile(prefix: String, suffix: String): Path =
+        createTempFile(prefix, suffix).also { path ->
+            openedResources.add(AutoCloseable { path.deleteIfExists() })
+        }
 }
 
 inline fun <R> safelyOpening(block: SafelyOpeningScope.() -> R): R {


### PR DESCRIPTION
## Summary

- Adds `safelyOpening` DSL to `IOUtil.kt` — a scope-based alternative to nested `closeOnCatch` chains for safe resource acquisition
- Converts `DenseUnionVector`, `Shuffle`, and `Spill` to use it
- Adds `openTempFile` to the scope for temp files that need cleanup on failure

## Context: the problem with `closeOnCatch`

When we need to open multiple resources and ensure they're all cleaned up if any subsequent allocation fails, we currently nest `closeOnCatch` calls:

```kotlin
// before: the 'pyramid of doom'
createTempFile("prefix-", ".arrow").deleteOnCatch { dataFile ->
    Relation(al, schema).closeOnCatch { rel ->
        rel.startUnload(dataFile).closeOnCatch { unloader ->
            MyThing(dataFile, rel, unloader)
        }
    }
}
```

Each level wraps the previous resource in a try/catch so that if a later allocation throws, earlier resources get closed.
This works, but each new resource adds another nesting level — and with 6+ resources (as in `Shuffle.open`) it becomes hard to read and easy to get wrong.

## `safelyOpening`: flat resource acquisition

`safelyOpening` provides a scope where you register resources as you open them.
If any allocation throws, all previously-opened resources are closed automatically:

```kotlin
// after: flat and readable
fun open(al: BufferAllocator, dataRel: Relation): Spill = safelyOpening {
    val dataPath = openTempFile("xtdb-build-side-", ".arrow")
    val dataUnloader = open { dataRel.startUnload(dataPath) }
    Spill(al, dataRel, dataPath, dataUnloader)
}
```

The scope tracks everything registered via `open { }` and closes them all (in reverse order) if the block throws.
On the happy path, ownership transfers to the returned object — no cleanup needed.

### Available scope functions

| Function | Use case |
|---|---|
| `open { }` | Single `AutoCloseable` resource |
| `openAll { }` | An `Iterable<AutoCloseable>` (e.g. `safeMap`) |
| `openAllMap { }` | A `Map<K, AutoCloseable>` |
| `openTempFile(prefix, suffix)` | Creates a temp file, registers `deleteIfExists` as cleanup |

### Before/after: `DenseUnionVector.openSlice`

```kotlin
// before: 3 levels of nesting
override fun openSlice(al: BufferAllocator): VectorReader =
    typeBuffer.openSlice(al).closeOnCatch { typeBuffer ->
        offsetBuffer.openSlice(al).closeOnCatch { offsetBuffer ->
            inner.openSlice(al).closeOnCatch { inner ->
                LegReader(valueCount, typeBuffer, offsetBuffer, true, typeId, inner, nested)
            }
        }
    }

// after
override fun openSlice(al: BufferAllocator): VectorReader = safelyOpening {
    val typeSlice = open { typeBuffer.openSlice(al) }
    val offsetSlice = open { offsetBuffer.openSlice(al) }
    val innerSlice = open { inner.openSlice(al) }
    LegReader(valueCount, typeSlice, offsetSlice, true, typeId, innerSlice, nested)
}
```

### Before/after: `Shuffle.open` (6 resources, 2 temp files)

```kotlin
// before: 6 levels deep, mixing closeOnCatch and deleteOnCatch
fun open(...): Shuffle =
    createTempFile("xtdb-build-side-shuffle-", ".arrow").deleteOnCatch { dataFile ->
        Relation(al, inDataRel.schema).closeOnCatch { outDataRel ->
            outDataRel.startUnload(dataFile).closeOnCatch { dataUnloader ->
                createTempFile("xtdb-build-side-shuffle-hash-", ".arrow").deleteOnCatch { hashFile ->
                    Relation(al, HASH_COL_NAME ofType I32).closeOnCatch { outHashRel ->
                        outHashRel.startUnload(hashFile).closeOnCatch { hashUnloader ->
                            Shuffle(al, inDataRel, hashColNames,
                                dataFile, outDataRel, dataUnloader,
                                hashFile, outHashRel, hashUnloader,
                                rowCount, blockCount, minParts)
                        }
                    }
                }
            }
        }
    }

// after
fun open(...): Shuffle = safelyOpening {
    val dataFile = openTempFile("xtdb-build-side-shuffle-", ".arrow")
    val outDataRel = open { Relation(al, inDataRel.schema) }
    val dataUnloader = open { outDataRel.startUnload(dataFile) }

    val hashFile = openTempFile("xtdb-build-side-shuffle-hash-", ".arrow")
    val outHashRel = open { Relation(al, HASH_COL_NAME ofType I32) }
    val hashUnloader = open { outHashRel.startUnload(hashFile) }

    Shuffle(al, inDataRel, hashColNames,
        dataFile, outDataRel, dataUnloader,
        hashFile, outHashRel, hashUnloader,
        rowCount, blockCount, minParts)
}
```

## Design notes

- This is the Kotlin equivalent of Clojure's `with-close-on-catch` macro (which we already have in `xtdb.util`).
  The old `Shuffle.open` even had a comment: _"my kingdom for `util/with-close-on-catch` in Kotlin"_ — now removed.
- The scope object is deliberately simple — it's a mutable list of `AutoCloseable`s, not a monad or framework.
- `openTempFile` unifies `createTempFile` + `deleteOnCatch` into a single call, since temp files always need the same cleanup pattern.
- On the happy path, the returned object takes ownership of all the resources — the scope doesn't close anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)