### PR TITLE
feat(external-log): wire external log through Demux into leader processor

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -192,9 +192,26 @@ class Database(
                                 indexerConfig.flushDuration,
                                 base.meterRegistry,
                             )
-                            return object : LogProcessor.LeaderSystem {
-                                override val proc get() = leaderProc
-                                override fun close() = leaderProc.close()
+
+                            val extFactory = dbConfig.externalLog
+                            val extLog = storage.externalLog
+
+                            return if (extFactory != null && extLog != null) {
+                                @Suppress("UNCHECKED_CAST")
+                                val extProc = extFactory.openProcessor(leaderProc, state) as Log.RecordProcessor<Any?>
+                                val token = state.blockCatalog.externalSourceToken
+
+                                @Suppress("UNCHECKED_CAST")
+                                val demux = ExternalLog.Demux(leaderProc, extLog as ExternalLog<Any?>, token, extProc)
+                                object : LogProcessor.LeaderSystem {
+                                    override val proc get() = demux
+                                    override fun close() { demux.close(); leaderProc.close() }
+                                }
+                            } else {
+                                object : LogProcessor.LeaderSystem {
+                                    override val proc get() = leaderProc
+                                    override fun close() = leaderProc.close()
+                                }
                             }
                         }
 

--- a/core/src/main/kotlin/xtdb/database/ExternalLog.kt
+++ b/core/src/main/kotlin/xtdb/database/ExternalLog.kt
@@ -1,12 +1,28 @@
 package xtdb.database
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.selects.selectUnbiased
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
+import xtdb.api.log.SourceMessage
 import xtdb.database.proto.DatabaseConfig
+import xtdb.indexer.LeaderLogProcessor
+import xtdb.indexer.LogProcessor.LeaderProcessor
 import java.util.*
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.seconds
 import com.google.protobuf.Any as ProtoAny
 
 typealias ExternalSourceToken = ProtoAny
@@ -18,6 +34,7 @@ interface ExternalLog<M> : AutoCloseable {
     interface Factory {
         fun writeTo(dbConfig: DatabaseConfig.Builder)
         fun open(clusters: Map<LogClusterAlias, Log.Cluster>): ExternalLog<*>
+        fun openProcessor(llp: LeaderLogProcessor, dbState: DatabaseState): Log.RecordProcessor<*>
 
         companion object {
             private val registrations = ServiceLoader.load(Registration::class.java).toList()
@@ -47,5 +64,47 @@ interface ExternalLog<M> : AutoCloseable {
         fun fromProto(msg: ProtoAny): Factory
         fun registerSerde(builder: PolymorphicModuleBuilder<Factory>)
         val serializersModule: SerializersModule get() = SerializersModule {}
+    }
+
+    class Demux<M> @JvmOverloads constructor(
+        private val leaderLogProcessor: LeaderLogProcessor,
+        externalLog: ExternalLog<M>, externalSourceToken: ExternalSourceToken?,
+        private val externalProc: Log.RecordProcessor<M>,
+        ctx: CoroutineContext = Dispatchers.Default
+    ) : LeaderProcessor by leaderLogProcessor {
+        private val externalCh = Channel<List<Log.Record<M>>>()
+        private val sourceCh = Channel<List<Log.Record<SourceMessage>>>()
+
+        private val job = CoroutineScope(ctx).launch {
+            try {
+                while (true) {
+                    selectUnbiased<Unit> {
+                        externalCh.onReceive { externalProc.processRecords(it) }
+                        sourceCh.onReceive { leaderLogProcessor.processRecords(it) }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: ClosedReceiveChannelException) {
+                // channels closed externally — normal shutdown, same as cancellation
+            } catch (e: Throwable) {
+                leaderLogProcessor.notifyError(e)
+                externalCh.close(e)
+                sourceCh.close(e)
+            }
+        }
+
+        private val externalSub = externalLog.tailAll(externalSourceToken) { records -> externalCh.send(records) }
+
+        override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+            sourceCh.send(records)
+        }
+
+        override fun close() {
+            externalSub.close()
+            sourceCh.close()
+            externalCh.close()
+            runBlocking { withTimeout(5.seconds) { job.cancelAndJoin() } }
+        }
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -183,6 +183,23 @@ class LeaderLogProcessor(
             finishBlock(txId, resolvedTx.externalSourceToken)
     }
 
+    suspend fun handleExternalTx(resolvedTx: ReplicaMessage.ResolvedTx) {
+        appendToReplica(resolvedTx)
+
+        val result =
+            if (resolvedTx.committed)
+                TransactionCommitted(resolvedTx.txId, resolvedTx.systemTime)
+            else
+                TransactionAborted(resolvedTx.txId, resolvedTx.systemTime, resolvedTx.error)
+
+        watchers.notifyTx(result, latestSourceMsgId, resolvedTx.externalSourceToken)
+
+        if (liveIndex.isFull())
+            finishBlock(latestSourceMsgId, resolvedTx.externalSourceToken)
+    }
+
+    fun notifyError(exception: Throwable) = watchers.notifyError(exception)
+
     override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
         maybeFlushBlock()
 

--- a/core/src/test/kotlin/xtdb/database/ExternalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalLogTest.kt
@@ -1,0 +1,333 @@
+package xtdb.database
+
+import com.google.protobuf.StringValue
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import xtdb.api.TransactionAborted
+import xtdb.api.TransactionCommitted
+import xtdb.api.log.InMemoryLog
+import xtdb.api.log.Log
+import xtdb.api.log.ReplicaMessage
+import xtdb.api.log.SourceMessage
+import xtdb.api.log.Watchers
+import xtdb.catalog.BlockCatalog
+import xtdb.compactor.Compactor
+import xtdb.indexer.*
+import xtdb.storage.MemoryStorage
+import java.time.Instant
+import java.time.InstantSource
+import com.google.protobuf.Any as ProtoAny
+
+class ExternalLogTest {
+
+    private lateinit var allocator: RootAllocator
+    private lateinit var bufferPool: MemoryStorage
+
+    @BeforeEach
+    fun setUp() {
+        allocator = RootAllocator()
+        bufferPool = MemoryStorage(allocator, 0)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        bufferPool.close()
+        allocator.close()
+    }
+
+    private fun leaderProc(
+        sourceLog: InMemoryLog<SourceMessage> = InMemoryLog(InstantSource.system(), 0),
+        replicaLog: InMemoryLog<ReplicaMessage> = InMemoryLog(InstantSource.system(), 0),
+        liveIndex: LiveIndex = mockk(relaxed = true),
+        watchers: Watchers = Watchers(-1),
+    ): LeaderLogProcessor {
+        val blockCatalog = BlockCatalog("test", null)
+        val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
+        val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
+        val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbStorage = DatabaseStorage(sourceLog, replicaLog, null, bufferPool, null)
+        val replicaProducer = replicaLog.openAtomicProducer("test-leader")
+        val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
+        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
+
+        return LeaderLogProcessor(
+            allocator, dbStorage, replicaProducer,
+            dbState, mockk(relaxed = true), watchers,
+            emptySet(), null, blockUploader, afterSourceMsgId = -1, afterReplicaMsgId = -1
+        )
+    }
+
+    /**
+     * Simple in-memory ExternalLog for testing.
+     * Send records to [channel] to simulate external events arriving.
+     */
+    class InMemoryExternalLog<M>(
+        val channel: Channel<List<Log.Record<M>>> = Channel(100)
+    ) : ExternalLog<M> {
+
+        override fun tailAll(
+            afterToken: ExternalSourceToken?,
+            processor: Log.RecordProcessor<M>
+        ): Log.Subscription {
+            val scope = CoroutineScope(Dispatchers.Default)
+            val job = scope.launch {
+                for (records in channel) {
+                    processor.processRecords(records)
+                }
+            }
+            return Log.Subscription { runBlocking { job.cancelAndJoin() } }
+        }
+
+        override fun close() {
+            channel.close()
+        }
+    }
+
+    @Test
+    fun `handleExternalTx appends to replica log and notifies watchers`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(-1)
+        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
+
+        val now = Instant.now()
+        lp.handleExternalTx(
+            ReplicaMessage.ResolvedTx(
+                txId = 0, systemTime = now,
+                committed = true, error = null,
+                tableData = emptyMap(),
+            )
+        )
+
+        assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have received a message")
+
+        val replicaMessages = mutableListOf<ReplicaMessage>()
+        val sub = replicaLog.tailAll(-1) { records ->
+            replicaMessages.addAll(records.map { it.message })
+        }
+        Thread.sleep(200)
+        sub.close()
+
+        assertEquals(1, replicaMessages.size)
+        val resolved = replicaMessages[0] as ReplicaMessage.ResolvedTx
+        assertTrue(resolved.committed)
+        assertEquals(0, resolved.txId)
+    }
+
+    @Test
+    fun `Demux routes external records to external processor`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(-1)
+        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
+
+        val externalLog = InMemoryExternalLog<String>()
+        val processedRecords = mutableListOf<String>()
+
+        val extProc = Log.RecordProcessor<String> { records ->
+            for (record in records) {
+                processedRecords.add(record.message)
+
+                lp.handleExternalTx(
+                    ReplicaMessage.ResolvedTx(
+                        txId = record.logOffset, systemTime = record.logTimestamp,
+                        committed = true, error = null,
+                        tableData = emptyMap(),
+                    )
+                )
+            }
+        }
+
+        val demux = ExternalLog.Demux(lp, externalLog, null, extProc)
+
+        try {
+            val now = Instant.now()
+            externalLog.channel.send(listOf(
+                Log.Record(0, 0, now, "event-1"),
+                Log.Record(0, 1, now, "event-2"),
+            ))
+
+            // give the demux coroutine time to process
+            Thread.sleep(500)
+
+            assertEquals(listOf("event-1", "event-2"), processedRecords)
+            assertTrue(replicaLog.latestSubmittedOffset >= 1, "replica log should have 2 messages")
+        } finally {
+            demux.close()
+        }
+    }
+
+    @Test
+    fun `Demux routes source records to leader processor`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val liveIndex = mockk<LiveIndex>(relaxed = true) {
+            every { latestCompletedTx } returns null
+        }
+        val lp = leaderProc(replicaLog = replicaLog, liveIndex = liveIndex)
+
+        val externalLog = InMemoryExternalLog<String>()
+        val extProc = Log.RecordProcessor<String> { }
+
+        val demux = ExternalLog.Demux(lp, externalLog, null, extProc)
+
+        try {
+            val now = Instant.now()
+
+            // send a source message through the demux
+            demux.processRecords(listOf(
+                Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
+            ))
+
+            // give the demux coroutine time to process
+            Thread.sleep(500)
+
+            // FlushBlock with matching CAS (-1 == no current block) should trigger block finish
+            // which writes BlockBoundary + BlockUploaded to replica
+            assertTrue(replicaLog.latestSubmittedOffset >= 0, "source records should flow through demux to leader")
+        } finally {
+            demux.close()
+        }
+    }
+
+    @Test
+    fun `Demux interleaves source and external records`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(-1)
+        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
+
+        val externalLog = InMemoryExternalLog<String>()
+        val events = mutableListOf<String>()
+
+        val extProc = Log.RecordProcessor<String> { records ->
+            for (record in records) {
+                events.add("ext:${record.message}")
+                lp.handleExternalTx(
+                    ReplicaMessage.ResolvedTx(
+                        txId = record.logOffset, systemTime = record.logTimestamp,
+                        committed = true, error = null,
+                        tableData = emptyMap(),
+                    )
+                )
+            }
+        }
+
+        val demux = ExternalLog.Demux(lp, externalLog, null, extProc)
+
+        try {
+            val now = Instant.now()
+
+            // send external event
+            externalLog.channel.send(listOf(Log.Record(0, 0, now, "first")))
+            Thread.sleep(200)
+
+            // send another external event
+            externalLog.channel.send(listOf(Log.Record(0, 1, now, "second")))
+            Thread.sleep(200)
+
+            assertEquals(listOf("ext:first", "ext:second"), events)
+
+            // replica log should have both external txs
+            val replicaMessages = mutableListOf<ReplicaMessage>()
+            val sub = replicaLog.tailAll(-1) { records ->
+                replicaMessages.addAll(records.map { it.message })
+            }
+            Thread.sleep(200)
+            sub.close()
+
+            assertEquals(2, replicaMessages.size)
+            assertTrue(replicaMessages.all { it is ReplicaMessage.ResolvedTx })
+        } finally {
+            demux.close()
+        }
+    }
+
+    @Test
+    fun `handleExternalTx with aborted transaction`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(-1)
+        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
+
+        val now = Instant.now()
+        lp.handleExternalTx(
+            ReplicaMessage.ResolvedTx(
+                txId = 0, systemTime = now,
+                committed = false, error = RuntimeException("bad data"),
+                tableData = emptyMap(),
+            )
+        )
+
+        val result = watchers.awaitTx(0)
+        assertNotNull(result)
+        assertInstanceOf(TransactionAborted::class.java, result)
+
+        val replicaMessages = mutableListOf<ReplicaMessage>()
+        val sub = replicaLog.tailAll(-1) { records ->
+            replicaMessages.addAll(records.map { it.message })
+        }
+        Thread.sleep(200)
+        sub.close()
+
+        assertEquals(1, replicaMessages.size)
+        val resolved = replicaMessages[0] as ReplicaMessage.ResolvedTx
+        assertFalse(resolved.committed)
+    }
+
+    @Test
+    fun `handleExternalTx threads externalSourceToken to watchers`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(-1)
+        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
+
+        val token = ProtoAny.pack(StringValue.of("kafka-offset:42"))
+        val now = Instant.now()
+
+        lp.handleExternalTx(
+            ReplicaMessage.ResolvedTx(
+                txId = 0, systemTime = now,
+                committed = true, error = null,
+                tableData = emptyMap(),
+                externalSourceToken = token,
+            )
+        )
+
+        val watcherToken = watchers.externalSourceToken
+        assertNotNull(watcherToken)
+        assertEquals("kafka-offset:42", watcherToken!!.unpack(StringValue::class.java).value)
+    }
+
+    @Test
+    fun `Demux error in external processor propagates to watchers`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(-1)
+        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
+
+        val externalLog = InMemoryExternalLog<String>()
+
+        val extProc = Log.RecordProcessor<String> {
+            throw RuntimeException("external processor failed")
+        }
+
+        val demux = ExternalLog.Demux(lp, externalLog, null, extProc)
+
+        try {
+            val now = Instant.now()
+            externalLog.channel.send(listOf(Log.Record(0, 0, now, "boom")))
+
+            Thread.sleep(500)
+
+            assertNotNull(watchers.exception, "watchers should be in failed state")
+        } finally {
+            demux.close()
+        }
+    }
+}

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumProcessor.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumProcessor.kt
@@ -4,20 +4,48 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 import org.slf4j.LoggerFactory
+import xtdb.api.TransactionKey
 import xtdb.api.log.KafkaCluster
 import xtdb.api.log.KafkaCluster.AtomicProducer.Companion.withTx
 import xtdb.api.log.Log
 import xtdb.api.log.SourceMessage
+import xtdb.database.DatabaseName
+import xtdb.database.ExternalSourceToken
+import xtdb.indexer.LiveIndex
+import xtdb.table.TableRef
+import xtdb.time.InstantUtil.asMicros
 import xtdb.tx.TxOp
-import xtdb.tx.toArrowBytes
 import xtdb.tx.serializeUserMetadata
+import xtdb.tx.toArrowBytes
+import xtdb.util.asIid
 import xtdb.util.safeMap
 import xtdb.util.useAll
+import java.nio.ByteBuffer
 import java.time.ZoneId
-import xtdb.database.ExternalSourceToken
 import com.google.protobuf.Any as ProtoAny
 
 private val logger = LoggerFactory.getLogger(DebeziumProcessor::class.java)
+
+fun LiveIndex.Tx.indexCdcEvent(
+    dbName: DatabaseName, event: CdcEvent, txKey: TransactionKey
+) {
+    val table = TableRef(dbName, event.schema, event.table)
+    val liveTableTx = liveTable(table)
+
+    when (event) {
+        is CdcEvent.Put -> {
+            val iid = ByteBuffer.wrap(event.doc["_id"]!!.asIid)
+            val validFrom = event.validFrom?.asMicros ?: txKey.systemTime.asMicros
+            val validTo = event.validTo?.asMicros ?: Long.MAX_VALUE
+            liveTableTx.logPut(iid, validFrom, validTo) { liveTableTx.docWriter.writeObject(event.doc) }
+        }
+
+        is CdcEvent.Delete -> {
+            val iid = ByteBuffer.wrap(event.id.asIid)
+            liveTableTx.logDelete(iid, txKey.systemTime.asMicros, Long.MAX_VALUE)
+        }
+    }
+}
 
 class DebeziumProcessor(
     private val producer: KafkaCluster.AtomicProducer<SourceMessage>,

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumSource.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumSource.kt
@@ -5,18 +5,62 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.subclass
+import xtdb.api.TransactionKey
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
+import xtdb.api.log.ReplicaMessage
+import xtdb.database.DatabaseState
 import xtdb.database.ExternalLog
 import xtdb.database.proto.DatabaseConfig
 import xtdb.debezium.proto.debeziumSourceConfig
+import xtdb.indexer.Indexer.Companion.addTxRow
+import xtdb.indexer.LeaderLogProcessor
+import xtdb.indexer.LiveIndex
 import xtdb.debezium.proto.DebeziumSourceConfig as DebeziumSourceConfigProto
 import com.google.protobuf.Any as ProtoAny
+
+private fun buildTableData(tx: LiveIndex.Tx): Map<String, ByteArray> =
+    tx.liveTables.mapNotNull { (tableRef, tableTx) ->
+        tableTx.serializeTxData()?.let { tableRef.schemaAndTable to it }
+    }.toMap()
 
 @Serializable
 @SerialName("!Debezium")
 data class DebeziumSource(val log: DebeziumLog.Factory) : ExternalLog.Factory {
     override fun open(clusters: Map<LogClusterAlias, Log.Cluster>) = log.openLog(clusters)
+
+    override fun openProcessor(
+        llp: LeaderLogProcessor, dbState: DatabaseState
+    ): Log.RecordProcessor<DebeziumMessage> {
+        val dbName = dbState.name
+        val liveIndex = dbState.liveIndex
+
+        return object : Log.RecordProcessor<DebeziumMessage> {
+            override suspend fun processRecords(records: List<Log.Record<DebeziumMessage>>) {
+                for (record in records) {
+                    val token = ProtoAny.pack(record.message.offsets, "xtdb.debezium")
+                    // TODO: extract upstream txId from message (#5330)
+                    val txKey = TransactionKey(record.logOffset, record.logTimestamp)
+
+                    liveIndex.startTx(txKey).use { tx ->
+                        for (event in record.message.ops) {
+                            tx.indexCdcEvent(dbName, event, txKey)
+                        }
+                        tx.addTxRow(dbName, txKey, null)
+
+                        val tableData = buildTableData(tx)
+                        tx.commit()
+
+                        llp.handleExternalTx(ReplicaMessage.ResolvedTx(
+                            txId = txKey.txId, systemTime = record.logTimestamp,
+                            committed = true, error = null, tableData = tableData,
+                            externalSourceToken = token,
+                        ))
+                    }
+                }
+            }
+        }
+    }
 
     override fun writeTo(dbConfig: DatabaseConfig.Builder) {
         dbConfig.externalLog = ProtoAny.pack(debeziumSourceConfig {

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.Network
 import org.testcontainers.containers.wait.strategy.Wait
@@ -757,6 +758,73 @@ class DebeziumIntegrationTest {
                    WHERE (user_metadata).source = 'debezium'"""
             )
             assertEquals(0, primaryTxs.size, "Primary database should have no debezium transactions")
+        }
+    }
+
+    @Test
+    fun `CDC events ingested via external log (direct indexing)`() = runTest(timeout = 120.seconds) {
+        assumeTrue(
+            System.getenv("XTDB_SINGLE_WRITER")?.toBooleanStrictOrNull() == true,
+            "external log requires single-writer mode"
+        )
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS cdc_direct (_id INT PRIMARY KEY, name TEXT, email TEXT)",
+            "INSERT INTO cdc_direct (_id, name, email) VALUES (1, 'Alice', 'alice@example.com')",
+        )
+
+        registerConnectorAndAwait()
+
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+        val debeziumGroupId = "test-debezium-direct-${UUID.randomUUID()}"
+
+        openNodeOnSourceTopic(sourceTopic).use { node ->
+            node.getConnection().use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("""ATTACH DATABASE cdc_direct_db WITH $$
+                        log: !Kafka
+                          cluster: kafka
+                          topic: test-direct-replica-${UUID.randomUUID()}
+                        externalLog: !Debezium
+                          log: !Kafka
+                            logCluster: kafka
+                            tableTopic: testdb.public.cdc_direct
+                            groupId: $debeziumGroupId
+                    $$""")
+                }
+            }
+
+            pgExecute(
+                "INSERT INTO cdc_direct (_id, name, email) VALUES (2, 'Bob', 'bob@example.com')",
+                "UPDATE cdc_direct SET email = 'alice-new@example.com' WHERE _id = 1",
+                "DELETE FROM cdc_direct WHERE _id = 2",
+            )
+
+            // snapshot(Alice) + insert(Bob) + update(Alice) + delete(Bob)
+            awaitTxs(node, 4, db = "cdc_direct_db")
+
+            val history = xtQueryDb(node, "cdc_direct_db",
+                """SELECT _id, name, email, _valid_from, _valid_to
+                   FROM public.cdc_direct
+                   FOR ALL VALID_TIME
+                   ORDER BY _id, _valid_from"""
+            )
+
+            assertEquals(3, history.size, "Expected 3 history rows (2 Alice + 1 Bob)")
+
+            // Alice: snapshot row then updated row
+            assertEquals(1L, (history[0]["_id"] as Number).toLong())
+            assertEquals("alice@example.com", history[0]["email"])
+            assertTrue(history[0]["_valid_to"] != null, "Snapshot row should be superseded")
+
+            assertEquals(1L, (history[1]["_id"] as Number).toLong())
+            assertEquals("alice-new@example.com", history[1]["email"])
+            assertNull(history[1]["_valid_to"], "Updated row should be current")
+
+            // Bob: inserted then deleted
+            assertEquals(2L, (history[2]["_id"] as Number).toLong())
+            assertEquals("bob@example.com", history[2]["email"])
+            assertTrue(history[2]["_valid_to"] != null, "Bob should have valid_to from DELETE")
         }
     }
 


### PR DESCRIPTION
## Context

Part of #5330 (multi-DB stage 3: external source logs).
This is Phase 6 — the leader integration that makes CDC events flow through the single-writer pipeline without touching the source log or Clojure indexer.

Prior phases (already merged) established the plumbing: `ExternalLog<M>` interface, `externalSourceToken` threaded through blocks/watchers/replica messages, `Database.Config.externalLog` with YAML+proto round-trip, and `KafkaDebeziumLog` as the Debezium implementation.
This PR wires it all together.

## Approach

CDC events are simple puts and deletes — they don't need the full SQL indexer.
`indexCdcEvent` applies them directly to `LiveIndex.Tx`, and `DebeziumSource.openProcessor` wraps that into a `Log.RecordProcessor<DebeziumMessage>` that builds `tableData` and hands a `ResolvedTx` to the leader.

The core abstraction is `ExternalLog.Demux<M>`, which multiplexes external and source log records into a single coroutine via `selectUnbiased` over two channels.
This ensures serialised access to the `LeaderLogProcessor` — external and source records never interleave within a single `processRecords` call.
On error from either processor, the demux tears down both channels and propagates to watchers via `notifyError`.

`LeaderLogProcessor.handleExternalTx` appends the resolved tx to the replica log and notifies watchers using `latestSourceMsgId` (not the external tx id) — external transactions don't advance the source message position.

`Database.openLeaderSystem` conditionally wraps the leader processor in a Demux when `externalLog` is configured.
Single-writer only — external log has no meaning in the multi-writer world.

## Reading guide

Best read bottom-up, following the data flow:

1. **`DebeziumProcessor.kt`** — `indexCdcEvent` extension on `LiveIndex.Tx`. Lowest layer: takes a `CdcEvent` (Put/Delete) and applies it directly to the live index via `docWriter.writeObject`. Uses `asIid` for internal ID conversion, same as the SQL indexer.

2. **`DebeziumSource.kt`** — `openProcessor` creates a typed `RecordProcessor<DebeziumMessage>`. Per record: opens a `LiveIndex.Tx`, applies each event, writes a tx row, serialises table data via `serializeTxData()`, commits, then calls `handleExternalTx` with the resolved tx and a packed Kafka offset token. One tx per Debezium record (not per event within a record).

3. **`LeaderLogProcessor.kt`** — `handleExternalTx` mirrors `handleResolvedTx` but passes `latestSourceMsgId` to watchers (external txs don't advance source position). Also passes `externalSourceToken` through for CDC resumption. `notifyError` exposes watcher error propagation for the Demux.

4. **`ExternalLog.kt`** — `Demux<M>` is the multiplexer. Two channels (`externalCh`, `sourceCh`), one coroutine running `selectUnbiased`. External subscription feeds `externalCh`; source records arrive via the overridden `processRecords` → `sourceCh`. `CancellationException` is rethrown (normal shutdown); other errors propagate to watchers and close both channels.

5. **`Database.kt`** — `openLeaderSystem` conditionally wraps the LLP in a Demux when both `dbConfig.externalLog` and `storage.externalLog` are present. The `@Suppress("UNCHECKED_CAST")` is unavoidable — `ExternalLog<M>` is erased by this point. Close order: demux first, then LLP (so watermark reads after close see final values).

6. **Tests** — `ExternalLogTest` validates core abstractions with `InMemoryExternalLog<String>` (no Debezium). `DebeziumIntegrationTest` validates the full pipeline end-to-end, gated on `XTDB_SINGLE_WRITER`.

## Known limitations

- **txId space**: `DebeziumSource.openProcessor` currently uses raw Kafka offsets as txIds (`TODO` in code). This works for epoch-0 in-memory Kafka but will need proper ID allocation for production use. Tracked under #5330 Phase 7.
- **Phase 5c** (`sendOffsetsToTransaction` removal) is blocked on this landing — the replica log is now the primary offset store, so the belt-and-braces Kafka offset commit can be removed in a follow-up.
- **Restart resumption** (Phase 7) is not yet tested end-to-end — the `externalSourceToken` plumbing is in place but the restart flow needs its own test.

## Tests

- **Core** (`ExternalLogTest`): 7 tests validating Demux routing (both channels), `handleExternalTx` (committed + aborted), `externalSourceToken` threading to watchers, and error propagation — uses `InMemoryExternalLog<String>`, no Debezium dependency.
- **Integration** (`DebeziumIntegrationTest`): full Postgres → Debezium Connect → Kafka → `ATTACH DATABASE` with `externalLog: !Debezium` → queryable via pgwire. Gated on `XTDB_SINGLE_WRITER=true` via `assumeTrue`.

Also includes a tidy-first change: `TrieCatalog.Factory` resolved internally in `DatabaseState.open` (removes factory threading through `Database.open` → `DatabaseCatalog` → `db_catalog.clj`), making `DatabaseState.open` self-contained for direct test construction.