### PR TITLE
fix(pgwire)!: handle comment-only queries and PG 16 version reporting

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1392,8 +1392,8 @@
        patch)))
 
 (defn current-setting [setting-name]
-  (if (= setting-name "server_version_num")
-    (parse-version (xtdb-server-version))
+  (case setting-name
+    "server_version_num" 160000
     (throw (err/unsupported ::unsupported-setting (str "Setting not supported: " setting-name)
                             {:setting-name setting-name}))))
 

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -723,6 +723,12 @@
 (defn- trim-sql [s]
   (-> s (str/triml) (str/replace #";\s*$" "")))
 
+(defn- comment-only?
+  "Returns true if the SQL string contains only whitespace and single-line comments.
+   Uses the same pattern as the ANTLR lexer's LINE_COMMENT rule."
+  [s]
+  (str/blank? (str/replace s #"--[^\r\n]*" "")))
+
 ;; yagni, is everything upper'd anyway by drivers / server?
 (defn- probably-same-query? [s substr]
   ;; TODO I bet this may cause some amusement. Not sure what to do about non-parsed query matching, it'll do for now.
@@ -740,7 +746,7 @@
       (if-let [replacement (replace-queries sql)]
         (recur replacement)
 
-        (or (when (str/blank? sql)
+        (or (when (or (str/blank? sql) (comment-only? sql))
               [{:statement-type :empty-query}])
 
             (when-some [canned-response (get-canned-response sql)]

--- a/src/test/clojure/xtdb/pgwire/grafana_test.clj
+++ b/src/test/clojure/xtdb/pgwire/grafana_test.clj
@@ -1,0 +1,14 @@
+(ns xtdb.pgwire.grafana-test
+  (:require [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.test-util :as tu]))
+
+(t/use-fixtures :each tu/with-node)
+
+(t/deftest comment-only-query-test
+  (t/testing "SQL comment-only queries don't throw (pgx driver sends '-- ping')"
+    (t/is (some? (xt/q tu/*node* "-- ping"))))
+
+  (t/testing "double-dash inside string literals is not treated as a comment"
+    (t/is (= [{:bar "--foo"}]
+             (xt/q tu/*node* "SELECT '--foo' AS bar")))))

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1032,9 +1032,8 @@
     "LOCALTIMESTAMP(6)" '(local-timestamp 6)))
 
 (t/deftest test-current-setting-server-version-num
-  (with-redefs [xtdb.expression/xtdb-server-version (fn [] "2.0.4-SNAPSHOT")]
-    (t/is (= [{:v 2000004}]
-             (xt/q tu/*node* "SELECT current_setting('server_version_num') AS v"))))
+  (t/is (= [{:v "160000"}]
+           (xt/q tu/*node* "SELECT current_setting('server_version_num') AS v")))
 
   (t/is (anomalous? [:unsupported ::expr/unsupported-setting]
                     (xt/q tu/*node* "SELECT current_setting('block_size') AS v"))))


### PR DESCRIPTION
These are small changes which get us started with compatibility with Grafana (handling comments in empty queries and returning PG version number).

Theoretically changing `current_setting('server_version_num')` is a breaking change, but unlikely to effect uses in practise I believe.