### PR TITLE
feat(sql)!: USER keyword and reserved word column aliases

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -143,7 +143,7 @@ identifier
         | 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE' | 'ERASE'
         | 'SETTING'
         | 'ROLE'
-        | 'USER' | 'PASSWORD'
+        | 'PASSWORD'
         | 'VARBINARY' | 'BYTEA'
         | 'URI' | 'OID'
         | 'COPY' | 'FORMAT'
@@ -345,7 +345,7 @@ exprPrimary
     | 'REPLACE' '(' source=expr ',' pattern=expr ',' replacement=expr ')' # ReplaceFunction
     | 'REGEXP_REPLACE' '(' source=expr ',' pattern=characterString ',' replacement=characterString (',' start=integerLiteral ( ',' n=integerLiteral )? )? (',' flags=characterString)? ')' # RegexpReplaceFunction
 
-    | (identifier '.')? 'CURRENT_USER' # CurrentUserFunction
+    | (identifier '.')? ('CURRENT_USER' | 'USER') # CurrentUserFunction
     | (identifier '.')? 'CURRENT_SCHEMA' ('(' ')')? # CurrentSchemaFunction
     | (identifier '.')? 'CURRENT_SCHEMAS' '(' expr ')' # CurrentSchemasFunction
     | (identifier '.')? 'CURRENT_CATALOG' ('(' ')')? # CurrentCatalogFunction

--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -148,6 +148,9 @@ identifier
         | 'URI' | 'OID'
         | 'COPY' | 'FORMAT'
         | 'ATTACH' | 'DETACH' | 'DATABASE' | 'LEVEL'
+        | 'BIGINT' | 'BOOLEAN' | 'CHAR' | 'DATE' | 'DOUBLE' | 'FLOAT'
+        | 'INT' | 'INTEGER' | 'INTERVAL' | 'NUMERIC' | 'REAL' | 'SMALLINT'
+        | 'TEXT' | 'TIME' | 'TIMESTAMP' | 'TIMESTAMPTZ' | 'VARCHAR'
         | METADATA
         | setFunctionType )
         # RegularIdentifier
@@ -155,11 +158,6 @@ identifier
     ;
 
 columnName : identifier ;
-
-columnLabel
-    : identifier
-    | 'CURRENT_USER'
-    ;
 
 // §6 Scalar Expressions
 
@@ -655,6 +653,63 @@ excludeClause
 
 derivedColumn : expr asClause? ;
 asClause : 'AS'? columnLabel ;
+
+// column alias label — identifier plus every keyword token, so any keyword can be a column alias
+columnLabel
+    : identifier
+    | 'ALL' | 'ALTER' | ANALYZE | 'AND' | 'ANY' | 'ARRAY_AGG' | 'ARRAY' | 'AS' | 'ASC'
+    | 'ASSERT' | 'ASYMMETRIC' | ASYNC | 'AT' | 'AVG' | AWAIT_TOKEN
+    | 'BEGIN' | 'BEGIN_FRAME' | 'BEGIN_PARTITION' | 'BETWEEN' | 'BIGINT' | 'BOOL_AND' | 'BOOL_OR'
+    | 'BOOLEAN' | 'BOTH' | 'BY'
+    | 'CASE' | 'CAST' | 'CENTURY' | 'CHAR_LENGTH' | 'CHAR' | 'CHARACTER_LENGTH' | 'CHARACTERS'
+    | 'CHARACTERISTICS' | 'CLOCK_TIME' | 'COALESCE' | 'COMMIT' | 'CONTAINS' | 'COUNT' | 'CREATE'
+    | 'CROSS' | 'CUME_DIST'
+    | 'CURRENT_CATALOG' | 'CURRENT_DATE' | 'CURRENT_ROW' | 'CURRENT_SCHEMA' | 'CURRENT_SCHEMAS'
+    | 'CURRENT_SETTING' | 'CURRENT_TIME' | 'CURRENT_TIMESTAMP' | 'CURRENT_USER' | 'CURRENT'
+    | 'DATE_BIN' | 'DATE_TRUNC' | 'DATE' | 'DAY' | 'DEC' | 'DECADE' | 'DECIMAL' | 'DEFAULT'
+    | 'DENSE_RANK' | 'DESC' | 'DISTINCT' | 'DOUBLE' | 'DOW' | 'DOY' | 'DURATION'
+    | 'ELSE' | 'END_FRAME' | 'END_PARTITION' | 'EPOCH' | 'EQUALS' | 'ESCAPE' | 'EVERY'
+    | 'EXCEPT' | 'EXCLUDE' | 'EXECUTE' | 'EXISTS' | 'EXPLAIN' | 'EXTRACT'
+    | 'FALSE' | 'FETCH' | 'FIRST_VALUE' | 'FIRST' | 'FLAG' | 'FLOAT' | 'FOLLOWING'
+    | 'FOR' | 'FRAME_ROW' | 'FROM' | 'FULL'
+    | 'GENERATE_SERIES' | 'GROUP' | 'GROUPS'
+    | 'HAS_ANY_COLUMN_PRIVILEGE' | 'HAS_SCHEMA_PRIVILEGE' | 'HAS_TABLE_PRIVILEGE'
+    | 'HAVING' | 'HOUR'
+    | 'IGNORE' | 'IMMEDIATELY' | 'IN' | 'INNER' | 'INT' | 'INTEGER' | 'INTERSECT' | 'INTERVAL'
+    | 'INTO' | 'IS' | 'ISODOW' | 'ISOLATION'
+    | 'JOIN'
+    | 'KEYWORD'
+    | 'LAG' | 'LAGS' | 'LAST_VALUE' | 'LAST' | 'LATERAL' | 'LEAD' | 'LEADING' | 'LEADS'
+    | 'LEFT' | 'LEVEL' | 'LIKE_REGEX' | 'LIKE' | 'LIMIT' | 'LOCAL'
+    | LOCAL_DATE | LOCAL_TIME | LOCAL_TIMESTAMP
+    | MATERIALIZED | 'MAX' | METADATA | 'MICROSECOND' | 'MILLENNIUM' | 'MILLISECOND' | 'MIN'
+    | 'MINUTE' | 'MONTH'
+    | 'NANOSECOND' | 'NATURAL' | 'NEST_MANY' | 'NEST_ONE' | 'NEXT' | 'NO' | NONE | 'NOT' | 'NOW'
+    | 'NTH_VALUE' | 'NTILE' | 'NULL' | 'NULLIF' | 'NULLS' | 'NUMERIC'
+    | 'OBJECT' | 'OCTETS' | 'OF' | OFF | 'OFFSET' | 'ON' | 'ONLY' | 'OR' | 'ORDER'
+    | 'ORDINALITY' | 'OTHERS' | 'OUTER' | 'OVER' | 'OVERLAPS' | 'OVERLAY'
+    | 'PARTITION' | PATCH | 'PERCENTILE_CONT' | 'PERCENTILE_DISC' | 'PERCENT_RANK' | 'PERIOD'
+    | '_PG_EXPANDARRAY' | 'PG_GET_EXPR' | 'PG_GET_INDEXDEF' | 'PG_GET_USERBYID'
+    | PG_SLEEP | PG_SLEEP_FOR | 'PG_TABLE_IS_VISIBLE'
+    | 'PLACING' | 'PORTION' | 'POSITION' | 'PRECEDES' | 'PRECEDING' | 'PRECISION' | PREPARE
+    | 'QUARTER'
+    | 'RANGE_BINS' | 'RANGE' | 'RANK' | 'READ' | 'REAL' | 'RECORD' | 'RECORDS'
+    | 'RECURSIVE' | 'REGCLASS' | 'REGEXP_REPLACE' | 'REGPROC' | 'RENAME' | 'REPEATABLE'
+    | 'REPLACE' | 'RESPECT' | 'RETURNING' | 'RIGHT' | 'ROLLBACK' | 'ROW_NUMBER' | 'ROW' | 'ROWS'
+    | 'SECOND' | 'SERIALIZABLE' | SESSION | 'SET' | SHOW | 'SMALLINT' | 'SNAPSHOT_TIME'
+    | 'SNAPSHOT_TOKEN' | 'SOME' | 'STDDEV_POP' | 'STDDEV_SAMP' | STDIN | 'STRICTLY'
+    | 'SUBSTRING' | 'SUCCEEDS' | 'SUM' | 'SYMMETRIC'
+    | 'TEXT' | 'THEN' | 'TIES' | 'TIME' | 'TIMESTAMP' | 'TIMESTAMPTZ' | 'TIMEZONE_HOUR'
+    | 'TIMEZONE_MINUTE' | 'TO' | 'TRAILING' | 'TRANSACTION' | 'TRIM_ARRAY' | 'TRIM' | 'TRUE'
+    | 'TSTZRANGE'
+    | 'UNBOUNDED' | 'UNION' | 'UNKNOWN' | 'UNNEST' | 'URI_FRAGMENT' | 'URI_HOST' | 'URI_PATH'
+    | 'URI_PORT' | 'URI_QUERY' | 'URI_SCHEME' | 'URI_USER_INFO' | 'USER' | 'USING' | 'UUID'
+    | 'VALUE_OF' | 'VALUES' | 'VAR_POP' | 'VAR_SAMP' | 'VARCHAR'
+    | 'WEEK' | 'WHEN' | 'WHERE' | 'WINDOW' | 'WITH' | 'WITHIN' | 'WITHOUT' | 'WRITE'
+    | 'XTQL'
+    | 'YEAR'
+    | 'ZONE'
+    ;
 
 /// §7.13 <query expression>
 

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1392,8 +1392,8 @@
        patch)))
 
 (defn current-setting [setting-name]
-  (if (= setting-name "server_version_num")
-    (parse-version (xtdb-server-version))
+  (case setting-name
+    "server_version_num" 160000
     (throw (err/unsupported ::unsupported-setting (str "Setting not supported: " setting-name)
                             {:setting-name setting-name}))))
 

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -723,6 +723,12 @@
 (defn- trim-sql [s]
   (-> s (str/triml) (str/replace #";\s*$" "")))
 
+(defn- comment-only?
+  "Returns true if the SQL string contains only whitespace and single-line comments.
+   Uses the same pattern as the ANTLR lexer's LINE_COMMENT rule."
+  [s]
+  (str/blank? (str/replace s #"--[^\r\n]*" "")))
+
 ;; yagni, is everything upper'd anyway by drivers / server?
 (defn- probably-same-query? [s substr]
   ;; TODO I bet this may cause some amusement. Not sure what to do about non-parsed query matching, it'll do for now.
@@ -740,7 +746,7 @@
       (if-let [replacement (replace-queries sql)]
         (recur replacement)
 
-        (or (when (str/blank? sql)
+        (or (when (or (str/blank? sql) (comment-only? sql))
               [{:statement-type :empty-query}])
 
             (when-some [canned-response (get-canned-response sql)]

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -848,8 +848,8 @@
                                                                               (let [renames (->> (for [^Sql$QualifiedRenameColumnContext rename-pair (some-> (.qualifiedRenameClause ctx)
                                                                                                                                                              (.qualifiedRenameColumn))]
                                                                                                    (let [sym (find-col scope [(identifier-sym (.identifier rename-pair)) table-name])
-                                                                                                         out-col-name (.columnLabel (.asClause rename-pair))]
-                                                                                                     (MapEntry/create sym (->col-sym (identifier-sym out-col-name)))))
+                                                                                                         out-col-name (identifier-sym (.asClause rename-pair))]
+                                                                                                     (MapEntry/create sym (->col-sym out-col-name))))
                                                                                                  (into {}))]
                                                                                 (->> table-cols
                                                                                      (into [] (map-indexed (fn [col-idx sym]
@@ -864,10 +864,10 @@
                                       (let [renames (->> (for [^Sql$RenameColumnContext rename-pair (some-> (.renameClause star-ctx)
                                                                                                             (.renameColumn))]
                                                            (let [chain (rseq (mapv identifier-sym (.identifier (.identifierChain (.columnReference rename-pair)))))
-                                                                 out-col-name (.columnLabel (.asClause rename-pair))
+                                                                 out-col-name (identifier-sym (.asClause rename-pair))
                                                                  sym (find-col scope chain)]
 
-                                                             (MapEntry/create sym (->col-sym (identifier-sym out-col-name)))))
+                                                             (MapEntry/create sym (->col-sym out-col-name))))
                                                          (into {}))
 
                                             excludes (set/union (into #{} (map (comp symbol name :col-sym)) explicitly-projected-cols)

--- a/modules/bench/src/main/clojure/xtdb/bench/auctionmark.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/auctionmark.clj
@@ -117,7 +117,7 @@
                             :status :open}]]
 
                          (when seller-id
-                           [[:sql "UPDATE user SET balance = balance - 1 WHERE _id = ? "
+                           [[:sql "UPDATE \"user\" SET balance = balance - 1 WHERE _id = ? "
                              [seller-id]]])))))
 
 (defn random-item
@@ -243,7 +243,7 @@
 (defn get-user-info [node user-id {:keys [seller-items? buyer-items? feedback?]}]
   [(xt/q node ["SELECT u._id user_id, rating, created, balance,
                        sattr0, sattr1, sattr2, sattr3, sattr4, r.name AS region
-                FROM user u JOIN region r ON (u.region_id = r._id)
+                FROM \"user\" u JOIN region r ON (u.region_id = r._id)
                 WHERE u._id = ?"
                user-id])
 
@@ -272,7 +272,7 @@
                          u._id user_id, u.rating, u.sattr0, u.sattr1
                   FROM item_feedback AS if
                     JOIN item i ON (if.item_id = i._id)
-                    JOIN user u ON (i.user_id = u._id)
+                    JOIN \"user\" u ON (i.user_id = u._id)
                   WHERE if.buyer_id = ?
                   ORDER BY if.date DESC
                   LIMIT 10"

--- a/src/test/clojure/xtdb/pgwire/grafana_test.clj
+++ b/src/test/clojure/xtdb/pgwire/grafana_test.clj
@@ -1,0 +1,14 @@
+(ns xtdb.pgwire.grafana-test
+  (:require [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.test-util :as tu]))
+
+(t/use-fixtures :each tu/with-node)
+
+(t/deftest comment-only-query-test
+  (t/testing "SQL comment-only queries don't throw (pgx driver sends '-- ping')"
+    (t/is (some? (xt/q tu/*node* "-- ping"))))
+
+  (t/testing "double-dash inside string literals is not treated as a comment"
+    (t/is (= [{:bar "--foo"}]
+             (xt/q tu/*node* "SELECT '--foo' AS bar")))))

--- a/src/test/clojure/xtdb/pgwire/grafana_test.clj
+++ b/src/test/clojure/xtdb/pgwire/grafana_test.clj
@@ -12,3 +12,8 @@
   (t/testing "double-dash inside string literals is not treated as a comment"
     (t/is (= [{:bar "--foo"}]
              (xt/q tu/*node* "SELECT '--foo' AS bar")))))
+
+(t/deftest version-detection-test
+  (t/testing "Grafana version detection query returns PG 16 compatible version"
+    (t/is (= [{:version 1600}]
+             (xt/q tu/*node* "SELECT current_setting('server_version_num')::int/100 AS version")))))

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1032,9 +1032,8 @@
     "LOCALTIMESTAMP(6)" '(local-timestamp 6)))
 
 (t/deftest test-current-setting-server-version-num
-  (with-redefs [xtdb.expression/xtdb-server-version (fn [] "2.0.4-SNAPSHOT")]
-    (t/is (= [{:v 2000004}]
-             (xt/q tu/*node* "SELECT current_setting('server_version_num') AS v"))))
+  (t/is (= [{:v "160000"}]
+           (xt/q tu/*node* "SELECT current_setting('server_version_num') AS v")))
 
   (t/is (anomalous? [:unsupported ::expr/unsupported-setting]
                     (xt/q tu/*node* "SELECT current_setting('block_size') AS v"))))
@@ -1572,6 +1571,10 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
     (t/is (= [{:x 3}]
              (xt/q tu/*node* "SELECT docs.x FROM docs WHERE has_table_privilege('docs', 'select') ")))))
 
+(t/deftest test-bare-user-keyword
+  (t/is (= [{:u "xtdb"}]
+           (xt/q tu/*node* "SELECT USER AS u"))
+        "bare USER is a synonym for CURRENT_USER per SQL spec"))
 ;; TODO: Add this?
 #_(t/deftest test-random-fn
     (t/is (= true (-> (xt/q tu/*node* "SELECT 0.0 <= random() AS greater") first :greater)))

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -3237,3 +3237,278 @@ UNION ALL
 
   (t/is (= [{:x "a", :xt/id 1} {:x "b", :xt/id 2} {:x "d", :xt/id 4}]
            (xt/q tu/*node* "SELECT _id, x FROM foo WHERE _id = 1 OR _id = 4 OR _id = 2 ORDER BY _id"))))
+
+(t/deftest reserved-keywords-as-column-aliases
+  (t/testing "aliasKeyword: safe as bare aliases (without AS)"
+    (t/is (= [{:user "xtdb"}]
+             (xt/q tu/*node* "SELECT CURRENT_USER user")))
+    (t/is (= [{:time 1}]
+             (xt/q tu/*node* "SELECT 1 time")))
+    (t/is (= [{:timestamp 1}]
+             (xt/q tu/*node* "SELECT 1 timestamp")))
+    (t/is (= [{:date 1}]
+             (xt/q tu/*node* "SELECT 1 date")))
+    (t/is (= [{:integer 1}]
+             (xt/q tu/*node* "SELECT 1 integer")))
+    (t/is (= [{:text "hello"}]
+             (xt/q tu/*node* "SELECT 'hello' text")))
+    (t/is (= [{:boolean true}]
+             (xt/q tu/*node* "SELECT true boolean"))))
+
+  (t/testing "aliasKeyword: also work with explicit AS"
+    (t/is (= [{:user "xtdb"}]
+             (xt/q tu/*node* "SELECT USER AS user")))
+    (t/is (= [{:time 1}]
+             (xt/q tu/*node* "SELECT 1 AS time")))
+    (t/is (= [{:date 1}]
+             (xt/q tu/*node* "SELECT 1 AS date"))))
+
+  (t/testing "clause-starting keywords work with explicit AS"
+    (t/is (= [{:from 1}]
+             (xt/q tu/*node* "SELECT 1 AS from")))
+    (t/is (= [{:where 1}]
+             (xt/q tu/*node* "SELECT 1 AS where")))
+    (t/is (= [{:order 1}]
+             (xt/q tu/*node* "SELECT 1 AS order")))
+    (t/is (= [{:limit 1}]
+             (xt/q tu/*node* "SELECT 1 AS limit")))
+    (t/is (= [{:offset 1}]
+             (xt/q tu/*node* "SELECT 1 AS offset"))))
+
+  (t/testing "identifier keywords still work as bare aliases"
+    (t/is (= [{:version 1}]
+             (xt/q tu/*node* "SELECT 1 version"))))
+
+  (t/testing "expression-continuing keywords as bare aliases"
+    (t/is (= [{:not 1}]
+             (xt/q tu/*node* "SELECT 1 not"))
+          "NOT as bare alias")
+    (t/is (= [{:in 1}]
+             (xt/q tu/*node* "SELECT 1 in"))
+          "IN as bare alias")
+    (t/is (= [{:between 1}]
+             (xt/q tu/*node* "SELECT 1 between"))
+          "BETWEEN as bare alias")
+    (t/is (= [{:like 1}]
+             (xt/q tu/*node* "SELECT 1 like"))
+          "LIKE as bare alias")
+    (t/is (= [{:is 1}]
+             (xt/q tu/*node* "SELECT 1 is"))
+          "IS as bare alias")
+    (t/is (= [{:and 1}]
+             (xt/q tu/*node* "SELECT 1 and"))
+          "AND as bare alias")
+    (t/is (= [{:or 1}]
+             (xt/q tu/*node* "SELECT 1 or"))
+          "OR as bare alias"))
+
+  (t/testing "keyword expression followed by keyword alias"
+    (t/is (= [{:user "xtdb"}]
+             (xt/q tu/*node* "SELECT user user"))
+          "USER expr then USER alias"))
+
+  (t/testing "multiple bare keyword aliases in select list"
+    (t/is (= [{:time 1, :date 2}]
+             (xt/q tu/*node* "SELECT 1 time, 2 date"))))
+
+  (t/testing "bare alias after complex expressions"
+    (t/is (= [{:time 3}]
+             (xt/q tu/*node* "SELECT 1 + 2 time"))
+          "alias after binary expression")
+    (t/is (= [{:time 1}]
+             (xt/q tu/*node* "SELECT CASE WHEN true THEN 1 END time"))
+          "alias after CASE expression"))
+
+  (t/testing "literal keywords as bare aliases"
+    (t/is (= [{:null 1}]
+             (xt/q tu/*node* "SELECT 1 null"))
+          "NULL as bare alias")
+    (t/is (= [{:true 1}]
+             (xt/q tu/*node* "SELECT 1 true"))
+          "TRUE as bare alias")
+    (t/is (= [{:false 1}]
+             (xt/q tu/*node* "SELECT 1 false"))
+          "FALSE as bare alias"))
+
+  (t/testing "keyword aliases referenceable in ORDER BY"
+    (t/is (= [{:time 2} {:time 1}]
+             (xt/q tu/*node* "SELECT x AS time FROM (VALUES (1), (2)) AS t(x) ORDER BY time DESC"))))
+
+  (t/testing "keyword aliases referenceable in GROUP BY"
+    (t/is (= [{:time "a", :cnt 2} {:time "b", :cnt 1}]
+             (xt/q tu/*node* "SELECT x AS time, COUNT(*) AS cnt FROM (VALUES ('a'), ('a'), ('b')) AS t(x) GROUP BY time ORDER BY cnt DESC"))))
+
+  (t/testing "data type keywords still work in their type roles"
+    (t/is (= [1] (mapv (comp val first) (xt/q tu/*node* "SELECT CAST(1 AS integer)")))
+          "CAST with data type keyword still works")
+    (t/is (= [{:xt/column-1 #xt/date "2024-01-01"}]
+             (xt/q tu/*node* "SELECT DATE '2024-01-01'"))
+          "DATE literal syntax still works")
+    (t/is (= [{:xt/column-1 #xt/date-time "2024-01-01T00:00:00"}]
+             (xt/q tu/*node* "SELECT TIMESTAMP '2024-01-01T00:00:00'"))
+          "TIMESTAMP literal syntax still works")
+    (t/is (= [{:xt/column-1 #xt/time "12:00:00"}]
+             (xt/q tu/*node* "SELECT TIME '12:00:00'"))
+          "TIME literal syntax still works")))
+
+(defn- sql-identifier->clojure-keyword [s]
+  "Convert a SQL identifier string to a Clojure keyword, replacing underscores with dashes.
+   Identifiers starting with _ get prefixed with 'xt/' namespace."
+  (if (str/starts-with? s "_")
+    (keyword "xt" (str/replace (subs s 1) "_" "-"))
+    (keyword (str/replace s "_" "-"))))
+
+
+(defn- extract-rule-keywords
+  "Extract keyword tokens from a named rule in the ANTLR grammar text.
+   Returns a set of lowercase keyword strings.
+   Parses both quoted tokens like 'KEYWORD' and unquoted lexer token references like METADATA."
+  [grammar-text rule-name]
+  (let [;; find the rule body between the rule name and the terminating semicolon
+        rule-pattern (re-pattern (str "(?m)^" rule-name "\\s*\\n([^;]+);"))
+        rule-body (second (re-find rule-pattern grammar-text))
+        ;; extract quoted keywords: 'SOME_KEYWORD'
+        quoted (set (map second (re-seq #"'([A-Z_][A-Z_0-9]*)'" rule-body)))
+        ;; extract unquoted uppercase token references: SOME_TOKEN
+        ;; these are lexer token refs that aren't wrapped in quotes
+        unquoted (set (map first (re-seq #"\b([A-Z][A-Z_0-9]*)\b" rule-body)))
+        ;; filter out known non-keyword references
+        non-keywords #{"REGULAR_IDENTIFIER" "DELIMITED_IDENTIFIER" "ASTERISK"
+                       "UNSIGNED_INTEGER" "ALL" "DISTINCT" "NOT" "ASYMMETRIC" "SYMMETRIC"}]
+    (->> (into quoted unquoted)
+         (remove non-keywords)
+         (map str/lower-case)
+         set)))
+
+(t/deftest systematic-keyword-alias-test
+  ;; Extract keywords directly from the grammar so this test stays in sync automatically.
+  (let [grammar-text (slurp "core/src/main/antlr/xtdb/antlr/Sql.g4")
+        set-fn-keywords (extract-rule-keywords grammar-text "setFunctionType")
+        identifier-keywords (into (extract-rule-keywords grammar-text "identifier")
+                                  set-fn-keywords)
+        ;; columnLabel = identifier | <keyword tokens> — extract the non-identifier keywords
+        column-label-keywords (disj (extract-rule-keywords grammar-text "columnLabel")
+                                    "identifier")]
+
+    (t/testing "identifier keywords work with explicit AS"
+      (doseq [kw (sort identifier-keywords)]
+        (t/testing (str "SELECT 1 AS " kw)
+          (let [result (xt/q tu/*node* (str "SELECT 1 AS " kw))]
+            (t/is (= 1 (get (first result) (sql-identifier->clojure-keyword kw)))
+                  (str "identifier keyword '" kw "' should work with AS"))))))
+
+    (t/testing "columnLabel keywords work as bare aliases"
+      (doseq [kw (sort column-label-keywords)]
+        (t/testing (str "SELECT 1 " kw " (bare)")
+          (let [result (xt/q tu/*node* (str "SELECT 1 " kw))]
+            (t/is (some? result)
+                  (str "columnLabel keyword '" kw "' should parse as bare alias"))))))
+
+    (t/testing "columnLabel keywords work with explicit AS"
+      (doseq [kw (sort column-label-keywords)]
+        (t/testing (str "SELECT 1 AS " kw)
+          (let [result (xt/q tu/*node* (str "SELECT 1 AS " kw))]
+            (t/is (= 1 (get (first result) (sql-identifier->clojure-keyword kw)))
+                  (str "columnLabel keyword '" kw "' should work with AS"))))))
+
+    (t/testing "keywords retain their structural roles outside alias position"
+      (xt/execute-tx tu/*node* [[:sql "INSERT INTO t1 (_id) VALUES (1)"]
+                                [:sql "INSERT INTO t2 (_id) VALUES (1)"]])
+
+      (t/testing "join keywords still start joins"
+        (t/is (= [{:xt/id 1}]
+                  (xt/q tu/*node* "SELECT t1._id FROM t1 JOIN t2 ON t1._id = t2._id"))
+              "JOIN starts a join, not an alias")
+        (t/is (= [{:xt/id 1}]
+                  (xt/q tu/*node* "SELECT t1._id FROM t1 LEFT JOIN t2 ON t1._id = t2._id"))
+              "LEFT starts a left join")
+        (t/is (= [{:xt/id 1}]
+                  (xt/q tu/*node* "SELECT t1._id FROM t1 RIGHT JOIN t2 ON t1._id = t2._id"))
+              "RIGHT starts a right join")
+        (t/is (= [{:xt/id 1}]
+                  (xt/q tu/*node* "SELECT t1._id FROM t1 FULL JOIN t2 ON t1._id = t2._id"))
+              "FULL starts a full join")
+        (t/is (= [{:xt/id 1}]
+                  (xt/q tu/*node* "SELECT t1._id FROM t1 CROSS JOIN t2"))
+              "CROSS starts a cross join")
+        (t/is (= [{:xt/id 1}]
+                  (xt/q tu/*node* "SELECT t1._id FROM t1 INNER JOIN t2 ON t1._id = t2._id"))
+              "INNER starts an inner join")
+        (t/is (= [{:xt/id 1}]
+                  (xt/q tu/*node* "SELECT t1._id FROM t1 NATURAL JOIN t2"))
+              "NATURAL starts a natural join"))
+
+      (t/testing "operators still work as operators"
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 WHERE 1 IN (1, 2)"))
+              "IN works as operator")
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 WHERE 1 BETWEEN 0 AND 2"))
+              "BETWEEN works as operator")
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 WHERE 1 = 1 AND 2 = 2"))
+              "AND works as operator")
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 WHERE 1 = 1 OR 2 = 3"))
+              "OR works as operator")
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 WHERE NOT false"))
+              "NOT works as operator")
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 WHERE 1 IS NOT NULL"))
+              "IS works as operator")
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 WHERE 'foo' LIKE 'f%'"))
+              "LIKE works as operator")
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 WHERE EXISTS (SELECT 1)"))
+              "EXISTS works as operator"))
+
+      (t/testing "CASE/WHEN/THEN/ELSE still work as control flow"
+        (t/is (= [{:x 1}]
+                  (xt/q tu/*node* "SELECT CASE WHEN true THEN 1 ELSE 2 END AS x"))
+              "CASE expression works"))
+
+      (t/testing "clause-start keywords still start clauses"
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 FROM (VALUES (1)) AS t(x)"))
+              "FROM starts a from clause")
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 FROM (VALUES (1)) AS t(x) WHERE true"))
+              "WHERE starts a where clause")
+        (t/is (= [{:x 1}]
+                  (xt/q tu/*node* "SELECT x FROM (VALUES (1)) AS t(x) GROUP BY x"))
+              "GROUP starts a group-by clause")
+        (t/is (= [{:x 1}]
+                  (xt/q tu/*node* "SELECT x FROM (VALUES (1)) AS t(x) ORDER BY x"))
+              "ORDER starts an order-by clause")
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 FROM (VALUES (1)) AS t(x) LIMIT 1"))
+              "LIMIT starts a limit clause")
+        (t/is (= [{:xt/column-1 1}]
+                  (xt/q tu/*node* "SELECT 1 FROM (VALUES (1)) AS t(x) OFFSET 0"))
+              "OFFSET starts an offset clause")
+        (t/is (some? (xt/q tu/*node* "SELECT 1 UNION SELECT 2"))
+              "UNION starts a set operation")
+        (t/is (some? (xt/q tu/*node* "SELECT 1 INTERSECT SELECT 1"))
+              "INTERSECT starts a set operation")
+        (t/is (some? (xt/q tu/*node* "SELECT 1 EXCEPT SELECT 2"))
+              "EXCEPT starts a set operation"))
+
+      (t/testing "identifier keywords work as aliases referenceable in ORDER BY and GROUP BY"
+        (doseq [[kw-name kw] [["time" "time"] ["date" "date"] ["boolean" "boolean"]
+                               ["integer" "integer"] ["timestamp" "timestamp"]]]
+          (t/testing (str kw-name " in ORDER BY")
+            (t/is (= [{(keyword kw) 2} {(keyword kw) 1}]
+                      (xt/q tu/*node* (str "SELECT x AS " kw " FROM (VALUES (1), (2)) AS t(x) ORDER BY " kw " DESC")))
+                  (str kw-name " alias referenceable in ORDER BY")))
+          (t/testing (str kw-name " in GROUP BY")
+            (t/is (some? (xt/q tu/*node* (str "SELECT x AS " kw ", COUNT(*) AS cnt FROM (VALUES ('a'), ('a'), ('b')) AS t(x) GROUP BY " kw)))
+                  (str kw-name " alias referenceable in GROUP BY")))))
+
+      (t/testing "clause-starting keyword aliases are NOT referenceable unquoted in ORDER BY"
+        (doseq [kw ["having" "from" "where" "order" "group" "limit" "offset"]]
+          (t/testing (str kw " in ORDER BY should fail")
+            (t/is (thrown? Exception
+                          (xt/q tu/*node* (str "SELECT 1 AS " kw " ORDER BY " kw)))
+                  (str "unquoted " kw " should not resolve in ORDER BY"))))))))

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-a5.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/sl-a5.test
@@ -34,8 +34,8 @@ Hello World!
 statement ok
 INSERT INTO people (_id, name, friends)
 	VALUES (5678, 'Sarah',
-			[{user: 'Dan'},
-			 {user: 'Kath'}])
+			[{"user": 'Dan'},
+			 {"user": 'Kath'}])
 
 query T nosort
 SELECT people.friends FROM people
@@ -49,7 +49,7 @@ SELECT people.friends[2] FROM people
 
 #Field Access works here but not in the general case, not on the a5
 query T nosort
-SELECT people.friends[2].user FROM people
+SELECT people.friends[2]."user" FROM people
 ----
 Kath
 


### PR DESCRIPTION
## Summary

- Treat bare `USER` as `CURRENT_USER` per SQL spec (breaking: bare `user` as table/column name now requires quoting)
- Allow reserved keywords as column aliases via an expanded `columnLabel` grammar rule

## Breaking

- `USER` is now a reserved keyword (synonym for `CURRENT_USER`).
  Bare `user` as a table or column name must be quoted as `"user"`.
  Use as an alias (`SELECT x AS user`) is unaffected.

## Design

The `columnLabel` rule now accepts nearly every keyword token in the grammar, so any keyword can be used as a column alias (with or without `AS`).
Data type keywords (`TIME`, `DATE`, `INTEGER`, etc.) are also added to the `identifier` rule so they're usable everywhere — table names, column refs, function names, bare aliases.

This mirrors PostgreSQL's approach: the lexer stamps keywords with token types, and the parser contextually reintroduces them where safe as identifiers or aliases.

One caveat: alias keywords used in ORDER BY / GROUP BY can conflict with clause-starters.
e.g. `SELECT 1 AS HAVING GROUP BY HAVING` throws a parse error.
This matches DuckDB behaviour.

## Tests

- Systematic coverage of keywords tested in alias positions (extracted from grammar at test time)
- `identifier` keywords verified referenceable in ORDER BY and GROUP BY
- Data type keywords still work in type roles (CAST, DATE/TIME/TIMESTAMP literals)

Builds on https://github.com/xtdb/xtdb/pull/5374