### PR TITLE
feat(debezium): add ExternalLog abstraction (#5330)

### DIFF
--- a/core/src/main/clojure/xtdb/db_catalog.clj
+++ b/core/src/main/clojure/xtdb/db_catalog.clj
@@ -41,11 +41,12 @@
 (defmethod ig/expand-key ::storage [k _opts]
   {k {:source-log (ig/ref :xtdb/source-log)
       :replica-log (ig/ref :xtdb/replica-log)
+      :external-source (ig/ref :xtdb/external-source-log)
       :buffer-pool (ig/ref :xtdb/buffer-pool)
       :metadata-manager (ig/ref :xtdb.metadata/metadata-manager)}})
 
-(defmethod ig/init-key ::storage [_ {:keys [source-log replica-log buffer-pool metadata-manager]}]
-  (DatabaseStorage. source-log replica-log buffer-pool metadata-manager))
+(defmethod ig/init-key ::storage [_ {:keys [source-log replica-log external-source buffer-pool metadata-manager]}]
+  (DatabaseStorage. source-log replica-log external-source buffer-pool metadata-manager))
 
 (defmethod ig/expand-key :xtdb/db-catalog [k _]
   {k {:base {:allocator (ig/ref :xtdb/allocator)
@@ -97,6 +98,7 @@
                  :xtdb/log (assoc opts :factory (.getLog db-config))
                  :xtdb/source-log opts
                  :xtdb/replica-log (assoc opts :factory (.getLog db-config))
+                 :xtdb/external-source-log opts
                  :xtdb/buffer-pool (assoc opts :factory (.getStorage db-config))
 
                  ::storage opts

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -18,7 +18,7 @@
            (xtdb.api.log Log Log$Cluster$Factory Log$Factory)
            (xtdb.arrow Relation Vector)
            xtdb.catalog.BlockCatalog
-           (xtdb.database Database DatabaseStorage Database$Catalog Database$Mode)
+           (xtdb.database Database DatabaseStorage Database$Catalog Database$Config Database$Mode)
            xtdb.table.TableRef
            (xtdb.tx TxOp$DeleteDocs TxOp$EraseDocs TxOp$PatchDocs TxOp$PutDocs TxOp$Sql TxOpts)
            (xtdb.tx_ops DeleteDocs EraseDocs PatchDocs PutDocs PutRel Sql SqlByteArgs)
@@ -221,6 +221,14 @@
 
 (defmethod ig/halt-key! :xtdb/replica-log [_ ^Log log]
   (util/close log))
+
+(defmethod ig/init-key :xtdb/external-source-log [_ {:keys [^Database$Config db-config]
+                                                      {:keys [log-clusters]} :base}]
+  (some-> (.getExternalLog db-config)
+          (.open log-clusters)))
+
+(defmethod ig/halt-key! :xtdb/external-source-log [_ external-source-log]
+  (util/close external-source-log))
 
 (defn- ->TxOps [tx-ops]
   (->> tx-ops

--- a/core/src/main/kotlin/xtdb/api/YamlSerde.kt
+++ b/core/src/main/kotlin/xtdb/api/YamlSerde.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.modules.SerializersModule
 import xtdb.api.log.Log
 import xtdb.api.module.XtdbModule
 import xtdb.api.storage.ObjectStore
+import xtdb.database.ExternalLog
 import java.net.InetAddress
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -149,6 +150,7 @@ val YAML_SERDE = Yaml(
         include(Log.Cluster.Factory.serializersModule)
         include(ObjectStore.Factory.serializersModule)
         include(XtdbModule.Factory.serializersModule)
+        include(ExternalLog.Factory.serializersModule)
     })
 
 /**

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -130,10 +130,12 @@ data class Database(
         val log: Log.Factory = Log.inMemoryLog,
         val storage: Storage.Factory = Storage.inMemory(),
         val mode: Mode = Mode.READ_WRITE,
+        val externalLog: ExternalLog.Factory? = null,
     ) {
         fun log(log: Log.Factory) = copy(log = log)
         fun storage(storage: Storage.Factory) = copy(storage = storage)
         fun mode(mode: Mode) = copy(mode = mode)
+        fun externalSource(externalLog: ExternalLog.Factory?) = copy(externalLog = externalLog)
 
         val isReadOnly: Boolean get() = mode == Mode.READ_ONLY
 
@@ -143,6 +145,7 @@ data class Database(
                     log.writeTo(dbConfig)
                     dbConfig.applyStorage(storage)
                     dbConfig.mode = mode.toProto()
+                    externalLog?.writeTo(dbConfig)
                 }.build()
 
         companion object {
@@ -155,6 +158,7 @@ data class Database(
                     .log(Log.Factory.fromProto(dbConfig))
                     .storage(Storage.Factory.fromProto(dbConfig))
                     .mode(Mode.fromProto(dbConfig.mode))
+                    .externalSource(ExternalLog.Factory.fromProto(dbConfig))
         }
     }
 

--- a/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
@@ -9,6 +9,7 @@ import xtdb.storage.BufferPool
 data class DatabaseStorage(
     val sourceLogOrNull: Log<SourceMessage>?,
     val replicaLogOrNull: Log<ReplicaMessage>?,
+    val externalLog: ExternalLog<*>?,
     val bufferPoolOrNull: BufferPool?,
     val metadataManagerOrNull: PageMetadata.Factory?,
 ) {

--- a/core/src/main/kotlin/xtdb/database/ExternalLog.kt
+++ b/core/src/main/kotlin/xtdb/database/ExternalLog.kt
@@ -1,0 +1,49 @@
+package xtdb.database
+
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import xtdb.api.log.Log
+import xtdb.api.log.LogClusterAlias
+import xtdb.database.proto.DatabaseConfig
+import java.util.*
+import com.google.protobuf.Any as ProtoAny
+
+interface ExternalLog<M> : AutoCloseable {
+
+    fun tailAll(processor: Log.RecordProcessor<M>): Log.Subscription
+
+    interface Factory {
+        fun writeTo(dbConfig: DatabaseConfig.Builder)
+        fun open(clusters: Map<LogClusterAlias, Log.Cluster>): ExternalLog<*>
+
+        companion object {
+            private val registrations = ServiceLoader.load(Registration::class.java).toList()
+            private val registrationsByTag = registrations.associateBy { it.protoTag }
+
+            val serializersModule = SerializersModule {
+                for (reg in registrations)
+                    include(reg.serializersModule)
+
+                polymorphic(Factory::class) {
+                    for (reg in registrations)
+                        reg.registerSerde(this)
+                }
+            }
+
+            fun fromProto(dbConfig: DatabaseConfig): Factory? {
+                if (!dbConfig.hasExternalLog()) return null
+                val any = dbConfig.externalLog
+                val reg = registrationsByTag[any.typeUrl] ?: error("unknown external source: ${any.typeUrl}")
+                return reg.fromProto(any)
+            }
+        }
+    }
+
+    interface Registration {
+        val protoTag: String
+        fun fromProto(msg: ProtoAny): Factory
+        fun registerSerde(builder: PolymorphicModuleBuilder<Factory>)
+        val serializersModule: SerializersModule get() = SerializersModule {}
+    }
+}

--- a/core/src/main/proto/xtdb/database/proto/db.proto
+++ b/core/src/main/proto/xtdb/database/proto/db.proto
@@ -48,5 +48,6 @@ message DatabaseConfig {
     }
 
     DatabaseMode mode = 7;
+    google.protobuf.Any external_log = 8;
 }
 

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -116,7 +116,7 @@ class NodeSimulationTest : SimulationTestBase() {
             val trieCatalog = createTrieCatalog()
             val blockCatalog = BlockCatalog("xtdb", sharedBufferPool.latestBlock)
             val compactor = Compactor.Impl(compactorDriver, null, jobCalculator, false, 2, dispatcher)
-            val dbStorage = DatabaseStorage(null, null, sharedBufferPool, null)
+            val dbStorage = DatabaseStorage(null, null, null, sharedBufferPool, null)
             val dbState = DatabaseState("xtdb", blockCatalog, null, trieCatalog, null)
             val compactorForDb = compactor.openForDatabase(allocator, dbStorage, dbState, Watchers(-1))
             val garbageCollector = GarbageCollector.Impl(sharedBufferPool, dbState, gcDriver, 2, garbageLifetime, Duration.ofSeconds(30), dispatcher)

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -60,7 +60,7 @@ class MockDb(
     val bufferPool: BufferPool,
     val compactor: Compactor,
 ) {
-    val dbStorage: DatabaseStorage get() = DatabaseStorage(null, null, bufferPool, null)
+    val dbStorage: DatabaseStorage get() = DatabaseStorage(null, null, null, bufferPool, null)
     val dbState: DatabaseState get() = DatabaseState(name, null, null, trieCatalog, null)
 }
 

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -42,7 +42,7 @@ class LeaderLogProcessorTest {
     ): LeaderLogProcessor {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(sourceLog, replicaLog, null, bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader")
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
 
@@ -95,7 +95,7 @@ class LeaderLogProcessorTest {
         val blockCatalog = BlockCatalog("test", null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(sourceLog, replicaLog, null, bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader")
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
 
@@ -159,7 +159,7 @@ class LeaderLogProcessorTest {
         val blockCatalog = BlockCatalog("test", null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(sourceLog, replicaLog, null, bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader")
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
 

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -96,7 +96,7 @@ class LogProcessorTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val bufferPool = mockBufferPool()
         val dbState = dbState()
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(sourceLog, replicaLog, null, bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
         val watchers = Watchers(-1)
 
@@ -120,7 +120,7 @@ class LogProcessorTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 1)
         val bufferPool = mockBufferPool(epoch = 1)
         val dbState = dbState()
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(sourceLog, replicaLog, null, bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
         val watchers = Watchers(-1)
 
@@ -147,7 +147,7 @@ class LogProcessorTest {
             every { latestCompletedTx } returns null
         }
         val dbState = dbState(liveIndex = liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(sourceLog, replicaLog, null, bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
         val watchers = Watchers(-1)
 
@@ -182,7 +182,7 @@ class LogProcessorTest {
             every { latestCompletedTx } returns null
         }
         val dbState = dbState(liveIndex = liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(sourceLog, replicaLog, null, bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
         val watchers = Watchers(-1)
 

--- a/modules/debezium/build.gradle.kts
+++ b/modules/debezium/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.clojurephant)
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.protobuf)
 }
 
 java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
@@ -14,8 +15,23 @@ dependencies {
 
     api(kotlin("stdlib"))
     api(libs.kotlinx.serialization.json)
+    api(libs.protobuf.kotlin)
 
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.pgjdbc)
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.asProvider().get()}"
+    }
+
+    generateProtoTasks {
+        all().forEach {
+            it.builtins {
+                create("kotlin")
+            }
+        }
+    }
 }

--- a/modules/debezium/src/main/clojure/xtdb/debezium.clj
+++ b/modules/debezium/src/main/clojure/xtdb/debezium.clj
@@ -4,22 +4,23 @@
             [xtdb.util :as util])
   (:import (org.apache.arrow.memory RootAllocator)
            (xtdb.api.log KafkaCluster$ClusterFactory KafkaCluster$LogFactory)
-           (xtdb.debezium DebeziumConsumer DebeziumProcessor)))
+           (xtdb.debezium DebeziumProcessor DebeziumSource KafkaDebeziumLog$Factory)))
 
 (defn start!
   "Starts a CDC ingestion node, returns an AutoCloseable."
   [node-opts {:keys [kafka-cluster source-topic debezium-topic]}]
   (let [cfg (xtn/->config node-opts)
         cluster (.open ^KafkaCluster$ClusterFactory (get (.getLogClusters cfg) kafka-cluster))
-        kafka-config (.getKafkaConfigMap cluster)
+        clusters {kafka-cluster cluster}
         source-log (.openSourceLog (doto (KafkaCluster$LogFactory. kafka-cluster source-topic)
                                      (.groupId (str "xtdb-" source-topic "-debezium")))
-                                   {kafka-cluster cluster})
+                                   clusters)
         producer (.openAtomicProducer source-log (str "debezium-" source-topic))
-        debezium-log (DebeziumConsumer. kafka-config debezium-topic (str "xtdb-" debezium-topic "-debezium"))
+        external-log (.open (DebeziumSource. (KafkaDebeziumLog$Factory. kafka-cluster debezium-topic (str "xtdb-" debezium-topic "-debezium")))
+                            clusters)
         allocator (RootAllocator.)
         processor (DebeziumProcessor. producer allocator (.getDefaultTz cfg))
-        subscription (.tailAll debezium-log processor)]
+        subscription (.tailAll external-log processor)]
     (log/info "Debezium CDC process started"
               {:kafka-cluster kafka-cluster
                :source-topic source-topic
@@ -30,7 +31,7 @@
         (util/close subscription)
         (util/close processor)
         (util/close allocator)
-        (util/close debezium-log)
+        (util/close external-log)
         (util/close producer)
         (util/close source-log)
         (util/close cluster)

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
@@ -1,0 +1,31 @@
+package xtdb.debezium
+
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import xtdb.api.log.Log
+import xtdb.api.log.LogClusterAlias
+import xtdb.database.ExternalLog
+import xtdb.debezium.proto.DebeziumSourceConfig
+import xtdb.debezium.proto.DebeziumSourceConfig.LogCase.*
+
+sealed interface DebeziumLog : ExternalLog<DebeziumMessage> {
+
+    interface Factory {
+        fun openLog(clusters: Map<LogClusterAlias, Log.Cluster>): DebeziumLog
+
+        companion object {
+            val serializersModule = SerializersModule {
+                polymorphic(Factory::class) {
+                    subclass(KafkaDebeziumLog.Factory::class)
+                }
+            }
+
+            fun fromProto(config: DebeziumSourceConfig): Factory =
+                when (config.logCase) {
+                    KAFKA_LOG -> KafkaDebeziumLog.Factory.fromProto(config.kafkaLog)
+                    else -> error("unknown debezium log: ${config.logCase}")
+                }
+        }
+    }
+}

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumMessage.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumMessage.kt
@@ -1,0 +1,11 @@
+package xtdb.debezium
+
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+
+class DebeziumMessage(
+    val payload: ByteArray,
+    val offsets: Map<TopicPartition, OffsetAndMetadata>,
+    val consumerGroupMetadata: ConsumerGroupMetadata,
+)

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumSource.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumSource.kt
@@ -1,0 +1,43 @@
+package xtdb.debezium
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.subclass
+import xtdb.api.log.Log
+import xtdb.api.log.LogClusterAlias
+import xtdb.database.ExternalLog
+import xtdb.database.proto.DatabaseConfig
+import xtdb.debezium.proto.debeziumSourceConfig
+import xtdb.debezium.proto.DebeziumSourceConfig as DebeziumSourceConfigProto
+import com.google.protobuf.Any as ProtoAny
+
+@Serializable
+@SerialName("!Debezium")
+data class DebeziumSource(val log: DebeziumLog.Factory) : ExternalLog.Factory {
+    override fun open(clusters: Map<LogClusterAlias, Log.Cluster>) = log.openLog(clusters)
+
+    override fun writeTo(dbConfig: DatabaseConfig.Builder) {
+        dbConfig.externalLog = ProtoAny.pack(debeziumSourceConfig {
+            when (val l = log) {
+                is KafkaDebeziumLog.Factory -> kafkaLog = l.toProto()
+            }
+        }, "proto.xtdb.com")
+    }
+
+    class Registration : ExternalLog.Registration {
+        override val protoTag: String get() = "proto.xtdb.com/xtdb.debezium.proto.DebeziumSourceConfig"
+
+        override fun fromProto(msg: ProtoAny): ExternalLog.Factory {
+            val config = msg.unpack(DebeziumSourceConfigProto::class.java)
+            return DebeziumSource(log = DebeziumLog.Factory.fromProto(config))
+        }
+
+        override fun registerSerde(builder: PolymorphicModuleBuilder<ExternalLog.Factory>) {
+            builder.subclass(DebeziumSource::class)
+        }
+
+        override val serializersModule: SerializersModule get() = DebeziumLog.Factory.serializersModule
+    }
+}

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/KafkaDebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/KafkaDebeziumLog.kt
@@ -1,8 +1,9 @@
 package xtdb.debezium
 
 import kotlinx.coroutines.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
@@ -10,49 +11,77 @@ import org.apache.kafka.common.errors.InterruptException
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.Deserializer
 import org.slf4j.LoggerFactory
+import xtdb.api.log.KafkaCluster
 import xtdb.api.log.Log
+import xtdb.api.log.LogClusterAlias
+import xtdb.debezium.proto.KafkaDebeziumLogConfig
+import xtdb.debezium.proto.kafkaDebeziumLogConfig
 import java.time.Duration
 import java.time.Instant
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.seconds
 
-private val logger = LoggerFactory.getLogger(DebeziumConsumer::class.java)
+private val LOG = LoggerFactory.getLogger(KafkaDebeziumLog::class.java)
 
-object UnitDeserializer : Deserializer<Unit> {
-    override fun deserialize(topic: String?, data: ByteArray) = Unit
-}
-
-class DebeziumMessage(
-    val payload: ByteArray,
-    val offsets: Map<TopicPartition, OffsetAndMetadata>,
-    val consumerGroupMetadata: ConsumerGroupMetadata,
-)
-
-class DebeziumConsumer @JvmOverloads constructor(
+class KafkaDebeziumLog @JvmOverloads constructor(
     private val kafkaConfig: Map<String, String>,
     private val topic: String,
     private val groupId: String,
     private val pollDuration: Duration = Duration.ofSeconds(1),
     coroutineContext: CoroutineContext = Dispatchers.Default,
-) : AutoCloseable {
+) : DebeziumLog {
+
+    object UnitDeserializer : Deserializer<Unit> {
+        override fun deserialize(topic: String?, data: ByteArray) = Unit
+    }
+
+    @Serializable
+    @SerialName("!Kafka")
+    data class Factory(
+        val logCluster: LogClusterAlias, val tableTopic: String, val groupId: String
+    ) : DebeziumLog.Factory {
+
+        override fun openLog(clusters: Map<LogClusterAlias, Log.Cluster>): DebeziumLog {
+            val cluster =
+                requireNotNull(clusters[logCluster] as? KafkaCluster) { "missing Kafka cluster: '${logCluster}'" }
+            return KafkaDebeziumLog(cluster.kafkaConfigMap, tableTopic, groupId)
+        }
+
+        fun toProto(): KafkaDebeziumLogConfig = kafkaDebeziumLogConfig {
+            this.logCluster = this@Factory.logCluster
+            this.tableTopic = this@Factory.tableTopic
+            this.groupId = this@Factory.groupId
+        }
+
+        companion object {
+            fun fromProto(proto: KafkaDebeziumLogConfig) =
+                Factory(
+                    logCluster = proto.logCluster,
+                    tableTopic = proto.tableTopic,
+                    groupId = proto.groupId,
+                )
+        }
+    }
 
     // TODO: non-deterministic failures (e.g. node down) currently kill this coroutine silently.
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        logger.error("Fatal error in CDC ingestion — ingestion has stopped", throwable)
+        LOG.error("Fatal error in CDC ingestion — ingestion has stopped", throwable)
     }
 
     private val scope = CoroutineScope(SupervisorJob() + coroutineContext + exceptionHandler)
     val epoch: Int get() = 0
 
-    fun tailAll(processor: Log.RecordProcessor<DebeziumMessage>): Log.Subscription {
+    override fun tailAll(processor: Log.RecordProcessor<DebeziumMessage>): Log.Subscription {
         val job = scope.launch {
             KafkaConsumer(
-                kafkaConfig.plus(mapOf(
-                    ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false",
-                    ConsumerConfig.GROUP_ID_CONFIG to groupId,
-                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
-                    ConsumerConfig.ISOLATION_LEVEL_CONFIG to "read_committed",
-                )),
+                kafkaConfig.plus(
+                    mapOf(
+                        ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false",
+                        ConsumerConfig.GROUP_ID_CONFIG to groupId,
+                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
+                        ConsumerConfig.ISOLATION_LEVEL_CONFIG to "read_committed",
+                    )
+                ),
                 UnitDeserializer,
                 ByteArrayDeserializer()
             ).use { c ->

--- a/modules/debezium/src/main/proto/debezium.proto
+++ b/modules/debezium/src/main/proto/debezium.proto
@@ -1,0 +1,17 @@
+edition = "2023";
+
+package xtdb.debezium.proto;
+
+option java_multiple_files = true;
+
+message KafkaDebeziumLogConfig {
+    string log_cluster = 1;
+    string table_topic = 2;
+    string group_id = 3;
+}
+
+message DebeziumSourceConfig {
+    oneof log {
+        KafkaDebeziumLogConfig kafka_log = 1;
+    }
+}

--- a/modules/debezium/src/main/resources/META-INF/services/xtdb.database.ExternalLog$Registration
+++ b/modules/debezium/src/main/resources/META-INF/services/xtdb.database.ExternalLog$Registration
@@ -1,0 +1,1 @@
+xtdb.debezium.DebeziumSource$Registration

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
@@ -351,7 +351,7 @@ class DebeziumIntegrationTest {
         val sourceTopic = "test-topic-${UUID.randomUUID()}"
         openNodeOnSourceTopic(sourceTopic).use { node ->
             withSourceProducer(sourceTopic) { processor ->
-                val log = DebeziumConsumer(kafkaConfig(), "testdb.public.cdc_users", "test-group")
+                val log = KafkaDebeziumLog(kafkaConfig(), "testdb.public.cdc_users", "test-group")
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
@@ -410,7 +410,7 @@ class DebeziumIntegrationTest {
         val sourceTopic = "test-topic-${UUID.randomUUID()}"
         openNodeOnSourceTopic(sourceTopic).use { node ->
             withSourceProducer(sourceTopic) { processor ->
-                val log = DebeziumConsumer(kafkaConfig(), "testdb.public.cdc_no_envelope", "test-group")
+                val log = KafkaDebeziumLog(kafkaConfig(), "testdb.public.cdc_no_envelope", "test-group")
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
@@ -467,7 +467,7 @@ class DebeziumIntegrationTest {
         val sourceTopic = "test-topic-${UUID.randomUUID()}"
         openNodeOnSourceTopic(sourceTopic).use { node ->
             withSourceProducer(sourceTopic) { processor ->
-                val log = DebeziumConsumer(kafkaConfig(), "testdb.public.timed_docs", "test-group")
+                val log = KafkaDebeziumLog(kafkaConfig(), "testdb.public.timed_docs", "test-group")
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
@@ -544,7 +544,7 @@ class DebeziumIntegrationTest {
         val sourceTopic = "test-topic-${UUID.randomUUID()}"
         openNodeOnSourceTopic(sourceTopic).use { node ->
             withSourceProducer(sourceTopic) { processor ->
-                val log = DebeziumConsumer(kafkaConfig(), "testdb.public.no_id_table", "test-group")
+                val log = KafkaDebeziumLog(kafkaConfig(), "testdb.public.no_id_table", "test-group")
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
@@ -601,7 +601,7 @@ class DebeziumIntegrationTest {
         val sourceTopic = "test-topic-${UUID.randomUUID()}"
         openNodeOnSourceTopic(sourceTopic).use { node ->
             withSourceProducer(sourceTopic) { processor ->
-                val log = DebeziumConsumer(kafkaConfig(), "testdb.public.typed_docs", "test-group")
+                val log = KafkaDebeziumLog(kafkaConfig(), "testdb.public.typed_docs", "test-group")
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
@@ -661,7 +661,7 @@ class DebeziumIntegrationTest {
         val sourceTopic = "test-topic-${UUID.randomUUID()}"
         openNodeOnSourceTopic(sourceTopic).use { node ->
             withSourceProducer(sourceTopic) { processor ->
-                val log = DebeziumConsumer(kafkaConfig(), "testdb.inventory.products", "test-group")
+                val log = KafkaDebeziumLog(kafkaConfig(), "testdb.inventory.products", "test-group")
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
@@ -711,7 +711,7 @@ class DebeziumIntegrationTest {
             }
 
             withSourceProducer(secondarySourceTopic) { processor ->
-                val log = DebeziumConsumer(kafkaConfig(), "testdb.public.cdc_secondary_test", "test-group")
+                val log = KafkaDebeziumLog(kafkaConfig(), "testdb.public.cdc_secondary_test", "test-group")
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
@@ -764,7 +764,7 @@ class DebeziumIntegrationTest {
         val sourceTopic = "test-topic-${UUID.randomUUID()}"
         openNodeOnSourceTopic(sourceTopic).use { node ->
             withSourceProducer(sourceTopic) { processor ->
-                val log = DebeziumConsumer(kafkaConfig(), "testdb.public.bad_times", "test-group")
+                val log = KafkaDebeziumLog(kafkaConfig(), "testdb.public.bad_times", "test-group")
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
@@ -827,11 +827,11 @@ class DebeziumIntegrationTest {
         // First run: process the snapshot record (Alice), committing offsets
         openNodeOnSourceTopic(sourceTopic).use { node ->
             withSourceProducer(sourceTopic) { processor ->
-                val debeziumConsumer = DebeziumConsumer(kafkaConfig(), debeziumTopic, debeziumGroupId)
+                val kafkaDebeziumLog = KafkaDebeziumLog(kafkaConfig(), debeziumTopic, debeziumGroupId)
                 val (capturing, received) = capturingProcessor(processor)
 
-                debeziumConsumer.use {
-                    debeziumConsumer.tailAll(capturing).use {
+                kafkaDebeziumLog.use {
+                    kafkaDebeziumLog.tailAll(capturing).use {
                         while (received.size < 1) delay(100)
                     }
                 }
@@ -846,11 +846,11 @@ class DebeziumIntegrationTest {
 
             // Second run: same group ID — should NOT re-process Alice, only Bob
             withSourceProducer(sourceTopic) { processor ->
-                val debeziumConsumer = DebeziumConsumer(kafkaConfig(), debeziumTopic, debeziumGroupId)
+                val kafkaDebeziumLog = KafkaDebeziumLog(kafkaConfig(), debeziumTopic, debeziumGroupId)
                 val (capturing, received) = capturingProcessor(processor)
 
-                debeziumConsumer.use {
-                    debeziumConsumer.tailAll(capturing).use {
+                kafkaDebeziumLog.use {
+                    kafkaDebeziumLog.tailAll(capturing).use {
                         while (received.size < 1) delay(100)
                     }
                 }

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumSourceTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumSourceTest.kt
@@ -1,0 +1,79 @@
+package xtdb.debezium
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import xtdb.database.Database
+
+class DebeziumSourceTest {
+
+    private fun protoRoundTrip(source: DebeziumSource): DebeziumSource {
+        val dbConfig = Database.Config().externalSource(source)
+        val restored = Database.Config.fromProto(dbConfig.serializedConfig)
+        return restored.externalLog as DebeziumSource
+    }
+
+    @Test
+    fun `proto round-trips DebeziumSource with KafkaDebeziumLog`() {
+        val original = DebeziumSource(
+            log = KafkaDebeziumLog.Factory(
+                logCluster = "my-cluster",
+                tableTopic = "cdc.public.users",
+                groupId = "xtdb-cdc-users",
+            )
+        )
+
+        val restored = protoRoundTrip(original)
+        val restoredLog = restored.log as KafkaDebeziumLog.Factory
+
+        assertEquals("my-cluster", restoredLog.logCluster)
+        assertEquals("cdc.public.users", restoredLog.tableTopic)
+        assertEquals("xtdb-cdc-users", restoredLog.groupId)
+    }
+
+    @Test
+    fun `proto round-trips Database Config without external source`() {
+        val dbConfig = Database.Config()
+        val restored = Database.Config.fromProto(dbConfig.serializedConfig)
+
+        assertNull(restored.externalLog)
+    }
+
+    @Test
+    fun `YAML round-trips DebeziumSource with KafkaDebeziumLog`() {
+        val yaml = """
+            externalLog: !Debezium
+              log: !Kafka
+                logCluster: my-cluster
+                tableTopic: cdc.public.users
+                groupId: xtdb-cdc-users
+        """.trimIndent()
+
+        val config = Database.Config.fromYaml(yaml)
+        val source = config.externalLog as DebeziumSource
+        val log = source.log as KafkaDebeziumLog.Factory
+
+        assertEquals("my-cluster", log.logCluster)
+        assertEquals("cdc.public.users", log.tableTopic)
+        assertEquals("xtdb-cdc-users", log.groupId)
+    }
+
+    @Test
+    fun `YAML parses Database Config without external source`() {
+        val config = Database.Config.fromYaml("mode: read-write")
+        assertNull(config.externalLog)
+    }
+
+    @Test
+    fun `external source is nullable in Config`() {
+        val config = Database.Config()
+        assertNull(config.externalLog)
+
+        val withSource = config.externalSource(DebeziumSource(
+            log = KafkaDebeziumLog.Factory("cluster", "topic", "group")
+        ))
+        assertNotNull(withSource.externalLog)
+
+        val withoutSource = withSource.externalSource(null)
+        assertNull(withoutSource.externalLog)
+    }
+}

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/KafkaDebeziumLogTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/KafkaDebeziumLogTest.kt
@@ -15,7 +15,7 @@ import java.util.Collections
 import kotlin.time.Duration.Companion.seconds
 
 @Tag("integration")
-class DebeziumConsumerTest {
+class KafkaDebeziumLogTest {
 
     private lateinit var kafka: ConfluentKafkaContainer
 
@@ -76,7 +76,7 @@ class DebeziumConsumerTest {
         produceMessages(topic, listOf(cdcMessage("c", 1, "Alice")))
 
         val (subscriber, received) = capturingProcessor()
-        val log = DebeziumConsumer(kafkaConfig(), topic, "test-group")
+        val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
         log.use {
             log.tailAll(subscriber).use {
                 while (received.isEmpty()) delay(100)
@@ -96,7 +96,7 @@ class DebeziumConsumerTest {
         produceMessages(topic, listOf(cdcMessage("c", 1, "Alice")))
 
         val (subscriber, received) = capturingProcessor()
-        val log = DebeziumConsumer(kafkaConfig(), topic, "test-group")
+        val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
 
         val subscription = log.tailAll(subscriber)
         while (received.isEmpty()) delay(100)

--- a/src/test/clojure/xtdb/sql/multi_db_test.clj
+++ b/src/test/clojure/xtdb/sql/multi_db_test.clj
@@ -201,9 +201,9 @@ ATTACH DATABASE new_db WITH $$
 (t/deftest dodgy-yaml
   (with-open [node (xtn/start-node)]
     (t/is (= {:sql-state "08P01"
-              :message "Invalid database config in `ATTACH DATABASE`: Unknown property 'somethingElse'. Known properties are: log, mode, storage" ,
+              :message "Invalid database config in `ATTACH DATABASE`: Unknown property 'somethingElse'. Known properties are: externalLog, log, mode, storage" ,
               :detail #xt/error [:incorrect :xtdb/invalid-database-config
-                                 "Invalid database config in `ATTACH DATABASE`: Unknown property 'somethingElse'. Known properties are: log, mode, storage"
+                                 "Invalid database config in `ATTACH DATABASE`: Unknown property 'somethingElse'. Known properties are: externalLog, log, mode, storage"
                                  {:sql "ATTACH DATABASE new_db WITH $$ somethingElse: $$ "}]},
 
              (pgw-test/reading-ex


### PR DESCRIPTION
## Summary

Introduces `ExternalLog<M>` — a generic subscribable log interface in core that decouples the database from Debezium-specific types.
Part of the external source (CDC) integration work tracked in #5330.

- **`ExternalLog<M>`** with `tailAll(processor)` and `AutoCloseable`.
  `ExternalLog.Factory` follows the same extensibility pattern as `Log.Factory` — proto via `google.protobuf.Any`, YAML via kotlinx.serialization polymorphism, `ServiceLoader` for registration.

- **`:xtdb/external-source-log` integrant component** — opened from `ExternalLog.Factory` in the database config, stored on `DatabaseStorage` alongside source-log and replica-log.
  The leader processor will consume this in a later phase.

- **`DebeziumLog extends ExternalLog<DebeziumMessage>`** — the type hierarchy is explicit rather than relying on casts.
  `KafkaDebeziumLog` is the runtime Kafka consumer; `KafkaDebeziumLog.Factory` is the serializable config.

- **Debezium module restructure** — `DebeziumConsumer` renamed to `KafkaDebeziumLog`, config moved to nested `Factory`, `DebeziumMessage` extracted to its own file.
  `debezium.clj` `start!` wired through `DebeziumSource.open` instead of constructing a consumer directly.

No `afterToken`/resume parameter on `tailAll` yet — the Debezium consumer currently stores its offsets in Kafka consumer groups, so resumption works without our help.
A later phase will add explicit token-based resumption so the leader can track progress in block metadata.

This can be deployed independently of the multi-writer/single-writer work — it's purely additive config and abstraction with no behaviour change for existing nodes.

## Test plan

- [x] Full `./gradlew test` passes
- [x] Debezium module tests (proto/YAML round-trips, consumer tests)
- [x] Multi-db tests (ATTACH DATABASE error messages with renamed property)
- [ ] Integration tests with Kafka (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)