### PR TITLE
ops: include suspended call site in Kotlin stacktraces

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ ENTRYPOINT ["java", \
     "--add-opens=java.base/java.nio=ALL-UNNAMED", \
     "--enable-native-access=ALL-UNNAMED", \
     "-Dio.netty.tryReflectionSetAccessible=true", \
+    "-Dkotlinx.coroutines.debug=on", \
     "-cp","xtdb.jar", \
     "clojure.main", "-m", "xtdb.main"]
 


### PR DESCRIPTION
Enabling the `kotlinx.coroutines.debug` flag is documented to have "negligible overhead", but is helpful for troubleshooting. (https://github.com/Kotlin/kotlinx.coroutines/blob/master/docs/topics/debugging.md#debug-mode)

If it actually has negligible cost, we may want to have it in the XTDB Dockerfile. Otherwise, we may want to move to deployment-specific configuration.