### PR TITLE
feat: block and table-block admin tables

### DIFF
--- a/core/src/main/clojure/xtdb/block_tables.clj
+++ b/core/src/main/clojure/xtdb/block_tables.clj
@@ -1,0 +1,263 @@
+(ns xtdb.block-tables
+  (:require [xtdb.error :as err]
+            [xtdb.expression :as expr]
+            [xtdb.expression.constraints :as constraints]
+            [xtdb.table :as table]
+            [xtdb.table-catalog :as table-cat]
+            [xtdb.trie-catalog :as trie-cat]
+            [xtdb.types :as types]
+            [xtdb.util :as util]
+            [xtdb.vector.reader :as vr])
+  (:import (java.util Map)
+           (org.apache.arrow.memory BufferAllocator)
+           (xtdb ICursor)
+           (xtdb.arrow Relation RelationReader VectorReader)
+           (xtdb.block.proto Block TableBlock)
+           (xtdb.catalog BlockCatalog)
+           (xtdb.database Database)
+           (xtdb.log.proto TrieDetails)
+           (xtdb.operator SelectionSpec)
+           (xtdb.storage BufferPool)
+           (xtdb.table TableRef)
+           (xtdb.time InstantUtil)
+           (xtdb.trie Trie)
+           (xtdb.util HyperLogLog)))
+
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn- map->vec-types [m]
+  (update-vals m types/->type))
+
+(def block-tables
+  (-> '{xt/block_files {block_idx :i64
+                        tx_id [:? :i64]
+                        system_time [:? :timestamp-tz :micro "UTC"]
+                        latest_processed_msg_id :i64
+                        table_names :utf8
+                        boundary_replica_msg_id [:? :i64]
+                        file_size :i64}
+
+        xt/table_block_files {table_name :utf8
+                              block_idx :i64
+                              row_count :i64
+                              fields :utf8
+                              hlls :utf8
+                              partition_count :i32}
+
+        xt/table_block_file_tries {table_name :utf8
+                                   block_idx :i64
+                                   level :i32
+                                   recency [:? :utf8]
+                                   part :utf8
+                                   trie_key :utf8
+                                   data_file_size :i64
+                                   trie_state [:? :utf8]
+                                   row_count [:? :i64]
+                                   temporal_metadata [:? :utf8]}}
+      (update-vals map->vec-types)))
+
+(defn block-table
+  "Returns the table schema if this is a block table, nil otherwise."
+  [table-ref]
+  (get block-tables (table/ref->schema+table table-ref)))
+
+;;; helpers
+
+(defn- ->env [derived-table-schema args]
+  {:var-types derived-table-schema
+   :param-types (if args (expr/->param-types args) {})})
+
+(def ^:private ^:const batch-size 1024)
+
+(defn- take-batch
+  "Takes up to `n` elements from an Iterator, returning a vector."
+  [^java.util.Iterator iter ^long n]
+  (loop [acc (transient []), i 0]
+    (if (and (< i n) (.hasNext iter))
+      (recur (conj! acc (.next iter)) (inc i))
+      (persistent! acc))))
+
+(defn- emit-batch
+  [^BufferAllocator allocator derived-table-schema col-names col-preds schema args rows c]
+  (util/with-open [out-rel (Relation. allocator ^Map (update-keys derived-table-schema str))]
+    (.writeRows out-rel (into-array java.util.Map rows))
+    (let [out-rel-view (reduce (fn [^RelationReader rel ^SelectionSpec col-pred]
+                                 (.select rel (.select col-pred allocator rel schema args)))
+                               (-> out-rel
+                                   (->> (filter (comp (set col-names) #(.getName ^VectorReader %))))
+                                   (vr/rel-reader (.getRowCount out-rel))
+                                   (vr/with-absent-cols allocator col-names))
+                               (vals col-preds))]
+      (.accept c out-rel-view))))
+
+;;; xt.block_files
+
+(defn- block->row [^Block block ^long file-size]
+  (let [has-tx? (.hasLatestCompletedTx block)]
+    {"block_idx" (.getBlockIndex block)
+     "tx_id" (when has-tx? (.getTxId (.getLatestCompletedTx block)))
+     "system_time" (when has-tx? (InstantUtil/fromMicros (.getSystemTime (.getLatestCompletedTx block))))
+     "latest_processed_msg_id" (.getLatestProcessedMsgId block)
+     "table_names" (pr-str (vec (.getTableNamesList block)))
+     "boundary_replica_msg_id" (when (.hasBoundaryReplicaMsgId block) (.getBoundaryReplicaMsgId block))
+     "file_size" file-size}))
+
+(defn- try-read-block
+  "Attempts to read a block file at the given index. Returns a row map or nil."
+  [^BufferPool buffer-pool ^long block-idx]
+  (try
+    (let [path (BlockCatalog/blockFilePath block-idx)
+          ^bytes ba (.getByteArray buffer-pool path)
+          block (Block/parseFrom ba)]
+      (block->row block (alength ba)))
+    (catch Exception _e
+      nil)))
+
+(defn- ->block-files-cursor
+  [^Database db ^BufferAllocator allocator col-names col-preds selects schema args]
+  (let [derived-table-schema (get block-tables 'xt/block_files)
+        env (->env derived-table-schema args)
+        bounds (when-let [form (get selects "block_idx")]
+                 (constraints/extract-range form env args))]
+
+    (when-not bounds
+      (throw (err/incorrect :xtdb/missing-block-idx-bounds
+                            "Queries on xt.block_files require block_idx bounds (e.g. WHERE block_idx BETWEEN x AND y)")))
+
+    (let [[^long from-idx ^long to-idx] bounds
+          ^BufferPool buffer-pool (.getBufferPool db)
+          idx (volatile! from-idx)]
+
+      (reify ICursor
+        (getCursorType [_] "block-table")
+        (getChildCursors [_] [])
+        (tryAdvance [_ c]
+          (boolean
+           (when (< ^long @idx to-idx)
+             (let [batch (loop [acc (transient []), i (long 0)]
+                           (if (and (< i batch-size) (< (+ ^long @idx i) to-idx))
+                             (let [row (try-read-block buffer-pool (+ ^long @idx i))]
+                               (recur (if row (conj! acc row) acc) (inc i)))
+                             (do (vswap! idx (fn [^long v] (+ v i)))
+                                 (persistent! acc))))]
+               (when (seq batch)
+                 (emit-batch allocator derived-table-schema col-names col-preds schema args batch c)
+                 true)))))
+        (close [_])))))
+
+;;; xt.table_block_files
+
+(defn- table-block->row [^String table-name ^long block-idx {:keys [^long row-count fields hlls partitions]}]
+  {"table_name" table-name
+   "block_idx" block-idx
+   "row_count" row-count
+   "fields" (pr-str (update-vals fields #(types/field->col-type %)))
+   "hlls" (pr-str (update-vals hlls #(long (HyperLogLog/estimate %))))
+   "partition_count" (int (count partitions))})
+
+(defn- resolve-table-block
+  "Resolves a table-block file given db name, table name and block idx. Returns parsed map or nil."
+  [^BufferPool buffer-pool ^String db-name ^String table-name ^long block-idx]
+  (let [table-ref (table/->ref db-name table-name)
+        table-path (Trie/getTablePath table-ref)
+        obj-key (table-cat/->table-block-metadata-obj-key table-path block-idx)]
+    (try
+      (-> (.getByteArray buffer-pool obj-key)
+          (TableBlock/parseFrom)
+          (table-cat/<-table-block))
+      (catch Exception _e
+        nil))))
+
+(defn- ->table-block-files-cursor
+  [^Database db ^BufferAllocator allocator col-names col-preds selects schema args]
+  (let [derived-table-schema (get block-tables 'xt/table_block_files)
+        env (->env derived-table-schema args)
+        table-name (when-let [form (get selects "table_name")]
+                     (constraints/extract-equality form env args))
+        block-idx (when-let [form (get selects "block_idx")]
+                    (constraints/extract-equality form env args))]
+
+    (when-not (and table-name block-idx)
+      (throw (err/incorrect :xtdb/missing-table-block-predicates
+                            "Queries on xt.table_block_files require table_name = '...' AND block_idx = N")))
+
+    (let [^BufferPool buffer-pool (.getBufferPool db)
+          table-block (resolve-table-block buffer-pool (.getName db) (str table-name) (long block-idx))
+          rows (if table-block
+                 [(table-block->row (str table-name) (long block-idx) table-block)]
+                 [])
+          done? (volatile! false)]
+
+      (reify ICursor
+        (getCursorType [_] "table-block-file")
+        (getChildCursors [_] [])
+        (tryAdvance [_ c]
+          (boolean
+           (when (and (seq rows) (not @done?))
+             (vreset! done? true)
+             (emit-batch allocator derived-table-schema col-names col-preds schema args rows c)
+             true)))
+        (close [_])))))
+
+;;; xt.table_block_file_tries
+
+(defn- trie-details->rows [^String table-name ^long block-idx partitions]
+  (vec
+   (for [{:keys [^int level recency part tries]} partitions
+         ^TrieDetails td tries
+         :let [trie-meta (some-> (.getTrieMetadata td) trie-cat/<-trie-metadata)]]
+     {"table_name" table-name
+      "block_idx" block-idx
+      "level" (int level)
+      "recency" (some-> recency str)
+      "part" (pr-str part)
+      "trie_key" (.getTrieKey td)
+      "data_file_size" (.getDataFileSize td)
+      "trie_state" (when (.hasTrieState td)
+                     (name (condp = (.getTrieState td)
+                             xtdb.log.proto.TrieState/LIVE :live
+                             xtdb.log.proto.TrieState/NASCENT :nascent
+                             xtdb.log.proto.TrieState/GARBAGE :garbage)))
+      "row_count" (:row-count trie-meta)
+      "temporal_metadata" (some-> trie-meta (dissoc :row-count :iid-bloom) not-empty pr-str)})))
+
+(defn- ->table-block-file-tries-cursor
+  [^Database db ^BufferAllocator allocator col-names col-preds selects schema args]
+  (let [derived-table-schema (get block-tables 'xt/table_block_file_tries)
+        env (->env derived-table-schema args)
+        table-name (when-let [form (get selects "table_name")]
+                     (constraints/extract-equality form env args))
+        block-idx (when-let [form (get selects "block_idx")]
+                    (constraints/extract-equality form env args))]
+
+    (when-not (and table-name block-idx)
+      (throw (err/incorrect :xtdb/missing-table-block-predicates
+                            "Queries on xt.table_block_file_tries require table_name = '...' AND block_idx = N")))
+
+    (let [^BufferPool buffer-pool (.getBufferPool db)
+          table-block (resolve-table-block buffer-pool (.getName db) (str table-name) (long block-idx))
+          rows (if table-block
+                 (trie-details->rows (str table-name) (long block-idx) (:partitions table-block))
+                 [])
+          iter (.iterator ^Iterable rows)]
+
+      (reify ICursor
+        (getCursorType [_] "table-block-file-tries")
+        (getChildCursors [_] [])
+        (tryAdvance [_ c]
+          (boolean
+           (when (.hasNext iter)
+             (let [batch (take-batch iter batch-size)]
+               (emit-batch allocator derived-table-schema col-names col-preds schema args batch c)
+               true))))
+        (close [_])))))
+
+;;; dispatch
+
+(defn ->cursor
+  [^Database db ^BufferAllocator allocator ^TableRef table
+   col-names col-preds selects schema args]
+  (case (table/ref->schema+table table)
+    xt/block_files (->block-files-cursor db allocator col-names col-preds selects schema args)
+    xt/table_block_files (->table-block-files-cursor db allocator col-names col-preds selects schema args)
+    xt/table_block_file_tries (->table-block-file-tries-cursor db allocator col-names col-preds selects schema args)))

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [integrant.core :as ig]
             [xtdb.authn.crypt :as authn.crypt]
+            [xtdb.block-tables :as block-tables]
             [xtdb.log-tables :as log-tables]
             [xtdb.serde.types :as st]
             [xtdb.table :as table]
@@ -123,7 +124,7 @@
         (update-vals map->vec-types)))
 
   (def derived-tables
-    (merge info-tables pg-catalog-tables xt-derived-tables log-tables/log-tables))
+    (merge info-tables pg-catalog-tables xt-derived-tables log-tables/log-tables block-tables/block-tables))
 
   (defn derived-table [table-ref]
     (get derived-tables (table/ref->schema+table table-ref)))

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -6,6 +6,7 @@
             [xtdb.expression :as expr]
             [xtdb.expression.metadata :as expr.meta]
             [xtdb.information-schema :as info-schema]
+            [xtdb.block-tables :as block-tables]
             [xtdb.log-tables :as log-tables]
             [xtdb.logical-plan :as lp]
             xtdb.object-store
@@ -282,6 +283,9 @@
                        (cond
                          (log-tables/log-table table)
                          (log-tables/->cursor db allocator table col-names col-preds selects schema args)
+
+                         (block-tables/block-table table)
+                         (block-tables/->cursor db allocator table col-names col-preds selects schema args)
 
                          (and derived-table-schema (not template-table?))
                          (info-schema/->cursor info-schema allocator db snapshot derived-table-schema table col-names col-preds schema args)

--- a/src/test/clojure/xtdb/block_tables_test.clj
+++ b/src/test/clojure/xtdb/block_tables_test.clj
@@ -1,0 +1,116 @@
+(ns xtdb.block-tables-test
+  (:require [clojure.test :as t :refer [deftest]]
+            [xtdb.api :as xt]
+            [xtdb.test-util :as tu]))
+
+(t/use-fixtures :each tu/with-mock-clock tu/with-allocator tu/with-node)
+
+(deftest test-block-files-basic
+  (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 1, :v "hello"}]])
+  (tu/flush-block! tu/*node*)
+
+  (t/testing "can read block files with BETWEEN bounds"
+    (let [rows (xt/q tu/*node*
+                     "SELECT block_idx, tx_id, system_time, latest_processed_msg_id, table_names, boundary_replica_msg_id, file_size
+                      FROM xt.block_files WHERE block_idx BETWEEN 0 AND 100")]
+      (t/is (pos? (count rows)) "should return at least one block")
+
+      (let [row (first rows)]
+        (t/is (number? (:block-idx row)))
+        (t/is (number? (:latest-processed-msg-id row)))
+        (t/is (string? (:table-names row)))
+        (t/is (pos? (:file-size row)))))))
+
+(deftest test-block-files-requires-predicate
+  (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 1}]])
+  (tu/flush-block! tu/*node*)
+
+  (t/is (thrown-with-msg? Exception #"require block_idx bounds"
+          (xt/q tu/*node* "SELECT * FROM xt.block_files"))))
+
+(deftest test-block-files-with-params
+  (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 1, :v "hello"}]])
+  (tu/flush-block! tu/*node*)
+
+  (t/testing "parameterised BETWEEN bounds"
+    (let [rows (xt/q tu/*node*
+                     ["SELECT block_idx FROM xt.block_files WHERE block_idx BETWEEN ? AND ?" 0 100])]
+      (t/is (pos? (count rows)))))
+
+  (t/testing "parameterised equality on table-block tables"
+    (let [rows (xt/q tu/*node*
+                     ["SELECT row_count FROM xt.table_block_files WHERE table_name = ? AND block_idx = ?"
+                      "public/foo" 0])]
+      (t/is (= 1 (count rows))))))
+
+(deftest test-block-files-empty-range
+  (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 1}]])
+  (tu/flush-block! tu/*node*)
+
+  (let [rows (xt/q tu/*node*
+                   "SELECT * FROM xt.block_files WHERE block_idx BETWEEN 99999 AND 99999")]
+    (t/is (empty? rows))))
+
+(deftest test-table-block-files-basic
+  (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 1, :v "hello"}]])
+  (tu/flush-block! tu/*node*)
+
+  (t/testing "can read table-block metadata"
+    (let [rows (xt/q tu/*node*
+                     "SELECT table_name, block_idx, row_count, fields, hlls, partition_count
+                      FROM xt.table_block_files
+                      WHERE table_name = 'public/foo' AND block_idx = 0")]
+      (t/is (= 1 (count rows)))
+
+      (let [row (first rows)]
+        (t/is (= "public/foo" (:table-name row)))
+        (t/is (= 0 (:block-idx row)))
+        (t/is (pos? (:row-count row)))
+        (t/is (string? (:fields row)))
+        (t/is (string? (:hlls row)))
+        (t/is (pos? (:partition-count row)))))))
+
+(deftest test-table-block-files-requires-predicates
+  (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 1}]])
+  (tu/flush-block! tu/*node*)
+
+  (t/testing "missing both predicates"
+    (t/is (thrown-with-msg? Exception #"require table_name.*AND block_idx"
+            (xt/q tu/*node* "SELECT * FROM xt.table_block_files"))))
+
+  (t/testing "missing block_idx"
+    (t/is (thrown-with-msg? Exception #"require table_name.*AND block_idx"
+            (xt/q tu/*node* "SELECT * FROM xt.table_block_files WHERE table_name = 'public/foo'")))))
+
+(deftest test-table-block-file-tries-basic
+  (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 1, :v "hello"}]])
+  (tu/flush-block! tu/*node*)
+
+  (t/testing "can read trie metadata"
+    (let [rows (xt/q tu/*node*
+                     "SELECT table_name, block_idx, level, trie_key, data_file_size, trie_state, row_count
+                      FROM xt.table_block_file_tries
+                      WHERE table_name = 'public/foo' AND block_idx = 0")]
+      (t/is (pos? (count rows)) "should return at least one trie")
+
+      (let [row (first rows)]
+        (t/is (= "public/foo" (:table-name row)))
+        (t/is (= 0 (:block-idx row)))
+        (t/is (string? (:trie-key row)))
+        (t/is (number? (:data-file-size row)))))))
+
+(deftest test-table-block-nonexistent
+  (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 1}]])
+  (tu/flush-block! tu/*node*)
+
+  (t/testing "nonexistent table returns empty"
+    (let [rows (xt/q tu/*node*
+                     "SELECT * FROM xt.table_block_files
+                      WHERE table_name = 'public/nonexistent' AND block_idx = 0")]
+      (t/is (empty? rows))))
+
+  (t/testing "nonexistent block returns empty"
+    (let [rows (xt/q tu/*node*
+                     "SELECT * FROM xt.table_block_files
+                      WHERE table_name = 'public/foo' AND block_idx = 999")]
+      (t/is (empty? rows)))))


### PR DESCRIPTION
## Context

Following on from the log-tables work (#5397), operators need visibility into the storage layer without reaching for Gradle CLI tools.
Three new admin tables expose block and table-block file metadata via SQL.

## Usage

**Block files** — top-level block metadata:
```sql
SELECT *
FROM xt.block_files
WHERE block_idx BETWEEN '00' AND '1a';
```
```
 block_idx | tx_id |        system_time         | latest_processed_msg_id |                         table_names                          | boundary_replica_msg_id | file_size
-----------+-------+----------------------------+-------------------------+--------------------------------------------------------------+-------------------------+-----------
 00        |   511 | 2026-03-28 14:22:01.234+00 |                    1024 | ["xt/txs" "public/users" "public/orders"]                    |                    1026 |      1284
 01        |  1023 | 2026-03-28 14:25:12.567+00 |                    2048 | ["xt/txs" "public/users" "public/orders"]                    |                    2050 |      1312
 02        |  1535 | 2026-03-28 14:28:44.891+00 |                    3072 | ["xt/txs" "public/users" "public/orders" "public/items"]     |                    3074 |      1456
(3 rows)
```
Requires a `block_idx` predicate — equality (`= '00'`) or a range (`BETWEEN '00' AND '1a'`).
`block_idx` uses lex-hex encoding, matching the format used in object store paths.

**Table-block files** — per-table block metadata:
```sql
SELECT table_name, block_idx, row_count, fields, hlls, partition_count
FROM xt.table_block_files
WHERE table_name = 'public/users' AND block_idx = '00';
```
```
  table_name  | block_idx | row_count |                          fields                           |              hlls              | partition_count
--------------+-----------+-----------+-----------------------------------------------------------+--------------------------------+-----------------
 public/users | 00        |       512 | {"_id" :i64, "name" :utf8, "email" :utf8, "age" :i64}     | {"_id" 512, "name" 508, "email" 512, "age" 47} |               1
(1 row)
```
Requires equality on both `table_name` and `block_idx`.

**Table-block trie metadata** — trie details within a table-block:
```sql
SELECT table_name, block_idx, level, trie_key, data_file_size, trie_state, row_count, temporal_metadata
FROM xt.table_block_file_tries
WHERE table_name = 'public/users' AND block_idx = '02';
```
```
  table_name  | block_idx | level |       trie_key       | data_file_size | trie_state | row_count |                                   temporal_metadata
--------------+-----------+-------+----------------------+----------------+------------+-----------+--------------------------------------------------------------------------------------
 public/users | 02        |     0 | l00-rc-b2100         |         524288 | live       |       512 | {:min-valid-from #inst "2026-03-28T14:28:00Z", :max-valid-from #inst "2026-03-28T...}
 public/users | 02        |     1 | l01-rc-b2100         |        2097152 | live       |      1536 | {:min-valid-from #inst "2026-03-01T00:00:00Z", :max-valid-from #inst "2026-03-28T...}
(2 rows)
```
Same required predicates as `table_block_files`.

## Implementation notes

### Tidies already applied to main

Two tidy-first commits are included in this branch but have already been cherry-picked to main:

1. **Inline simple `between` subjects** — the `between` macro unconditionally wrapped its subject in a `:let`, hiding comparison operators from metadata pushdown.
Now inlines when the subject is a variable/literal/param.
Partial improvement toward #2101.

2. **Shared constraint extraction** (`expression.constraints`) — extracted `normalise-bool-args` from `expression/metadata.clj` into a shared namespace.
New functions `resolve-value`, `extract-equality`, `extract-range` work at the AST level, using proper macro expansion and operand normalisation.
Rewired `log_tables.clj` to use `constraints/extract-range`, replacing ~60 lines of ad-hoc form parsing from #5397.

### New code

`xtdb.block-tables` namespace with:
- Schema definitions for the three tables, registered via `information_schema/derived-tables`
- Scan routing in `operator/scan.clj` (same pattern as log-tables)
- Predicate enforcement via `expression.constraints` — errors on missing required predicates
- Cursor implementations: streaming batches for `block_files`, single-row for `table_block_files`, multi-row for `table_block_file_tries`
- Complex fields (table_names, fields, hlls, temporal_metadata) serialised as EDN strings

### Follow-up commits (merged to main after this PR)

- **`block_idx` as lex-hex** — changed from `:i64` to `:utf8` using lex-hex encoding, matching the format in object store paths (`blocks/b00.binpb`).
  `extract-range` generalised to return structured `{:lower [op value] :upper [op value]}` bounds (no longer coerces to long), and now also handles equality.
- **`msg_type` column on log tables** — added a dedicated `msg_type` column to `xt.source_log_msgs` and `xt.replica_log_msgs` for easy filtering without parsing the `msg` EDN.
- **Richer log message EDN** — surfaced missing useful fields: tries lists, latest-processed-msg-id, config, db-op, table-names across all message types.

Part of #2101