### PR TITLE
fix(log): exception on Kafka Producer tx `abort` was hiding `commit` exception

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -149,11 +149,15 @@ interface Log<M> : AutoCloseable {
             inline fun <M, R> AtomicProducer<M>.withTx(block: (Tx<M>) -> R): R =
                 openTx().use { tx ->
                     try {
-                        block(tx).also { tx.commit() }
+                        block(tx)
                     } catch (e: Throwable) {
-                        tx.abort()
+                        try {
+                            tx.abort()
+                        } catch (abortEx: Throwable) {
+                            e.addSuppressed(abortEx)
+                        }
                         throw e
-                    }
+                    }.also { tx.commit() }
                 }
         }
     }

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -169,11 +169,15 @@ class KafkaCluster(
             inline fun <M, R> AtomicProducer<M>.withTx(block: (Tx<M>) -> R): R =
                 openTx().use { tx ->
                     try {
-                        block(tx).also { tx.commit() }
+                        block(tx)
                     } catch (e: Throwable) {
-                        tx.abort()
+                        try {
+                            tx.abort()
+                        } catch (abortEx: Throwable) {
+                            e.addSuppressed(abortEx)
+                        }
                         throw e
-                    }
+                    }.also { tx.commit() }
                 }
         }
     }


### PR DESCRIPTION
Solution is to remove `abort` in case of a `commit` exception, as a Kakfa transaction can't be aborted anyway once started committing.

Relates to #5376 where we don't see the exception causing the Kafka `commit` error:

```
level	
ERROR
log	
leader: failed to process log record with msgId 562950016061053 (Tx)
java.lang.IllegalStateException: Transaction already closed
	at xtdb.api.log.KafkaCluster$KafkaLog$openAtomicProducer$1$openTx$1.abort(KafkaCluster.kt:283)
	at xtdb.indexer.LeaderLogProcessor.appendToReplica(LeaderLogProcessor.kt:273)
	at xtdb.indexer.LeaderLogProcessor.handleResolvedTx(LeaderLogProcessor.kt:154)
	at xtdb.indexer.LeaderLogProcessor.processRecords(LeaderLogProcessor.kt:170)
	at xtdb.api.log.KafkaCluster$KafkaLog$openGroupSubscription$pollingJob$1.invokeSuspend(KafkaCluster.kt:363)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:124)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
logger	
xtdb.indexer.LeaderLogProcessor
stream	
stdout
time	
2026-03-23T21:45:12.278452311Z
```