### PR TITLE
feat: add xt.source_log_msgs and xt.replica_log_msgs system tables

### DIFF
--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [integrant.core :as ig]
             [xtdb.authn.crypt :as authn.crypt]
+            [xtdb.log-tables :as log-tables]
             [xtdb.serde.types :as st]
             [xtdb.table :as table]
             [xtdb.trie :as trie]
@@ -122,7 +123,7 @@
         (update-vals map->vec-types)))
 
   (def derived-tables
-    (merge info-tables pg-catalog-tables xt-derived-tables))
+    (merge info-tables pg-catalog-tables xt-derived-tables log-tables/log-tables))
 
   (defn derived-table [table-ref]
     (get derived-tables (table/ref->schema+table table-ref)))

--- a/core/src/main/clojure/xtdb/log_tables.clj
+++ b/core/src/main/clojure/xtdb/log_tables.clj
@@ -1,0 +1,249 @@
+(ns xtdb.log-tables
+  (:require [clojure.tools.logging :as log]
+            [xtdb.error :as err]
+            [xtdb.table :as table]
+            [xtdb.types :as types]
+            [xtdb.util :as util]
+            [xtdb.vector.reader :as vr])
+  (:import (java.util Map)
+           (org.apache.arrow.memory BufferAllocator)
+           (xtdb ICursor)
+           (xtdb.api.log Log Log$Record SourceMessage SourceMessage$Tx
+                         SourceMessage$FlushBlock SourceMessage$TriesAdded
+                         SourceMessage$AttachDatabase SourceMessage$DetachDatabase
+                         SourceMessage$BlockUploaded SourceMessage$LegacyTx
+                         ReplicaMessage ReplicaMessage$ResolvedTx
+                         ReplicaMessage$TriesAdded ReplicaMessage$BlockBoundary
+                         ReplicaMessage$BlockUploaded ReplicaMessage$NoOp)
+           (xtdb.arrow Relation RelationReader VectorReader)
+           (xtdb.database Database)
+           (xtdb.operator SelectionSpec)
+           (xtdb.table TableRef)))
+
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn- map->vec-types [m]
+  (update-vals m types/->type))
+
+(def log-tables
+  (-> '{xt/source_log_msgs {msg_id :i64, log_offset :i64,
+                            log_timestamp [:timestamp-tz :micro "UTC"],
+                            msg :utf8, tx_ops [:? :utf8]}
+        xt/replica_log_msgs {msg_id :i64, log_offset :i64,
+                             log_timestamp [:timestamp-tz :micro "UTC"],
+                             msg :utf8}}
+      (update-vals map->vec-types)))
+
+(defn log-table
+  "Returns the table schema if this is a log table, nil otherwise."
+  [table-ref]
+  (get log-tables (table/ref->schema+table table-ref)))
+
+(defn- source-msg->edn [^SourceMessage msg]
+  (pr-str
+   (condp instance? msg
+     SourceMessage$Tx
+     (let [^SourceMessage$Tx tx msg]
+       {:type :tx
+        :default-tz (str (.getDefaultTz tx))
+        :user (.getUser tx)
+        :system-time (.getSystemTime tx)})
+
+     SourceMessage$FlushBlock
+     {:type :flush-block
+      :expected-block-idx (.getExpectedBlockIdx ^SourceMessage$FlushBlock msg)}
+
+     SourceMessage$TriesAdded
+     (let [^SourceMessage$TriesAdded m msg]
+       {:type :tries-added
+        :storage-version (.getStorageVersion m)
+        :storage-epoch (.getStorageEpoch m)})
+
+     SourceMessage$AttachDatabase
+     {:type :attach-database
+      :db-name (.getDbName ^SourceMessage$AttachDatabase msg)}
+
+     SourceMessage$DetachDatabase
+     {:type :detach-database
+      :db-name (.getDbName ^SourceMessage$DetachDatabase msg)}
+
+     SourceMessage$BlockUploaded
+     (let [^SourceMessage$BlockUploaded m msg]
+       {:type :block-uploaded
+        :block-index (.getBlockIndex m)
+        :storage-version (.getStorageVersion m)
+        :storage-epoch (.getStorageEpoch m)})
+
+     SourceMessage$LegacyTx
+     {:type :legacy-tx}
+
+     {:type :unknown})))
+
+(defn- decode-tx-ops
+  "Decodes Arrow-encoded tx-ops bytes into an EDN string."
+  [^BufferAllocator allocator ^bytes tx-ops-bytes]
+  (when tx-ops-bytes
+    (try
+      (with-open [rel (Relation/openFromArrowStream allocator tx-ops-bytes)]
+        (pr-str (util/->clj (.getAsMaps rel))))
+      (catch Exception e
+        (log/warn e "Failed to decode tx-ops from source log message")
+        "<error decoding tx-ops>"))))
+
+(defn- replica-msg->edn [^ReplicaMessage msg]
+  (pr-str
+   (condp instance? msg
+     ReplicaMessage$ResolvedTx
+     (let [^ReplicaMessage$ResolvedTx m msg]
+       {:type :resolved-tx
+        :tx-id (.getTxId m)
+        :system-time (.getSystemTime m)
+        :committed (.getCommitted m)
+        :error (some-> (.getError m) str)})
+
+     ReplicaMessage$TriesAdded
+     (let [^ReplicaMessage$TriesAdded m msg]
+       {:type :tries-added
+        :storage-version (.getStorageVersion m)
+        :storage-epoch (.getStorageEpoch m)
+        :source-msg-id (.getSourceMsgId m)})
+
+     ReplicaMessage$BlockBoundary
+     (let [^ReplicaMessage$BlockBoundary m msg]
+       {:type :block-boundary
+        :block-index (.getBlockIndex m)
+        :latest-processed-msg-id (.getLatestProcessedMsgId m)})
+
+     ReplicaMessage$BlockUploaded
+     (let [^ReplicaMessage$BlockUploaded m msg]
+       {:type :block-uploaded
+        :block-index (.getBlockIndex m)
+        :storage-version (.getStorageVersion m)
+        :storage-epoch (.getStorageEpoch m)})
+
+     ReplicaMessage$NoOp
+     {:type :no-op}
+
+     {:type :unknown})))
+
+(defn- resolve-expr-value
+  "Resolves a literal value or param reference from a predicate expression form."
+  [expr args]
+  (cond
+    (number? expr) (long expr)
+
+    (symbol? expr)
+    (when args
+      (let [^xtdb.arrow.RelationReader args-rel args]
+        (when-let [^VectorReader col (.readerForName args-rel (str expr))]
+          (.getObject col 0))))
+
+    (and (seq? expr) (= 'param (first expr)))
+    (let [[_ param-name _param-type] expr
+          param-str (str param-name)]
+      (when args
+        (let [^xtdb.arrow.RelationReader args-rel args]
+          (when-let [^VectorReader col (.readerForName args-rel param-str)]
+            (.getObject col 0)))))
+
+    :else nil))
+
+(defn- extract-msg-id-bounds
+  "Extracts [from-msg-id to-msg-id) bounds from the selects map for msg_id.
+  BETWEEN is inclusive, so we add 1 to the upper bound for end-exclusive semantics."
+  [selects args]
+  (when-let [pred (get selects "msg_id")]
+    (when (seq? pred)
+      (let [op (first pred)]
+        (case op
+          between
+          (let [[_ _col lower upper] pred
+                from (resolve-expr-value lower args)
+                to (resolve-expr-value upper args)]
+            (when (and from to)
+              [(long from) (inc (long to))]))
+
+          ;; fallback: try to extract >= and <= from an `and` form
+          and
+          (let [clauses (rest pred)
+                bounds (reduce (fn [acc clause]
+                                 (if (seq? clause)
+                                   (let [[op _col val] clause
+                                         v (some-> (resolve-expr-value val args) long)]
+                                     (if v
+                                       (let [v (long v)]
+                                         (case op
+                                           >= (assoc acc :from v)
+                                           > (assoc acc :from (inc v))
+                                           <= (assoc acc :to (inc v))
+                                           < (assoc acc :to v)
+                                           acc))
+                                       acc))
+                                   acc))
+                               {} clauses)]
+            (when (and (:from bounds) (:to bounds))
+              [(:from bounds) (:to bounds)]))
+
+          nil)))))
+
+(defn ->cursor
+  "Creates a cursor for log table queries.
+  Extracts msg_id bounds from selects, reads the bounded range from the appropriate log,
+  and returns rows as an InformationSchemaCursor."
+  [^Database db ^BufferAllocator allocator ^TableRef table
+   col-names col-preds selects schema args]
+  (let [table-sym (table/ref->schema+table table)
+        source? (= 'xt/source_log_msgs table-sym)
+        ^Log log (if source? (.getSourceLog db) (.getReplicaLog db))
+        derived-table-schema (log-table table)
+        bounds (extract-msg-id-bounds selects args)]
+
+    (when-not bounds
+      (throw (err/incorrect :xtdb/missing-log-bounds
+                            "Queries on log tables require msg_id bounds (e.g. WHERE msg_id BETWEEN x AND y)")))
+
+    (let [[^long from-msg-id ^long to-msg-id] bounds
+          records (.readRecords log from-msg-id to-msg-id)
+          decode-tx-ops? (and source? (contains? col-names "tx_ops"))
+          rows (if source?
+                 (mapv (fn [^Log$Record rec]
+                         (let [msg (.getMessage rec)]
+                           {"msg_id" (.getMsgId rec)
+                            "log_offset" (.getLogOffset rec)
+                            "log_timestamp" (.getLogTimestamp rec)
+                            "msg" (source-msg->edn msg)
+                            "tx_ops" (when (and decode-tx-ops? (instance? SourceMessage$Tx msg))
+                                       (decode-tx-ops allocator (.getTxOps ^SourceMessage$Tx msg)))}))
+                       records)
+                 (mapv (fn [^Log$Record rec]
+                         {"msg_id" (.getMsgId rec)
+                          "log_offset" (.getLogOffset rec)
+                          "log_timestamp" (.getLogTimestamp rec)
+                          "msg" (replica-msg->edn (.getMessage rec))})
+                       records))]
+
+      (util/with-close-on-catch [out-rel (Relation. allocator ^Map (update-keys derived-table-schema str))]
+        (.writeRows out-rel (into-array java.util.Map rows))
+
+        (let [out-rel-view (reduce (fn [^RelationReader rel ^SelectionSpec col-pred]
+                                     (.select rel (.select col-pred allocator rel schema args)))
+                                   (-> out-rel
+                                       (->> (filter (comp (set col-names) #(.getName ^VectorReader %))))
+                                       (vr/rel-reader (.getRowCount out-rel))
+                                       (vr/with-absent-cols allocator col-names))
+                                   (vals col-preds))
+              !out-rel (volatile! out-rel)]
+          (reify ICursor
+            (getCursorType [_] "log-table")
+            (getChildCursors [_] [])
+            (tryAdvance [_ c]
+              (boolean
+               (when-let [rel @!out-rel]
+                 (try
+                   (vreset! !out-rel nil)
+                   (.accept c out-rel-view)
+                   true
+                   (finally
+                     (util/close rel))))))
+            (close [_]
+              (some-> @!out-rel util/close))))))))

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -6,6 +6,7 @@
             [xtdb.expression :as expr]
             [xtdb.expression.metadata :as expr.meta]
             [xtdb.information-schema :as info-schema]
+            [xtdb.log-tables :as log-tables]
             [xtdb.logical-plan :as lp]
             xtdb.object-store
             [xtdb.table :as table]
@@ -278,8 +279,14 @@
                      (let [^Snapshot snapshot (get snaps db-name)
                            derived-table-schema (info-schema/derived-table table)
                            template-table? (boolean (info-schema/template-table table))]
-                       (if (and derived-table-schema (not template-table?))
+                       (cond
+                         (log-tables/log-table table)
+                         (log-tables/->cursor db allocator table col-names col-preds selects schema args)
+
+                         (and derived-table-schema (not template-table?))
                          (info-schema/->cursor info-schema allocator db snapshot derived-table-schema table col-names col-preds schema args)
+
+                         :else
 
                          (let [iid-set (or (selects->iid-set selects args)
                                            (get pushdown-iids '_iid) ; usually patch

--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -10,7 +10,10 @@ import kotlinx.serialization.Transient
 import xtdb.api.log.Log.*
 import xtdb.database.proto.DatabaseConfig
 import xtdb.util.MsgIdUtil
+import xtdb.util.MsgIdUtil.msgIdToOffset
+import xtdb.util.MsgIdUtil.offsetToMsgId
 import xtdb.database.proto.inMemoryLog
+import java.util.concurrent.CopyOnWriteArrayList
 import java.time.Instant
 import java.time.InstantSource
 import java.time.temporal.ChronoUnit.MICROS
@@ -60,6 +63,8 @@ class InMemoryLog<M> @JvmOverloads constructor(
         val onCommit: CompletableDeferred<MessageMetadata>
     )
 
+    private val allRecords = CopyOnWriteArrayList<Record<M>>()
+
     private val appendCh: Channel<NewMessage<M>> = Channel(100)
     private val committedCh = appendCh.receiveAsFlow()
         .map { (message, onCommit) ->
@@ -68,6 +73,7 @@ class InMemoryLog<M> @JvmOverloads constructor(
             val ts = if (message is SourceMessage.Tx || message is SourceMessage.LegacyTx) instantSource.instant() else Instant.now()
 
             val record = Record(epoch, ++latestSubmittedOffset, ts.truncatedTo(MICROS), message)
+            allRecords.add(record)
             onCommit.complete(MessageMetadata(epoch, record.logOffset, ts.truncatedTo(MICROS)))
             record
         }
@@ -118,6 +124,13 @@ class InMemoryLog<M> @JvmOverloads constructor(
     }
 
     override fun readLastMessage(): M? = null
+
+    override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId): List<Record<M>> {
+        if (MsgIdUtil.msgIdToEpoch(fromMsgId) != epoch || MsgIdUtil.msgIdToEpoch(toMsgId) != epoch) return emptyList()
+        val fromOffset = msgIdToOffset(fromMsgId)
+        val toOffset = msgIdToOffset(toMsgId)
+        return allRecords.filter { it.logOffset in fromOffset until toOffset }
+    }
 
     override fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>): Subscription {
         var latestCompletedOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -17,6 +17,7 @@ import xtdb.api.PathWithEnvVarSerde
 import xtdb.api.log.Log.*
 import xtdb.database.proto.DatabaseConfig
 import xtdb.util.MsgIdUtil
+import xtdb.util.MsgIdUtil.msgIdToOffset
 import xtdb.database.proto.localLog
 import xtdb.time.InstantUtil.asMicros
 import xtdb.time.InstantUtil.fromMicros
@@ -251,6 +252,24 @@ class LocalLog<M>(
         return FileChannel.open(logFilePath).use { ch ->
             ch.position(latestSubmittedOffset)
             ch.readMessage()?.message
+        }
+    }
+
+    override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId): List<Record<M>> {
+        if (MsgIdUtil.msgIdToEpoch(fromMsgId) != epoch || MsgIdUtil.msgIdToEpoch(toMsgId) != epoch) return emptyList()
+        val fromOffset = msgIdToOffset(fromMsgId)
+        val toOffset = msgIdToOffset(toMsgId)
+        if (fromOffset > latestSubmittedOffset || fromOffset >= toOffset) return emptyList()
+
+        return FileChannel.open(logFilePath).use { ch ->
+            ch.position(fromOffset)
+            buildList {
+                while (ch.position() < ch.size()) {
+                    val record = ch.readMessage() ?: continue
+                    if (record.logOffset >= toOffset) break
+                    add(record)
+                }
+            }
         }
     }
 

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -160,6 +160,13 @@ interface Log<M> : AutoCloseable {
 
     fun readLastMessage(): M?
 
+    /**
+     * Reads records in the range [fromMsgId, toMsgId) (start-inclusive, end-exclusive).
+     * Returns a list of decoded records in offset order.
+     * If toMsgId exceeds the latest submitted offset, reads up to the latest available record.
+     */
+    fun readRecords(fromMsgId: MessageId, toMsgId: MessageId): List<Record<M>>
+
     fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>): Subscription
     fun openGroupSubscription(listener: SubscriptionListener<M>): Subscription
 

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.channels.Channel
 import xtdb.api.log.Log.*
 import xtdb.error.Incorrect
 import xtdb.util.MsgIdUtil
+import xtdb.util.MsgIdUtil.msgIdToOffset
 import xtdb.time.InstantUtil.fromMicros
 import java.io.DataInputStream
 import java.nio.ByteBuffer
@@ -105,6 +106,24 @@ class ReadOnlyLocalLog<M>(
         return FileChannel.open(logFilePath, READ).use { ch ->
             ch.position(latestSubmittedOffset)
             ch.readMessage()?.message
+        }
+    }
+
+    override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId): List<Record<M>> {
+        if (MsgIdUtil.msgIdToEpoch(fromMsgId) != epoch || MsgIdUtil.msgIdToEpoch(toMsgId) != epoch) return emptyList()
+        val fromOffset = msgIdToOffset(fromMsgId)
+        val toOffset = msgIdToOffset(toMsgId)
+        if (fromOffset > latestSubmittedOffset || fromOffset >= toOffset) return emptyList()
+
+        return FileChannel.open(logFilePath, READ).use { ch ->
+            ch.position(fromOffset)
+            buildList {
+                while (ch.position() < ch.size()) {
+                    val record = ch.readMessage() ?: continue
+                    if (record.logOffset >= toOffset) break
+                    add(record)
+                }
+            }
         }
     }
 

--- a/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
+++ b/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
@@ -5,11 +5,14 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
+import xtdb.api.log.MessageId
 import xtdb.api.log.SourceMessage
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.LogOffset
 import xtdb.api.log.ReadOnlyLog
 import xtdb.database.proto.DatabaseConfig
+import xtdb.util.MsgIdUtil.msgIdToEpoch
+import xtdb.util.MsgIdUtil.msgIdToOffset
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import java.time.Instant
@@ -19,6 +22,7 @@ import java.time.temporal.ChronoUnit
 class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M>) : Log<M> {
     override val epoch = 0
     val messages = messages.toMutableList()
+    private val records = mutableListOf<Log.Record<M>>()
 
     @SerialName("!Recording")
     @Serializable
@@ -51,15 +55,20 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
         messages.add(message)
 
         val ts = if (message is SourceMessage.Tx || message is SourceMessage.LegacyTx) instantSource.instant() else Instant.now()
+        val offset = ++latestSubmittedOffset
+        records.add(Log.Record(epoch, offset, ts.truncatedTo(ChronoUnit.MICROS), message))
 
-        return Log.MessageMetadata(
-            epoch,
-            ++latestSubmittedOffset,
-            ts.truncatedTo(ChronoUnit.MICROS)
-        )
+        return Log.MessageMetadata(epoch, offset, ts.truncatedTo(ChronoUnit.MICROS))
     }
 
     override fun readLastMessage(): M? = messages.lastOrNull()
+
+    override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId): List<Log.Record<M>> {
+        if (msgIdToEpoch(fromMsgId) != epoch || msgIdToEpoch(toMsgId) != epoch) return emptyList()
+        val fromOffset = msgIdToOffset(fromMsgId)
+        val toOffset = msgIdToOffset(toMsgId)
+        return records.filter { it.logOffset in fromOffset until toOffset }
+    }
 
     override fun openAtomicProducer(transactionalId: String) = object : Log.AtomicProducer<M> {
         override fun openTx() = object : Log.AtomicProducer.Tx<M> {

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -37,6 +37,8 @@ import xtdb.database.proto.DatabaseConfig
 import xtdb.kafka.proto.KafkaLogConfig
 import xtdb.kafka.proto.kafkaLogConfig
 import xtdb.util.MsgIdUtil.afterMsgIdToOffset
+import xtdb.util.MsgIdUtil.msgIdToEpoch
+import xtdb.util.MsgIdUtil.msgIdToOffset
 import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant.ofEpochMilli
@@ -221,6 +223,36 @@ class KafkaCluster(
                 val records = c.poll(pollDuration).records(topic)
                 records.firstOrNull()?.let { record -> codec.decode(record.value()) }
             }
+
+        override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId): List<Log.Record<M>> {
+            if (msgIdToEpoch(fromMsgId) != epoch || msgIdToEpoch(toMsgId) != epoch) return emptyList()
+            val fromOffset = msgIdToOffset(fromMsgId)
+            val toOffset = msgIdToOffset(toMsgId)
+            if (fromOffset >= toOffset) return emptyList()
+
+            return kafkaConfigMap.openConsumer().use { c ->
+                val tp = TopicPartition(topic, 0)
+                c.assign(listOf(tp))
+
+                val endOffset = c.endOffsets(listOf(tp))[tp] ?: 0
+                val effectiveToOffset = minOf(toOffset, endOffset)
+                if (fromOffset >= effectiveToOffset) return emptyList()
+
+                c.seek(tp, fromOffset)
+
+                buildList {
+                    while (c.position(tp) < effectiveToOffset) {
+                        val batch = c.poll(pollDuration).records(topic).toList()
+
+                        for (rec in batch) {
+                            if (rec.offset() >= effectiveToOffset) return@buildList
+                            val msg = codec.decode(rec.value()) ?: continue
+                            add(Log.Record(epoch, rec.offset(), ofEpochMilli(rec.timestamp()), msg))
+                        }
+                    }
+                }
+            }
+        }
 
         override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer<M> {
             private val producer = KafkaProducer(

--- a/src/test/clojure/xtdb/log_tables_test.clj
+++ b/src/test/clojure/xtdb/log_tables_test.clj
@@ -1,0 +1,47 @@
+(ns xtdb.log-tables-test
+  (:require [clojure.test :as t :refer [deftest]]
+            [xtdb.api :as xt]
+            [xtdb.test-util :as tu]))
+
+(t/use-fixtures :each tu/with-mock-clock tu/with-allocator tu/with-node)
+
+(deftest test-source-log-msgs-basic
+  (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 1, :v "hello"}]])
+  (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 2, :v "world"}]])
+
+  (t/testing "can read source log messages with BETWEEN bounds"
+    (let [rows (xt/q tu/*node*
+                     "SELECT msg_id, log_offset, log_timestamp, msg, tx_ops FROM xt.source_log_msgs WHERE msg_id BETWEEN 0 AND 100")]
+      (t/is (pos? (count rows)) "should return at least one row")
+
+      (t/testing "msg column contains readable EDN with :type key"
+        (t/is (string? (:msg (first rows))))
+        (t/is (re-find #":type" (:msg (first rows)))))
+
+      (t/testing "tx_ops column is present for tx messages"
+        (let [rows-with-tx-ops (filter :tx-ops rows)]
+          (when (seq rows-with-tx-ops)
+            (t/is (string? (:tx-ops (first rows-with-tx-ops)))))))))
+
+  (t/testing "msg_id and log_offset are present and numeric"
+    (let [rows (xt/q tu/*node*
+                     "SELECT msg_id, log_offset FROM xt.source_log_msgs WHERE msg_id BETWEEN 0 AND 100")]
+      (doseq [row rows]
+        (t/is (number? (:msg-id row)))
+        (t/is (number? (:log-offset row))))))
+
+  (t/testing "empty range returns no rows"
+    (let [rows (xt/q tu/*node*
+                     "SELECT * FROM xt.source_log_msgs WHERE msg_id BETWEEN 99999 AND 99999")]
+      (t/is (empty? rows)))))
+
+(deftest test-source-log-msgs-tx-ops-decoded
+  (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 1, :v "hello"}]])
+
+  (let [rows (xt/q tu/*node*
+                   "SELECT msg, tx_ops FROM xt.source_log_msgs WHERE msg_id BETWEEN 0 AND 100")
+        tx-rows (filter :tx-ops rows)]
+    (t/is (seq tx-rows) "should have at least one tx message")
+
+    (t/testing "tx_ops contains decoded operations"
+      (t/is (re-find #"put-docs" (:tx-ops (first tx-rows)))))))


### PR DESCRIPTION
## Summary

- Adds system tables for reading source and replica log messages via SQL
- Adds `readRecords(fromMsgId, toMsgId)` to the `Log` interface
- New `xtdb.log-tables` namespace, wired into the scan operator

## Design notes

**Why a new namespace instead of extending info-schema?**
Info-schema materializes all rows then applies predicates post-hoc.
Log tables need predicate pushdown — we extract `msg_id` bounds from the `selects` map (the raw predicate forms from the SQL planner) before reading, so that we can seek directly to the right offset in Kafka/local log files.
The scan emitter dispatches to `log-tables/->cursor` before the info-schema branch, passing `selects` through (which info-schema doesn't receive).

**Why EDN strings instead of typed columns?**
Messages have many variants (Tx, FlushBlock, TriesAdded, AttachDatabase, etc.) each with different fields.
A single `msg` column with `pr-str`'d EDN keeps the schema stable as message types evolve and avoids needing to project out irrelevant columns.
`tx_ops` is a separate column because the decoded Arrow operations are large — admins who don't need them can avoid the decode cost by not selecting it.

**readRecords semantics**: `[fromMsgId, toMsgId)` — start-inclusive, end-exclusive.
Each Log implementation validates the epoch from the MessageId and extracts the offset.
Kafka opens a consumer, seeks, polls until the end offset, then closes.
LocalLog/ReadOnlyLocalLog seek in the file.
InMemoryLog stores records in a CopyOnWriteArrayList and filters.

**Replica log** is only populated in single-writer mode (no data in default test config).

## Example

```sql
SELECT msg_id, log_offset, log_timestamp, msg, tx_ops
FROM xt.source_log_msgs
WHERE msg_id BETWEEN 0 AND 100
```

## Test plan

- [x] `xtdb.log-tables-test` — source log BETWEEN queries, tx_ops decoding, empty ranges
- [x] `xtdb.information-schema-test` — no regression (21 tests)
- [x] Full `./gradlew test` — all passing, no boxed math or reflection warnings

🤖 Generated with [Claude Code](https://claude.ai/code)