### PR TITLE
fix: trie catalog L0/L1C ordering invariant violation (#5395)

### DIFF
--- a/core/src/main/clojure/xtdb/trie_catalog.clj
+++ b/core/src/main/clojure/xtdb/trie_catalog.clj
@@ -417,6 +417,17 @@
 (defn new-partition? [partition]
   (some? (:max-block-idx partition)))
 
+(defn- repair-l0-l1c-consistency
+  "If a live L1C exists, ensure all L0s with block-idx <= the L1C's max live block-idx are marked garbage.
+   Repairs an inconsistency where L0 and L1C are both live at the same block-idx,
+   caused by concurrent MW/SW operation — see #5395."
+  [tries]
+  (let [{l1c-live :live} (get tries [1 nil []])
+        l1c-max-live-block-idx (some-> (first l1c-live) :block-idx)]
+    (cond-> tries
+      l1c-max-live-block-idx
+      (update [0 nil []] supersede-by-block-idx l1c-max-live-block-idx {:as-of (Instant/now)}))))
+
 (defn partition->entry [{:keys [level recency part tries max-block-idx] :as _partition}]
   (MapEntry/create [level recency part]
                    (let [{:keys [live nascent garbage]} (group-by :state tries)]
@@ -505,7 +516,8 @@
                     tries (into {} (map partition->entry) partitions)
                     tries (if (new-partition? (first partitions))
                             tries
-                            (merge-with merge tries (partitions->max-block-idx-map partitions)))]]
+                            (merge-with merge tries (partitions->max-block-idx-map partitions)))
+                    tries (repair-l0-l1c-consistency tries)]]
         (s/assert ::catalog-tries tries)
         (.put !table-cats table {:tries tries}))
 

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -7,6 +7,7 @@ import xtdb.api.log.MessageId
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.ReplicaMessage.BlockBoundary
 import xtdb.api.log.ReplicaMessage.BlockUploaded
+import xtdb.api.log.SourceMessage
 import xtdb.api.storage.Storage
 import xtdb.catalog.BlockCatalog
 import xtdb.compactor.Compactor
@@ -27,13 +28,14 @@ class BlockUploader(
     private val compactor: Compactor.ForDatabase,
     private val dbCatalog: Database.Catalog?,
 ) {
+    private val sourceLog = dbStorage.sourceLog
     private val bufferPool = dbStorage.bufferPool
     private val liveIndex = dbState.liveIndex
     private val blockCatalog = dbState.blockCatalog
     private val trieCatalog = dbState.trieCatalog
     private val tableCatalog = dbState.tableCatalog
 
-    fun uploadBlock(
+    suspend fun uploadBlock(
         replicaProducer: Log.AtomicProducer<ReplicaMessage>, boundaryReplicaMsgId: MessageId, boundary: BlockBoundary,
     ): MessageId {
         val latestProcessedMsgId = boundary.latestProcessedMsgId
@@ -56,6 +58,10 @@ class BlockUploader(
 
                 trieDetails
             }
+
+        // Publish L0 tries to source log so that all nodes (including concurrent MW nodes)
+        // see the L0 before any compaction L1C on the source log — see #5395.
+        sourceLog.appendMessage(SourceMessage.TriesAdded(Storage.VERSION, bufferPool.epoch, addedTries))
 
         val allTables = finishedBlocks.keys + blockCatalog.allTables
         val tablePartitions = allTables.associateWith { trieCatalog.getPartitions(it) }

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -52,7 +52,7 @@ class TransitionLogProcessor(
             is ReplicaMessage.NoOp -> false
         }
 
-    private fun processRecord(record: Log.Record<ReplicaMessage>) {
+    private suspend fun processRecord(record: Log.Record<ReplicaMessage>) {
         val msgId = record.msgId
         when (val msg = record.message) {
             is ReplicaMessage.ResolvedTx -> {

--- a/src/test/clojure/xtdb/healthz_test.clj
+++ b/src/test/clojure/xtdb/healthz_test.clj
@@ -57,7 +57,7 @@
 
               (let [resp (clj-http/get (->healthz-url port "started")
                                        {:throw-exceptions false})
-                    msg-id (if (db/single-writer?) 1540 1905)]
+                    msg-id (if (db/single-writer?) 1575 1905)]
 
                 (case (long (:status resp))
                   503 (do

--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -802,3 +802,35 @@
               "Compaction should have created non-L0 files")
         (t/is (= 4 (count blocks))
               "All L0 blocks should be visible even after compaction")))))
+
+(t/deftest test-repair-l0-l1c-consistency-5395
+  (let [->trie-details (partial trie/->trie-details #xt/table foo)]
+    (t/testing "L0 and L1C both live at same block-idx — L0 should be repaired to garbage"
+      (let [table-blocks {:partitions
+                          [{:level 0 :recency nil :part []
+                            :max-block-idx 2
+                            :tries [(->trie-details {:trie-key "l00-rc-b02" :data-file-size 10 :state :live})
+                                    (->trie-details {:trie-key "l00-rc-b03" :data-file-size 10 :state :live})]}
+                           {:level 1 :recency nil :part []
+                            :max-block-idx 2
+                            :tries [(->trie-details {:trie-key "l01-rc-b02" :data-file-size 10 :state :live})
+                                    (->trie-details {:trie-key "l01-rc-b01" :data-file-size 10 :state :garbage
+                                                     :garbage-as-of #xt/instant "2000-01-01T00:00:00Z"})]}]}
+            cat (trie-catalog-init {#xt/table foo table-blocks})]
+
+        (t/is (= #{"l00-rc-b03" "l01-rc-b02"}
+                 (->> (cat/current-tries (cat/trie-state cat #xt/table foo))
+                      (into (sorted-set) (map :trie-key))))
+              "L0 b02 should be garbage (superseded by L1C b02), L0 b03 should remain live")))
+
+    (t/testing "no L1C — L0s should be unaffected"
+      (let [table-blocks {:partitions
+                          [{:level 0 :recency nil :part []
+                            :max-block-idx 2
+                            :tries [(->trie-details {:trie-key "l00-rc-b01" :data-file-size 10 :state :live})
+                                    (->trie-details {:trie-key "l00-rc-b02" :data-file-size 10 :state :live})]}]}
+            cat (trie-catalog-init {#xt/table foo table-blocks})]
+
+        (t/is (= #{"l00-rc-b01" "l00-rc-b02"}
+                 (->> (cat/current-tries (cat/trie-state cat #xt/table foo))
+                      (into (sorted-set) (map :trie-key)))))))))

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b01.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 1,
  :latest-completed-tx
- {:tx-id 2114, :system-time #xt/instant "2020-01-02T00:00:00Z"},
- :latest-processed-msg-id 3799,
+ {:tx-id 2441, :system-time #xt/instant "2020-01-02T00:00:00Z"},
+ :latest-processed-msg-id 4126,
  :table-names #{"xt/txs" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b02.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b02.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 2,
  :latest-completed-tx
- {:tx-id 2114, :system-time #xt/instant "2020-01-02T00:00:00Z"},
- :latest-processed-msg-id 4270,
+ {:tx-id 2441, :system-time #xt/instant "2020-01-02T00:00:00Z"},
+ :latest-processed-msg-id 4916,
  :table-names #{"xt/txs" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b01.binpb.edn
@@ -6,7 +6,7 @@
   "user_metadata" #xt/field {"user_metadata" [:? :struct]},
   "error" #xt/field {"error" [:? :transit]}},
  :hlls
- {"_id" [-1123589697 2.001955671862574],
+ {"_id" [-1094124609 2.001955671862574],
   "system_time" [2144534777 2.001955671862574],
   "committed" [1743138479 1.0004885993744506],
   "user_metadata" [1743287434 1.0004885993744506],
@@ -25,7 +25,7 @@
       :min-system-from #xt/instant "2020-01-02T00:00:00Z",
       :max-system-from #xt/instant "2020-01-02T00:00:00Z",
       :row-count 1,
-      :iid-bloom [369981870 5]}}
+      :iid-bloom [1612620730 5]}}
     {:trie-key "l00-rc-b00",
      :data-file-size 2894,
      :trie-metadata nil}],

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b02.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b02.binpb.edn
@@ -6,7 +6,7 @@
   "user_metadata" #xt/field {"user_metadata" [:? :struct]},
   "error" #xt/field {"error" [:? :transit]}},
  :hlls
- {"_id" [-1123589697 2.001955671862574],
+ {"_id" [-1094124609 2.001955671862574],
   "system_time" [2144534777 2.001955671862574],
   "committed" [1743138479 1.0004885993744506],
   "user_metadata" [1743287434 1.0004885993744506],
@@ -33,7 +33,7 @@
       :min-system-from #xt/instant "2020-01-01T00:00:00Z",
       :max-system-from #xt/instant "2020-01-02T00:00:00Z",
       :row-count 2,
-      :iid-bloom [1666514655 10]}}
+      :iid-bloom [-1650918420 10]}}
     {:trie-key "l01-rc-b00",
      :data-file-size 2894,
      :trie-metadata nil}],

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b01.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 1,
  :latest-completed-tx
- {:tx-id 1632, :system-time #xt/instant "2020-01-02T00:00:00Z"},
- :latest-processed-msg-id 3221,
+ {:tx-id 2012, :system-time #xt/instant "2020-01-02T00:00:00Z"},
+ :latest-processed-msg-id 3601,
  :table-names #{"xt/txs" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/tables/xt$txs/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/tables/xt$txs/blocks/b01.binpb.edn
@@ -6,7 +6,7 @@
   "user_metadata" #xt/field {"user_metadata" [:? :struct]},
   "error" #xt/field {"error" [:? :transit]}},
  :hlls
- {"_id" [-700589889 2.001955671862574],
+ {"_id" [-538341635 2.001955671862574],
   "system_time" [2144534777 2.001955671862574],
   "committed" [1743138479 1.0004885993744506],
   "user_metadata" [1743287434 1.0004885993744506],
@@ -25,7 +25,7 @@
       :min-system-from #xt/instant "2020-01-02T00:00:00Z",
       :max-system-from #xt/instant "2020-01-02T00:00:00Z",
       :row-count 1,
-      :iid-bloom [-1618898884 5]}}
+      :iid-bloom [1533965778 5]}}
     {:trie-key "l00-rc-b00",
      :data-file-size 2894,
      :trie-metadata


### PR DESCRIPTION
## Summary

- Fixes compaction getting permanently stuck when a MW node runs concurrently with SW nodes
- The MW node could see compaction `TriesAdded(L1C)` on the source log before its own `TriesAdded(L0)`, creating an inconsistent trie catalog state (both L0 and L1C live at the same block-idx)
- This inconsistent state was persisted to table-block files and propagated on every restart

## Changes

1. **tidy: remove dead `TrieCatalog.refresh`** — unused since the `ReplicaLogProcessor` fold in ce3c844
2. **fix: SW leader publishes L0 TriesAdded to source log** — restores the invariant that L0 always appears before L1C on the source log, preventing the ordering violation on MW nodes
3. **fix: repair L0/L1C trie catalog inconsistency on startup** — detects and fixes the inconsistency at load time, so existing corrupted block files are repaired on restart

## Test plan

- [x] Existing trie catalog tests pass
- [x] New test for `repair-l0-l1c-consistency` (both repair case and no-op case)
- [x] Compactor and indexer tests pass
- [x] `compileTestFixturesClojure` succeeds
- [ ] CI single-writer tests (golden files updated for shifted source log message IDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)