### PR TITLE
tidy(compactor): prevent ERROR log message on job cancellation

### DIFF
--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -126,8 +126,10 @@ interface Compactor : AutoCloseable {
                                     TriesAdded(Storage.VERSION, bp.epoch, addedTries)
                                 }
                             } catch (e: ClosedByInterruptException) {
-                                throw InterruptedException(e.message)
+                                throw if (Thread.interrupted()) InterruptedException().initCause(e) else e
                             } catch (e: InterruptedException) {
+                                throw e
+                            } catch (e: CancellationException) {
                                 throw e
                             } catch (e: Throwable) {
                                 LOGGER.error(e) { "error running compaction job: ${job.table.sym}/${job.outputTrieKey}, files in job: '${job.trieKeys}'" }


### PR DESCRIPTION
As seen in FHIR env, when terminating an XTDB node:

```
level	
ERROR
log	
error running compaction job: public/condition/l01-rc-b3192c, files in job: '["l01-rc-b3192a" "l00-rc-b3192c"]'
kotlinx.coroutines.JobCancellationException: Job was cancelled
logger	
xtdb.compactor.Compactor
stream	
stdout
time	
2026-03-20T09:13:55.399018149Z
```