### PR TITLE
feat(sql): add string_to_array function

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1585,15 +1585,13 @@
 
 (defmethod codegen-call [:string_to_array :utf8 :utf8] [_]
   {:return-type #xt/type [:list :utf8]
-   :continue-call (fn [f [s delim]]
-                    (f #xt/type [:list :utf8]
-                       `(string-to-array (resolve-string ~s) (resolve-string ~delim))))})
+   :->call-code (fn [[s delim]]
+                  `(string-to-array (resolve-string ~s) (resolve-string ~delim)))})
 
 (defmethod codegen-call [:string_to_array :utf8 :null] [_]
   {:return-type #xt/type [:list :utf8]
-   :continue-call (fn [f [s _delim]]
-                    (f #xt/type [:list :utf8]
-                       `(string-to-chars (resolve-string ~s))))})
+   :->call-code (fn [[s _delim]]
+                  `(string-to-chars (resolve-string ~s)))})
 
 (defmethod codegen-call [:string_to_array :null :utf8] [_]
   {:return-type #xt/type :null, :->call-code (constantly nil)})

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1595,6 +1595,12 @@
                     (f #xt/type [:list :utf8]
                        `(string-to-chars (resolve-string ~s))))})
 
+(defmethod codegen-call [:string_to_array :null :utf8] [_]
+  {:return-type #xt/type :null, :->call-code (constantly nil)})
+
+(defmethod codegen-call [:string_to_array :null :null] [_]
+  {:return-type #xt/type :null, :->call-code (constantly nil)})
+
 (defmethod codegen-call [:overlay :varbinary :varbinary :int :int] [_]
   {:return-type #xt/type :varbinary
    :->call-code (fn [[target replacement from len]]

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -629,7 +629,8 @@
   (complement (comp #{:is_true :is_false :is_null :true? :false? :nil? :boolean
                       :=== :null_eq :compare_nulls_first :compare_nulls_last
                       :distinct_from
-                      :period :str :_patch}
+                      :period :str :_patch
+                      :string_to_array}
                     normalise-fn-name)))
 
 (defn- cont-b3-call [arg-type code]
@@ -1557,6 +1558,42 @@
    :->call-code (fn [[s target replacement]]
                   `(-> (.replace (resolve-string ~s) (resolve-string ~target) (resolve-string ~replacement))
                        (resolve-utf8-buf)))})
+
+(defn- strings->list-reader ^xtdb.arrow.ListValueReader [^objects arr]
+  (let [box (ValueBox.)
+        bufs (object-array (mapv #(resolve-utf8-buf ^String %) arr))]
+    (reify ListValueReader
+      (size [_] (alength bufs))
+      (nth [_ idx]
+        (doto box
+          (.writeBytes (.duplicate ^ByteBuffer (aget bufs idx))))))))
+
+(defn string-to-array ^xtdb.arrow.ListValueReader [^String s ^String delimiter]
+  (if (.isEmpty s)
+    ;; PG returns {} for empty input regardless of delimiter
+    (strings->list-reader (into-array String []))
+    (if (.isEmpty delimiter)
+      (strings->list-reader (into-array String [s]))
+      (let [parts (.split s (java.util.regex.Pattern/quote delimiter) -1)]
+        (strings->list-reader parts)))))
+
+(defn string-to-chars ^xtdb.arrow.ListValueReader [^String s]
+  (if (.isEmpty s)
+    (strings->list-reader (into-array String []))
+    (let [parts (into-array String (mapv str (.toCharArray s)))]
+      (strings->list-reader parts))))
+
+(defmethod codegen-call [:string_to_array :utf8 :utf8] [_]
+  {:return-type #xt/type [:list :utf8]
+   :continue-call (fn [f [s delim]]
+                    (f #xt/type [:list :utf8]
+                       `(string-to-array (resolve-string ~s) (resolve-string ~delim))))})
+
+(defmethod codegen-call [:string_to_array :utf8 :null] [_]
+  {:return-type #xt/type [:list :utf8]
+   :continue-call (fn [f [s _delim]]
+                    (f #xt/type [:list :utf8]
+                       `(string-to-chars (resolve-string ~s))))})
 
 (defmethod codegen-call [:overlay :varbinary :varbinary :int :int] [_]
   {:return-type #xt/type :varbinary

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -1199,6 +1199,7 @@
 (def-sql-fns [str] 1 Long/MAX_VALUE)
 (def-sql-fns [format] 1 Long/MAX_VALUE)
 (def-sql-fns [namespace local_name reverse] 1 1)
+(def-sql-fns [string_to_array] 2 2)
 
 ;; system info
 (def-sql-fns [col_description] 2 2)

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1643,11 +1643,11 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
     "'a\\b'"      "E'\\\\'" ["a" "b"]
 
     ;; greedy consumption
-    "'aaa'"       "'aa'"   ["" "a"]
+    "'aaa'"       "'aa'"   ["" "a"])
 
-    ;; NULL string input
-    "NULL"        "','"    nil
-    "NULL"        "NULL"   nil))
+  (t/testing "NULL string input returns NULL"
+    (t/is (= [{}] (xt/q tu/*node* "SELECT string_to_array(NULL, ',') AS x")))
+    (t/is (= [{}] (xt/q tu/*node* "SELECT string_to_array(NULL, NULL) AS x")))))
 
 ;; TODO: Add this?
 #_(t/deftest test-random-fn

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1610,6 +1610,41 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
   (t/testing "bare USER fallback in UNION with column resolution"
     (t/is (= #{{:user "alice"} {:user "xtdb"}}
              (set (xt/q tu/*node* "SELECT user FROM docs UNION ALL SELECT user AS user FROM foo"))))))
+
+(t/deftest test-string-to-array
+  (t/are [s delim expected]
+    (= [{:x expected}] (xt/q tu/*node* (str "SELECT string_to_array(" s ", " delim ") AS x")))
+
+    ;; basic splitting
+    "'a, b, c'"   "','"    ["a" " b" " c"]
+    "'a::b::c'"   "'::'"   ["a" "b" "c"]
+    "'a.b.c.d'"   "'.b.'"  ["a" "c.d"]
+
+    ;; NULL delimiter splits each character
+    "'abc'"       "NULL"   ["a" "b" "c"]
+
+    ;; empty delimiter returns whole string
+    "'abc'"       "''"     ["abc"]
+
+    ;; empty strings between/around delimiters
+    "'a,,b'"      "','"    ["a" "" "b"]
+    "',,'"        "','"    ["" "" ""]
+    "',foo,'"     "','"    ["" "foo" ""]
+    "','"         "','"    ["" ""]
+
+    ;; empty input
+    "''"          "','"    []
+    "''"          "NULL"   []
+    "''"          "''"     []
+
+    ;; regex metacharacters treated literally
+    "'a.*b'"      "'.*'"   ["a" "b"]
+    "'a[b'"       "'['"    ["a" "b"]
+    "'a\\b'"      "E'\\\\'" ["a" "b"]
+
+    ;; greedy consumption
+    "'aaa'"       "'aa'"   ["" "a"]))
+
 ;; TODO: Add this?
 #_(t/deftest test-random-fn
     (t/is (= true (-> (xt/q tu/*node* "SELECT 0.0 <= random() AS greater") first :greater)))

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1643,7 +1643,11 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
     "'a\\b'"      "E'\\\\'" ["a" "b"]
 
     ;; greedy consumption
-    "'aaa'"       "'aa'"   ["" "a"]))
+    "'aaa'"       "'aa'"   ["" "a"]
+
+    ;; NULL string input
+    "NULL"        "','"    nil
+    "NULL"        "NULL"   nil))
 
 ;; TODO: Add this?
 #_(t/deftest test-random-fn


### PR DESCRIPTION
## Summary
- Adds PostgreSQL-compatible `string_to_array(string, delimiter)` function
- Supports NULL delimiter (per-character split) and empty delimiter (whole string as single element)
- Matches PG semantics for empty input, consecutive delimiters, and regex metacharacters in delimiters
- Introduces `strings->list-reader` helper for constructing ListValueReader from string arrays