### PR TITLE
fix: structured concurrency for database subscriptions

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -55,8 +55,6 @@ class InMemoryLog<M> @JvmOverloads constructor(
         }
     }
 
-    private val subscriberScope = scope + SupervisorJob(scope.coroutineContext.job)
-
     internal data class NewMessage<M>(
         val message: M,
         val onCommit: CompletableDeferred<MessageMetadata>
@@ -135,43 +133,41 @@ class InMemoryLog<M> @JvmOverloads constructor(
         }
     }
 
-    override fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>): Subscription {
+    override suspend fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>) = coroutineScope {
         var latestCompletedOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
-        val job = subscriberScope.launch {
-            val ch = committedCh
-                .filter {
-                    val logOffset = it.logOffset
-                    check(logOffset <= latestCompletedOffset + 1) {
-                        "InMemoryLog emitted out-of-order record (expected ${latestCompletedOffset + 1}, got $logOffset)"
-                    }
-                    logOffset > latestCompletedOffset
+        val ch = committedCh
+            .filter {
+                val logOffset = it.logOffset
+                check(logOffset <= latestCompletedOffset + 1) {
+                    "InMemoryLog emitted out-of-order record (expected ${latestCompletedOffset + 1}, got $logOffset)"
                 }
-                .onEach { latestCompletedOffset = it.logOffset }
-                .buffer(100)
-                .produceIn(this)
-
-            while (isActive) {
-                val records = select {
-                    ch.onReceiveCatching { if (it.isClosed) emptyList() else listOf(it.getOrThrow()) }
-
-                    @OptIn(ExperimentalCoroutinesApi::class)
-                    onTimeout(1.minutes) { emptyList() }
-                }
-
-                processor.processRecords(records)
+                logOffset > latestCompletedOffset
             }
-        }
+            .onEach { latestCompletedOffset = it.logOffset }
+            .buffer(100)
+            .produceIn(this)
 
-        return Subscription { runBlocking { withTimeout(5.seconds) { job.cancelAndJoin() } } }
+        while (isActive) {
+            val records = select {
+                ch.onReceiveCatching { if (it.isClosed) emptyList() else listOf(it.getOrThrow()) }
+
+                @OptIn(ExperimentalCoroutinesApi::class)
+                onTimeout(1.minutes) { emptyList() }
+            }
+
+            processor.processRecords(records)
+        }
     }
 
-    override fun openGroupSubscription(listener: SubscriptionListener<M>): Subscription {
+    override suspend fun openGroupSubscription(listener: SubscriptionListener<M>) {
         val spec = listener.onPartitionsAssignedSync(listOf(0))
-        val sub = spec?.let { tailAll(it.afterMsgId, it.processor) }
-        return Subscription {
-            sub?.close()
-            listener.onPartitionsRevokedSync(listOf(0))
+        if (spec != null) {
+            try {
+                tailAll(spec.afterMsgId, spec.processor)
+            } finally {
+                listener.onPartitionsRevokedSync(listOf(0))
+            }
         }
     }
 

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -271,76 +271,74 @@ class LocalLog<M>(
         }
     }
 
-    override fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>): Subscription {
+    override suspend fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>) = coroutineScope {
         var latestCompletedOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
         val ch = Channel<Record<M>>(100)
 
-        val subscription = scope.launch(SupervisorJob()) {
-            launch {
-                committedCh
-                    .onSubscription {
-                        val targetOffset = mutex.withLock { latestSubmittedOffset }
-                        if (targetOffset < 0) return@onSubscription
+        launch {
+            committedCh
+                .onSubscription {
+                    val targetOffset = mutex.withLock { latestSubmittedOffset }
+                    if (targetOffset < 0) return@onSubscription
 
-                        val catchUpRecords = runInterruptible {
-                            FileChannel.open(logFilePath).use { fileCh ->
-                                val latestCompleted = latestCompletedOffset
-                                if (latestCompleted >= 0) {
-                                    fileCh.position(latestCompleted)
-                                    fileCh.readMessage()
-                                }
+                    val catchUpRecords = runInterruptible {
+                        FileChannel.open(logFilePath).use { fileCh ->
+                            val latestCompleted = latestCompletedOffset
+                            if (latestCompleted >= 0) {
+                                fileCh.position(latestCompleted)
+                                fileCh.readMessage()
+                            }
 
-                                buildList {
-                                    while (fileCh.position() <= targetOffset) {
-                                        fileCh.readMessage()?.let { add(it) }
-                                    }
+                            buildList {
+                                while (fileCh.position() <= targetOffset) {
+                                    fileCh.readMessage()?.let { add(it) }
                                 }
                             }
                         }
-
-                        for (record in catchUpRecords) {
-                            ch.send(record)
-                        }
-
-                        latestCompletedOffset = targetOffset
                     }
-                    .onEach {
-                        if (it.logOffset > latestCompletedOffset) {
-                            latestCompletedOffset = it.logOffset
-                            ch.send(it)
-                        }
-                    }
-                    .onCompletion { ch.close() }
-                    .catch {
-                        try {
-                            throw it
-                        } catch (_: ClosedByInterruptException) {
-                            throw CancellationException()
-                        } catch (_: InterruptedException) {
-                            throw CancellationException()
-                        }
-                    }
-                    .collect()
-            }
 
-            while (isActive) {
-                val msg = withTimeoutOrNull(1.minutes) {
-                    ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
+                    for (record in catchUpRecords) {
+                        ch.send(record)
+                    }
+
+                    latestCompletedOffset = targetOffset
                 }
-                if (msg != null) processor.processRecords(listOf(msg))
-            }
+                .onEach {
+                    if (it.logOffset > latestCompletedOffset) {
+                        latestCompletedOffset = it.logOffset
+                        ch.send(it)
+                    }
+                }
+                .onCompletion { ch.close() }
+                .catch {
+                    try {
+                        throw it
+                    } catch (_: ClosedByInterruptException) {
+                        throw CancellationException()
+                    } catch (_: InterruptedException) {
+                        throw CancellationException()
+                    }
+                }
+                .collect()
         }
 
-        return Subscription { runBlocking { withTimeout(5.seconds) { subscription.cancelAndJoin() } } }
+        while (isActive) {
+            val msg = withTimeoutOrNull(1.minutes) {
+                ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
+            }
+            if (msg != null) processor.processRecords(listOf(msg))
+        }
     }
 
-    override fun openGroupSubscription(listener: SubscriptionListener<M>): Subscription {
+    override suspend fun openGroupSubscription(listener: SubscriptionListener<M>) {
         val spec = listener.onPartitionsAssignedSync(listOf(0))
-        val sub = spec?.let { tailAll(it.afterMsgId, it.processor) }
-        return Subscription {
-            sub?.close()
-            listener.onPartitionsRevokedSync(listOf(0))
+        if (spec != null) {
+            try {
+                tailAll(spec.afterMsgId, spec.processor)
+            } finally {
+                listener.onPartitionsRevokedSync(listOf(0))
+            }
         }
     }
 

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -167,8 +167,8 @@ interface Log<M> : AutoCloseable {
      */
     fun readRecords(fromMsgId: MessageId, toMsgId: MessageId): Sequence<Record<M>>
 
-    fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>): Subscription
-    fun openGroupSubscription(listener: SubscriptionListener<M>): Subscription
+    suspend fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>)
+    suspend fun openGroupSubscription(listener: SubscriptionListener<M>)
 
     interface SubscriptionListener<M> {
         suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<M>?

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
@@ -125,10 +125,10 @@ class ReadOnlyLocalLog<M>(
         }
     }
 
-    override fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>): Log.Subscription {
+    override suspend fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) = coroutineScope {
         val ch = Channel<Log.Record<M>>(100)
 
-        val producerJob = scope.launch(SupervisorJob()) {
+        launch {
             var currentOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
             FileSystems.getDefault().newWatchService().use { watchService ->
@@ -164,28 +164,22 @@ class ReadOnlyLocalLog<M>(
             }
         }
 
-        val consumerJob = scope.launch(SupervisorJob()) {
-            try {
-                while (isActive) {
-                    val msg = withTimeoutOrNull(1.minutes) {
-                        ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
-                    }
-                    if (msg != null) processor.processRecords(listOf(msg))
-                }
-            } finally {
-                producerJob.cancelAndJoin()
+        while (isActive) {
+            val msg = withTimeoutOrNull(1.minutes) {
+                ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
             }
+            if (msg != null) processor.processRecords(listOf(msg))
         }
-
-        return Log.Subscription { runBlocking { withTimeout(5.seconds) { consumerJob.cancelAndJoin() } } }
     }
 
-    override fun openGroupSubscription(listener: Log.SubscriptionListener<M>): Log.Subscription {
+    override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>) {
         val spec = listener.onPartitionsAssignedSync(listOf(0))
-        val sub = spec?.let { tailAll(it.afterMsgId, it.processor) }
-        return Subscription {
-            sub?.close()
-            listener.onPartitionsRevokedSync(listOf(0))
+        if (spec != null) {
+            try {
+                tailAll(spec.afterMsgId, spec.processor)
+            } finally {
+                listener.onPartitionsRevokedSync(listOf(0))
+            }
         }
     }
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -169,8 +169,10 @@ class Database(
             }
 
             var processor: AutoCloseable? = null
-            val job = SupervisorJob()
-            val scope = CoroutineScope(job)
+            val job = Job()
+            val scope = CoroutineScope(job + CoroutineExceptionHandler { _, e ->
+                watchers.notifyError(e)
+            })
 
             if (indexerConfig.enabled) {
                 if (singleWriter) {

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -59,7 +59,7 @@ class Database(
     private val watchers: Watchers,
     private val meterRegistry: MeterRegistry?,
     val compactorOrNull: Compactor.ForDatabase? = null,
-    private val subscription: Log.Subscription? = null,
+    private val job: Job? = null,
     private val processor: AutoCloseable? = null,
     private val indexerForDb: Indexer.ForDatabase? = null,
     private val registeredGauges: List<Gauge> = emptyList(),
@@ -104,7 +104,8 @@ class Database(
 
     override fun close() {
         meterRegistry?.let { reg -> registeredGauges.forEach { reg.remove(it) } }
-        listOf(subscription, processor, compactorOrNull, indexerForDb, queryState, storage, allocator).closeAll()
+        job?.let { runBlocking { it.cancelAndJoin() } }
+        listOf(processor, compactorOrNull, indexerForDb, queryState, storage, allocator).closeAll()
     }
 
     fun submitTxBlocking(ops: List<TxOp>, opts: TxOpts): Xtdb.SubmittedTx {
@@ -168,7 +169,8 @@ class Database(
             }
 
             var processor: AutoCloseable? = null
-            var subscription: Log.Subscription? = null
+            val job = SupervisorJob()
+            val scope = CoroutineScope(job)
 
             if (indexerConfig.enabled) {
                 if (singleWriter) {
@@ -233,11 +235,11 @@ class Database(
                         )
                     }
 
-                    val lp = LogProcessor(procFactory, storage, state, blockUploader, base.meterRegistry)
+                    val lp = LogProcessor(procFactory, storage, state, blockUploader, scope, base.meterRegistry)
                     processor = lp
 
                     if (!readOnly) {
-                        subscription = storage.sourceLog.openGroupSubscription(lp)
+                        scope.launch { storage.sourceLog.openGroupSubscription(lp) }
                     }
                 } else {
                     val srcProc = SourceLogProcessor(
@@ -252,7 +254,7 @@ class Database(
                     processor = srcProc
 
                     val latestProcessedMsgId = blockCatalog.latestProcessedMsgId ?: -1
-                    subscription = storage.sourceLog.tailAll(latestProcessedMsgId, srcProc)
+                    scope.launch { storage.sourceLog.tailAll(latestProcessedMsgId, srcProc) }
                 }
             }
 
@@ -288,7 +290,7 @@ class Database(
                 watchers = watchers,
                 meterRegistry = meterRegistry,
                 compactorOrNull = compactorForDb,
-                subscription = subscription,
+                job = job,
                 processor = processor,
                 indexerForDb = indexerForDb,
                 registeredGauges = gauges,

--- a/core/src/main/kotlin/xtdb/database/ExternalLog.kt
+++ b/core/src/main/kotlin/xtdb/database/ExternalLog.kt
@@ -5,11 +5,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.selects.selectUnbiased
-import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
@@ -21,14 +18,13 @@ import xtdb.indexer.LeaderLogProcessor
 import xtdb.indexer.LogProcessor.LeaderProcessor
 import java.util.*
 import kotlin.coroutines.CoroutineContext
-import kotlin.time.Duration.Companion.seconds
 import com.google.protobuf.Any as ProtoAny
 
 typealias ExternalSourceToken = ProtoAny
 
 interface ExternalLog<M> : AutoCloseable {
 
-    fun tailAll(afterToken: ExternalSourceToken?, processor: MessageProcessor<M>): Log.Subscription
+    suspend fun tailAll(afterToken: ExternalSourceToken?, processor: MessageProcessor<M>)
 
     fun interface MessageProcessor<M> {
         suspend fun processMessages(msgs: List<M>)
@@ -78,8 +74,12 @@ interface ExternalLog<M> : AutoCloseable {
         private val externalCh = Channel<List<M>>()
         private val sourceCh = Channel<List<Log.Record<SourceMessage>>>()
 
-        private val job = CoroutineScope(ctx).launch {
+        private val scope = CoroutineScope(ctx)
+
+        private val job = scope.launch {
             try {
+                launch { externalLog.tailAll(externalSourceToken) { msgs -> externalCh.send(msgs) } }
+
                 while (true) {
                     selectUnbiased {
                         externalCh.onReceive { externalProc.processMessages(it) }
@@ -97,17 +97,14 @@ interface ExternalLog<M> : AutoCloseable {
             }
         }
 
-        private val externalSub = externalLog.tailAll(externalSourceToken) { msgs -> externalCh.send(msgs) }
-
         override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
             sourceCh.send(records)
         }
 
         override fun close() {
-            externalSub.close()
             sourceCh.close()
             externalCh.close()
-            runBlocking { withTimeout(5.seconds) { job.cancelAndJoin() } }
+            job.cancel()
         }
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -2,6 +2,9 @@ package xtdb.indexer
 
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.database.DatabaseState
@@ -18,6 +21,7 @@ class LogProcessor(
     dbStorage: DatabaseStorage,
     private val dbState: DatabaseState,
     private val blockUploader: BlockUploader,
+    private val scope: CoroutineScope,
     meterRegistry: MeterRegistry? = null,
 ) : Log.SubscriptionListener<SourceMessage>, AutoCloseable {
 
@@ -66,9 +70,9 @@ class LogProcessor(
         val proc: LeaderProcessor
     }
 
-    private class FollowerSystem(val proc: FollowerProcessor, private val sub: Log.Subscription) : SubSystem {
+    private class FollowerSystem(val proc: FollowerProcessor, private val job: Job) : SubSystem {
         override fun close() {
-            sub.close()
+            job.cancel()
             proc.close()
         }
     }
@@ -88,7 +92,7 @@ class LogProcessor(
                 }
             }
 
-            FollowerSystem(proc, replicaLog.tailAll(latestReplicaMsgId, proc))
+            FollowerSystem(proc, scope.launch { replicaLog.tailAll(latestReplicaMsgId, proc) })
         }
 
     @Volatile

--- a/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
+++ b/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
@@ -108,9 +108,9 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
         override fun close() {}
     }
 
-    override fun tailAll(afterMsgId: Long, processor: Log.RecordProcessor<M>): Log.Subscription = error("tailAll")
+    override suspend fun tailAll(afterMsgId: Long, processor: Log.RecordProcessor<M>): Unit = error("tailAll")
 
-    override fun openGroupSubscription(listener: Log.SubscriptionListener<M>): Log.Subscription = error("openGroupSubscription")
+    override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>): Unit = error("openGroupSubscription")
 
     override fun close() = Unit
 }

--- a/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
@@ -1,5 +1,7 @@
 package xtdb.api.log
 
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.RepeatedTest
@@ -22,18 +24,20 @@ class LocalLogTest {
 
         // Create a subscription
         val receivedRecords = mutableListOf<Record<SourceMessage>>()
-        val subscription = log.tailAll(
-            -1L,
-            object : Log.RecordProcessor<SourceMessage> {
-                override suspend fun processRecords(records: List<Record<SourceMessage>>) {
-                    records.forEach { receivedRecords.add(it) }
+        val job = launch {
+            log.tailAll(
+                -1L,
+                object : Log.RecordProcessor<SourceMessage> {
+                    override suspend fun processRecords(records: List<Record<SourceMessage>>) {
+                        records.forEach { receivedRecords.add(it) }
+                    }
                 }
-            }
-        )
+            )
+        }
 
         log.appendMessage(SourceMessage.FlushBlock(1))
 
-        subscription.close()
+        job.cancelAndJoin()
 
         log.close()
     }

--- a/core/src/test/kotlin/xtdb/database/ExternalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalLogTest.kt
@@ -3,12 +3,8 @@ package xtdb.database
 import com.google.protobuf.StringValue
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
@@ -77,17 +73,13 @@ class ExternalLogTest {
         val channel: Channel<List<M>> = Channel(100)
     ) : ExternalLog<M> {
 
-        override fun tailAll(
+        override suspend fun tailAll(
             afterToken: ExternalSourceToken?,
             processor: ExternalLog.MessageProcessor<M>
-        ): Log.Subscription {
-            val scope = CoroutineScope(Dispatchers.Default)
-            val job = scope.launch {
-                for (msgs in channel) {
-                    processor.processMessages(msgs)
-                }
+        ) {
+            for (msgs in channel) {
+                processor.processMessages(msgs)
             }
-            return Log.Subscription { runBlocking { job.cancelAndJoin() } }
         }
 
         override fun close() {
@@ -113,11 +105,11 @@ class ExternalLogTest {
         assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have received a message")
 
         val replicaMessages = mutableListOf<ReplicaMessage>()
-        val sub = replicaLog.tailAll(-1) { records ->
+        val job = launch { replicaLog.tailAll(-1) { records ->
             replicaMessages.addAll(records.map { it.message })
-        }
-        Thread.sleep(200)
-        sub.close()
+        } }
+        delay(200)
+        job.cancelAndJoin()
 
         assertEquals(1, replicaMessages.size)
         val resolved = replicaMessages[0] as ReplicaMessage.ResolvedTx
@@ -148,13 +140,13 @@ class ExternalLogTest {
             }
         }
 
-        val demux = ExternalLog.Demux(lp, externalLog, null, extProc)
+        val demux = ExternalLog.Demux(lp, externalLog, null, extProc, coroutineContext)
 
         try {
             externalLog.channel.send(listOf("event-1", "event-2"))
 
-            // give the demux coroutine time to process
-            Thread.sleep(500)
+            // Demux runs on Dispatchers.Default — real time, not virtual
+            delay(500)
 
             assertEquals(listOf("event-1", "event-2"), processedRecords)
             assertTrue(replicaLog.latestSubmittedOffset >= 1, "replica log should have 2 messages")
@@ -174,7 +166,7 @@ class ExternalLogTest {
         val externalLog = InMemoryExternalLog<String>()
         val extProc = ExternalLog.MessageProcessor<String> { }
 
-        val demux = ExternalLog.Demux(lp, externalLog, null, extProc)
+        val demux = ExternalLog.Demux(lp, externalLog, null, extProc, coroutineContext)
 
         try {
             val now = Instant.now()
@@ -184,8 +176,8 @@ class ExternalLogTest {
                 Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
             ))
 
-            // give the demux coroutine time to process
-            Thread.sleep(500)
+            // Demux runs on Dispatchers.Default — real time, not virtual
+            delay(500)
 
             // FlushBlock with matching CAS (-1 == no current block) should trigger block finish
             // which writes BlockBoundary + BlockUploaded to replica
@@ -217,26 +209,26 @@ class ExternalLogTest {
             }
         }
 
-        val demux = ExternalLog.Demux(lp, externalLog, null, extProc)
+        val demux = ExternalLog.Demux(lp, externalLog, null, extProc, coroutineContext)
 
         try {
             // send external event
             externalLog.channel.send(listOf("first"))
-            Thread.sleep(200)
+            delay(200)
 
             // send another external event
             externalLog.channel.send(listOf("second"))
-            Thread.sleep(200)
+            delay(200)
 
             assertEquals(listOf("ext:first", "ext:second"), events)
 
             // replica log should have both external txs
             val replicaMessages = mutableListOf<ReplicaMessage>()
-            val sub = replicaLog.tailAll(-1) { records ->
+            val job = launch { replicaLog.tailAll(-1) { records ->
                 replicaMessages.addAll(records.map { it.message })
-            }
-            Thread.sleep(200)
-            sub.close()
+            } }
+            delay(200)
+            job.cancelAndJoin()
 
             assertEquals(2, replicaMessages.size)
             assertTrue(replicaMessages.all { it is ReplicaMessage.ResolvedTx })
@@ -265,11 +257,11 @@ class ExternalLogTest {
         assertInstanceOf(TransactionAborted::class.java, result)
 
         val replicaMessages = mutableListOf<ReplicaMessage>()
-        val sub = replicaLog.tailAll(-1) { records ->
+        val job = launch { replicaLog.tailAll(-1) { records ->
             replicaMessages.addAll(records.map { it.message })
-        }
-        Thread.sleep(200)
-        sub.close()
+        } }
+        delay(200)
+        job.cancelAndJoin()
 
         assertEquals(1, replicaMessages.size)
         val resolved = replicaMessages[0] as ReplicaMessage.ResolvedTx
@@ -311,12 +303,12 @@ class ExternalLogTest {
             throw RuntimeException("external processor failed")
         }
 
-        val demux = ExternalLog.Demux(lp, externalLog, null, extProc)
+        val demux = ExternalLog.Demux(lp, externalLog, null, extProc, coroutineContext)
 
         try {
             externalLog.channel.send(listOf("boom"))
 
-            Thread.sleep(500)
+            delay(500)
 
             assertNotNull(watchers.exception, "watchers should be in failed state")
         } finally {

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -3,8 +3,11 @@ package xtdb.indexer
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.apache.arrow.memory.RootAllocator
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import xtdb.api.log.InMemoryLog
@@ -175,12 +178,12 @@ class LeaderLogProcessorTest {
         ))
 
         val replicaMessages = mutableListOf<ReplicaMessage>()
-        val sub = replicaLog.tailAll(-1) { records ->
+        val job = launch { replicaLog.tailAll(-1) { records ->
             replicaMessages.addAll(records.map { it.message })
-        }
+        } }
 
-        Thread.sleep(200)
-        sub.close()
+        delay(200)
+        job.cancelAndJoin()
 
         assertEquals(2, replicaMessages.size, "expected 2 replica messages, got: $replicaMessages")
         assertTrue(replicaMessages[0] is ReplicaMessage.BlockBoundary)

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -3,6 +3,7 @@ package xtdb.indexer
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
@@ -99,7 +100,7 @@ class LogProcessorTest {
         }
 
     @Test
-    fun `fresh node starts up with epoch 0`() {
+    fun `fresh node starts up with epoch 0`() = runTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val bufferPool = mockBufferPool()
@@ -108,21 +109,22 @@ class LogProcessorTest {
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
         val watchers = Watchers(-1)
 
+        val scope = CoroutineScope(SupervisorJob())
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader
+            dbStorage, dbState, blockUploader, scope
         )
 
-        val subscription = sourceLog.openGroupSubscription(logProc)
+        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
 
-        subscription.close()
+        job.cancelAndJoin()
         logProc.close()
         sourceLog.close()
         replicaLog.close()
     }
 
     @Test
-    fun `fresh node starts up with non-zero epoch`() {
+    fun `fresh node starts up with non-zero epoch`() = runTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 1)
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 1)
         val bufferPool = mockBufferPool(epoch = 1)
@@ -131,14 +133,15 @@ class LogProcessorTest {
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
         val watchers = Watchers(-1)
 
+        val scope = CoroutineScope(SupervisorJob())
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader
+            dbStorage, dbState, blockUploader, scope
         )
 
-        val subscription = sourceLog.openGroupSubscription(logProc)
+        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
 
-        subscription.close()
+        job.cancelAndJoin()
         logProc.close()
         sourceLog.close()
         replicaLog.close()
@@ -162,17 +165,20 @@ class LogProcessorTest {
         replicaLog.appendMessage(ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap()))
         replicaProducer.close()
 
+        val scope = CoroutineScope(SupervisorJob())
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader
+            dbStorage, dbState, blockUploader, scope
         )
 
-        val subscription = sourceLog.openGroupSubscription(logProc)
+        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
 
-        // The transition should have replayed the ResolvedTx
+        // wait for the follower→leader transition to complete (runs on Dispatchers.Default)
+        watchers.awaitTx(1)
+
         verify { liveIndex.importTx(any()) }
 
-        subscription.close()
+        runBlocking { job.cancelAndJoin() }
         logProc.close()
         sourceLog.close()
         replicaLog.close()
@@ -194,16 +200,19 @@ class LogProcessorTest {
         // Pre-populate the replica log
         replicaLog.appendMessage(ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap()))
 
+        val scope = CoroutineScope(SupervisorJob())
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader
+            dbStorage, dbState, blockUploader, scope
         )
 
-        val subscription = sourceLog.openGroupSubscription(logProc)
+        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
+
+        watchers.awaitTx(1)
 
         verify { liveIndex.importTx(any()) }
 
-        subscription.close()
+        runBlocking { job.cancelAndJoin() }
         logProc.close()
         sourceLog.close()
         replicaLog.close()

--- a/modules/debezium/build.gradle.kts
+++ b/modules/debezium/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     api(libs.kotlinx.serialization.json)
     api(libs.protobuf.kotlin)
 
+    testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.pgjdbc)

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/KafkaDebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/KafkaDebeziumLog.kt
@@ -17,16 +17,14 @@ import xtdb.api.log.ensureTopicExists
 import xtdb.api.log.LogClusterAlias
 import xtdb.database.ExternalLog
 import xtdb.database.ExternalLog.MessageProcessor
+import xtdb.database.ExternalSourceToken
 import xtdb.debezium.proto.DebeziumOffsetToken
 import xtdb.debezium.proto.KafkaDebeziumLogConfig
 import xtdb.debezium.proto.debeziumOffsetToken
 import xtdb.debezium.proto.kafkaDebeziumLogConfig
 import xtdb.debezium.proto.partitionOffsets
-import xtdb.database.ExternalSourceToken
 import java.time.Duration
 import java.time.Instant
-import kotlin.coroutines.CoroutineContext
-import kotlin.time.Duration.Companion.seconds
 
 private val LOG = LoggerFactory.getLogger(KafkaDebeziumLog::class.java)
 
@@ -36,7 +34,6 @@ class KafkaDebeziumLog @JvmOverloads constructor(
     private val topic: String,
     private val groupId: String,
     private val pollDuration: Duration = Duration.ofSeconds(1),
-    coroutineContext: CoroutineContext = Dispatchers.Default,
 ) : DebeziumLog {
 
     object UnitDeserializer : Deserializer<Unit> {
@@ -76,97 +73,80 @@ class KafkaDebeziumLog @JvmOverloads constructor(
         }
     }
 
-    private val _error = CompletableDeferred<Throwable>()
-    val error: Throwable? get() = if (_error.isCompleted) _error.getCompleted() else null
-    suspend fun awaitError(): Throwable = _error.await()
-
-    // TODO: non-deterministic failures (e.g. node down) currently kill this coroutine silently.
-    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        LOG.error("Fatal error in CDC ingestion — ingestion has stopped", throwable)
-        _error.complete(throwable)
-    }
-
-    private val scope = CoroutineScope(SupervisorJob() + coroutineContext + exceptionHandler)
     val epoch: Int get() = 0
 
-    override fun tailAll(afterToken: ExternalSourceToken?, processor: MessageProcessor<DebeziumMessage>): Log.Subscription {
-        val job = scope.launch {
-            KafkaConsumer(
-                kafkaConfig.plus(
-                    mapOf(
-                        ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false",
-                        ConsumerConfig.GROUP_ID_CONFIG to groupId,
-                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
-                        ConsumerConfig.ISOLATION_LEVEL_CONFIG to "read_committed",
-                    )
-                ),
-                UnitDeserializer,
-                ByteArrayDeserializer()
-            ).use { c ->
-                val partitionOffsets = afterToken?.let { tok ->
-                    val token = tok.unpack(DebeziumOffsetToken::class.java)
-                    token.dbzmTopicOffsetsMap[topic]?.offsetsList
-                        ?.mapIndexedNotNull { partition, offset ->
-                            if (offset >= 0) TopicPartition(topic, partition) to offset else null
-                        }
-                        ?.takeIf { it.isNotEmpty() }
+    override suspend fun tailAll(afterToken: ExternalSourceToken?, processor: MessageProcessor<DebeziumMessage>) {
+        KafkaConsumer(
+            kafkaConfig.plus(
+                mapOf(
+                    ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false",
+                    ConsumerConfig.GROUP_ID_CONFIG to groupId,
+                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
+                    ConsumerConfig.ISOLATION_LEVEL_CONFIG to "read_committed",
+                )
+            ),
+            UnitDeserializer,
+            ByteArrayDeserializer()
+        ).use { c ->
+            val partitionOffsets = afterToken?.let { tok ->
+                val token = tok.unpack(DebeziumOffsetToken::class.java)
+                token.dbzmTopicOffsetsMap[topic]?.offsetsList
+                    ?.mapIndexedNotNull { partition, offset ->
+                        if (offset >= 0) TopicPartition(topic, partition) to offset else null
+                    }
+                    ?.takeIf { it.isNotEmpty() }
+            }
+
+            if (partitionOffsets != null) {
+                c.assign(partitionOffsets.map { it.first })
+                partitionOffsets.forEach { (tp, offset) -> c.seek(tp, offset + 1) }
+            } else {
+                c.subscribe(listOf(topic))
+            }
+
+            while (currentCoroutineContext().isActive) {
+                val records = runInterruptible(Dispatchers.IO) {
+                    try {
+                        c.poll(pollDuration)
+                    } catch (_: InterruptException) {
+                        throw InterruptedException()
+                    }
                 }
 
-                if (partitionOffsets != null) {
-                    c.assign(partitionOffsets.map { it.first })
-                    partitionOffsets.forEach { (tp, offset) -> c.seek(tp, offset + 1) }
-                } else {
-                    c.subscribe(listOf(topic))
-                }
+                if (!records.isEmpty()) {
+                    val ops = mutableListOf<CdcEvent>()
+                    var maxOffset = -1L
+                    var latestTimestamp = Instant.EPOCH
 
-                while (isActive) {
-                    val records = runInterruptible(Dispatchers.IO) {
-                        try {
-                            c.poll(pollDuration)
-                        } catch (_: InterruptException) {
-                            throw InterruptedException()
-                        }
+                    for (consumerRecord in records) {
+                        maxOffset = maxOf(maxOffset, consumerRecord.offset())
+                        latestTimestamp = maxOf(latestTimestamp, Instant.ofEpochMilli(consumerRecord.timestamp()))
+                        val value = consumerRecord.value() ?: continue
+                        ops.add(CdcEvent.fromJson(value))
                     }
 
-                    if (!records.isEmpty()) {
-                        val ops = mutableListOf<CdcEvent>()
-                        var maxOffset = -1L
-                        var latestTimestamp = Instant.EPOCH
-
-                        for (consumerRecord in records) {
-                            maxOffset = maxOf(maxOffset, consumerRecord.offset())
-                            latestTimestamp = maxOf(latestTimestamp, Instant.ofEpochMilli(consumerRecord.timestamp()))
-                            val value = consumerRecord.value() ?: continue
-                            ops.add(CdcEvent.fromJson(value))
+                    val offsets = debeziumOffsetToken {
+                        dbzmTopicOffsets[topic] = partitionOffsets {
+                            offsets += listOf(maxOffset)
                         }
-
-                        val offsets = debeziumOffsetToken {
-                            dbzmTopicOffsets[topic] = partitionOffsets {
-                                offsets += listOf(maxOffset)
-                            }
-                        }
-                        processor.processMessages(listOf(
-                            DebeziumMessage(
-                                maxOffset,
-                                latestTimestamp,
-                                ops,
-                                offsets,
-                                // TODO: groupMetadata captured at poll-time may become stale if a rebalance
-                                //  occurs before sendOffsetsToTransaction — would cause ProducerFencedException.
-                                //  Acceptable for single-consumer setups; no data loss (transaction aborts).
-                                c.groupMetadata(),
-                            )
-                        ))
                     }
-
+                    processor.processMessages(listOf(
+                        DebeziumMessage(
+                            maxOffset,
+                            latestTimestamp,
+                            ops,
+                            offsets,
+                            // TODO: groupMetadata captured at poll-time may become stale if a rebalance
+                            //  occurs before sendOffsetsToTransaction — would cause ProducerFencedException.
+                            //  Acceptable for single-consumer setups; no data loss (transaction aborts).
+                            c.groupMetadata(),
+                        )
+                    ))
                 }
             }
         }
-
-        return Log.Subscription { runBlocking { withTimeout(5.seconds) { job.cancelAndJoin() } } }
     }
 
     override fun close() {
-        runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
     }
 }

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
@@ -1,6 +1,6 @@
 package xtdb.debezium
 
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.*
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -359,7 +359,8 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(null, capturing).use {
+                    val tailJob = launch { log.tailAll(null, capturing) }
+                    try {
                         pgExecute(
                             "INSERT INTO cdc_users (_id, name, email) VALUES (2, 'Bob', 'bob@example.com')",
                             "UPDATE cdc_users SET email = 'alice-new@example.com' WHERE _id = 1",
@@ -370,6 +371,8 @@ class DebeziumIntegrationTest {
                         while (received.size < 4) delay(100)
 
                         awaitTxs(node, 4)
+                    } finally {
+                        tailJob.cancelAndJoin()
                     }
                 }
             }
@@ -418,7 +421,8 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(null, capturing).use {
+                    val tailJob = launch { log.tailAll(null, capturing) }
+                    try {
                         pgExecute(
                             "INSERT INTO cdc_no_envelope (_id, name, email) VALUES (2, 'Bob', 'bob@example.com')",
                             "UPDATE cdc_no_envelope SET email = 'alice-new@example.com' WHERE _id = 1",
@@ -428,6 +432,8 @@ class DebeziumIntegrationTest {
                         // snapshot(Alice) + insert(Bob) + update(Alice) + delete(Bob)
                         while (received.size < 4) delay(100)
                         awaitTxs(node, 4)
+                    } finally {
+                        tailJob.cancelAndJoin()
                     }
                 }
             }
@@ -475,7 +481,8 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(null, capturing).use {
+                    val tailJob = launch { log.tailAll(null, capturing) }
+                    try {
                         pgExecute(
                             """INSERT INTO timed_docs (_id, name, _valid_from, _valid_to)
                             VALUES (1, 'bounded', '2024-01-01T00:00:00Z', '2025-01-01T00:00:00Z')""",
@@ -486,6 +493,8 @@ class DebeziumIntegrationTest {
                         )
 
                         awaitTxs(node, 3)
+                    } finally {
+                        tailJob.cancelAndJoin()
                     }
                 }
             }
@@ -540,17 +549,22 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(null, capturing).use {
-                        // Alice (valid) is ingested first
-                        awaitTxs(node, 1)
+                    supervisorScope {
+                        val tailJob = launch(CoroutineExceptionHandler { _, _ -> }) { log.tailAll(null, capturing) }
+                        try {
+                            // Alice (valid) is ingested first
+                            awaitTxs(node, 1)
 
-                        // Now insert a record with _valid_to but no _valid_from — halts ingestion
-                        pgExecute(
-                            """INSERT INTO bad_valid_to (_id, name, _valid_to)
-                            VALUES (2, 'bad', '2025-01-01T00:00:00Z')""",
-                        )
+                            // Now insert a record with _valid_to but no _valid_from — halts ingestion
+                            pgExecute(
+                                """INSERT INTO bad_valid_to (_id, name, _valid_to)
+                                VALUES (2, 'bad', '2025-01-01T00:00:00Z')""",
+                            )
 
-                        log.awaitError()
+                            tailJob.join()
+                        } finally {
+                            tailJob.cancelAndJoin()
+                        }
                     }
                 }
             }
@@ -580,13 +594,18 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(null, capturing).use {
-                        pgExecute(
-                            "INSERT INTO no_id_table (id, name) VALUES (2, 'also-no-_id')",
-                        )
+                    supervisorScope {
+                        val tailJob = launch(CoroutineExceptionHandler { _, _ -> }) { log.tailAll(null, capturing) }
+                        try {
+                            pgExecute(
+                                "INSERT INTO no_id_table (id, name) VALUES (2, 'also-no-_id')",
+                            )
 
-                        // snapshot record lacks _id — processor crashes, no records ingested
-                        log.awaitError()
+                            // snapshot record lacks _id — processor crashes, no records ingested
+                            tailJob.join()
+                        } finally {
+                            tailJob.cancelAndJoin()
+                        }
                     }
                 }
             }
@@ -621,7 +640,8 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(null, capturing).use {
+                    val tailJob = launch { log.tailAll(null, capturing) }
+                    try {
                         pgExecute(
                             """INSERT INTO typed_docs (_id, name, score, active, metadata, tags, notes)
                             VALUES (1, 'Alice', 3.14, true, '{"city": "London", "nested": {"deep": true}}',
@@ -632,6 +652,8 @@ class DebeziumIntegrationTest {
 
                         while (received.size < 2) delay(100)
                         awaitTxs(node, 2)
+                    } finally {
+                        tailJob.cancelAndJoin()
                     }
                 }
             }
@@ -681,13 +703,16 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(null, capturing).use {
+                    val tailJob = launch { log.tailAll(null, capturing) }
+                    try {
                         pgExecute(
                             "INSERT INTO inventory.products (_id, name, qty) VALUES (1, 'Widget', 100)",
                         )
 
                         while (received.size < 1) delay(100)
                         awaitTxs(node, 1)
+                    } finally {
+                        tailJob.cancelAndJoin()
                     }
                 }
             }
@@ -731,7 +756,8 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(null, capturing).use {
+                    val tailJob = launch { log.tailAll(null, capturing) }
+                    try {
                         pgExecute(
                             "INSERT INTO cdc_secondary_test (_id, name, email) VALUES (2, 'Bob', 'bob@example.com')",
                         )
@@ -739,6 +765,8 @@ class DebeziumIntegrationTest {
                         // snapshot(Alice) + insert(Bob) = 2 records
                         while (received.size < 2) delay(100)
                         awaitTxs(node, 2, db = "cdc_secondary")
+                    } finally {
+                        tailJob.cancelAndJoin()
                     }
                 }
             }
@@ -853,20 +881,25 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 log.use {
-                    log.tailAll(null, capturing).use {
-                        // TIMESTAMP (no tz) → Debezium sends as Long, not a string
-                        pgExecute(
-                            """INSERT INTO bad_times (_id, name, _valid_from)
-                            VALUES (1, 'wrong-type', '2024-01-01 00:00:00')""",
-                        )
-                        // TEXT with non-ISO content → string that won't parse
-                        pgExecute(
-                            """INSERT INTO bad_times (_id, name, _valid_to)
-                            VALUES (2, 'bad-string', 'not-a-date')""",
-                        )
+                    supervisorScope {
+                        val tailJob = launch(CoroutineExceptionHandler { _, _ -> }) { log.tailAll(null, capturing) }
+                        try {
+                            // TIMESTAMP (no tz) → Debezium sends as Long, not a string
+                            pgExecute(
+                                """INSERT INTO bad_times (_id, name, _valid_from)
+                                VALUES (1, 'wrong-type', '2024-01-01 00:00:00')""",
+                            )
+                            // TEXT with non-ISO content → string that won't parse
+                            pgExecute(
+                                """INSERT INTO bad_times (_id, name, _valid_to)
+                                VALUES (2, 'bad-string', 'not-a-date')""",
+                            )
 
-                        // invalid valid time types — processor crashes, no records ingested
-                        log.awaitError()
+                            // invalid valid time types — processor crashes, no records ingested
+                            tailJob.join()
+                        } finally {
+                            tailJob.cancelAndJoin()
+                        }
                     }
                 }
             }
@@ -898,8 +931,11 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 kafkaDebeziumLog.use {
-                    kafkaDebeziumLog.tailAll(null, capturing).use {
+                    val tailJob = launch { kafkaDebeziumLog.tailAll(null, capturing) }
+                    try {
                         while (received.size < 1) delay(100)
+                    } finally {
+                        tailJob.cancelAndJoin()
                     }
                 }
             }
@@ -917,8 +953,11 @@ class DebeziumIntegrationTest {
                 val (capturing, received) = capturingProcessor(processor)
 
                 kafkaDebeziumLog.use {
-                    kafkaDebeziumLog.tailAll(null, capturing).use {
+                    val tailJob = launch { kafkaDebeziumLog.tailAll(null, capturing) }
+                    try {
                         while (received.size < 1) delay(100)
+                    } finally {
+                        tailJob.cancelAndJoin()
                     }
                 }
             }

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumProcessorTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumProcessorTest.kt
@@ -1,6 +1,6 @@
 package xtdb.debezium
 
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import org.apache.arrow.memory.RootAllocator
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
@@ -80,10 +80,15 @@ class DebeziumProcessorTest {
         return cluster.use {
             KafkaCluster.LogFactory("kafka", sourceTopic, groupId = "xtdb-$sourceTopic-debezium")
                 .openSourceLog(mapOf("kafka" to cluster)).use { log ->
-                    log.tailAll(-1) { records -> received.addAll(records) }.use {
-                        log.openAtomicProducer("test-debezium").use { producer ->
-                            val processor = DebeziumProcessor(producer as KafkaCluster.AtomicProducer, allocator, defaultTz)
-                            block(processor, received)
+                    coroutineScope {
+                        val job = launch { log.tailAll(-1) { records -> received.addAll(records) } }
+                        try {
+                            log.openAtomicProducer("test-debezium").use { producer ->
+                                val processor = DebeziumProcessor(producer as KafkaCluster.AtomicProducer, allocator, defaultTz)
+                                block(processor, received)
+                            }
+                        } finally {
+                            job.cancelAndJoin()
                         }
                     }
                 }

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/KafkaDebeziumLogTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/KafkaDebeziumLogTest.kt
@@ -1,12 +1,13 @@
 package xtdb.debezium
 
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.*
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer
+import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -82,9 +83,9 @@ class KafkaDebeziumLogTest {
         val (subscriber, received) = capturingProcessor()
         val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
         log.use {
-            log.tailAll(null, subscriber).use {
-                while (received.isEmpty()) delay(100)
-            }
+            val job = launch { log.tailAll(null, subscriber) }
+            while (received.isEmpty()) delay(100)
+            job.cancelAndJoin()
             // Subscription closed — produce more messages
             produceMessages(topic, listOf(cdcMessage("c", 2, "Bob")))
             delay(500)
@@ -109,21 +110,20 @@ class KafkaDebeziumLogTest {
         val (subscriber, received) = capturingProcessor()
         val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
 
-        val subscription = log.tailAll(null, subscriber)
+        val job = launch { log.tailAll(null, subscriber) }
         while (received.isEmpty()) delay(100)
 
         assertEquals(1, received.size, "Should have received Alice before closing")
 
-        // Close log directly (not via subscription) — should cancel the poll coroutine
+        // Close log directly — should not affect the tailAll job (caller owns lifecycle)
+        // Cancel the job to stop processing
+        job.cancelAndJoin()
         log.close()
 
         produceMessages(topic, listOf(cdcMessage("c", 2, "Bob")))
         delay(500)
 
-        assertEquals(1, received.size, "Should not receive messages after log close")
-
-        // Closing subscription after log close should not throw
-        subscription.close()
+        assertEquals(1, received.size, "Should not receive messages after close")
     }
 
     @Test
@@ -136,9 +136,12 @@ class KafkaDebeziumLogTest {
         val (subscriber, received) = capturingProcessor()
         val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
         log.use {
-            log.tailAll(null, subscriber).use {
+            val tailJob = launch { log.tailAll(null, subscriber) }
+            try {
                 while (received.isEmpty()) delay(100)
                 delay(500)
+            } finally {
+                tailJob.cancelAndJoin()
             }
         }
 
@@ -169,9 +172,12 @@ class KafkaDebeziumLogTest {
         val (subscriber, received) = capturingProcessor()
         val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
         log.use {
-            log.tailAll(token, subscriber).use {
+            val tailJob = launch { log.tailAll(token, subscriber) }
+            try {
                 while (received.isEmpty()) delay(100)
                 delay(500)
+            } finally {
+                tailJob.cancelAndJoin()
             }
         }
 
@@ -198,9 +204,12 @@ class KafkaDebeziumLogTest {
         val (subscriber, received) = capturingProcessor()
         val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
         log.use {
-            log.tailAll(null, subscriber).use {
+            val tailJob = launch { log.tailAll(null, subscriber) }
+            try {
                 while (received.isEmpty()) delay(100)
                 delay(500) // give time — should not receive additional messages
+            } finally {
+                tailJob.cancelAndJoin()
             }
         }
 
@@ -229,8 +238,11 @@ class KafkaDebeziumLogTest {
         val (subscriber, received) = capturingProcessor()
         val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
         log.use {
-            log.tailAll(null, subscriber).use {
+            val tailJob = launch { log.tailAll(null, subscriber) }
+            try {
                 while (received.sumOf { it.ops.size } < 3) delay(100)
+            } finally {
+                tailJob.cancelAndJoin()
             }
         }
 
@@ -248,9 +260,7 @@ class KafkaDebeziumLogTest {
         val (subscriber, _) = capturingProcessor()
         val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
         log.use {
-            log.tailAll(null, subscriber)
-            val error = log.awaitError()
-            assertTrue(error is Exception, "Expected an exception from invalid JSON")
+            assertFailsWith<Exception> { runBlocking { log.tailAll(null, subscriber) } }
         }
     }
 
@@ -265,9 +275,7 @@ class KafkaDebeziumLogTest {
         val (subscriber, _) = capturingProcessor()
         val log = KafkaDebeziumLog(kafkaConfig(), topic, "test-group")
         log.use {
-            log.tailAll(null, subscriber)
-            val error = log.awaitError()
-            assertTrue(error is Exception)
+            assertFailsWith<Exception> { runBlocking { log.tailAll(null, subscriber) } }
         }
     }
 }

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -338,68 +338,54 @@ class KafkaCluster(
                 throw InterruptedException().initCause(e)
             }
 
-        override fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>): Log.Subscription {
+        override suspend fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) = coroutineScope {
             val c = kafkaConfigMap.openConsumer()
-            val tp = TopicPartition(topic, 0)
-            c.assign(listOf(tp))
-            c.seek(tp, afterMsgIdToOffset(epoch, afterMsgId) + 1)
+            try {
+                val tp = TopicPartition(topic, 0)
+                c.assign(listOf(tp))
+                c.seek(tp, afterMsgIdToOffset(epoch, afterMsgId) + 1)
 
-            val pollingJob = scope.launch(Dispatchers.IO) {
-                try {
-                    while (isActive) {
-                        val records = c.pollRecords()
-                        if (records.isNotEmpty()) processor.processRecords(records)
-                    }
-                } finally {
-                    c.close()
+                while (isActive) {
+                    val records = runInterruptible(Dispatchers.IO) { c.pollRecords() }
+                    if (records.isNotEmpty()) processor.processRecords(records)
                 }
-            }
-
-            return Log.Subscription {
-                c.wakeup()
-                runBlocking { withTimeout(30.seconds) { pollingJob.cancelAndJoin() } }
+            } finally {
+                c.close()
             }
         }
 
-        override fun openGroupSubscription(listener: Log.SubscriptionListener<M>): Log.Subscription {
+        override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>) = coroutineScope {
             val c = kafkaConfigMap.plus(mapOf("group.id" to groupId)).openConsumer()
-            val tp = TopicPartition(topic, 0)
-            var currentProcessor: Log.RecordProcessor<M>? = null
+            try {
+                val tp = TopicPartition(topic, 0)
+                var currentProcessor: Log.RecordProcessor<M>? = null
 
-            c.subscribe(listOf(topic), object : ConsumerRebalanceListener {
-                private inline fun launderInterruptedException(block: () -> Unit) =
-                    try { block() } catch (e: InterruptedException) { throw InterruptException(e) }
+                c.subscribe(listOf(topic), object : ConsumerRebalanceListener {
+                    private inline fun launderInterruptedException(block: () -> Unit) =
+                        try { block() } catch (e: InterruptedException) { throw InterruptException(e) }
 
-                override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) =
-                    launderInterruptedException {
-                        listener.onPartitionsAssignedSync(partitions.map { it.partition() })
-                            ?.let { tailSpec ->
-                                currentProcessor = tailSpec.processor
-                                c.seek(tp, afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1)
-                            }
-                    }
+                    override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) =
+                        launderInterruptedException {
+                            listener.onPartitionsAssignedSync(partitions.map { it.partition() })
+                                ?.let { tailSpec ->
+                                    currentProcessor = tailSpec.processor
+                                    c.seek(tp, afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1)
+                                }
+                        }
 
-                override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) =
-                    launderInterruptedException {
-                        listener.onPartitionsRevokedSync(partitions.map { it.partition() })
-                        currentProcessor = null
-                    }
-            })
+                    override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) =
+                        launderInterruptedException {
+                            listener.onPartitionsRevokedSync(partitions.map { it.partition() })
+                            currentProcessor = null
+                        }
+                })
 
-            val pollingJob = scope.launch(Dispatchers.IO) {
-                try {
-                    while (isActive) {
-                        val records = c.pollRecords()
-                        if (records.isNotEmpty()) currentProcessor?.processRecords(records)
-                    }
-                } finally {
-                    c.close()
+                while (isActive) {
+                    val records = runInterruptible(Dispatchers.IO) { c.pollRecords() }
+                    if (records.isNotEmpty()) currentProcessor?.processRecords(records)
                 }
-            }
-
-            return Log.Subscription {
-                c.wakeup()
-                runBlocking { withTimeout(30.seconds) { pollingJob.cancelAndJoin() } }
+            } finally {
+                c.close()
             }
         }
 

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
@@ -2,7 +2,9 @@ package xtdb.api.log
 
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -61,7 +63,8 @@ class KafkaAtomicProducerTest {
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster)).use { log ->
-                        log.tailAll(-1, subscriber).use {
+                        val tailJob = launch { log.tailAll(-1, subscriber) }
+                        try {
                             log.openAtomicProducer("tx-producer-1").use { producer ->
                                 producer.withTx { tx ->
                                     tx.appendMessage(txMessage(1))
@@ -70,6 +73,8 @@ class KafkaAtomicProducerTest {
                             }
 
                             while (synchronized(msgs) { msgs.flatten().size } < 2) delay(100)
+                        } finally {
+                            tailJob.cancelAndJoin()
                         }
                     }
             }
@@ -102,7 +107,8 @@ class KafkaAtomicProducerTest {
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
-                        log.tailAll(-1, subscriber).use {
+                        val tailJob = launch { log.tailAll(-1, subscriber) }
+                        try {
                             log.openAtomicProducer("tx-producer-1").use { producer ->
                                 // Abort this transaction
                                 producer.openTx().use { tx ->
@@ -121,6 +127,8 @@ class KafkaAtomicProducerTest {
 
                             // Give extra time to ensure no more messages arrive
                             delay(500)
+                        } finally {
+                            tailJob.cancelAndJoin()
                         }
                     }
             }
@@ -149,7 +157,8 @@ class KafkaAtomicProducerTest {
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
-                        log.tailAll(-1, subscriber).use {
+                        val tailJob = launch { log.tailAll(-1, subscriber) }
+                        try {
                             log.openAtomicProducer("tx-producer-1").use { producer ->
                                 producer.withTx { tx -> tx.appendMessage(txMessage(1)) }
                                 producer.withTx { tx ->
@@ -160,6 +169,8 @@ class KafkaAtomicProducerTest {
                             }
 
                             while (synchronized(msgs) { msgs.flatten().size } < 4) delay(100)
+                        } finally {
+                            tailJob.cancelAndJoin()
                         }
                     }
             }
@@ -186,7 +197,8 @@ class KafkaAtomicProducerTest {
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
-                        log.tailAll(-1, subscriber).use {
+                        val tailJob = launch { log.tailAll(-1, subscriber) }
+                        try {
                             log.openAtomicProducer("tx-producer-1").use { producer ->
                                 producer.openTx().use { tx ->
                                     tx.appendMessage(txMessage(1))
@@ -200,6 +212,8 @@ class KafkaAtomicProducerTest {
                             }
 
                             while (synchronized(msgs) { msgs.flatten().size } < 1) delay(100)
+                        } finally {
+                            tailJob.cancelAndJoin()
                         }
                     }
             }
@@ -250,7 +264,8 @@ class KafkaAtomicProducerTest {
                 .open().use { cluster ->
                     KafkaCluster.LogFactory("my-cluster", outputTopic)
                         .openSourceLog(mapOf("my-cluster" to cluster)).use { log ->
-                            log.tailAll(-1, subscriber).use {
+                            val tailJob = launch { log.tailAll(-1, subscriber) }
+                            try {
                                 (log.openAtomicProducer("tx-producer-1") as KafkaCluster.AtomicProducer).use { producer ->
                                     producer.openTx().use { tx ->
                                         tx.appendMessage(txMessage(1))
@@ -260,6 +275,8 @@ class KafkaAtomicProducerTest {
                                 }
 
                                 while (synchronized(msgs) { msgs.flatten().size } < 1) delay(100)
+                            } finally {
+                                tailJob.cancelAndJoin()
                             }
                         }
                 }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -2,7 +2,9 @@ package xtdb.api.log
 
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -68,7 +70,8 @@ class KafkaClusterTest {
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
-                        log.tailAll(-1, subscriber).use { _ ->
+                        val job = launch { log.tailAll(-1, subscriber) }
+                        try {
                             val txPayload = ByteBuffer.allocate(9).put(-1).putLong(42).flip().array()
                             log.appendMessage(SourceMessage.LegacyTx(txPayload))
 
@@ -79,6 +82,8 @@ class KafkaClusterTest {
                             log.appendMessage(SourceMessage.AttachDatabase("foo", databaseConfig))
 
                             while (synchronized(msgs) { msgs.flatten().size } < 4) delay(100)
+                        } finally {
+                            job.cancelAndJoin()
                         }
                     }
             }


### PR DESCRIPTION
## Context

After a `RecordTooLargeException` during block finalization (#5398), the node was supposed to stop — `IngestionStoppedException` is meant to be fatal.
Instead, it recovered through Kafka rebalancing and continued processing.
The root cause: subscriptions (source log, replica log) were independent background coroutines with no shared lifecycle.
One could fail while the others carried on.

The principle we're enforcing: **whenever the state of a database is even slightly compromised, it must stop entirely**.
Not the whole node — just the affected database.
Other databases on the same node continue unaffected.

## Approach

Two commits, deliberately separated for review:

### 1. `refactor(log)`: make `tailAll` and `openGroupSubscription` suspend

**This is a pure equivalence change** — no behaviour difference.
The functions no longer return `Log.Subscription`; callers launch them in a scope and cancel the job to stop.

Previously the log implementation owned the coroutine lifecycle (internal `scope.launch`, return a close handle).
Now the caller owns it — launch in a shared scope, and cancellation replaces `close()`.
This is the prerequisite for structured concurrency: siblings in a shared scope, one dies, all die.

For Kafka, `runInterruptible` replaces `scope.launch(Dispatchers.IO)`.
Cancellation converts to thread interruption, which breaks `consumer.poll()`.
Consumer lifecycle stays in try-finally.

`KafkaDebeziumLog`'s internal error-reporting machinery (`_error`, `exceptionHandler`, `scope`) is now dead — errors propagate via the suspend function.
Removed it; tests use `assertFailsWith` / `supervisorScope` instead of `log.awaitError()`.

### 2. `fix(database)`: cancel all subscriptions when any ingestion error occurs

**This is the behaviour change** — one file, 4 lines.

`SupervisorJob()` → `Job()` on the Database's coroutine scope, plus a `CoroutineExceptionHandler` that calls `watchers.notifyError()`.

With a regular Job, any child coroutine failure cancels all siblings.
A `RecordTooLargeException` in the source log subscription now cancels the replica `tailAll` too — the database stops entirely.
The exception handler ensures `awaitTx` callers see the error immediately rather than hanging.
`healthz` watches `ingestionError` and shuts down the node.

## Mental model for reviewers

**Database now owns a `CoroutineScope` with a regular `Job`.**
All subscriptions (source log group subscription, follower replica tailAll) are children of this scope.
If any child fails, the Job cancels all siblings — the database is dead.

`LogProcessor` receives this scope so it can launch follower `tailAll`s as siblings of the source log subscription.
When the follower→leader transition happens, the old follower's tailAll job is cancelled and a new one is launched in the same scope.

The `Log.Subscription` type is kept for now — `ExternalLog` still uses it.

## Dead ends

- Tried an `onError` callback on `Watchers` to close the subscription — too much plumbing for the same result.
- Considered pausing Kafka topic partitions on error instead of crashing — but a paused partition is a partition held hostage. Better to release it.

## Out of scope

- The `BlockUploaded` / `TriesAdded` message exceeding `max.request.size` is the upstream trigger but not addressed here — that's a configuration or message-sizing question.
- Full structured concurrency with `suspend fun` close (the `runBlocking` in `Database.close()` is a sync/async boundary that stays for now).

Resolves #5398

🤖 Generated with [Claude Code](https://claude.com/claude-code)