### PR TITLE
fix(log): drop Log.Consumer, return tail-spec from onPartitionsAssigned s.t. it happens on the Kafka poll thread

### DIFF
--- a/core/src/main/clojure/xtdb/log/processor.clj
+++ b/core/src/main/clojure/xtdb/log/processor.clj
@@ -4,7 +4,7 @@
   (:import [xtdb.api IndexerConfig]
            [xtdb.api.log Log]
            [xtdb.database Database$Mode DatabaseState DatabaseStorage]
-           [xtdb.indexer BlockUploader FollowerLogProcessor LeaderLogProcessor LogProcessor LogProcessor$LeaderSystem LogProcessor$ProcessorFactory SourceLogProcessor TransitionLogProcessor]
+           [xtdb.indexer BlockUploader FollowerLogProcessor LeaderLogProcessor LogProcessor LogProcessor$ProcessorFactory SourceLogProcessor TransitionLogProcessor]
            [xtdb.util MsgIdUtil]))
 
 (defn- open-source-processor [{:keys [allocator ^DatabaseStorage db-storage ^DatabaseState db-state
@@ -23,7 +23,7 @@
 (defn- subscribe-source-log [^DatabaseStorage db-storage ^DatabaseState db-state ^SourceLogProcessor src-proc]
   (let [source-log (.getSourceLog db-storage)
         latest-processed-msg-id (or (.getLatestProcessedMsgId (.getBlockCatalog db-state)) -1)]
-    (Log/tailAll source-log latest-processed-msg-id src-proc)))
+    (.tailAll source-log latest-processed-msg-id src-proc)))
 
 (defmethod ig/expand-key :xtdb.log.processor/source [k opts]
   {k (into {:allocator (ig/ref :xtdb.db-catalog/allocator)
@@ -79,22 +79,15 @@
                                                   source-watchers
                                                   db-catalog pending-block after-source-msg-id))
 
-                         (openLeaderSystem [_ replica-producer after-source-msg-id after-replica-msg-id]
-                           (util/with-close-on-catch [proc (LeaderLogProcessor. allocator
-                                                                                db-storage replica-producer db-state
-                                                                                indexer-for-db source-watchers
-                                                                                (set (.getSkipTxs indexer-conf))
-                                                                                db-catalog block-uploader
-                                                                                after-replica-msg-id
-                                                                                (.getFlushDuration indexer-conf)
-                                                                                meter-registry)
-                                                      sub (Log/tailAll (.getSourceLog db-storage) after-source-msg-id proc)]
-                             (reify LogProcessor$LeaderSystem
-                               (getPendingBlock [_] (.getPendingBlock proc))
-                               (getLatestReplicaMsgId [_] (.getLatestReplicaMsgId proc))
-                               (close [_]
-                                 (.close sub)
-                                 (.close proc)))))
+                         (openLeaderProcessor [_ replica-producer after-replica-msg-id]
+                           (LeaderLogProcessor. allocator
+                                                db-storage replica-producer db-state
+                                                indexer-for-db source-watchers
+                                                (set (.getSkipTxs indexer-conf))
+                                                db-catalog block-uploader
+                                                after-replica-msg-id
+                                                (.getFlushDuration indexer-conf)
+                                                meter-registry))
 
                          (openTransition [_ replica-producer after-source-msg-id]
                            (TransitionLogProcessor. allocator
@@ -108,9 +101,9 @@
           log-processor (LogProcessor. proc-factory db-storage db-state block-uploader source-watchers meter-registry)]
 
       {:log-processor log-processor
-       :consumer (when-not (= mode Database$Mode/READ_ONLY)
-                   (.openGroupConsumer (.getSourceLog db-storage) log-processor))})))
+       :subscription (when-not (= mode Database$Mode/READ_ONLY)
+                       (.openGroupSubscription (.getSourceLog db-storage) log-processor))})))
 
-(defmethod ig/halt-key! :xtdb.log/processor [_ {:keys [consumer log-processor]}]
-  (util/close consumer)
+(defmethod ig/halt-key! :xtdb.log/processor [_ {:keys [subscription log-processor]}]
+  (util/close subscription)
   (util/close log-processor))

--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -119,52 +119,43 @@ class InMemoryLog<M> @JvmOverloads constructor(
 
     override fun readLastMessage(): M? = null
 
-    override fun openConsumer(): Consumer<M> = object : Consumer<M> {
-        override fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>): Subscription {
-            var latestCompletedOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
+    override fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>): Subscription {
+        var latestCompletedOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
-            val job = subscriberScope.launch {
-                val ch = committedCh
-                    .filter {
-                        val logOffset = it.logOffset
-                        check(logOffset <= latestCompletedOffset + 1) {
-                            "InMemoryLog emitted out-of-order record (expected ${latestCompletedOffset + 1}, got $logOffset)"
-                        }
-                        logOffset > latestCompletedOffset
+        val job = subscriberScope.launch {
+            val ch = committedCh
+                .filter {
+                    val logOffset = it.logOffset
+                    check(logOffset <= latestCompletedOffset + 1) {
+                        "InMemoryLog emitted out-of-order record (expected ${latestCompletedOffset + 1}, got $logOffset)"
                     }
-                    .onEach { latestCompletedOffset = it.logOffset }
-                    .buffer(100)
-                    .produceIn(this)
-
-                while (isActive) {
-                    val records = select {
-                        ch.onReceiveCatching { if (it.isClosed) emptyList() else listOf(it.getOrThrow()) }
-
-                        @OptIn(ExperimentalCoroutinesApi::class)
-                        onTimeout(1.minutes) { emptyList() }
-                    }
-
-                    processor.processRecords(records)
+                    logOffset > latestCompletedOffset
                 }
-            }
+                .onEach { latestCompletedOffset = it.logOffset }
+                .buffer(100)
+                .produceIn(this)
 
-            return Subscription { runBlocking { withTimeout(5.seconds) { job.cancelAndJoin() } } }
+            while (isActive) {
+                val records = select {
+                    ch.onReceiveCatching { if (it.isClosed) emptyList() else listOf(it.getOrThrow()) }
+
+                    @OptIn(ExperimentalCoroutinesApi::class)
+                    onTimeout(1.minutes) { emptyList() }
+                }
+
+                processor.processRecords(records)
+            }
         }
 
-        override fun close() {}
+        return Subscription { runBlocking { withTimeout(5.seconds) { job.cancelAndJoin() } } }
     }
 
-    override fun openGroupConsumer(listener: SubscriptionListener): Consumer<M> {
-        listener.onPartitionsAssignedSync(listOf(0))
-        val inner = openConsumer()
-        return object : Consumer<M> {
-            override fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>) =
-                inner.tailAll(afterMsgId, processor)
-
-            override fun close() {
-                inner.close()
-                listener.onPartitionsRevokedSync(listOf(0))
-            }
+    override fun openGroupSubscription(listener: SubscriptionListener<M>): Subscription {
+        val spec = listener.onPartitionsAssignedSync(listOf(0))
+        val sub = spec?.let { tailAll(it.afterMsgId, it.processor) }
+        return Subscription {
+            sub?.close()
+            listener.onPartitionsRevokedSync(listOf(0))
         }
     }
 

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -254,85 +254,76 @@ class LocalLog<M>(
         }
     }
 
-    override fun openConsumer(): Consumer<M> = object : Consumer<M> {
-        override fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>): Subscription {
-            var latestCompletedOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
+    override fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>): Subscription {
+        var latestCompletedOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
-            val ch = Channel<Record<M>>(100)
+        val ch = Channel<Record<M>>(100)
 
-            val subscription = scope.launch(SupervisorJob()) {
-                launch {
-                    committedCh
-                        .onSubscription {
-                            val targetOffset = mutex.withLock { latestSubmittedOffset }
-                            if (targetOffset < 0) return@onSubscription
+        val subscription = scope.launch(SupervisorJob()) {
+            launch {
+                committedCh
+                    .onSubscription {
+                        val targetOffset = mutex.withLock { latestSubmittedOffset }
+                        if (targetOffset < 0) return@onSubscription
 
-                            val catchUpRecords = runInterruptible {
-                                FileChannel.open(logFilePath).use { fileCh ->
-                                    val latestCompleted = latestCompletedOffset
-                                    if (latestCompleted >= 0) {
-                                        fileCh.position(latestCompleted)
-                                        fileCh.readMessage()
-                                    }
+                        val catchUpRecords = runInterruptible {
+                            FileChannel.open(logFilePath).use { fileCh ->
+                                val latestCompleted = latestCompletedOffset
+                                if (latestCompleted >= 0) {
+                                    fileCh.position(latestCompleted)
+                                    fileCh.readMessage()
+                                }
 
-                                    buildList {
-                                        while (fileCh.position() <= targetOffset) {
-                                            fileCh.readMessage()?.let { add(it) }
-                                        }
+                                buildList {
+                                    while (fileCh.position() <= targetOffset) {
+                                        fileCh.readMessage()?.let { add(it) }
                                     }
                                 }
                             }
-
-                            for (record in catchUpRecords) {
-                                ch.send(record)
-                            }
-
-                            latestCompletedOffset = targetOffset
                         }
-                        .onEach {
-                            if (it.logOffset > latestCompletedOffset) {
-                                latestCompletedOffset = it.logOffset
-                                ch.send(it)
-                            }
-                        }
-                        .onCompletion { ch.close() }
-                        .catch {
-                            try {
-                                throw it
-                            } catch (_: ClosedByInterruptException) {
-                                throw CancellationException()
-                            } catch (_: InterruptedException) {
-                                throw CancellationException()
-                            }
-                        }
-                        .collect()
-                }
 
-                while (isActive) {
-                    val msg = withTimeoutOrNull(1.minutes) {
-                        ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
+                        for (record in catchUpRecords) {
+                            ch.send(record)
+                        }
+
+                        latestCompletedOffset = targetOffset
                     }
-                    if (msg != null) processor.processRecords(listOf(msg))
-                }
+                    .onEach {
+                        if (it.logOffset > latestCompletedOffset) {
+                            latestCompletedOffset = it.logOffset
+                            ch.send(it)
+                        }
+                    }
+                    .onCompletion { ch.close() }
+                    .catch {
+                        try {
+                            throw it
+                        } catch (_: ClosedByInterruptException) {
+                            throw CancellationException()
+                        } catch (_: InterruptedException) {
+                            throw CancellationException()
+                        }
+                    }
+                    .collect()
             }
 
-            return Subscription { runBlocking { withTimeout(5.seconds) { subscription.cancelAndJoin() } } }
+            while (isActive) {
+                val msg = withTimeoutOrNull(1.minutes) {
+                    ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
+                }
+                if (msg != null) processor.processRecords(listOf(msg))
+            }
         }
 
-        override fun close() {}
+        return Subscription { runBlocking { withTimeout(5.seconds) { subscription.cancelAndJoin() } } }
     }
 
-    override fun openGroupConsumer(listener: SubscriptionListener): Consumer<M> {
-        listener.onPartitionsAssignedSync(listOf(0))
-        val inner = openConsumer()
-        return object : Consumer<M> {
-            override fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>) =
-                inner.tailAll(afterMsgId, processor)
-
-            override fun close() {
-                inner.close()
-                listener.onPartitionsRevokedSync(listOf(0))
-            }
+    override fun openGroupSubscription(listener: SubscriptionListener<M>): Subscription {
+        val spec = listener.onPartitionsAssignedSync(listOf(0))
+        val sub = spec?.let { tailAll(it.afterMsgId, it.processor) }
+        return Subscription {
+            sub?.close()
+            listener.onPartitionsRevokedSync(listOf(0))
         }
     }
 

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -3,10 +3,7 @@
 package xtdb.api.log
 
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.runInterruptible
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.SerializersModule
@@ -18,11 +15,9 @@ import xtdb.database.proto.DatabaseConfig
 import xtdb.database.proto.DatabaseConfig.LogCase.*
 import xtdb.util.MsgIdUtil.offsetToMsgId
 import xtdb.util.asPath
-import xtdb.util.closeOnCatch
 import java.nio.file.Path
 import java.time.Instant
 import java.util.*
-import kotlin.time.Duration.Companion.seconds
 import com.google.protobuf.Any as ProtoAny
 
 
@@ -91,10 +86,6 @@ interface Log<M> : AutoCloseable {
         suspend fun processRecords(records: List<Record<M>>)
     }
 
-    interface Consumer<M> : AutoCloseable {
-        fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>): Subscription
-    }
-
     fun interface Subscription : AutoCloseable
 
     companion object {
@@ -107,20 +98,6 @@ interface Log<M> : AutoCloseable {
         @Suppress("unused")
         @JvmSynthetic
         fun localLog(path: Path, configure: LocalLog.Factory.() -> Unit) = localLog(path).also(configure)
-
-        @JvmStatic
-        fun <M> Log<M>.tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>) =
-            openConsumer().closeOnCatch { c ->
-                c.tailAll(afterMsgId, processor).closeOnCatch { subs ->
-                    Subscription {
-                        runBlocking {
-                            withTimeoutOrNull(5.seconds) { runInterruptible { subs.close() } }
-                        }
-
-                        c.close()
-                    }
-                }
-            }
     }
 
     interface Registration {
@@ -183,17 +160,19 @@ interface Log<M> : AutoCloseable {
 
     fun readLastMessage(): M?
 
-    fun openConsumer(): Consumer<M>
-    fun openGroupConsumer(listener: SubscriptionListener): Consumer<M>
+    fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>): Subscription
+    fun openGroupSubscription(listener: SubscriptionListener<M>): Subscription
 
-    interface SubscriptionListener {
-        suspend fun onPartitionsAssigned(partitions: Collection<Int>)
-        fun onPartitionsAssignedSync(partitions: Collection<Int>) = runBlocking { onPartitionsAssigned(partitions) }
+    interface SubscriptionListener<M> {
+        suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<M>?
+        fun onPartitionsAssignedSync(partitions: Collection<Int>): TailSpec<M>? = runBlocking { onPartitionsAssigned(partitions) }
         suspend fun onPartitionsRevoked(partitions: Collection<Int>)
         fun onPartitionsRevokedSync(partitions: Collection<Int>) = runBlocking { onPartitionsRevoked(partitions) }
         suspend fun onPartitionsLost(partitions: Collection<Int>) = onPartitionsRevoked(partitions)
         fun onPartitionsLostSync(partitions: Collection<Int>) = runBlocking { onPartitionsLost(partitions) }
     }
+
+    data class TailSpec<M>(val afterMsgId: MessageId, val processor: RecordProcessor<M>)
 
     class Record<out M>(
         val epoch: Int,

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
@@ -108,76 +108,67 @@ class ReadOnlyLocalLog<M>(
         }
     }
 
-    override fun openConsumer(): Log.Consumer<M> = object : Log.Consumer<M> {
-        override fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>): Log.Subscription {
-            val ch = Channel<Log.Record<M>>(100)
+    override fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>): Log.Subscription {
+        val ch = Channel<Log.Record<M>>(100)
 
-            val producerJob = scope.launch(SupervisorJob()) {
-                var currentOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
+        val producerJob = scope.launch(SupervisorJob()) {
+            var currentOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
-                FileSystems.getDefault().newWatchService().use { watchService ->
-                    rootPath.register(watchService, ENTRY_MODIFY)
+            FileSystems.getDefault().newWatchService().use { watchService ->
+                rootPath.register(watchService, ENTRY_MODIFY)
 
-                    try {
-                        readNewMessages(currentOffset, ch)?.let { currentOffset = it }
-
-                        while (true) {
-                            val key: WatchKey = runInterruptible(Dispatchers.IO) { watchService.take() }
-
-                            var logModified = false
-                            for (event in key.pollEvents()) {
-                                val changedPath = event.context() as? Path
-                                if (changedPath?.name == logFileName) {
-                                    logModified = true
-                                }
-                            }
-
-                            if (logModified) {
-                                readNewMessages(currentOffset, ch)?.let { currentOffset = it }
-                            }
-
-                            if (!key.reset()) {
-                                break
-                            }
-                        }
-                    } catch (_: ClosedByInterruptException) {
-                        cancel()
-                    } catch (_: InterruptedException) {
-                        cancel()
-                    }
-                }
-            }
-
-            val consumerJob = scope.launch(SupervisorJob()) {
                 try {
-                    while (isActive) {
-                        val msg = withTimeoutOrNull(1.minutes) {
-                            ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
+                    readNewMessages(currentOffset, ch)?.let { currentOffset = it }
+
+                    while (true) {
+                        val key: WatchKey = runInterruptible(Dispatchers.IO) { watchService.take() }
+
+                        var logModified = false
+                        for (event in key.pollEvents()) {
+                            val changedPath = event.context() as? Path
+                            if (changedPath?.name == logFileName) {
+                                logModified = true
+                            }
                         }
-                        if (msg != null) processor.processRecords(listOf(msg))
+
+                        if (logModified) {
+                            readNewMessages(currentOffset, ch)?.let { currentOffset = it }
+                        }
+
+                        if (!key.reset()) {
+                            break
+                        }
                     }
-                } finally {
-                    producerJob.cancelAndJoin()
+                } catch (_: ClosedByInterruptException) {
+                    cancel()
+                } catch (_: InterruptedException) {
+                    cancel()
                 }
             }
-
-            return Log.Subscription { runBlocking { withTimeout(5.seconds) { consumerJob.cancelAndJoin() } } }
         }
 
-        override fun close() {}
+        val consumerJob = scope.launch(SupervisorJob()) {
+            try {
+                while (isActive) {
+                    val msg = withTimeoutOrNull(1.minutes) {
+                        ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
+                    }
+                    if (msg != null) processor.processRecords(listOf(msg))
+                }
+            } finally {
+                producerJob.cancelAndJoin()
+            }
+        }
+
+        return Log.Subscription { runBlocking { withTimeout(5.seconds) { consumerJob.cancelAndJoin() } } }
     }
 
-    override fun openGroupConsumer(listener: Log.SubscriptionListener): Log.Consumer<M> {
-        listener.onPartitionsAssignedSync(listOf(0))
-        val inner = openConsumer()
-        return object : Log.Consumer<M> {
-            override fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) =
-                inner.tailAll(afterMsgId, processor)
-
-            override fun close() {
-                inner.close()
-                listener.onPartitionsRevokedSync(listOf(0))
-            }
+    override fun openGroupSubscription(listener: Log.SubscriptionListener<M>): Log.Subscription {
+        val spec = listener.onPartitionsAssignedSync(listOf(0))
+        val sub = spec?.let { tailAll(it.afterMsgId, it.processor) }
+        return Subscription {
+            sub?.close()
+            listener.onPartitionsRevokedSync(listOf(0))
         }
     }
 

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -4,16 +4,13 @@ import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
-import xtdb.api.log.Log.Companion.tailAll
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
-import xtdb.util.MsgIdUtil.offsetToMsgId
 import xtdb.util.StringUtil.asLexHex
 import xtdb.util.closeOnCatch
 import xtdb.util.debug
 import xtdb.util.info
 import xtdb.util.logger
-import kotlin.math.max
 
 private val LOG = LogProcessor::class.logger
 
@@ -24,7 +21,7 @@ class LogProcessor(
     private val blockUploader: BlockUploader,
     private val watchers: Watchers,
     meterRegistry: MeterRegistry? = null,
-) : Log.SubscriptionListener, AutoCloseable {
+) : Log.SubscriptionListener<SourceMessage>, AutoCloseable {
 
     interface LeaderProcessor : Log.RecordProcessor<SourceMessage>, AutoCloseable
 
@@ -40,10 +37,10 @@ class LogProcessor(
     private val replicaLog = dbStorage.replicaLog
 
     interface ProcessorFactory {
-        fun openLeaderSystem(
+        fun openLeaderProcessor(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
-            afterSourceMsgId: MessageId, afterReplicaMsgId: MessageId,
-        ): SubSystem
+            afterReplicaMsgId: MessageId,
+        ): LeaderLogProcessor
 
         fun openTransition(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>, afterSourceMsgId: MessageId
@@ -54,17 +51,13 @@ class LogProcessor(
         ): FollowerProcessor
     }
 
-    sealed interface SubSystem : AutoCloseable {
-        val pendingBlock: PendingBlock?
-    }
+    private sealed interface SubSystem : AutoCloseable
 
-    interface LeaderSystem : SubSystem {
-        val latestReplicaMsgId: MessageId
+    private class LeaderSystem(val proc: LeaderLogProcessor) : SubSystem {
+        override fun close() = proc.close()
     }
 
     private class FollowerSystem(val proc: FollowerProcessor, private val sub: Log.Subscription) : SubSystem {
-        override val pendingBlock: PendingBlock? get() = proc.pendingBlock
-
         override fun close() {
             sub.close()
             proc.close()
@@ -101,13 +94,13 @@ class LogProcessor(
         }
     }
 
-    override suspend fun onPartitionsAssigned(partitions: Collection<Int>) {
-        if (partitions != listOf(0)) return
+    override suspend fun onPartitionsAssigned(partitions: Collection<Int>): Log.TailSpec<SourceMessage>? {
+        if (partitions != listOf(0)) return null
 
-        this.sys = when (val oldSys = sys) {
+        return when (val oldSys = sys) {
             is LeaderSystem -> {
                 LOG.info("partitions assigned: $partitions — already leader, no transition needed")
-                oldSys
+                null
             }
 
             is FollowerSystem -> {
@@ -145,12 +138,10 @@ class LogProcessor(
                             val latestSourceMsgId = transition.latestSourceMsgId
                             LOG.debug("transition: opening leader processor")
 
-                            procFactory.openLeaderSystem(
-                                replicaProducer,
-                                latestSourceMsgId,
-                                replayTarget
-                            )
-                                .also { LOG.info("leader startup complete, resuming after $latestSourceMsgId") }
+                            val proc = procFactory.openLeaderProcessor(replicaProducer, replayTarget)
+                            this.sys = LeaderSystem(proc)
+                            LOG.info("leader startup complete, resuming after $latestSourceMsgId")
+                            Log.TailSpec(latestSourceMsgId, proc)
                         }
                 }
             }
@@ -161,19 +152,19 @@ class LogProcessor(
         if (partitions != listOf(0)) return
 
         LOG.debug("partitions revoked: $partitions — transitioning to follower")
-        this.sys = when (val oldSys = sys) {
+        when (val oldSys = sys) {
             is LeaderSystem -> {
                 LOG.info("partitions revoked: $partitions — was leader, transitioning to follower")
-                val pendingBlock = oldSys.pendingBlock
-                val latestReplica = oldSys.latestReplicaMsgId
+                val proc = oldSys.proc
+                val pendingBlock = proc.pendingBlock
+                val latestReplica = proc.latestReplicaMsgId
                 oldSys.close()
                 LOG.debug("revocation: pending block: ${pendingBlock != null}, opening follower system from $latestReplica")
-                openFollowerSystem(latestReplica, pendingBlock)
+                this.sys = openFollowerSystem(latestReplica, pendingBlock)
             }
 
             is FollowerSystem -> {
                 LOG.info("partitions revoked: $partitions — already follower, no transition needed")
-                oldSys
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
+++ b/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
@@ -96,9 +96,9 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
         override fun close() {}
     }
 
-    override fun openConsumer(): Log.Consumer<M> = error("openConsumer")
+    override fun tailAll(afterMsgId: Long, processor: Log.RecordProcessor<M>): Log.Subscription = error("tailAll")
 
-    override fun openGroupConsumer(listener: Log.SubscriptionListener): Log.Consumer<M> = error("openGroupConsumer")
+    override fun openGroupSubscription(listener: Log.SubscriptionListener<M>): Log.Subscription = error("openGroupSubscription")
 
     override fun close() = Unit
 }

--- a/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import xtdb.api.log.Log.Companion.tailAll
 import xtdb.api.log.Log.Record
 import java.nio.file.Path
 import kotlin.time.Duration.Companion.seconds

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -175,14 +175,12 @@ class LeaderLogProcessorTest {
         ))
 
         val replicaMessages = mutableListOf<ReplicaMessage>()
-        val consumer = replicaLog.openConsumer()
-        val sub = consumer.tailAll(-1) { records ->
+        val sub = replicaLog.tailAll(-1) { records ->
             replicaMessages.addAll(records.map { it.message })
         }
 
         Thread.sleep(200)
         sub.close()
-        consumer.close()
 
         assertEquals(2, replicaMessages.size, "expected 2 replica messages, got: $replicaMessages")
         assertTrue(replicaMessages[0] is ReplicaMessage.BlockBoundary)

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import xtdb.api.log.*
-import xtdb.api.log.Log.Companion.tailAll
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
@@ -18,7 +17,6 @@ import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
 import xtdb.storage.BufferPool
 import xtdb.trie.TrieCatalog
-import xtdb.util.closeOnCatch
 import java.time.InstantSource
 import java.util.concurrent.TimeUnit
 
@@ -57,28 +55,17 @@ class LogProcessorTest {
         watchers: Watchers,
     ) =
         object : LogProcessor.ProcessorFactory {
-            override fun openLeaderSystem(
+            override fun openLeaderProcessor(
                 replicaProducer: Log.AtomicProducer<ReplicaMessage>,
-                afterSourceMsgId: MessageId,
                 afterReplicaMsgId: MessageId,
-            ): LogProcessor.LeaderSystem {
+            ): LeaderLogProcessor {
                 val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
                 val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
                 return LeaderLogProcessor(
                     allocator, dbStorage, replicaProducer,
                     dbState, mockk(relaxed = true), watchers,
                     emptySet(), null, blockUploader, afterReplicaMsgId
-                ).closeOnCatch { proc ->
-                    val sub = dbStorage.sourceLog.tailAll(afterSourceMsgId, proc)
-                    object : LogProcessor.LeaderSystem {
-                        override val pendingBlock: PendingBlock? get() = proc.pendingBlock
-                        override val latestReplicaMsgId: MessageId get() = proc.latestReplicaMsgId
-                        override fun close() {
-                            sub.close()
-                            proc.close()
-                        }
-                    }
-                }
+                )
             }
 
             override fun openTransition(
@@ -118,10 +105,9 @@ class LogProcessorTest {
             dbStorage, dbState, blockUploader, watchers
         )
 
-        // openGroupConsumer triggers onPartitionsAssigned synchronously
-        val consumer = sourceLog.openGroupConsumer(logProc)
+        val subscription = sourceLog.openGroupSubscription(logProc)
 
-        consumer.close()
+        subscription.close()
         logProc.close()
         watchers.close()
         sourceLog.close()
@@ -143,9 +129,9 @@ class LogProcessorTest {
             dbStorage, dbState, blockUploader, watchers
         )
 
-        val consumer = sourceLog.openGroupConsumer(logProc)
+        val subscription = sourceLog.openGroupSubscription(logProc)
 
-        consumer.close()
+        subscription.close()
         logProc.close()
         watchers.close()
         sourceLog.close()
@@ -175,12 +161,12 @@ class LogProcessorTest {
             dbStorage, dbState, blockUploader, watchers
         )
 
-        val consumer = sourceLog.openGroupConsumer(logProc)
+        val subscription = sourceLog.openGroupSubscription(logProc)
 
         // The transition should have replayed the ResolvedTx
         verify { liveIndex.importTx(any()) }
 
-        consumer.close()
+        subscription.close()
         logProc.close()
         watchers.close()
         sourceLog.close()
@@ -208,11 +194,11 @@ class LogProcessorTest {
             dbStorage, dbState, blockUploader, watchers
         )
 
-        val consumer = sourceLog.openGroupConsumer(logProc)
+        val subscription = sourceLog.openGroupSubscription(logProc)
 
         verify { liveIndex.importTx(any()) }
 
-        consumer.close()
+        subscription.close()
         logProc.close()
         watchers.close()
         sourceLog.close()

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumProcessorTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumProcessorTest.kt
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.assertThrows
 import org.testcontainers.kafka.ConfluentKafkaContainer
 import xtdb.api.log.KafkaCluster
 import xtdb.api.log.Log
-import xtdb.api.log.Log.Companion.tailAll
 import xtdb.api.log.Log.Record
 import xtdb.api.log.SourceMessage
 import xtdb.api.query.IKeyFn

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -8,9 +8,6 @@
 package xtdb.api.log
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.selects.onTimeout
-import kotlinx.coroutines.selects.select
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
@@ -27,6 +24,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.InterruptException
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+import org.apache.kafka.common.errors.WakeupException
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.serialization.Deserializer
@@ -39,7 +37,6 @@ import xtdb.database.proto.DatabaseConfig
 import xtdb.kafka.proto.KafkaLogConfig
 import xtdb.kafka.proto.kafkaLogConfig
 import xtdb.util.MsgIdUtil.afterMsgIdToOffset
-import xtdb.util.closeOnCatch
 import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant.ofEpochMilli
@@ -113,10 +110,6 @@ private fun AdminClient.ensureTopicExists(topic: String, autoCreate: Boolean) {
     }
 }
 
-private sealed interface ConsumerControl<out M> {
-    data class TailAll<M>(val afterMsgId: MessageId, val processor: Log.RecordProcessor<M>) : ConsumerControl<M>
-    data class StopTailing<M>(val onStop: CompletableDeferred<Unit>) : ConsumerControl<M>
-}
 
 class KafkaCluster(
     val kafkaConfigMap: KafkaConfigMap,
@@ -303,113 +296,80 @@ class KafkaCluster(
             }
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
-        private inner class PollingConsumer(private val c: KafkaConsumer<*, ByteArray>) : Log.Consumer<M> {
-
-            private val tp = TopicPartition(topic, 0)
-            private val controlChannel = Channel<ConsumerControl<M>>()
-            private var currentProcessor: Log.RecordProcessor<M>? = null
-
-            private fun handleControl(msg: ConsumerControl<M>) {
-                when (msg) {
-                    is ConsumerControl.TailAll -> {
-                        currentProcessor = msg.processor
-                        val afterOffset = afterMsgIdToOffset(epoch, msg.afterMsgId)
-                        c.seek(tp, afterOffset + 1)
-                        c.resume(listOf(tp))
+        private fun KafkaConsumer<*, ByteArray>.pollRecords(): List<Log.Record<M>> =
+            try {
+                poll(pollDuration).records(topic)
+                    .mapNotNull { rec ->
+                        val msg = codec.decode(rec.value()) ?: return@mapNotNull null
+                        Log.Record(epoch, rec.offset(), ofEpochMilli(rec.timestamp()), msg)
                     }
-
-                    is ConsumerControl.StopTailing -> {
-                        c.pause(listOf(tp))
-                        currentProcessor = null
-                        msg.onStop.complete(Unit)
-                    }
-                }
+            } catch (_: WakeupException) {
+                emptyList()
+            } catch (e: InterruptException) {
+                throw InterruptedException().initCause(e)
             }
 
-            private val pollingJob = scope.launch(Dispatchers.IO) {
+        override fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>): Log.Subscription {
+            val c = kafkaConfigMap.openConsumer()
+            val tp = TopicPartition(topic, 0)
+            c.assign(listOf(tp))
+            c.seek(tp, afterMsgIdToOffset(epoch, afterMsgId) + 1)
+
+            val pollingJob = scope.launch(Dispatchers.IO) {
                 while (isActive) {
-                    select {
-                        controlChannel.onReceive { msg -> handleControl(msg) }
-
-                        onTimeout(0) {
-                            val records = runInterruptible {
-                                try {
-                                    c.poll(pollDuration).records(topic)
-                                        .mapNotNull { rec ->
-                                            val msg = codec.decode(rec.value()) ?: return@mapNotNull null
-
-                                            Log.Record(epoch, rec.offset(), ofEpochMilli(rec.timestamp()), msg)
-                                        }
-                                } catch (e: InterruptException) {
-                                    throw InterruptedException().initCause(e)
-                                }
-                            }
-
-                            currentProcessor?.processRecords(records)
-                        }
-                    }
+                    val records = c.pollRecords()
+                    if (records.isNotEmpty()) processor.processRecords(records)
                 }
             }
 
-            override fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) =
-                runBlocking {
-                    controlChannel.send(ConsumerControl.TailAll(afterMsgId, processor))
-
-                    Log.Subscription {
-                        runBlocking {
-                            val ack = CompletableDeferred<Unit>()
-                            controlChannel.send(ConsumerControl.StopTailing(ack))
-                            ack.await()
-                        }
-                    }
-                }
-
-            override fun close() {
-                runBlocking {
-                    withTimeout(30.seconds) { pollingJob.cancelAndJoin() }
-                    c.close()
-                }
+            return Log.Subscription {
+                c.wakeup()
+                runBlocking { withTimeout(30.seconds) { pollingJob.cancelAndJoin() } }
+                c.close()
             }
         }
 
-        override fun openConsumer(): Log.Consumer<M> =
-            kafkaConfigMap.openConsumer().closeOnCatch { c ->
-                val tp = listOf(TopicPartition(topic, 0))
-                c.assign(tp)
-                c.pause(tp)
+        override fun openGroupSubscription(listener: Log.SubscriptionListener<M>): Log.Subscription {
+            val c = kafkaConfigMap.plus(mapOf("group.id" to groupId)).openConsumer()
+            val tp = TopicPartition(topic, 0)
+            var currentProcessor: Log.RecordProcessor<M>? = null
 
-                PollingConsumer(c)
+            c.subscribe(listOf(topic), object : ConsumerRebalanceListener {
+                private inline fun launderInterruptedException(block: () -> Unit) =
+                    try { block() } catch (e: InterruptedException) { throw InterruptException(e) }
+
+                override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) =
+                    launderInterruptedException {
+                        c.pause(partitions)
+
+                        listener.onPartitionsAssignedSync(partitions.map { it.partition() })
+                            ?.let { tailSpec ->
+                                currentProcessor = tailSpec.processor
+                                c.seek(tp, afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1)
+                                c.resume(partitions)
+                            }
+                    }
+
+                override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) =
+                    launderInterruptedException {
+                        listener.onPartitionsRevokedSync(partitions.map { it.partition() })
+                        currentProcessor = null
+                    }
+            })
+
+            val pollingJob = scope.launch(Dispatchers.IO) {
+                while (isActive) {
+                    val records = c.pollRecords()
+                    if (records.isNotEmpty()) currentProcessor?.processRecords(records)
+                }
             }
 
-        override fun openGroupConsumer(listener: Log.SubscriptionListener): Log.Consumer<M> =
-            kafkaConfigMap.plus(mapOf("group.id" to groupId))
-                .openConsumer()
-                .closeOnCatch { c ->
-                    c.subscribe(listOf(topic), object : ConsumerRebalanceListener {
-                        private fun launderInterruptedException(block: () -> Unit) =
-                            try { block() } catch (e: InterruptedException) { throw InterruptException(e) }
-
-                        // onPartitionsAssigned is called from the poll thread, so pause is safe here
-                        override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) =
-                            launderInterruptedException {
-                                c.pause(partitions)
-                                listener.onPartitionsAssignedSync(partitions.map { it.partition() })
-                            }
-
-                        override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) =
-                            launderInterruptedException {
-                                listener.onPartitionsRevokedSync(partitions.map { it.partition() })
-                            }
-
-                        override fun onPartitionsLost(partitions: Collection<TopicPartition>) =
-                            launderInterruptedException {
-                                listener.onPartitionsLostSync(partitions.map { it.partition() })
-                            }
-                    })
-
-                    PollingConsumer(c)
-                }
+            return Log.Subscription {
+                c.wakeup()
+                runBlocking { withTimeout(30.seconds) { pollingJob.cancelAndJoin() } }
+                c.close()
+            }
+        }
 
         override fun close() = Unit
     }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.testcontainers.kafka.ConfluentKafkaContainer
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
-import xtdb.api.log.Log.Companion.tailAll
 import xtdb.api.log.Log.Record
 import xtdb.api.log.Log.RecordProcessor
 import java.time.Duration

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.testcontainers.kafka.ConfluentKafkaContainer
-import xtdb.api.log.Log.Companion.tailAll
 import xtdb.api.log.Log.*
 import xtdb.api.storage.Storage
 import xtdb.database.Database


### PR DESCRIPTION
## Summary

related to #5340 — `ClosedByInterruptException` in `LeaderLogProcessor.finishBlock()` during leader→follower transitions, causing `IngestionStoppedException`.

- Simplifies the `Log` consumer API: removes `Consumer` interface, collapses `tailAll` into an instance method, replaces `openGroupConsumer` with `openGroupSubscription`
- `SubscriptionListener<M>.onPartitionsAssigned` now returns `TailSpec<M>?` — the consumer actions seek/resume directly on the poll thread
- Kafka shutdown uses `wakeup()` instead of thread interruption
- Leader no longer owns a source log subscription — the group consumer manages the lifecycle

## The bug

During leader→follower transitions (Kafka rebalance), the leader's `processRecords` could be interrupted mid-flight:

1. `onPartitionsRevoked` fires inside `poll()` on the group consumer
2. It closes the `LeaderSystem`, which closes the leader's **separate** source log subscription
3. The subscription close does `withTimeoutOrNull(5s)` then `c.close()` → `pollingJob.cancelAndJoin()`
4. This interrupts the thread running `processRecords` via `runInterruptible` → `ClosedByInterruptException`
5. `notifyError` → `IngestionStoppedException` — node is dead

The root cause was commit `15316189c` which moved the source log subscription into the `LeaderSystem`, creating a **second** consumer on the source topic — separate from the group consumer. Closing this separate consumer during the rebalance callback is what caused the interrupt.

## Why not just use the group consumer's `tailAll`?

We tried routing the leader through the existing group consumer's `tailAll` method. This **deadlocks** with Kafka's `PollingConsumer`:

- `onPartitionsAssigned` fires inside `poll()`, inside the `select` loop's `onTimeout(0)` branch
- `tailAll` sends to a rendezvous `controlChannel`
- The `controlChannel.onReceive` branch of the same `select` can't fire until the current `onTimeout(0)` branch completes
- Circular wait — confirmed via `jstack`

## The fix

Instead of calling `tailAll` from the rebalance callback (cross-thread API via channel), we changed the API so the callback **returns** what to tail:

```kotlin
interface SubscriptionListener<M> {
    suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<M>?
    suspend fun onPartitionsRevoked(partitions: Collection<Int>)
}

data class TailSpec<M>(val afterMsgId: MessageId, val processor: RecordProcessor<M>)
```

The consumer (still on the poll thread, inside the callback) actions the `TailSpec` directly — `seek`, `resume`, set processor. No channel, no deadlock.

For shutdown, `KafkaConsumer.wakeup()` (the only thread-safe Kafka method) replaces coroutine cancellation. It only interrupts `poll()`, never `processRecords`.

The `Consumer` intermediate interface and `Log.Companion.tailAll` extension are removed — `tailAll` becomes an instance method on `Log`, and `openGroupSubscription` returns a `Subscription` directly.

## Why is this safe?

The Kafka `PollingConsumer` poll loop is sequential: `poll()` → `processRecords()` → `poll()` → ...

Rebalance callbacks fire **inside** `poll()`. By the time `onPartitionsRevoked` runs, `processRecords` has already finished its current batch. There is no concurrent processing to interrupt — the transition is naturally serialized.

## Test plan

- [x] `LogProcessorTest` — unit tests for leader/follower transitions (InMemoryLog)
- [x] `xtdb-core:test` — full core test suite
- [x] `XTDB_SINGLE_WRITER=true ./gradlew :integration-test --tests '*kafka_test*'` — the test that previously deadlocked now passes (9/9 tests, ~1m40s)
- [ ] CI: `./gradlew test integration-test`
- [ ] CI: `XTDB_SINGLE_WRITER=true ./gradlew test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)