### PR TITLE
fix(log): track source+replica positions on all processors to fix stale handoff during transitions

### DIFF
--- a/core/src/main/clojure/xtdb/db_catalog.clj
+++ b/core/src/main/clojure/xtdb/db_catalog.clj
@@ -66,10 +66,8 @@
 (defmethod ig/init-key ::watchers [_ {:keys [^DatabaseStorage db-storage, ^DatabaseState db-state]}]
   (let [block-cat (.getBlockCatalog db-state)
         source-msg-id (max (or (.getLatestProcessedMsgId block-cat) -1)
-                           (MsgIdUtil/offsetToMsgId (.getEpoch (.getSourceLog db-storage)) -1))
-        replica-msg-id (max (or (.getBoundaryReplicaMsgId block-cat) -1)
-                            (MsgIdUtil/offsetToMsgId (.getEpoch (.getReplicaLog db-storage)) -1))]
-    (Watchers. source-msg-id source-msg-id replica-msg-id)))
+                           (MsgIdUtil/offsetToMsgId (.getEpoch (.getSourceLog db-storage)) -1))]
+    (Watchers. source-msg-id source-msg-id)))
 
 (defmethod ig/halt-key! ::watchers [_ ^Watchers watchers]
   (util/close watchers))

--- a/core/src/main/clojure/xtdb/log/processor.clj
+++ b/core/src/main/clojure/xtdb/log/processor.clj
@@ -74,29 +74,31 @@
                                                {:keys [meter-registry]} :base}]
   (when (.getEnabled indexer-conf)
     (let [proc-factory (reify LogProcessor$ProcessorFactory
-                         (openFollower [_ pending-block after-source-msg-id]
+                         (openFollower [_ pending-block after-source-msg-id after-replica-msg-id]
                            (FollowerLogProcessor. allocator buffer-pool db-state compactor-for-db
                                                   source-watchers
-                                                  db-catalog pending-block after-source-msg-id))
+                                                  db-catalog pending-block after-source-msg-id after-replica-msg-id))
 
-                         (openLeaderProcessor [_ replica-producer after-replica-msg-id]
+                         (openLeaderProcessor [_ replica-producer after-source-msg-id after-replica-msg-id]
                            (LeaderLogProcessor. allocator
                                                 db-storage replica-producer db-state
                                                 indexer-for-db source-watchers
                                                 (set (.getSkipTxs indexer-conf))
                                                 db-catalog block-uploader
+                                                after-source-msg-id
                                                 after-replica-msg-id
                                                 (.getFlushDuration indexer-conf)
                                                 meter-registry))
 
-                         (openTransition [_ replica-producer after-source-msg-id]
+                         (openTransition [_ replica-producer after-source-msg-id after-replica-msg-id]
                            (TransitionLogProcessor. allocator
                                                     buffer-pool db-state
                                                     (.getLiveIndex db-state)
                                                     block-uploader
                                                     replica-producer
                                                     source-watchers db-catalog
-                                                    after-source-msg-id)))
+                                                    after-source-msg-id
+                                                    after-replica-msg-id)))
 
           log-processor (LogProcessor. proc-factory db-storage db-state block-uploader source-watchers meter-registry)]
 

--- a/core/src/main/clojure/xtdb/log/processor.clj
+++ b/core/src/main/clojure/xtdb/log/processor.clj
@@ -100,7 +100,7 @@
                                                     after-source-msg-id
                                                     after-replica-msg-id)))
 
-          log-processor (LogProcessor. proc-factory db-storage db-state block-uploader source-watchers meter-registry)]
+          log-processor (LogProcessor. proc-factory db-storage db-state block-uploader meter-registry)]
 
       {:log-processor log-processor
        :subscription (when-not (= mode Database$Mode/READ_ONLY)

--- a/core/src/main/clojure/xtdb/log/processor.clj
+++ b/core/src/main/clojure/xtdb/log/processor.clj
@@ -74,27 +74,29 @@
                                                {:keys [meter-registry]} :base}]
   (when (.getEnabled indexer-conf)
     (let [proc-factory (reify LogProcessor$ProcessorFactory
-                         (openFollower [_ pending-block]
+                         (openFollower [_ pending-block after-source-msg-id]
                            (FollowerLogProcessor. allocator buffer-pool db-state compactor-for-db
                                                   source-watchers
-                                                  db-catalog pending-block))
+                                                  db-catalog pending-block after-source-msg-id))
 
-                         (openLeaderProcessor [_ replica-producer]
+                         (openLeaderProcessor [_ replica-producer after-replica-msg-id]
                            (LeaderLogProcessor. allocator
                                                 db-storage replica-producer db-state
                                                 indexer-for-db source-watchers
                                                 (set (.getSkipTxs indexer-conf))
                                                 db-catalog block-uploader
+                                                after-replica-msg-id
                                                 (.getFlushDuration indexer-conf)
                                                 meter-registry))
 
-                         (openTransition [_ replica-producer]
+                         (openTransition [_ replica-producer after-source-msg-id]
                            (TransitionLogProcessor. allocator
                                                     buffer-pool db-state
                                                     (.getLiveIndex db-state)
                                                     block-uploader
                                                     replica-producer
-                                                    source-watchers db-catalog)))
+                                                    source-watchers db-catalog
+                                                    after-source-msg-id)))
 
           log-processor (LogProcessor. proc-factory db-storage db-state block-uploader source-watchers meter-registry)]
 

--- a/core/src/main/kotlin/xtdb/api/log/Watchers.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Watchers.kt
@@ -16,18 +16,17 @@ import kotlin.time.Duration.Companion.seconds
 class Watchers @JvmOverloads constructor(
     latestTxId: TxId,
     latestSourceMsgId: MessageId,
-    latestReplicaMsgId: MessageId,
     coroutineContext: CoroutineContext = Dispatchers.Default
 ) : AutoCloseable {
 
     /**
-     * Backward-compat constructor for source-only (no replica) setups.
+     * Backward-compat constructor for setups where tx-id is always a src msg-id.
      */
     @JvmOverloads
     constructor(
         latestSourceMsgId: MessageId,
         coroutineContext: CoroutineContext = Dispatchers.Default
-    ) : this(latestSourceMsgId, latestSourceMsgId, latestSourceMsgId, coroutineContext)
+    ) : this(latestTxId = latestSourceMsgId, latestSourceMsgId = latestSourceMsgId, coroutineContext)
 
     @Volatile
     var latestTxId: TxId = latestTxId
@@ -36,13 +35,6 @@ class Watchers @JvmOverloads constructor(
     @Volatile
     var latestSourceMsgId: MessageId = latestSourceMsgId
         private set
-
-    @Volatile
-    var latestReplicaMsgId: MessageId = latestReplicaMsgId
-        private set
-
-    /** Backward compat for metrics/status. */
-    val latestProcessedMsgId: MessageId get() = latestSourceMsgId
 
     @Volatile
     var exception: IngestionStoppedException? = null
@@ -54,15 +46,10 @@ class Watchers @JvmOverloads constructor(
 
     data class TxWatcher(val txId: TxId, override val cont: CancellableContinuation<TransactionResult?>) : Watcher
     data class SourceWatcher(val msgId: MessageId, override val cont: CancellableContinuation<Unit>) : Watcher
-    data class ReplicaWatcher(val msgId: MessageId, override val cont: CancellableContinuation<Unit>) : Watcher
 
     private sealed interface Event {
-        data class NotifyTx(
-            // replica only nullable until SourceLogProcessor goes
-            val result: TransactionResult, val srcMsgId: MessageId, val replicaMsgId: MessageId?
-        ) : Event
-
-        data class NotifyMsg(val srcMsgId: MessageId?, val replicaMsgId: MessageId?) : Event
+        data class NotifyTx(val result: TransactionResult, val srcMsgId: MessageId) : Event
+        data class NotifyMsg(val srcMsgId: MessageId) : Event
         data class NotifyError(val exception: Throwable) : Event
         data class NewWatcher(val watcher: Watcher) : Event
     }
@@ -74,7 +61,6 @@ class Watchers @JvmOverloads constructor(
 
     private val txWatchers = PriorityBlockingQueue<TxWatcher>(16) { a, b -> a.txId.compareTo(b.txId) }
     private val sourceWatchers = PriorityBlockingQueue<SourceWatcher>(16) { a, b -> a.msgId.compareTo(b.msgId) }
-    private val replicaWatchers = PriorityBlockingQueue<ReplicaWatcher>(16) { a, b -> a.msgId.compareTo(b.msgId) }
 
     private fun Queue<out Watcher>.resumeWithException(ex: Throwable) {
         for (watcher in this) watcher.cont.resumeWithException(ex)
@@ -99,17 +85,6 @@ class Watchers @JvmOverloads constructor(
         }
     }
 
-    private fun handleNotifyReplica(replicaMsgId: MessageId) {
-        check(replicaMsgId > latestReplicaMsgId) { "replicaMsgId $replicaMsgId <= latestReplicaMsgId $latestReplicaMsgId" }
-        latestReplicaMsgId = replicaMsgId
-
-        for (watcher in replicaWatchers) {
-            if (watcher.msgId > replicaMsgId) break
-            replicaWatchers.remove(watcher)
-            watcher.cont.resume(Unit)
-        }
-    }
-
     private fun handleNotifyTx(result: TransactionResult) {
         val txId = result.txId
         check(txId > latestTxId) { "txId $txId <= latestTxId $latestTxId" }
@@ -129,12 +104,10 @@ class Watchers @JvmOverloads constructor(
                     is NotifyTx -> {
                         handleNotifyTx(event.result)
                         handleNotifySource(event.srcMsgId)
-                        event.replicaMsgId?.let { handleNotifyReplica(it) }
                     }
 
                     is NotifyMsg -> {
-                        event.srcMsgId?.let { handleNotifySource(it) }
-                        event.replicaMsgId?.let { handleNotifyReplica(it) }
+                        handleNotifySource(event.srcMsgId)
                     }
 
                     is NotifyError -> {
@@ -144,7 +117,6 @@ class Watchers @JvmOverloads constructor(
 
                         txWatchers.resumeWithException(ex)
                         sourceWatchers.resumeWithException(ex)
-                        replicaWatchers.resumeWithException(ex)
                     }
 
                     is NewWatcher -> {
@@ -161,10 +133,6 @@ class Watchers @JvmOverloads constructor(
                             is SourceWatcher ->
                                 if (latestSourceMsgId >= watcher.msgId) watcher.cont.resume(Unit)
                                 else sourceWatchers.add(watcher)
-
-                            is ReplicaWatcher ->
-                                if (latestReplicaMsgId >= watcher.msgId) watcher.cont.resume(Unit)
-                                else replicaWatchers.add(watcher)
                         }
                     }
                 }
@@ -172,7 +140,6 @@ class Watchers @JvmOverloads constructor(
         } finally {
             txWatchers.cancel()
             sourceWatchers.cancel()
-            replicaWatchers.cancel()
         }
     }
 
@@ -190,18 +157,12 @@ class Watchers @JvmOverloads constructor(
 
     // --- notify methods ---
 
-    /** Source-only path (no replica) — advances tx + source watermarks. */
     suspend fun notifyTx(result: TransactionResult, srcMsgId: MessageId) {
-        channel.send(NotifyTx(result, srcMsgId, replicaMsgId = null))
+        channel.send(NotifyTx(result, srcMsgId))
     }
 
-    /** Leader/follower path — advances tx + source + replica watermarks. */
-    suspend fun notifyTx(result: TransactionResult, srcMsgId: MessageId, replicaMsgId: MessageId) {
-        channel.send(NotifyTx(result, srcMsgId, replicaMsgId))
-    }
-
-    suspend fun notifyMsg(srcMsgId: MessageId?, replicaMsgId: MessageId?) {
-        channel.send(NotifyMsg(srcMsgId, replicaMsgId))
+    suspend fun notifyMsg(srcMsgId: MessageId) {
+        channel.send(NotifyMsg(srcMsgId))
     }
 
     suspend fun notifyError(exception: Throwable) {
@@ -230,17 +191,12 @@ class Watchers @JvmOverloads constructor(
         }
     }
 
-    suspend fun awaitReplica(replicaMsgId: MessageId) {
-        exception?.let { throw it }
-        if (latestReplicaMsgId >= replicaMsgId) return
-
-        suspendCancellableCoroutine { cont ->
-            channel.trySend(NewWatcher(ReplicaWatcher(replicaMsgId, cont)))
-                .onClosed { cont.cancel() }
-        }
-    }
-
     override fun toString() =
-        "(Watchers {txWatchers=${txWatchers.size}, sourceWatchers=${sourceWatchers.size}, replicaWatchers=${replicaWatchers.size}, " +
-                "latestTxId=$latestTxId, latestSourceMsgId=$latestSourceMsgId, latestReplicaMsgId=$latestReplicaMsgId, exception=$exception)})"
+        listOf(
+            "txWatchers=${txWatchers.size}",
+            "sourceWatchers=${sourceWatchers.size}",
+            "latestTxId=$latestTxId",
+            "latestSourceMsgId=$latestSourceMsgId",
+            "exception=$exception"
+        ).joinToString(", ", "(Watchers {", "})")
 }

--- a/core/src/main/kotlin/xtdb/api/log/Watchers.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Watchers.kt
@@ -25,11 +25,9 @@ class Watchers @JvmOverloads constructor(
      */
     @JvmOverloads
     constructor(
-        latestSourceMsgId: MessageId, coroutineContext: CoroutineContext = Dispatchers.Default
-    ) : this(
-        latestTxId = latestSourceMsgId, latestSourceMsgId = latestSourceMsgId, latestReplicaMsgId = -1,
-        coroutineContext
-    )
+        latestSourceMsgId: MessageId,
+        coroutineContext: CoroutineContext = Dispatchers.Default
+    ) : this(latestSourceMsgId, latestSourceMsgId, latestSourceMsgId, coroutineContext)
 
     @Volatile
     var latestTxId: TxId = latestTxId
@@ -43,6 +41,9 @@ class Watchers @JvmOverloads constructor(
     var latestReplicaMsgId: MessageId = latestReplicaMsgId
         private set
 
+    /** Backward compat for metrics/status. */
+    val latestProcessedMsgId: MessageId get() = latestSourceMsgId
+
     @Volatile
     var exception: IngestionStoppedException? = null
         private set
@@ -54,7 +55,6 @@ class Watchers @JvmOverloads constructor(
     data class TxWatcher(val txId: TxId, override val cont: CancellableContinuation<TransactionResult?>) : Watcher
     data class SourceWatcher(val msgId: MessageId, override val cont: CancellableContinuation<Unit>) : Watcher
     data class ReplicaWatcher(val msgId: MessageId, override val cont: CancellableContinuation<Unit>) : Watcher
-    data class SyncWatcher(override val cont: CancellableContinuation<Unit>) : Watcher
 
     private sealed interface Event {
         data class NotifyTx(
@@ -165,8 +165,6 @@ class Watchers @JvmOverloads constructor(
                             is ReplicaWatcher ->
                                 if (latestReplicaMsgId >= watcher.msgId) watcher.cont.resume(Unit)
                                 else replicaWatchers.add(watcher)
-
-                            is SyncWatcher -> watcher.cont.resume(Unit)
                         }
                     }
                 }
@@ -238,17 +236,6 @@ class Watchers @JvmOverloads constructor(
 
         suspendCancellableCoroutine { cont ->
             channel.trySend(NewWatcher(ReplicaWatcher(replicaMsgId, cont)))
-                .onClosed { cont.cancel() }
-        }
-    }
-
-    /**
-     * Flushes the event channel — ensures all prior notifications have been applied
-     * before returning, so that [latestSourceMsgId]/[latestReplicaMsgId] reflect the latest state.
-     */
-    suspend fun sync() {
-        suspendCancellableCoroutine { cont ->
-            channel.trySend(NewWatcher(SyncWatcher(cont)))
                 .onClosed { cont.cancel() }
         }
     }

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -1,5 +1,7 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionAborted
 import xtdb.api.TransactionCommitted
@@ -41,8 +43,9 @@ class FollowerLogProcessor @JvmOverloads constructor(
     override var latestSourceMsgId: MessageId = afterSourceMsgId
         private set
 
-    override var latestReplicaMsgId: MessageId = afterReplicaMsgId
-        private set
+    private val latestSeenReplicaMsgId = MutableStateFlow(afterReplicaMsgId)
+
+    override val latestReplicaMsgId: MessageId get() = latestSeenReplicaMsgId.value
 
     private val blockCatalog = dbState.blockCatalog
     private val trieCatalog = dbState.trieCatalog
@@ -78,27 +81,19 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 this.pendingBlock = null
 
                 // replay buffered records — their typed notifications advance the watermarks
-                for (buffered in bufferedRecords) {
-                    handleRecord(buffered)
-                }
-
-                // advance replica watermark past the BlockUploaded record
-                // (source watermark already advanced by replayed records above)
-                watchers.notifyMsg(null, record.msgId)
-
-                return
+                bufferedRecords.forEach { handleRecord(it) }
             } else {
                 LOG.trace { "follower: buffering message ${record.msgId} (${msg::class.simpleName}) during pending block b${pendingBlockIdx} (${pendingBlock.bufferedRecords.size + 1} buffered)" }
                 pendingBlock += record
-                return
             }
+
+            return
         }
 
         when (msg) {
             is ReplicaMessage.ResolvedTx -> {
                 val latestTxId = liveIndex.latestCompletedTx?.txId
                 if (latestTxId != null && msg.txId <= latestTxId) {
-                    watchers.notifyMsg(null, record.msgId)
                     return
                 }
 
@@ -116,7 +111,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 } else TransactionAborted(msg.txId, systemTime, msg.error)
 
                 latestSourceMsgId = msg.txId
-                watchers.notifyTx(result, msg.txId, record.msgId)
+                watchers.notifyTx(result, msg.txId)
             }
 
             is ReplicaMessage.TriesAdded -> {
@@ -124,25 +119,23 @@ class FollowerLogProcessor @JvmOverloads constructor(
                     addTries(msg.tries, record.logTimestamp)
 
                 latestSourceMsgId = msg.sourceMsgId
-                watchers.notifyMsg(msg.sourceMsgId, record.msgId)
+                watchers.notifyMsg(msg.sourceMsgId)
             }
 
             is ReplicaMessage.BlockBoundary -> {
                 pendingBlock = PendingBlock(record.msgId, msg, maxBufferedRecords)
                 LOG.debug("block boundary b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=${record.msgId} — waiting for BlockUploaded...")
                 latestSourceMsgId = msg.latestProcessedMsgId
-                watchers.notifyMsg(msg.latestProcessedMsgId, record.msgId)
+                watchers.notifyMsg(msg.latestProcessedMsgId)
             }
 
             is ReplicaMessage.BlockUploaded -> {
                 if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch)
                     addTries(msg.tries, record.logTimestamp)
-                watchers.notifyMsg(msg.latestProcessedMsgId, record.msgId)
+                watchers.notifyMsg(msg.latestProcessedMsgId)
             }
 
-            is ReplicaMessage.NoOp -> {
-                watchers.notifyMsg(null, record.msgId)
-            }
+            is ReplicaMessage.NoOp -> Unit
         }
     }
 
@@ -150,7 +143,6 @@ class FollowerLogProcessor @JvmOverloads constructor(
         for (record in records) {
             try {
                 handleRecord(record)
-                latestReplicaMsgId = record.msgId
             } catch (e: InterruptedException) {
                 throw e
             } catch (e: Interrupted) {
@@ -162,8 +154,16 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 )
                 watchers.notifyError(e)
                 throw e
+            } finally {
+                latestSeenReplicaMsgId.value = record.msgId
             }
         }
+    }
+
+    override suspend fun awaitReplicaMsgId(target: MessageId) {
+        LOG.debug("transition: awaiting replica watcher catch-up to $target")
+        latestSeenReplicaMsgId.first { it >= target }
+        LOG.debug("transition: replica watchers caught up to $target")
     }
 
     override fun close() {

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -30,10 +30,14 @@ class FollowerLogProcessor @JvmOverloads constructor(
     private val watchers: Watchers,
     private val dbCatalog: Database.Catalog?,
     pendingBlock: PendingBlock?,
+    afterSourceMsgId: MessageId,
     private val maxBufferedRecords: Int = 1024,
 ) : LogProcessor.FollowerProcessor {
 
     override var pendingBlock: PendingBlock? = pendingBlock
+        private set
+
+    override var latestSourceMsgId: MessageId = afterSourceMsgId
         private set
 
     private val blockCatalog = dbState.blockCatalog
@@ -107,6 +111,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
                     TransactionCommitted(msg.txId, systemTime)
                 } else TransactionAborted(msg.txId, systemTime, msg.error)
 
+                latestSourceMsgId = msg.txId
                 watchers.notifyTx(result, msg.txId, record.msgId)
             }
 
@@ -114,12 +119,14 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch)
                     addTries(msg.tries, record.logTimestamp)
 
+                latestSourceMsgId = msg.sourceMsgId
                 watchers.notifyMsg(msg.sourceMsgId, record.msgId)
             }
 
             is ReplicaMessage.BlockBoundary -> {
                 pendingBlock = PendingBlock(record.msgId, msg, maxBufferedRecords)
                 LOG.debug("block boundary b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=${record.msgId} — waiting for BlockUploaded...")
+                latestSourceMsgId = msg.latestProcessedMsgId
                 watchers.notifyMsg(msg.latestProcessedMsgId, record.msgId)
             }
 

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -31,6 +31,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
     private val dbCatalog: Database.Catalog?,
     pendingBlock: PendingBlock?,
     afterSourceMsgId: MessageId,
+    afterReplicaMsgId: MessageId,
     private val maxBufferedRecords: Int = 1024,
 ) : LogProcessor.FollowerProcessor {
 
@@ -38,6 +39,9 @@ class FollowerLogProcessor @JvmOverloads constructor(
         private set
 
     override var latestSourceMsgId: MessageId = afterSourceMsgId
+        private set
+
+    override var latestReplicaMsgId: MessageId = afterReplicaMsgId
         private set
 
     private val blockCatalog = dbState.blockCatalog
@@ -146,6 +150,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
         for (record in records) {
             try {
                 handleRecord(record)
+                latestReplicaMsgId = record.msgId
             } catch (e: InterruptedException) {
                 throw e
             } catch (e: Interrupted) {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -125,7 +125,7 @@ class LeaderLogProcessor(
             }
         }
 
-    private suspend fun notifyTx(resolvedTx: ReplicaMessage.ResolvedTx, replicaMsgId: MessageId) {
+    private suspend fun notifyTx(resolvedTx: ReplicaMessage.ResolvedTx) {
         val txId = resolvedTx.txId
         val systemTime = resolvedTx.systemTime
 
@@ -135,7 +135,7 @@ class LeaderLogProcessor(
             else
                 TransactionAborted(txId, systemTime, resolvedTx.error)
 
-        watchers.notifyTx(result, txId, replicaMsgId)
+        watchers.notifyTx(result, txId)
     }
 
     private suspend fun finishBlock(latestProcessedMsgId: MessageId) {
@@ -143,6 +143,7 @@ class LeaderLogProcessor(
         val boundaryMsgId = appendToReplica(boundaryMsg).msgId
         LOG.debug("block boundary b${boundaryMsg.blockIndex.asLexHex}: source=$latestProcessedMsgId, replica=$boundaryMsgId")
         pendingBlock = PendingBlock(boundaryMsgId, boundaryMsg)
+
         latestReplicaMsgId = blockUploader.uploadBlock(replicaProducer, boundaryMsgId, boundaryMsg)
         pendingBlock = null
     }
@@ -150,8 +151,8 @@ class LeaderLogProcessor(
     private suspend fun handleResolvedTx(resolvedTx: ReplicaMessage.ResolvedTx) {
         val txId = resolvedTx.txId
 
-        val replicaMsgId = appendToReplica(resolvedTx).msgId
-        notifyTx(resolvedTx, replicaMsgId)
+        appendToReplica(resolvedTx)
+        notifyTx(resolvedTx)
 
         if (liveIndex.isFull())
             finishBlock(txId)
@@ -173,7 +174,7 @@ class LeaderLogProcessor(
                         if (expectedBlockIdx != null && expectedBlockIdx == (blockCatalog.currentBlockIndex ?: -1L)) {
                             finishBlock(msgId)
                         }
-                        watchers.notifyMsg(msgId, null)
+                        watchers.notifyMsg(msgId)
                     }
 
                     is SourceMessage.AttachDatabase -> {
@@ -189,12 +190,12 @@ class LeaderLogProcessor(
                         val resolvedTx = indexer.addTxRow(txKey, error)
                             .let { if (error == null) it.copy(dbOp = DbOp.Attach(msg.dbName, msg.config)) else it }
 
-                        val replicaMsgId = appendToReplica(resolvedTx).msgId
+                        appendToReplica(resolvedTx)
 
                         val result =
                             if (error == null) TransactionCommitted(txKey.txId, txKey.systemTime)
                             else TransactionAborted(txKey.txId, txKey.systemTime, error)
-                        watchers.notifyTx(result, msgId, replicaMsgId)
+                        watchers.notifyTx(result, msgId)
                     }
 
                     is SourceMessage.DetachDatabase -> {
@@ -210,11 +211,11 @@ class LeaderLogProcessor(
                         val resolvedTx = indexer.addTxRow(txKey, error)
                             .let { if (error == null) it.copy(dbOp = DbOp.Detach(msg.dbName)) else it }
 
-                        val replicaMsgId = appendToReplica(resolvedTx).msgId
+                        appendToReplica(resolvedTx)
 
                         val result = if (error == null) TransactionCommitted(txKey.txId, txKey.systemTime)
                         else TransactionAborted(txKey.txId, txKey.systemTime, error)
-                        watchers.notifyTx(result, msgId, replicaMsgId)
+                        watchers.notifyTx(result, msgId)
                     }
 
                     is SourceMessage.TriesAdded -> {
@@ -227,20 +228,19 @@ class LeaderLogProcessor(
                                 )
                             }
                         }
-                        val replicaMsgId = appendToReplica(
+
+                        appendToReplica(
                             ReplicaMessage.TriesAdded(
-                                msg.storageVersion,
-                                msg.storageEpoch,
-                                msg.tries,
-                                sourceMsgId = msgId
+                                msg.storageVersion, msg.storageEpoch, msg.tries, sourceMsgId = msgId
                             )
-                        ).msgId
-                        watchers.notifyMsg(msgId, replicaMsgId)
+                        )
+
+                        watchers.notifyMsg(msgId)
                     }
 
                     // TODO this one's going before release
                     is SourceMessage.BlockUploaded -> {
-                        watchers.notifyMsg(msgId, null)
+                        watchers.notifyMsg(msgId)
                     }
                 }
 

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -38,6 +38,7 @@ class LeaderLogProcessor(
     private val skipTxs: Set<MessageId>,
     private val dbCatalog: Database.Catalog?,
     private val blockUploader: BlockUploader,
+    afterReplicaMsgId: MessageId,
     flushTimeout: Duration = Duration.ofMinutes(5),
     meterRegistry: MeterRegistry? = null,
 ) : LogProcessor.LeaderProcessor {
@@ -68,6 +69,9 @@ class LeaderLogProcessor(
     override var pendingBlock: PendingBlock? = null
         private set
 
+    override var latestReplicaMsgId: MessageId = afterReplicaMsgId
+        private set
+
     private val blockFlusher = BlockFlusher(flushTimeout, blockCatalog)
 
     private suspend fun maybeFlushBlock() {
@@ -79,6 +83,7 @@ class LeaderLogProcessor(
 
     private suspend fun appendToReplica(message: ReplicaMessage): Log.MessageMetadata =
         replicaProducer.withTx { tx -> tx.appendMessage(message) }.await()
+            .also { latestReplicaMsgId = it.msgId }
 
     private fun resolveTx(
         msgId: MessageId, record: Log.Record<SourceMessage>, msg: SourceMessage.Tx
@@ -131,18 +136,11 @@ class LeaderLogProcessor(
 
     private suspend fun finishBlock(latestProcessedMsgId: MessageId) {
         val boundaryMsg = BlockBoundary((blockCatalog.currentBlockIndex ?: -1) + 1, latestProcessedMsgId)
-
-        // pendingBlock must be set atomically with the boundary write —
-        // if we're interrupted after the write but before setting pendingBlock,
-        // the transition won't know to finish the block upload.
-        pendingBlock = appendToReplica(boundaryMsg)
-            .also { LOG.debug("block boundary b${boundaryMsg.blockIndex.asLexHex}: source=$latestProcessedMsgId, replica=${it.msgId}") }
-            .let { PendingBlock(it.msgId, boundaryMsg) }
-
-        val uploadedReplicaMsgId = blockUploader.uploadBlock(replicaProducer, pendingBlock!!.boundaryMsgId, boundaryMsg)
+        val boundaryMsgId = appendToReplica(boundaryMsg).msgId
+        LOG.debug("block boundary b${boundaryMsg.blockIndex.asLexHex}: source=$latestProcessedMsgId, replica=$boundaryMsgId")
+        pendingBlock = PendingBlock(boundaryMsgId, boundaryMsg)
+        latestReplicaMsgId = blockUploader.uploadBlock(replicaProducer, boundaryMsgId, boundaryMsg)
         pendingBlock = null
-
-        watchers.notifyMsg(null, uploadedReplicaMsgId)
     }
 
     private suspend fun handleResolvedTx(resolvedTx: ReplicaMessage.ResolvedTx) {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -38,6 +38,7 @@ class LeaderLogProcessor(
     private val skipTxs: Set<MessageId>,
     private val dbCatalog: Database.Catalog?,
     private val blockUploader: BlockUploader,
+    afterSourceMsgId: MessageId,
     afterReplicaMsgId: MessageId,
     flushTimeout: Duration = Duration.ofMinutes(5),
     meterRegistry: MeterRegistry? = null,
@@ -67,6 +68,9 @@ class LeaderLogProcessor(
             }
 
     override var pendingBlock: PendingBlock? = null
+        private set
+
+    override var latestSourceMsgId: MessageId = afterSourceMsgId
         private set
 
     override var latestReplicaMsgId: MessageId = afterReplicaMsgId
@@ -187,8 +191,9 @@ class LeaderLogProcessor(
 
                         val replicaMsgId = appendToReplica(resolvedTx).msgId
 
-                        val result = if (error == null) TransactionCommitted(txKey.txId, txKey.systemTime)
-                        else TransactionAborted(txKey.txId, txKey.systemTime, error)
+                        val result =
+                            if (error == null) TransactionCommitted(txKey.txId, txKey.systemTime)
+                            else TransactionAborted(txKey.txId, txKey.systemTime, error)
                         watchers.notifyTx(result, msgId, replicaMsgId)
                     }
 
@@ -238,6 +243,8 @@ class LeaderLogProcessor(
                         watchers.notifyMsg(msgId, null)
                     }
                 }
+
+                latestSourceMsgId = msgId
             } catch (e: InterruptedException) {
                 throw e
             } catch (e: Interrupted) {

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -6,7 +6,6 @@ import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
-import xtdb.util.StringUtil.asLexHex
 import xtdb.util.closeOnCatch
 import xtdb.util.debug
 import xtdb.util.info
@@ -23,18 +22,19 @@ class LogProcessor(
     meterRegistry: MeterRegistry? = null,
 ) : Log.SubscriptionListener<SourceMessage>, AutoCloseable {
 
-    interface LeaderProcessor : Log.RecordProcessor<SourceMessage>, AutoCloseable {
-        val pendingBlock: PendingBlock?
+    interface Processor<M> : Log.RecordProcessor<M>, AutoCloseable {
+        val latestSourceMsgId: MessageId
         val latestReplicaMsgId: MessageId
     }
 
-    interface TransitionProcessor : Log.RecordProcessor<ReplicaMessage>, AutoCloseable {
-        val latestSourceMsgId: MessageId
+    interface LeaderProcessor : Processor<SourceMessage> {
+        val pendingBlock: PendingBlock?
     }
 
-    interface FollowerProcessor : Log.RecordProcessor<ReplicaMessage>, AutoCloseable {
+    interface TransitionProcessor : Processor<ReplicaMessage>
+
+    interface FollowerProcessor : Processor<ReplicaMessage> {
         val pendingBlock: PendingBlock?
-        val latestSourceMsgId: MessageId
     }
 
     private val replicaLog = dbStorage.replicaLog
@@ -42,15 +42,20 @@ class LogProcessor(
     interface ProcessorFactory {
         fun openLeaderProcessor(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+            afterSourceMsgId: MessageId,
             afterReplicaMsgId: MessageId,
         ): LeaderProcessor
 
         fun openTransition(
-            replicaProducer: Log.AtomicProducer<ReplicaMessage>, afterSourceMsgId: MessageId
+            replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+            afterSourceMsgId: MessageId,
+            afterReplicaMsgId: MessageId,
         ): TransitionProcessor
 
         fun openFollower(
-            pendingBlock: PendingBlock?, afterSourceMsgId: MessageId
+            pendingBlock: PendingBlock?,
+            afterSourceMsgId: MessageId,
+            afterReplicaMsgId: MessageId,
         ): FollowerProcessor
     }
 
@@ -67,28 +72,29 @@ class LogProcessor(
         }
     }
 
-    private val afterSourceMsgId: MessageId = dbState.blockCatalog.latestProcessedMsgId ?: -1
-
     private fun openFollowerSystem(
+        latestSourceMsgId: MessageId,
         latestReplicaMsgId: MessageId,
         pendingBlock: PendingBlock? = null,
-        afterSourceMsgId: MessageId = this.afterSourceMsgId
     ): FollowerSystem =
-        procFactory.openFollower(pendingBlock, afterSourceMsgId).closeOnCatch { proc ->
+        procFactory.openFollower(pendingBlock, latestSourceMsgId, latestReplicaMsgId).closeOnCatch { proc ->
+            LOG.info {
+                buildString {
+                    append("starting follower: ")
+                    append("pending block: ${pendingBlock != null}, ")
+                    append("src: $latestSourceMsgId, ")
+                    append("replica: $latestReplicaMsgId")
+                }
+            }
+
             FollowerSystem(proc, replicaLog.tailAll(latestReplicaMsgId, proc))
         }
 
     @Volatile
-    private var sys: SubSystem = openFollowerSystem(watchers.latestReplicaMsgId)
+    private var sys: SubSystem =
+        dbState.blockCatalog.let { openFollowerSystem(it.latestProcessedMsgId ?: -1, it.boundaryReplicaMsgId ?: -1) }
 
     init {
-        val blockCatalog = dbState.blockCatalog
-        LOG.info(
-            "starting follower — block: ${blockCatalog.currentBlockIndex?.asLexHex}, " +
-                    "source: ${blockCatalog.latestProcessedMsgId}, " +
-                    "replica: ${blockCatalog.boundaryReplicaMsgId}"
-        )
-
         meterRegistry?.let { reg ->
             Gauge.builder("xtdb.log.leader", this) { if (it.sys is LeaderSystem) 1.0 else 0.0 }
                 .description("1 if this node is the log leader, 0 if follower")
@@ -125,14 +131,16 @@ class LogProcessor(
                     oldSys.close()
                     val pendingBlock = followerProc.pendingBlock
 
-                    procFactory.openTransition(replicaProducer, followerProc.latestSourceMsgId)
+                    procFactory.openTransition(
+                        replicaProducer,
+                        followerProc.latestSourceMsgId,
+                        followerProc.latestReplicaMsgId
+                    )
                         .use { transition ->
                             if (pendingBlock != null) {
                                 LOG.debug("transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
                                 blockUploader.uploadBlock(
-                                    replicaProducer,
-                                    pendingBlock.boundaryMsgId,
-                                    pendingBlock.boundaryMessage,
+                                    replicaProducer, pendingBlock.boundaryMsgId, pendingBlock.boundaryMessage,
                                 )
                                 LOG.debug("transition: replaying ${pendingBlock.bufferedRecords.size} buffered records through transition processor")
                                 transition.processRecords(pendingBlock.bufferedRecords)
@@ -141,8 +149,9 @@ class LogProcessor(
                             val latestSourceMsgId = transition.latestSourceMsgId
                             LOG.debug("transition: opening leader processor")
 
-                            val proc = procFactory.openLeaderProcessor(replicaProducer, replayTarget)
+                            val proc = procFactory.openLeaderProcessor(replicaProducer, latestSourceMsgId, replayTarget)
                             this.sys = LeaderSystem(proc)
+
                             LOG.info("leader startup complete, resuming after $latestSourceMsgId")
                             Log.TailSpec(latestSourceMsgId, proc)
                         }
@@ -154,20 +163,16 @@ class LogProcessor(
     override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {
         if (partitions != listOf(0)) return
 
-        LOG.debug("partitions revoked: $partitions — transitioning to follower")
         when (val oldSys = sys) {
             is LeaderSystem -> {
                 LOG.info("partitions revoked: $partitions — was leader, transitioning to follower")
+                oldSys.close() // close first so no further processing can change the watermarks
                 val proc = oldSys.proc
-                val pendingBlock = proc.pendingBlock
-                val latestReplica = proc.latestReplicaMsgId
-                oldSys.close()
-                LOG.debug("revocation: pending block: ${pendingBlock != null}, opening follower system from $latestReplica")
-                this.sys = openFollowerSystem(latestReplica, pendingBlock)
+                this.sys = openFollowerSystem(proc.latestSourceMsgId, proc.latestReplicaMsgId, proc.pendingBlock)
             }
 
             is FollowerSystem -> {
-                LOG.info("partitions revoked: $partitions — already follower, no transition needed")
+                LOG.debug("partitions revoked: $partitions — already follower, no transition needed")
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -25,12 +25,16 @@ class LogProcessor(
 
     interface LeaderProcessor : Log.RecordProcessor<SourceMessage>, AutoCloseable {
         val pendingBlock: PendingBlock?
+        val latestReplicaMsgId: MessageId
     }
 
-    interface TransitionProcessor : Log.RecordProcessor<ReplicaMessage>, AutoCloseable
+    interface TransitionProcessor : Log.RecordProcessor<ReplicaMessage>, AutoCloseable {
+        val latestSourceMsgId: MessageId
+    }
 
     interface FollowerProcessor : Log.RecordProcessor<ReplicaMessage>, AutoCloseable {
         val pendingBlock: PendingBlock?
+        val latestSourceMsgId: MessageId
     }
 
     private val replicaLog = dbStorage.replicaLog
@@ -38,14 +42,15 @@ class LogProcessor(
     interface ProcessorFactory {
         fun openLeaderProcessor(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+            afterReplicaMsgId: MessageId,
         ): LeaderProcessor
 
         fun openTransition(
-            replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+            replicaProducer: Log.AtomicProducer<ReplicaMessage>, afterSourceMsgId: MessageId
         ): TransitionProcessor
 
         fun openFollower(
-            pendingBlock: PendingBlock?,
+            pendingBlock: PendingBlock?, afterSourceMsgId: MessageId
         ): FollowerProcessor
     }
 
@@ -62,13 +67,19 @@ class LogProcessor(
         }
     }
 
-    private fun openFollowerSystem(pendingBlock: PendingBlock? = null): FollowerSystem =
-        procFactory.openFollower(pendingBlock).closeOnCatch { proc ->
-            FollowerSystem(proc, replicaLog.tailAll(watchers.latestReplicaMsgId, proc))
+    private val afterSourceMsgId: MessageId = dbState.blockCatalog.latestProcessedMsgId ?: -1
+
+    private fun openFollowerSystem(
+        latestReplicaMsgId: MessageId,
+        pendingBlock: PendingBlock? = null,
+        afterSourceMsgId: MessageId = this.afterSourceMsgId
+    ): FollowerSystem =
+        procFactory.openFollower(pendingBlock, afterSourceMsgId).closeOnCatch { proc ->
+            FollowerSystem(proc, replicaLog.tailAll(latestReplicaMsgId, proc))
         }
 
     @Volatile
-    private var sys: SubSystem = openFollowerSystem()
+    private var sys: SubSystem = openFollowerSystem(watchers.latestReplicaMsgId)
 
     init {
         val blockCatalog = dbState.blockCatalog
@@ -109,29 +120,28 @@ class LogProcessor(
                     watchers.awaitReplica(replayTarget)
                     LOG.debug("transition: replica watchers caught up to $replayTarget")
 
-                    val pendingBlock = oldSys.proc.pendingBlock
+                    val followerProc = oldSys.proc
                     LOG.debug("transition: closing follower system")
                     oldSys.close()
+                    val pendingBlock = followerProc.pendingBlock
 
-                    procFactory.openTransition(replicaProducer)
+                    procFactory.openTransition(replicaProducer, followerProc.latestSourceMsgId)
                         .use { transition ->
                             if (pendingBlock != null) {
                                 LOG.debug("transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
-                                val uploadedReplicaMsgId = blockUploader.uploadBlock(
+                                blockUploader.uploadBlock(
                                     replicaProducer,
                                     pendingBlock.boundaryMsgId,
                                     pendingBlock.boundaryMessage,
                                 )
-                                watchers.notifyMsg(null, uploadedReplicaMsgId)
                                 LOG.debug("transition: replaying ${pendingBlock.bufferedRecords.size} buffered records through transition processor")
                                 transition.processRecords(pendingBlock.bufferedRecords)
-                                watchers.sync()
                             }
 
-                            val latestSourceMsgId = watchers.latestSourceMsgId
+                            val latestSourceMsgId = transition.latestSourceMsgId
                             LOG.debug("transition: opening leader processor")
 
-                            val proc = procFactory.openLeaderProcessor(replicaProducer)
+                            val proc = procFactory.openLeaderProcessor(replicaProducer, replayTarget)
                             this.sys = LeaderSystem(proc)
                             LOG.info("leader startup complete, resuming after $latestSourceMsgId")
                             Log.TailSpec(latestSourceMsgId, proc)
@@ -148,11 +158,12 @@ class LogProcessor(
         when (val oldSys = sys) {
             is LeaderSystem -> {
                 LOG.info("partitions revoked: $partitions — was leader, transitioning to follower")
-                val pendingBlock = oldSys.proc.pendingBlock
+                val proc = oldSys.proc
+                val pendingBlock = proc.pendingBlock
+                val latestReplica = proc.latestReplicaMsgId
                 oldSys.close()
-                watchers.sync()
-                LOG.debug("revocation: pending block: ${pendingBlock != null}, opening follower system")
-                this.sys = openFollowerSystem(pendingBlock)
+                LOG.debug("revocation: pending block: ${pendingBlock != null}, opening follower system from $latestReplica")
+                this.sys = openFollowerSystem(latestReplica, pendingBlock)
             }
 
             is FollowerSystem -> {

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -18,7 +18,6 @@ class LogProcessor(
     dbStorage: DatabaseStorage,
     private val dbState: DatabaseState,
     private val blockUploader: BlockUploader,
-    private val watchers: Watchers,
     meterRegistry: MeterRegistry? = null,
 ) : Log.SubscriptionListener<SourceMessage>, AutoCloseable {
 
@@ -35,6 +34,7 @@ class LogProcessor(
 
     interface FollowerProcessor : Processor<ReplicaMessage> {
         val pendingBlock: PendingBlock?
+        suspend fun awaitReplicaMsgId(target: MessageId)
     }
 
     private val replicaLog = dbStorage.replicaLog
@@ -115,20 +115,18 @@ class LogProcessor(
             is FollowerSystem -> {
                 LOG.info("partitions assigned: $partitions — transitioning to leader")
 
-                // Fence: open atomic producer on replica log.
-                LOG.debug("transition: opening atomic producer on replica log")
                 replicaLog.openAtomicProducer("${dbState.name}-leader").closeOnCatch { replicaProducer ->
+                    val followerProc = oldSys.proc
+
                     // Send a NoOp to get a known msgId we can await —
                     // we can't use latestSubmittedMsgId because Kafka's endOffsets
                     // includes transaction marker offsets that consumers never deliver.
                     val replayTarget = replicaProducer.withTx { it.appendMessage(ReplicaMessage.NoOp) }.await().msgId
-                    LOG.debug("transition: awaiting replica watcher catch-up to $replayTarget (replica latest: ${replicaLog.latestSubmittedMsgId})")
-                    watchers.awaitReplica(replayTarget)
-                    LOG.debug("transition: replica watchers caught up to $replayTarget")
 
-                    val followerProc = oldSys.proc
+                    followerProc.awaitReplicaMsgId(replayTarget)
                     LOG.debug("transition: closing follower system")
                     oldSys.close()
+
                     val pendingBlock = followerProc.pendingBlock
 
                     procFactory.openTransition(

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
@@ -322,11 +322,11 @@ class SourceLogProcessor(
                                     record.logTimestamp
                                 )
                             }
-                        watchers.notifyMsg(msgId, null)
+                        watchers.notifyMsg(msgId)
                     }
 
                     is SourceMessage.BlockUploaded -> {
-                        watchers.notifyMsg(msgId, null)
+                        watchers.notifyMsg(msgId)
                     }
                 }
             }

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -29,9 +29,13 @@ class TransitionLogProcessor(
     private val watchers: Watchers,
     private val dbCatalog: Database.Catalog?,
     afterSourceMsgId: MessageId,
+    afterReplicaMsgId: MessageId,
 ) : LogProcessor.TransitionProcessor {
 
     override var latestSourceMsgId: MessageId = afterSourceMsgId
+        private set
+
+    override var latestReplicaMsgId: MessageId = afterReplicaMsgId
         private set
 
     private val trieCatalog = dbState.trieCatalog
@@ -98,6 +102,8 @@ class TransitionLogProcessor(
                         watchers.notifyMsg(null, msgId)
                     }
                 }
+
+                latestReplicaMsgId = msgId
             } catch (e: InterruptedException) {
                 throw e
             } catch (e: Interrupted) {

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -5,6 +5,7 @@ import xtdb.api.TransactionAborted
 import xtdb.api.TransactionCommitted
 import xtdb.api.log.DbOp
 import xtdb.api.log.Log
+import xtdb.api.log.MessageId
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.Watchers
 import xtdb.api.storage.Storage
@@ -27,7 +28,11 @@ class TransitionLogProcessor(
     private val replicaProducer: Log.AtomicProducer<ReplicaMessage>,
     private val watchers: Watchers,
     private val dbCatalog: Database.Catalog?,
+    afterSourceMsgId: MessageId,
 ) : LogProcessor.TransitionProcessor {
+
+    override var latestSourceMsgId: MessageId = afterSourceMsgId
+        private set
 
     private val trieCatalog = dbState.trieCatalog
 
@@ -57,6 +62,7 @@ class TransitionLogProcessor(
                             TransactionCommitted(msg.txId, msg.systemTime)
                         } else TransactionAborted(msg.txId, msg.systemTime, msg.error)
 
+                        latestSourceMsgId = msg.txId
                         watchers.notifyTx(result, msg.txId, msgId)
                     }
 
@@ -70,18 +76,21 @@ class TransitionLogProcessor(
                                 )
                             }
                         }
+                        latestSourceMsgId = msg.sourceMsgId
                         watchers.notifyMsg(msg.sourceMsgId, msgId)
                     }
 
                     is ReplicaMessage.BlockBoundary -> {
                         LOG.debug("block boundary b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=$msgId")
-                        val uploadedReplicaMsgId = blockUploader.uploadBlock(replicaProducer, msgId, msg)
-                        watchers.notifyMsg(msg.latestProcessedMsgId, uploadedReplicaMsgId)
+                        blockUploader.uploadBlock(replicaProducer, msgId, msg)
+                        latestSourceMsgId = msg.latestProcessedMsgId
+                        watchers.notifyMsg(msg.latestProcessedMsgId, msgId)
                     }
 
                     // previously I errored here, but we need to just ignore them -
                     // the transition proc submits a BlockUploaded as part of finishing the BlockBoundary messages.
                     is ReplicaMessage.BlockUploaded -> {
+                        latestSourceMsgId = msg.latestProcessedMsgId
                         watchers.notifyMsg(msg.latestProcessedMsgId, msgId)
                     }
 

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -67,7 +67,7 @@ class TransitionLogProcessor(
                         } else TransactionAborted(msg.txId, msg.systemTime, msg.error)
 
                         latestSourceMsgId = msg.txId
-                        watchers.notifyTx(result, msg.txId, msgId)
+                        watchers.notifyTx(result, msg.txId)
                     }
 
                     is ReplicaMessage.TriesAdded -> {
@@ -81,26 +81,24 @@ class TransitionLogProcessor(
                             }
                         }
                         latestSourceMsgId = msg.sourceMsgId
-                        watchers.notifyMsg(msg.sourceMsgId, msgId)
+                        watchers.notifyMsg(msg.sourceMsgId)
                     }
 
                     is ReplicaMessage.BlockBoundary -> {
                         LOG.debug("block boundary b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=$msgId")
                         blockUploader.uploadBlock(replicaProducer, msgId, msg)
                         latestSourceMsgId = msg.latestProcessedMsgId
-                        watchers.notifyMsg(msg.latestProcessedMsgId, msgId)
+                        watchers.notifyMsg(msg.latestProcessedMsgId)
                     }
 
                     // previously I errored here, but we need to just ignore them -
                     // the transition proc submits a BlockUploaded as part of finishing the BlockBoundary messages.
                     is ReplicaMessage.BlockUploaded -> {
                         latestSourceMsgId = msg.latestProcessedMsgId
-                        watchers.notifyMsg(msg.latestProcessedMsgId, msgId)
+                        watchers.notifyMsg(msg.latestProcessedMsgId)
                     }
 
-                    is ReplicaMessage.NoOp -> {
-                        watchers.notifyMsg(null, msgId)
-                    }
+                    is ReplicaMessage.NoOp -> Unit
                 }
 
                 latestReplicaMsgId = msgId

--- a/core/src/main/kotlin/xtdb/util/SystemLogger.kt
+++ b/core/src/main/kotlin/xtdb/util/SystemLogger.kt
@@ -17,6 +17,7 @@ fun Logger.debug(message: Supplier<String>) = log(DEBUG, message)
 fun Logger.debug(throwable: Throwable, message: Supplier<String>) = log(DEBUG, message, throwable)
 
 fun Logger.info(message: String) = log(INFO, message)
+fun Logger.info(message: Supplier<String>) = log(INFO, message)
 fun Logger.info(throwable: Throwable, message: String) = log(INFO, message, throwable)
 
 fun Logger.warn(message: String) = log(WARNING, message)

--- a/core/src/test/kotlin/xtdb/api/log/WatchersSimTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/WatchersSimTest.kt
@@ -42,7 +42,7 @@ class WatchersSimTest : SimulationTestBase() {
                 if (res != null) {
                     watchers.notifyTx(res, i)
                 } else {
-                    watchers.notifyMsg(i, null)
+                    watchers.notifyMsg(i)
                 }
             }
         }

--- a/core/src/test/kotlin/xtdb/api/log/WatchersTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/WatchersTest.kt
@@ -53,44 +53,19 @@ class WatchersTest {
     }
 
     @Test
-    fun `notifyTx with replicaMsgId advances all watermarks`() = runTest(timeout = 1.seconds) {
-        Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1).use {
-            val awaitTx = async { it.awaitTx(0) }
-            val awaitSource = async { it.awaitSource(0) }
-            val awaitReplica = async { it.awaitReplica(10) }
-
-            assertThrows<TimeoutCancellationException> { withTimeout(50) { awaitTx.await() } }
-
-            val res = TransactionCommitted(0, Instant.parse("2021-01-01T00:00:00Z"))
-            it.notifyTx(result = res, srcMsgId = 0, replicaMsgId = 10)
-
-            assertEquals(res, awaitTx.await())
-            awaitSource.await()
-            awaitReplica.await()
-        }
-    }
-
-    @Test
     fun `notifyMsg advances specified watermarks`() = runTest(timeout = 1.seconds) {
-        Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1).use {
-            // source-only: advances source, not tx or replica
+        Watchers(latestTxId = -1, latestSourceMsgId = -1).use {
+            // source-only: advances source, not tx
             val awaitSource1 = async { it.awaitSource(5) }
-            it.notifyMsg(5, null)
+            it.notifyMsg(5)
             awaitSource1.await()
             assertThrows<TimeoutCancellationException> { withTimeout(50) { it.awaitTx(5) } }
-            assertThrows<TimeoutCancellationException> { withTimeout(50) { it.awaitReplica(0) } }
 
-            // both: advances source + replica, not tx
+            // both: advances source, not tx
             val awaitSource2 = async { it.awaitSource(8) }
-            val awaitReplica = async { it.awaitReplica(10) }
-            it.notifyMsg(8, 10)
+            it.notifyMsg(8)
             awaitSource2.await()
-            awaitReplica.await()
             assertThrows<TimeoutCancellationException> { withTimeout(50) { it.awaitTx(8) } }
-
-            // replica-only: advances replica, not source
-            it.notifyMsg(null, 15)
-            assertThrows<TimeoutCancellationException> { withTimeout(50) { it.awaitSource(9) } }
         }
     }
 
@@ -116,9 +91,6 @@ class WatchersTest {
                     .also { assertEquals(ex, it.cause) }
 
                 assertThrows<IngestionStoppedException> { watchers.awaitSource(5) }
-                    .also { assertEquals(ex, it.cause) }
-
-                assertThrows<IngestionStoppedException> { watchers.awaitReplica(5) }
                     .also { assertEquals(ex, it.cause) }
             }
         }

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -56,7 +56,7 @@ class FollowerLogProcessorTest {
     private fun makeProcessor(maxBufferedRecords: Int = 1024) =
         FollowerLogProcessor(
             allocator, bufferPool, dbState,
-            compactor, watchers, null, null, afterSourceMsgId = -1L, maxBufferedRecords
+            compactor, watchers, null, null, afterSourceMsgId = -1L, afterReplicaMsgId = -1L, maxBufferedRecords
         )
 
     private fun <M> record(offset: Long, message: M) =

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -56,7 +56,7 @@ class FollowerLogProcessorTest {
     private fun makeProcessor(maxBufferedRecords: Int = 1024) =
         FollowerLogProcessor(
             allocator, bufferPool, dbState,
-            compactor, watchers, null, null, maxBufferedRecords
+            compactor, watchers, null, null, afterSourceMsgId = -1L, maxBufferedRecords
         )
 
     private fun <M> record(offset: Long, message: M) =

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -49,7 +49,7 @@ class LeaderLogProcessorTest {
         return LeaderLogProcessor(
             RootAllocator(), dbStorage, replicaProducer,
             dbState, indexer, watchers,
-            emptySet(), null, blockUploader, afterReplicaMsgId = -1
+            emptySet(), null, blockUploader, afterSourceMsgId = -1, afterReplicaMsgId = -1
         )
     }
 
@@ -102,7 +102,7 @@ class LeaderLogProcessorTest {
         val lp = LeaderLogProcessor(
             RootAllocator(), dbStorage, replicaProducer,
             dbState, mockk(relaxed = true), Watchers(-1),
-            emptySet(), null, blockUploader, afterReplicaMsgId = -1
+            emptySet(), null, blockUploader, afterSourceMsgId = -1, afterReplicaMsgId = -1
         )
 
         val now = Instant.now()
@@ -166,7 +166,7 @@ class LeaderLogProcessorTest {
         val lp = LeaderLogProcessor(
             RootAllocator(), dbStorage, replicaProducer,
             dbState, mockk(relaxed = true), Watchers(-1),
-            emptySet(), null, blockUploader, afterReplicaMsgId = -1
+            emptySet(), null, blockUploader, afterSourceMsgId = -1, afterReplicaMsgId = -1
         )
 
         val now = Instant.now()

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -49,7 +49,7 @@ class LeaderLogProcessorTest {
         return LeaderLogProcessor(
             RootAllocator(), dbStorage, replicaProducer,
             dbState, indexer, watchers,
-            emptySet(), null, blockUploader
+            emptySet(), null, blockUploader, afterReplicaMsgId = -1
         )
     }
 
@@ -102,7 +102,7 @@ class LeaderLogProcessorTest {
         val lp = LeaderLogProcessor(
             RootAllocator(), dbStorage, replicaProducer,
             dbState, mockk(relaxed = true), Watchers(-1),
-            emptySet(), null, blockUploader
+            emptySet(), null, blockUploader, afterReplicaMsgId = -1
         )
 
         val now = Instant.now()
@@ -166,7 +166,7 @@ class LeaderLogProcessorTest {
         val lp = LeaderLogProcessor(
             RootAllocator(), dbStorage, replicaProducer,
             dbState, mockk(relaxed = true), Watchers(-1),
-            emptySet(), null, blockUploader
+            emptySet(), null, blockUploader, afterReplicaMsgId = -1
         )
 
         val now = Instant.now()

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -57,6 +57,7 @@ class LogProcessorTest {
         object : LogProcessor.ProcessorFactory {
             override fun openLeaderProcessor(
                 replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+                afterSourceMsgId: MessageId,
                 afterReplicaMsgId: MessageId,
             ): LeaderLogProcessor {
                 val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
@@ -64,29 +65,32 @@ class LogProcessorTest {
                 return LeaderLogProcessor(
                     allocator, dbStorage, replicaProducer,
                     dbState, mockk(relaxed = true), watchers,
-                    emptySet(), null, blockUploader, afterReplicaMsgId
+                    emptySet(), null, blockUploader, afterSourceMsgId, afterReplicaMsgId
                 )
             }
 
             override fun openTransition(
                 replicaProducer: Log.AtomicProducer<ReplicaMessage>,
                 afterSourceMsgId: MessageId,
+                afterReplicaMsgId: MessageId,
             ): LogProcessor.TransitionProcessor =
                 TransitionLogProcessor(
                     allocator, bufferPool, dbState, dbState.liveIndex,
                     BlockUploader(dbStorage, dbState, mockk(relaxed = true), null),
                     replicaProducer, watchers, dbCatalog = null,
                     afterSourceMsgId = afterSourceMsgId,
+                    afterReplicaMsgId = afterReplicaMsgId,
                 )
 
             override fun openFollower(
                 pendingBlock: PendingBlock?,
                 afterSourceMsgId: MessageId,
+                afterReplicaMsgId: MessageId,
             ): LogProcessor.FollowerProcessor =
                 FollowerLogProcessor(
                     allocator, bufferPool, dbState,
                     mockk(relaxed = true), watchers, null, pendingBlock,
-                    afterSourceMsgId,
+                    afterSourceMsgId, afterReplicaMsgId,
                 )
         }
 

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -106,7 +106,7 @@ class LogProcessorTest {
 
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader, watchers
+            dbStorage, dbState, blockUploader
         )
 
         val subscription = sourceLog.openGroupSubscription(logProc)
@@ -130,7 +130,7 @@ class LogProcessorTest {
 
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader, watchers
+            dbStorage, dbState, blockUploader
         )
 
         val subscription = sourceLog.openGroupSubscription(logProc)
@@ -162,7 +162,7 @@ class LogProcessorTest {
 
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader, watchers
+            dbStorage, dbState, blockUploader
         )
 
         val subscription = sourceLog.openGroupSubscription(logProc)
@@ -195,7 +195,7 @@ class LogProcessorTest {
 
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader, watchers
+            dbStorage, dbState, blockUploader
         )
 
         val subscription = sourceLog.openGroupSubscription(logProc)

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -57,31 +57,36 @@ class LogProcessorTest {
         object : LogProcessor.ProcessorFactory {
             override fun openLeaderProcessor(
                 replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+                afterReplicaMsgId: MessageId,
             ): LeaderLogProcessor {
                 val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
                 val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
                 return LeaderLogProcessor(
                     allocator, dbStorage, replicaProducer,
                     dbState, mockk(relaxed = true), watchers,
-                    emptySet(), null, blockUploader,
+                    emptySet(), null, blockUploader, afterReplicaMsgId
                 )
             }
 
             override fun openTransition(
                 replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+                afterSourceMsgId: MessageId,
             ): LogProcessor.TransitionProcessor =
                 TransitionLogProcessor(
                     allocator, bufferPool, dbState, dbState.liveIndex,
                     BlockUploader(dbStorage, dbState, mockk(relaxed = true), null),
                     replicaProducer, watchers, dbCatalog = null,
+                    afterSourceMsgId = afterSourceMsgId,
                 )
 
             override fun openFollower(
                 pendingBlock: PendingBlock?,
+                afterSourceMsgId: MessageId,
             ): LogProcessor.FollowerProcessor =
                 FollowerLogProcessor(
                     allocator, bufferPool, dbState,
                     mockk(relaxed = true), watchers, null, pendingBlock,
+                    afterSourceMsgId,
                 )
         }
 


### PR DESCRIPTION
## Summary

Reverts and replaces #5368 (which was merged earlier today) with a simpler approach: explicit position tracking on each processor instead of Watchers as source of truth.

- **fix(log)**: each processor now tracks both `latestSourceMsgId` and `latestReplicaMsgId`, passed explicitly through factory methods at every transition
- **tidy(log)**: move replica `await` from Watchers to FLP using `MutableStateFlow`, since the semantics for awaiting a replica msg ID were subtly different from the other Watchers awaits

## Root cause

During leader→follower→leader transitions, the new follower's `afterSourceMsgId` came from a `val` computed once at `LogProcessor` construction (from the block catalog), not the leader's actual latest position.
The follower then replayed deduplicated `ResolvedTx` messages (`txId <= latestTxId` in the shared liveIndex) which didn't advance the source watermark, so the stale value persisted into the next leader transition.
The new leader would resume from the stale position, re-processing source messages and writing duplicates to the replica log — crashing followers with `srcMsgId < latestSourceMsgId`.

## Why replace #5368?

The Watchers-as-source-of-truth approach in #5368 had cascading issues:
- Every replica write path needed a matching notification — easy to miss (`finishBlock`, `uploadBlock`, transition `BlockBoundary` handler all had gaps found during review)
- The async channel required `sync()` calls at transition points that were easy to forget
- Block lifecycle writes (finishBlock, uploadBlock) mixed infrastructure concerns with processing-progress notifications — the notification semantics were subtly different for "I processed a source record" vs "I wrote a block management message to the replica log"

The explicit-fields approach is simpler: each processor owns its watermarks, they're handed off at transitions, and there's no async channel in the critical path.

## Why move replica await to FLP?

The semantics for awaiting a replica msg ID were subtly different from the other Watchers awaits: the replica watermark needed to advance even for messages buffered during a pending block (specifically the NoOp fence), but Watchers' channel-based processing meant buffered records didn't notify it.
Rather than adding special-case punch-through logic, the await now lives on FLP itself using a `MutableStateFlow` updated in the `finally` block of `processRecords` (so it advances for every record, even buffered ones).

## Test plan

- [ ] Full test suite passes locally
- [ ] Verify on benchmark cluster that `srcMsgId < latestSourceMsgId` no longer occurs during leader transitions
- [ ] Verify rapid rebalance scenarios (the auctionmark benchmark pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)