### PR TITLE
feat(debezium): external source token + offset tracking (#5330)

### DIFF
--- a/core/src/main/clojure/xtdb/db_catalog.clj
+++ b/core/src/main/clojure/xtdb/db_catalog.clj
@@ -67,7 +67,7 @@
   (let [block-cat (.getBlockCatalog db-state)
         source-msg-id (max (or (.getLatestProcessedMsgId block-cat) -1)
                            (MsgIdUtil/offsetToMsgId (.getEpoch (.getSourceLog db-storage)) -1))]
-    (Watchers. source-msg-id source-msg-id)))
+    (Watchers. source-msg-id source-msg-id (.getExternalSourceToken block-cat))))
 
 (defmethod ig/halt-key! ::watchers [_ _])
 

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -552,6 +552,7 @@
                               committed?
                               error
                               table-data
+                              nil
                               nil))
 
 (defn- commit [tx-key ^LiveIndex$Tx live-idx-tx committed? error]

--- a/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
@@ -1,6 +1,7 @@
 package xtdb.api.log
 
 import com.google.protobuf.ByteString
+import xtdb.database.ExternalSourceToken
 import xtdb.database.Database
 import xtdb.log.proto.ReplicaLogMessage
 import xtdb.log.proto.TrieDetails
@@ -53,7 +54,8 @@ sealed interface ReplicaMessage {
                                     if (bs.isEmpty()) null else readTransit(bs, MSGPACK) as Throwable
                                 },
                                 it.tableDataMap.mapValues { (_, v) -> v.toByteArray() },
-                                dbOp
+                                dbOp,
+                                it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }
                             )
                         }
 
@@ -62,11 +64,17 @@ sealed interface ReplicaMessage {
                         }
 
                         ReplicaLogMessage.MessageCase.BLOCK_BOUNDARY -> msg.blockBoundary.let {
-                            BlockBoundary(it.blockIndex, it.latestProcessedMsgId)
+                            BlockBoundary(
+                                it.blockIndex, it.latestProcessedMsgId,
+                                it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }
+                            )
                         }
 
                         ReplicaLogMessage.MessageCase.BLOCK_UPLOADED -> msg.blockUploaded.let {
-                            BlockUploaded(it.storageVersion, it.storageEpoch, it.blockIndex, it.latestProcessedMsgId, it.triesList)
+                            BlockUploaded(
+                                it.storageVersion, it.storageEpoch, it.blockIndex, it.latestProcessedMsgId, it.triesList,
+                                it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }
+                            )
                         }
 
                         ReplicaLogMessage.MessageCase.NO_OP -> NoOp
@@ -95,7 +103,8 @@ sealed interface ReplicaMessage {
         val committed: Boolean,
         val error: Throwable?,
         val tableData: Map<String, ByteArray>,
-        val dbOp: DbOp? = null
+        val dbOp: DbOp? = null,
+        val externalSourceToken: ExternalSourceToken? = null,
     ) : ProtobufMessage() {
         override fun toLogMessage() = replicaLogMessage {
             resolvedTx = resolvedTx {
@@ -118,6 +127,7 @@ sealed interface ReplicaMessage {
 
                     null -> {}
                 }
+                this@ResolvedTx.externalSourceToken?.let { externalSourceToken = it }
             }
         }
     }
@@ -136,11 +146,15 @@ sealed interface ReplicaMessage {
         }
     }
 
-    data class BlockBoundary(val blockIndex: BlockIndex, val latestProcessedMsgId: MessageId) : ProtobufMessage() {
+    data class BlockBoundary(
+        val blockIndex: BlockIndex, val latestProcessedMsgId: MessageId,
+        val externalSourceToken: ExternalSourceToken? = null
+    ) : ProtobufMessage() {
         override fun toLogMessage() = replicaLogMessage {
             blockBoundary = blockBoundary {
                 this.blockIndex = this@BlockBoundary.blockIndex
                 this.latestProcessedMsgId = this@BlockBoundary.latestProcessedMsgId
+                this@BlockBoundary.externalSourceToken?.let { this.externalSourceToken = it }
             }
         }
     }
@@ -148,7 +162,8 @@ sealed interface ReplicaMessage {
     data class BlockUploaded(
         val storageVersion: Int, val storageEpoch: StorageEpoch,
         val blockIndex: BlockIndex, val latestProcessedMsgId: MessageId,
-        val tries: List<TrieDetails>
+        val tries: List<TrieDetails>,
+        val externalSourceToken: ExternalSourceToken? = null
     ) : ProtobufMessage() {
         override fun toLogMessage() = replicaLogMessage {
             blockUploaded = blockUploaded {
@@ -157,6 +172,7 @@ sealed interface ReplicaMessage {
                 this.blockIndex = this@BlockUploaded.blockIndex
                 this.latestProcessedMsgId = this@BlockUploaded.latestProcessedMsgId
                 tries.addAll(this@BlockUploaded.tries)
+                this@BlockUploaded.externalSourceToken?.let { this.externalSourceToken = it }
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/api/log/SourceMessage.kt
+++ b/core/src/main/kotlin/xtdb/api/log/SourceMessage.kt
@@ -1,6 +1,7 @@
 package xtdb.api.log
 
 import com.google.protobuf.ByteString
+import xtdb.database.ExternalSourceToken
 import xtdb.database.Database
 import xtdb.database.DatabaseName
 import xtdb.log.proto.SourceLogMessage
@@ -82,7 +83,10 @@ sealed interface SourceMessage {
                             SourceLogMessage.MessageCase.DETACH_DATABASE -> DetachDatabase(msg.detachDatabase.dbName)
 
                             SourceLogMessage.MessageCase.BLOCK_UPLOADED -> msg.blockUploaded.let {
-                                BlockUploaded(it.storageVersion, it.storageEpoch, it.blockIndex, it.latestProcessedMsgId, it.triesList)
+                                BlockUploaded(
+                                    it.storageVersion, it.storageEpoch, it.blockIndex, it.latestProcessedMsgId, it.triesList,
+                                    it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }
+                                )
                             }
 
                             SourceLogMessage.MessageCase.TX -> msg.tx.let {
@@ -91,7 +95,8 @@ sealed interface SourceMessage {
                                     systemTime = if (it.hasSystemTimeMicros()) InstantUtil.fromMicros(it.systemTimeMicros) else null,
                                     defaultTz = ZoneId.of(it.defaultTz),
                                     user = if (it.hasUser()) it.user else null,
-                                    userMetadata = if (it.userMetadata.isEmpty) null else it.userMetadata.toByteArray()
+                                    userMetadata = if (it.userMetadata.isEmpty) null else it.userMetadata.toByteArray(),
+                                    externalSourceToken = it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }
                                 )
                             }
 
@@ -106,7 +111,8 @@ sealed interface SourceMessage {
         val systemTime: Instant?,
         val defaultTz: ZoneId,
         val user: String?,
-        val userMetadata: ByteArray?
+        val userMetadata: ByteArray?,
+        val externalSourceToken: ExternalSourceToken? = null
     ) : ProtobufMessage() {
         override fun toLogMessage() = sourceLogMessage {
             tx = tx {
@@ -115,6 +121,7 @@ sealed interface SourceMessage {
                 defaultTz = this@Tx.defaultTz.id
                 this@Tx.user?.let { user = it }
                 this@Tx.userMetadata?.let { userMetadata = ByteString.copyFrom(it) }
+                this@Tx.externalSourceToken?.let { externalSourceToken = it }
             }
         }
 
@@ -124,7 +131,8 @@ sealed interface SourceMessage {
                 && systemTime == other.systemTime
                 && defaultTz == other.defaultTz
                 && user == other.user
-                && userMetadata.contentEquals(other.userMetadata))
+                && userMetadata.contentEquals(other.userMetadata)
+                && externalSourceToken == other.externalSourceToken)
 
         override fun hashCode(): Int {
             var result = txOps.contentHashCode()
@@ -132,6 +140,7 @@ sealed interface SourceMessage {
             result = 31 * result + defaultTz.hashCode()
             result = 31 * result + (user?.hashCode() ?: 0)
             result = 31 * result + (userMetadata?.contentHashCode() ?: 0)
+            result = 31 * result + (externalSourceToken?.hashCode() ?: 0)
             return result
         }
     }
@@ -174,7 +183,8 @@ sealed interface SourceMessage {
     data class BlockUploaded(
         val storageVersion: Int, val storageEpoch: StorageEpoch,
         val blockIndex: BlockIndex, val latestProcessedMsgId: MessageId,
-        val tries: List<TrieDetails>
+        val tries: List<TrieDetails>,
+        val externalSourceToken: ExternalSourceToken? = null
     ) : ProtobufMessage() {
         override fun toLogMessage() = sourceLogMessage {
             blockUploaded = blockUploaded {
@@ -183,6 +193,7 @@ sealed interface SourceMessage {
                 this.blockIndex = this@BlockUploaded.blockIndex
                 this.latestProcessedMsgId = this@BlockUploaded.latestProcessedMsgId
                 tries.addAll(this@BlockUploaded.tries)
+                this@BlockUploaded.externalSourceToken?.let { this.externalSourceToken = it }
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/api/log/Watchers.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Watchers.kt
@@ -3,8 +3,9 @@ package xtdb.api.log
 import kotlinx.coroutines.flow.*
 import xtdb.api.TransactionResult
 import xtdb.api.TxId
+import xtdb.database.ExternalSourceToken
 
-class Watchers(latestTxId: TxId, latestSourceMsgId: MessageId) {
+class Watchers(latestTxId: TxId, latestSourceMsgId: MessageId, externalSourceToken: ExternalSourceToken? = null) {
 
     /**
      * Backward-compat constructor for setups where tx-id is always a src msg-id.
@@ -14,12 +15,13 @@ class Watchers(latestTxId: TxId, latestSourceMsgId: MessageId) {
     private sealed interface State
 
     private data class Active(
-        val latestSourceMsgId: MessageId, val latestTxId: TxId, val latestTxResult: TransactionResult?
+        val latestSourceMsgId: MessageId, val latestTxId: TxId, val latestTxResult: TransactionResult?,
+        val externalSourceToken: ExternalSourceToken? = null,
     ) : State
 
     private data class Failed(val exception: IngestionStoppedException) : State
 
-    private val state = MutableStateFlow<State>(Active(latestSourceMsgId, latestTxId, null))
+    private val state = MutableStateFlow<State>(Active(latestSourceMsgId, latestTxId, null, externalSourceToken))
 
     private fun State.activeOrThrow(): Active = when (this) {
         is Active -> this
@@ -38,6 +40,7 @@ class Watchers(latestTxId: TxId, latestSourceMsgId: MessageId) {
     }
 
     val latestSourceMsgId get() = state.value.activeOrThrow().latestSourceMsgId
+    val externalSourceToken: ExternalSourceToken? get() = state.value.activeOrThrow().externalSourceToken
 
     val exception
         get() = when (val v = state.value) {
@@ -47,13 +50,16 @@ class Watchers(latestTxId: TxId, latestSourceMsgId: MessageId) {
 
     // --- notify methods ---
 
-    fun notifyTx(result: TransactionResult, srcMsgId: MessageId) {
+    fun notifyTx(result: TransactionResult, srcMsgId: MessageId, externalSourceToken: ExternalSourceToken?) {
         state.updateIfActive {
             check(result.txId > it.latestTxId) { "txId ${result.txId} <= latestTxId ${it.latestTxId}" }
             // >= not >: BlockBoundary can carry the same source msgId as the preceding ResolvedTx
             // when the block was triggered by isFull() (no FlushBlock in between)
             check(srcMsgId >= it.latestSourceMsgId) { "srcMsgId $srcMsgId < latestSourceMsgId ${it.latestSourceMsgId}" }
-            it.copy(latestSourceMsgId = srcMsgId, latestTxId = result.txId, latestTxResult = result)
+            it.copy(
+                latestSourceMsgId = srcMsgId, latestTxId = result.txId, latestTxResult = result,
+                externalSourceToken = externalSourceToken ?: it.externalSourceToken,
+            )
         }
     }
 

--- a/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
@@ -1,5 +1,6 @@
 package xtdb.catalog
 
+import xtdb.database.ExternalSourceToken
 import xtdb.api.TransactionKey
 import xtdb.api.log.MessageId
 import xtdb.api.storage.ObjectStore
@@ -62,7 +63,8 @@ class BlockCatalog(
         latestProcessedMsgId: MessageId,
         boundaryReplicaMsgId: MessageId?,
         tables: Collection<TableRef>,
-        secondaryDatabases: Map<String, DatabaseConfig>?
+        secondaryDatabases: Map<String, DatabaseConfig>?,
+        externalSourceToken: ExternalSourceToken? = null
     ): Block {
         val currentBlockIndex = this.currentBlockIndex
         check(currentBlockIndex == null || currentBlockIndex < blockIndex) {
@@ -81,6 +83,7 @@ class BlockCatalog(
             boundaryReplicaMsgId?.let { this.boundaryReplicaMsgId = it }
             this.tableNames.addAll(tables.map { it.sym.toString() })
             secondaryDatabases?.let { this.secondaryDatabases.putAll(it) }
+            externalSourceToken?.let { this.externalSourceToken = it }
         }
     }
 
@@ -98,6 +101,9 @@ class BlockCatalog(
 
     val boundaryReplicaMsgId: MessageId?
         get() = latestBlock?.let { block -> block.boundaryReplicaMsgId.takeIf { block.hasBoundaryReplicaMsgId() } }
+
+    val externalSourceToken: ExternalSourceToken?
+        get() = latestBlock?.takeIf { it.hasExternalSourceToken() }?.externalSourceToken
 
     val allTables: List<TableRef> get() = latestBlock?.tableNamesList.orEmpty().map { TableRef.parse(dbName, it) }
 

--- a/core/src/main/kotlin/xtdb/database/ExternalLog.kt
+++ b/core/src/main/kotlin/xtdb/database/ExternalLog.kt
@@ -9,9 +9,11 @@ import xtdb.database.proto.DatabaseConfig
 import java.util.*
 import com.google.protobuf.Any as ProtoAny
 
+typealias ExternalSourceToken = ProtoAny
+
 interface ExternalLog<M> : AutoCloseable {
 
-    fun tailAll(processor: Log.RecordProcessor<M>): Log.Subscription
+    fun tailAll(afterToken: ExternalSourceToken?, processor: Log.RecordProcessor<M>): Log.Subscription
 
     interface Factory {
         fun writeTo(dbConfig: DatabaseConfig.Builder)

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -68,9 +68,12 @@ class BlockUploader(
         }
         val secondaryDatabasesForBlock = dbCatalog?.serialisedSecondaryDatabases
 
+        val externalSourceToken = boundary.externalSourceToken
+
         val block = blockCatalog.buildBlock(
             blockIdx, liveIndex.latestCompletedTx, latestProcessedMsgId,
-            boundaryReplicaMsgId, tableBlocks.keys, secondaryDatabasesForBlock
+            boundaryReplicaMsgId, tableBlocks.keys, secondaryDatabasesForBlock,
+            externalSourceToken
         )
 
         bufferPool.putObject(BlockCatalog.blockFilePath(blockIdx), ByteBuffer.wrap(block.toByteArray()))
@@ -83,7 +86,7 @@ class BlockUploader(
                 BlockUploaded(
                     Storage.VERSION, bufferPool.epoch,
                     blockIdx, latestProcessedMsgId,
-                    addedTries
+                    addedTries, externalSourceToken
                 )
             )
         }.getCompleted().msgId

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -111,7 +111,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 } else TransactionAborted(msg.txId, systemTime, msg.error)
 
                 latestSourceMsgId = msg.txId
-                watchers.notifyTx(result, msg.txId)
+                watchers.notifyTx(result, msg.txId, msg.externalSourceToken)
             }
 
             is ReplicaMessage.TriesAdded -> {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -3,6 +3,7 @@ package xtdb.indexer
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import org.apache.arrow.memory.BufferAllocator
+import xtdb.database.ExternalSourceToken
 import xtdb.api.TransactionAborted
 import xtdb.api.TransactionCommitted
 import xtdb.api.TransactionKey
@@ -165,11 +166,11 @@ class LeaderLogProcessor(
             else
                 TransactionAborted(txId, systemTime, resolvedTx.error)
 
-        watchers.notifyTx(result, txId)
+        watchers.notifyTx(result, txId, resolvedTx.externalSourceToken)
     }
 
-    private suspend fun finishBlock(latestProcessedMsgId: MessageId) {
-        val boundaryMsg = BlockBoundary((blockCatalog.currentBlockIndex ?: -1) + 1, latestProcessedMsgId)
+    private suspend fun finishBlock(latestProcessedMsgId: MessageId, externalSourceToken: ExternalSourceToken?) {
+        val boundaryMsg = BlockBoundary((blockCatalog.currentBlockIndex ?: -1) + 1, latestProcessedMsgId, externalSourceToken)
         val boundaryMsgId = appendToReplica(boundaryMsg).msgId
         LOG.debug("block boundary b${boundaryMsg.blockIndex.asLexHex}: source=$latestProcessedMsgId, replica=$boundaryMsgId")
         pendingBlock = PendingBlock(boundaryMsgId, boundaryMsg)
@@ -185,7 +186,7 @@ class LeaderLogProcessor(
         notifyTx(resolvedTx)
 
         if (liveIndex.isFull())
-            finishBlock(txId)
+            finishBlock(txId, resolvedTx.externalSourceToken)
     }
 
     override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
@@ -197,12 +198,17 @@ class LeaderLogProcessor(
 
             try {
                 when (val msg = record.message) {
-                    is SourceMessage.Tx, is SourceMessage.LegacyTx -> handleResolvedTx(resolveTx(msgId, record, msg))
+                    is SourceMessage.Tx -> {
+                        val resolved = resolveTx(msgId, record, msg)
+                        handleResolvedTx(msg.externalSourceToken?.let { resolved.copy(externalSourceToken = it) } ?: resolved)
+                    }
+
+                    is SourceMessage.LegacyTx -> handleResolvedTx(resolveTx(msgId, record, msg))
 
                     is SourceMessage.FlushBlock -> {
                         val expectedBlockIdx = msg.expectedBlockIdx
                         if (expectedBlockIdx != null && expectedBlockIdx == (blockCatalog.currentBlockIndex ?: -1L)) {
-                            finishBlock(msgId)
+                            finishBlock(msgId, watchers.externalSourceToken)
                         }
                         watchers.notifyMsg(msgId)
                     }
@@ -225,7 +231,7 @@ class LeaderLogProcessor(
                         val result =
                             if (error == null) TransactionCommitted(txKey.txId, txKey.systemTime)
                             else TransactionAborted(txKey.txId, txKey.systemTime, error)
-                        watchers.notifyTx(result, msgId)
+                        watchers.notifyTx(result, msgId, null)
                     }
 
                     is SourceMessage.DetachDatabase -> {
@@ -245,7 +251,7 @@ class LeaderLogProcessor(
 
                         val result = if (error == null) TransactionCommitted(txKey.txId, txKey.systemTime)
                         else TransactionAborted(txKey.txId, txKey.systemTime, error)
-                        watchers.notifyTx(result, msgId)
+                        watchers.notifyTx(result, msgId, null)
                     }
 
                     is SourceMessage.TriesAdded -> {

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
@@ -228,7 +228,8 @@ class SourceLogProcessor(
 
         val block = blockCatalog.buildBlock(
             blockIdx, liveIndex.latestCompletedTx, latestProcessedMsgId,
-            boundaryReplicaMsgId = null, tableBlocks.keys, secondaryDatabasesForBlock
+            boundaryReplicaMsgId = null, tableBlocks.keys, secondaryDatabasesForBlock,
+            externalSourceToken = null
         )
 
         bufferPool.putObject(BlockCatalog.blockFilePath(blockIdx), ByteBuffer.wrap(block.toByteArray()))
@@ -291,7 +292,10 @@ class SourceLogProcessor(
 
                 when (val msg = record.message) {
                     is SourceMessage.Tx, is SourceMessage.LegacyTx -> {
-                        val resolvedTx = resolveTx(msgId, record, msg)
+                        val token = (msg as? SourceMessage.Tx)?.externalSourceToken
+                        val resolvedTx = resolveTx(msgId, record, msg).let {
+                            if (token != null) it.copy(externalSourceToken = token) else it
+                        }
                         notifyTx(msgId, resolvedTx)
 
                         if (liveIndex.isFull()) {
@@ -322,7 +326,7 @@ class SourceLogProcessor(
 
                         val result = if (error == null) TransactionCommitted(txKey.txId, txKey.systemTime)
                         else TransactionAborted(txKey.txId, txKey.systemTime, error)
-                        watchers.notifyTx(result, msgId)
+                        watchers.notifyTx(result, msgId, null)
                     }
 
                     is SourceMessage.DetachDatabase -> {
@@ -339,7 +343,7 @@ class SourceLogProcessor(
 
                         val result = if (error == null) TransactionCommitted(txKey.txId, txKey.systemTime)
                         else TransactionAborted(txKey.txId, txKey.systemTime, error)
-                        watchers.notifyTx(result, msgId)
+                        watchers.notifyTx(result, msgId, null)
                     }
 
                     is SourceMessage.TriesAdded -> {
@@ -377,6 +381,6 @@ class SourceLogProcessor(
             TransactionAborted(resolvedTx.txId, resolvedTx.systemTime, resolvedTx.error!!)
         }
 
-        watchers.notifyTx(result, msgId)
+        watchers.notifyTx(result, msgId, resolvedTx.externalSourceToken)
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -67,7 +67,7 @@ class TransitionLogProcessor(
                         } else TransactionAborted(msg.txId, msg.systemTime, msg.error)
 
                         latestSourceMsgId = msg.txId
-                        watchers.notifyTx(result, msg.txId)
+                        watchers.notifyTx(result, msg.txId, msg.externalSourceToken)
                     }
 
                     is ReplicaMessage.TriesAdded -> {

--- a/core/src/main/proto/xtdb/log/proto/log.proto
+++ b/core/src/main/proto/xtdb/log/proto/log.proto
@@ -2,6 +2,7 @@ edition = "2023";
 
 package xtdb.log.proto;
 
+import "google/protobuf/any.proto";
 import "xtdb/database/proto/db.proto";
 
 option java_multiple_files = true;
@@ -25,6 +26,7 @@ message Tx {
     string default_tz = 3;
     string user = 4;
     bytes user_metadata = 5;
+    google.protobuf.Any external_source_token = 6;
 }
 
 message BlockUploaded {
@@ -33,6 +35,7 @@ message BlockUploaded {
     int64 block_index = 3;
     int64 latest_processed_msg_id = 4;
     repeated TrieDetails tries = 5;
+    google.protobuf.Any external_source_token = 6;
 }
 
 message FlushBlock {

--- a/core/src/main/proto/xtdb/log/proto/replica-log.proto
+++ b/core/src/main/proto/xtdb/log/proto/replica-log.proto
@@ -2,6 +2,7 @@ edition = "2023";
 
 package xtdb.log.proto;
 
+import "google/protobuf/any.proto";
 import "xtdb/log/proto/log.proto";
 
 option java_multiple_files = true;
@@ -27,11 +28,14 @@ message ResolvedTx {
         AttachDatabase attach_database = 6;
         DetachDatabase detach_database = 7;
     }
+
+    google.protobuf.Any external_source_token = 8;
 }
 
 message BlockBoundary {
     int64 block_index = 1;
     int64 latest_processed_msg_id = 2;
+    google.protobuf.Any external_source_token = 3;
 }
 
 message NoOp {}

--- a/core/src/main/proto/xtdb/meta/block/proto/block.proto
+++ b/core/src/main/proto/xtdb/meta/block/proto/block.proto
@@ -43,4 +43,7 @@ message Block {
 
     // the replica-log message ID of the BlockBoundary message for this block
     int64 boundary_replica_msg_id = 6;
+
+    // opaque token tracking how far the leader consumed an external source (e.g. CDC offset)
+    google.protobuf.Any external_source_token = 7;
 }

--- a/core/src/test/kotlin/xtdb/api/log/ExternalSourceTokenTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/ExternalSourceTokenTest.kt
@@ -1,0 +1,116 @@
+package xtdb.api.log
+
+import com.google.protobuf.Any as ProtoAny
+import com.google.protobuf.StringValue
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import xtdb.block.proto.Block
+import xtdb.catalog.BlockCatalog
+
+class ExternalSourceTokenTest {
+
+    private val testToken: ProtoAny = ProtoAny.pack(StringValue.of("kafka-offset:42"))
+
+    @Test
+    fun `BlockBoundary round-trips external source token`() {
+        val boundary = ReplicaMessage.BlockBoundary(1, 100, testToken)
+        val encoded = boundary.encode()
+        val decoded = ReplicaMessage.decode(encoded)
+
+        assertInstanceOf(ReplicaMessage.BlockBoundary::class.java, decoded)
+        decoded as ReplicaMessage.BlockBoundary
+        assertEquals(1, decoded.blockIndex)
+        assertEquals(100, decoded.latestProcessedMsgId)
+        assertNotNull(decoded.externalSourceToken)
+        assertEquals(testToken, decoded.externalSourceToken)
+    }
+
+    @Test
+    fun `BlockBoundary round-trips without token`() {
+        val boundary = ReplicaMessage.BlockBoundary(1, 100)
+        val encoded = boundary.encode()
+        val decoded = ReplicaMessage.decode(encoded) as ReplicaMessage.BlockBoundary
+
+        assertEquals(1, decoded.blockIndex)
+        assertEquals(100, decoded.latestProcessedMsgId)
+        assertNull(decoded.externalSourceToken)
+    }
+
+    @Test
+    fun `ReplicaMessage BlockUploaded round-trips external source token`() {
+        val uploaded = ReplicaMessage.BlockUploaded(1, 0, 1, 100, emptyList(), testToken)
+        val encoded = uploaded.encode()
+        val decoded = ReplicaMessage.decode(encoded)
+
+        assertInstanceOf(ReplicaMessage.BlockUploaded::class.java, decoded)
+        decoded as ReplicaMessage.BlockUploaded
+        assertEquals(testToken, decoded.externalSourceToken)
+    }
+
+    @Test
+    fun `SourceMessage BlockUploaded round-trips external source token`() {
+        val uploaded = SourceMessage.BlockUploaded(1, 0, 1, 100, emptyList(), testToken)
+        val encoded = uploaded.encode()
+        val decoded = SourceMessage.decode(encoded)
+
+        assertInstanceOf(SourceMessage.BlockUploaded::class.java, decoded)
+        decoded as SourceMessage.BlockUploaded
+        assertEquals(testToken, decoded.externalSourceToken)
+    }
+
+    @Test
+    fun `Block proto round-trips external source token`() {
+        val blockCatalog = BlockCatalog("test-db", null)
+
+        val block = blockCatalog.buildBlock(
+            blockIndex = 0,
+            latestCompletedTx = null,
+            latestProcessedMsgId = 100,
+            boundaryReplicaMsgId = null,
+            tables = emptySet(),
+            secondaryDatabases = null,
+            externalSourceToken = testToken
+        )
+
+        val parsed = Block.parseFrom(block.toByteArray())
+        assertTrue(parsed.hasExternalSourceToken())
+        assertEquals(testToken, parsed.externalSourceToken)
+    }
+
+    @Test
+    fun `BlockCatalog externalSourceToken reads from latest block`() {
+        val blockCatalog = BlockCatalog("test-db", null)
+
+        assertNull(blockCatalog.externalSourceToken)
+
+        val block = blockCatalog.buildBlock(
+            blockIndex = 0,
+            latestCompletedTx = null,
+            latestProcessedMsgId = 100,
+            boundaryReplicaMsgId = null,
+            tables = emptySet(),
+            secondaryDatabases = null,
+            externalSourceToken = testToken
+        )
+        blockCatalog.refresh(block)
+
+        assertEquals(testToken, blockCatalog.externalSourceToken)
+    }
+
+    @Test
+    fun `BlockCatalog externalSourceToken returns null when no token`() {
+        val blockCatalog = BlockCatalog("test-db", null)
+
+        val block = blockCatalog.buildBlock(
+            blockIndex = 0,
+            latestCompletedTx = null,
+            latestProcessedMsgId = 100,
+            boundaryReplicaMsgId = null,
+            tables = emptySet(),
+            secondaryDatabases = null
+        )
+        blockCatalog.refresh(block)
+
+        assertNull(blockCatalog.externalSourceToken)
+    }
+}

--- a/core/src/test/kotlin/xtdb/api/log/WatchersTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/WatchersTest.kt
@@ -38,13 +38,13 @@ class WatchersTest {
         assertThrows<TimeoutCancellationException> { withTimeout(50) { await4.await() } }
 
         val res4 = TransactionCommitted(4, Instant.parse("2021-01-01T00:00:00Z"))
-        watchers.notifyTx(res4, 4)
+        watchers.notifyTx(res4, 4, null)
 
         assertThrows<TimeoutCancellationException> { withTimeout(50) { await5.await() } }
         assertEquals(res4, await4.await())
 
         val res5 = TransactionAborted(5, Instant.parse("2021-01-02T00:00:00Z"), Exception("test"))
-        watchers.notifyTx(res5, 5)
+        watchers.notifyTx(res5, 5, null)
 
         assertEquals(res5, await5.await())
     }

--- a/modules/debezium/src/main/clojure/xtdb/debezium.clj
+++ b/modules/debezium/src/main/clojure/xtdb/debezium.clj
@@ -20,7 +20,7 @@
                             clusters)
         allocator (RootAllocator.)
         processor (DebeziumProcessor. producer allocator (.getDefaultTz cfg))
-        subscription (.tailAll external-log processor)]
+        subscription (.tailAll external-log nil processor)]
     (log/info "Debezium CDC process started"
               {:kafka-cluster kafka-cluster
                :source-topic source-topic

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumProcessor.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumProcessor.kt
@@ -1,15 +1,21 @@
 package xtdb.debezium
 
 import org.apache.arrow.memory.BufferAllocator
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
 import org.slf4j.LoggerFactory
 import xtdb.api.log.KafkaCluster
 import xtdb.api.log.KafkaCluster.AtomicProducer.Companion.withTx
 import xtdb.api.log.Log
 import xtdb.api.log.SourceMessage
+import xtdb.debezium.proto.debeziumOffsetToken
+import xtdb.debezium.proto.partitionOffsets
 import xtdb.tx.TxOp
 import xtdb.tx.toArrowBytes
 import xtdb.tx.serializeUserMetadata
 import java.time.ZoneId
+import xtdb.database.ExternalSourceToken
+import com.google.protobuf.Any as ProtoAny
 
 private val logger = LoggerFactory.getLogger(DebeziumProcessor::class.java)
 
@@ -19,13 +25,36 @@ class DebeziumProcessor(
     private val defaultTz: ZoneId,
 ) : Log.RecordProcessor<DebeziumMessage>, AutoCloseable {
 
-    private fun buildTxMessage(txOps: List<TxOp>, userMetadata: Map<String, Any>): SourceMessage.Tx =
+    companion object {
+        fun buildOffsetToken(kafkaOffsets: Map<TopicPartition, OffsetAndMetadata>): ExternalSourceToken {
+            // OffsetAndMetadata stores next-to-read (offset+1); token stores last-seen
+            val byTopic = kafkaOffsets.entries.groupBy({ it.key.topic() }, { it.key.partition() to (it.value.offset() - 1) })
+            val token = debeziumOffsetToken {
+                for ((topic, partitionEntries) in byTopic) {
+                    val maxPartition = partitionEntries.maxOf { it.first }
+                    val offsetArray = LongArray(maxPartition + 1) { partition ->
+                        partitionEntries.firstOrNull { it.first == partition }?.second ?: -1L
+                    }
+                    dbzmTopicOffsets[topic] = partitionOffsets {
+                        offsets += offsetArray.toList()
+                    }
+                }
+            }
+            return ProtoAny.pack(token, "xtdb.debezium")
+        }
+    }
+
+    private fun buildTxMessage(
+        txOps: List<TxOp>, userMetadata: Map<String, Any>,
+        externalSourceToken: ExternalSourceToken? = null
+    ): SourceMessage.Tx =
         SourceMessage.Tx(
             txOps = txOps.toArrowBytes(allocator),
             systemTime = null,
             defaultTz = defaultTz,
             user = null,
-            userMetadata = serializeUserMetadata(allocator, userMetadata)
+            userMetadata = serializeUserMetadata(allocator, userMetadata),
+            externalSourceToken = externalSourceToken
         )
 
     override suspend fun processRecords(records: List<Log.Record<DebeziumMessage>>) {
@@ -33,13 +62,14 @@ class DebeziumProcessor(
             producer.withTx { tx ->
                 tx.sendOffsetsToTransaction(record.message.offsets, record.message.consumerGroupMetadata)
                 val event = CdcEvent.fromJson((record.message).payload)
+                val token = buildOffsetToken(record.message.offsets)
 
                 event.toTxOp(allocator).use { txOp ->
                     val metadata = mapOf(
                         "source" to "debezium",
                         "kafka_offset" to record.logOffset,
                     )
-                    val message = buildTxMessage(listOf(txOp), metadata)
+                    val message = buildTxMessage(listOf(txOp), metadata, externalSourceToken = token)
                     tx.appendMessage(message)
                     logger.debug("Submitted tx at offset {}", record.logOffset)
                 }

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/KafkaDebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/KafkaDebeziumLog.kt
@@ -14,8 +14,10 @@ import org.slf4j.LoggerFactory
 import xtdb.api.log.KafkaCluster
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
+import xtdb.debezium.proto.DebeziumOffsetToken
 import xtdb.debezium.proto.KafkaDebeziumLogConfig
 import xtdb.debezium.proto.kafkaDebeziumLogConfig
+import xtdb.database.ExternalSourceToken
 import java.time.Duration
 import java.time.Instant
 import kotlin.coroutines.CoroutineContext
@@ -77,7 +79,7 @@ class KafkaDebeziumLog @JvmOverloads constructor(
     private val scope = CoroutineScope(SupervisorJob() + coroutineContext + exceptionHandler)
     val epoch: Int get() = 0
 
-    override fun tailAll(processor: Log.RecordProcessor<DebeziumMessage>): Log.Subscription {
+    override fun tailAll(afterToken: ExternalSourceToken?, processor: Log.RecordProcessor<DebeziumMessage>): Log.Subscription {
         val job = scope.launch {
             KafkaConsumer(
                 kafkaConfig.plus(
@@ -91,7 +93,22 @@ class KafkaDebeziumLog @JvmOverloads constructor(
                 UnitDeserializer,
                 ByteArrayDeserializer()
             ).use { c ->
-                c.subscribe(listOf(topic))
+                val partitionOffsets = afterToken?.let { tok ->
+                    val token = tok.unpack(DebeziumOffsetToken::class.java)
+                    token.dbzmTopicOffsetsMap[topic]?.offsetsList
+                        ?.mapIndexedNotNull { partition, offset ->
+                            if (offset >= 0) TopicPartition(topic, partition) to offset else null
+                        }
+                        ?.takeIf { it.isNotEmpty() }
+                }
+
+                if (partitionOffsets != null) {
+                    c.assign(partitionOffsets.map { it.first })
+                    partitionOffsets.forEach { (tp, offset) -> c.seek(tp, offset + 1) }
+                } else {
+                    c.subscribe(listOf(topic))
+                }
+
                 while (isActive) {
                     val records = runInterruptible(Dispatchers.IO) {
                         try {

--- a/modules/debezium/src/main/proto/debezium.proto
+++ b/modules/debezium/src/main/proto/debezium.proto
@@ -15,3 +15,11 @@ message DebeziumSourceConfig {
         KafkaDebeziumLogConfig kafka_log = 1;
     }
 }
+
+message PartitionOffsets {
+    repeated int64 offsets = 1;
+}
+
+message DebeziumOffsetToken {
+    map<string, PartitionOffsets> dbzm_topic_offsets = 1;
+}

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
@@ -355,7 +355,7 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(capturing).use {
+                    log.tailAll(null, capturing).use {
                         pgExecute(
                             "INSERT INTO cdc_users (_id, name, email) VALUES (2, 'Bob', 'bob@example.com')",
                             "UPDATE cdc_users SET email = 'alice-new@example.com' WHERE _id = 1",
@@ -414,7 +414,7 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(capturing).use {
+                    log.tailAll(null, capturing).use {
                         pgExecute(
                             "INSERT INTO cdc_no_envelope (_id, name, email) VALUES (2, 'Bob', 'bob@example.com')",
                             "UPDATE cdc_no_envelope SET email = 'alice-new@example.com' WHERE _id = 1",
@@ -471,7 +471,7 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(capturing).use {
+                    log.tailAll(null, capturing).use {
                         pgExecute(
                             """INSERT INTO timed_docs (_id, name, _valid_from, _valid_to)
                             VALUES (1, 'bounded', '2024-01-01T00:00:00Z', '2025-01-01T00:00:00Z')""",
@@ -536,7 +536,7 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(capturing).use {
+                    log.tailAll(null, capturing).use {
                         // Alice (valid) is ingested first
                         awaitTxs(node, 1)
 
@@ -576,7 +576,7 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(capturing).use {
+                    log.tailAll(null, capturing).use {
                         pgExecute(
                             "INSERT INTO no_id_table (id, name) VALUES (2, 'also-no-_id')",
                         )
@@ -617,7 +617,7 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(capturing).use {
+                    log.tailAll(null, capturing).use {
                         pgExecute(
                             """INSERT INTO typed_docs (_id, name, score, active, metadata, tags, notes)
                             VALUES (1, 'Alice', 3.14, true, '{"city": "London", "nested": {"deep": true}}',
@@ -677,7 +677,7 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(capturing).use {
+                    log.tailAll(null, capturing).use {
                         pgExecute(
                             "INSERT INTO inventory.products (_id, name, qty) VALUES (1, 'Widget', 100)",
                         )
@@ -727,7 +727,7 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(capturing).use {
+                    log.tailAll(null, capturing).use {
                         pgExecute(
                             "INSERT INTO cdc_secondary_test (_id, name, email) VALUES (2, 'Bob', 'bob@example.com')",
                         )
@@ -780,7 +780,7 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(capturing).use {
+                    log.tailAll(null, capturing).use {
                         // TIMESTAMP (no tz) → Debezium sends as Long, not a string
                         pgExecute(
                             """INSERT INTO bad_times (_id, name, _valid_from)
@@ -825,7 +825,7 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 kafkaDebeziumLog.use {
-                    kafkaDebeziumLog.tailAll(capturing).use {
+                    kafkaDebeziumLog.tailAll(null, capturing).use {
                         while (received.size < 1) delay(100)
                     }
                 }
@@ -844,7 +844,7 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 kafkaDebeziumLog.use {
-                    kafkaDebeziumLog.tailAll(capturing).use {
+                    kafkaDebeziumLog.tailAll(null, capturing).use {
                         while (received.size < 1) delay(100)
                     }
                 }

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/KafkaDebeziumLogTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/KafkaDebeziumLogTest.kt
@@ -78,7 +78,7 @@ class KafkaDebeziumLogTest {
         val (subscriber, received) = capturingProcessor()
         val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
         log.use {
-            log.tailAll(subscriber).use {
+            log.tailAll(null, subscriber).use {
                 while (received.isEmpty()) delay(100)
             }
             // Subscription closed — produce more messages
@@ -98,7 +98,7 @@ class KafkaDebeziumLogTest {
         val (subscriber, received) = capturingProcessor()
         val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
 
-        val subscription = log.tailAll(subscriber)
+        val subscription = log.tailAll(null, subscriber)
         while (received.isEmpty()) delay(100)
 
         assertEquals(1, received.size, "Should have received Alice before closing")

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -188,7 +188,7 @@
 
                          {:system-time tick-at}))
 
-        (c/compact-all! node #xt/duration "PT1S")
+        (c/compact-all! node #xt/duration "PT5S")
 
         (aet/check-arrow-edn-dir (.toPath (io/as-file (io/resource "xtdb/compactor-test/test-l2+-compaction-by-recency/readings")))
                                  (table-path node "public$readings")


### PR DESCRIPTION
## Summary

Adds block-level token tracking for CDC offsets, threading them through the full pipeline so that on restart we know exactly where the Debezium consumer got to.
Part of the external source (CDC) integration work tracked in #5330.
Depends on #5367 (SourceMessage.Tx protobuf migration).

### `external_source_token` in block metadata

An opaque `google.protobuf.Any` field added to Block, BlockBoundary, BlockUploaded, `SourceMessage.Tx`, and `ReplicaMessage.ResolvedTx` protos.
Initialized from `BlockCatalog.externalSourceToken` at startup into `Watchers`.

A `typealias ExternalSourceToken = ProtoAny` in `ExternalLog.kt` makes token-passing code self-documenting.

### `DebeziumOffsetToken`

New proto in the debezium module:

```protobuf
message PartitionOffsets {
    repeated int64 offsets = 1;   // indexed by partition number
}
message DebeziumOffsetToken {
    map<string, PartitionOffsets> dbzm_topic_offsets = 1;
}
```

Key is the topic name, value is a list of offsets indexed by partition.
Extensible to the Debezium transaction metadata topic later.

### Token flow

The token flows through the full pipeline:

1. **`DebeziumProcessor`** builds a `DebeziumOffsetToken` from each record's Kafka offsets (storing last-seen offset, not next-to-read), packs as `ProtoAny` on `SourceMessage.Tx.externalSourceToken`
2. **Leader** extracts the token, copies it onto `ReplicaMessage.ResolvedTx`
3. **`notifyTx`** propagates through `Watchers` (alongside the existing source/tx watermarks)
4. **`finishBlock`** reads `watchers.externalSourceToken` for the block boundary → persisted
5. **Follower** and **transition** processors also propagate the token from `ResolvedTx` into `Watchers`

### `ExternalLog.tailAll(afterToken, processor)`

`KafkaDebeziumLog` unpacks the token, filters to partitions with valid offsets (>= 0), seeks to `offset + 1` (since the token stores the last-seen offset).
Falls back to `subscribe` with `earliest` when no token or no valid offsets.

### What's NOT changed

`sendOffsetsToTransaction` is still called as belt-and-braces alongside the block token.
Removing it depends on migrating the Debezium processor to target the replica log directly (which depends on single-writer).
At that point, on startup we can replay through the replica log to discover the latest token before starting the CDC consumer — the same pattern as the other logs.

## Test plan

- [x] `./gradlew test` passes
- [x] `ExternalSourceTokenTest` — round-trip through messages and block catalog
- [ ] Integration tests with Kafka (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)