### PR TITLE
feat(sql): add quote_ident function

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1568,7 +1568,10 @@
   Multi-alternative rules (e.g. ANALYZE : 'ANALYZE' | 'ANALYSE') have no single
   literal name — these are added explicitly below."
   (let [vocab (xtdb.antlr.SqlLexer/VOCABULARY)
-        ks (java.util.HashSet. #{"analyze" "analyse"})]
+        ks (java.util.HashSet. #{"analyze" "analyse"
+                               "localdate" "local_date"
+                               "localtime" "local_time"
+                               "localtimestamp" "local_timestamp"})]
     (dotimes [i (.getMaxTokenType vocab)]
       (when-let [lit (.getLiteralName vocab (inc i))]
         (let [s (subs lit 1 (dec (count lit)))]

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1560,6 +1560,33 @@
                   `(-> (.replace (resolve-string ~s) (resolve-string ~target) (resolve-string ~replacement))
                        (resolve-utf8-buf)))})
 
+(def ^:private ^java.util.Set sql-keywords
+  "SQL keywords derived from SqlLexer's vocabulary at load time, used by quote_ident.
+  A token is a keyword if its literal name is all letters/underscores (e.g. 'SELECT').
+  Tokens with no literal name (pattern-based like REGULAR_IDENTIFIER) or non-alpha
+  literals (operators like '||') are excluded automatically.
+  Multi-alternative rules (e.g. ANALYZE : 'ANALYZE' | 'ANALYSE') have no single
+  literal name — these are added explicitly below."
+  (let [vocab (xtdb.antlr.SqlLexer/VOCABULARY)
+        ks (java.util.HashSet. #{"analyze" "analyse"})]
+    (dotimes [i (.getMaxTokenType vocab)]
+      (when-let [lit (.getLiteralName vocab (inc i))]
+        (let [s (subs lit 1 (dec (count lit)))]
+          (when (re-matches #"[a-zA-Z_]+" s)
+            (.add ks (.toLowerCase s java.util.Locale/ROOT))))))
+    ks))
+
+(defn quote-ident ^String [^String s]
+  (if (and (re-matches #"[a-z_][a-z0-9_]*" s)
+           (not (.contains sql-keywords s)))
+    s
+    (str \" (.replace s "\"" "\"\"") \")))
+
+(defmethod codegen-call [:quote_ident :utf8] [_]
+  {:return-type #xt/type :utf8
+   :->call-code (fn [[s]]
+                  `(resolve-utf8-buf (quote-ident (resolve-string ~s))))})
+
 (defn- strings->list-reader ^xtdb.arrow.ListValueReader [^objects arr]
   (let [box (ValueBox.)
         bufs (object-array (mapv #(resolve-utf8-buf ^String %) arr))]

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -1199,6 +1199,7 @@
 (def-sql-fns [str] 1 Long/MAX_VALUE)
 (def-sql-fns [format] 1 Long/MAX_VALUE)
 (def-sql-fns [namespace local_name reverse] 1 1)
+(def-sql-fns [quote_ident] 1 1)
 (def-sql-fns [string_to_array] 2 2)
 
 ;; system info

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1629,6 +1629,10 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
     "'from'"               "\"from\""
     "'null'"               "\"null\""
 
+    ;; multi-alternative lexer keywords
+    "'local_date'"         "\"local_date\""
+    "'localdate'"          "\"localdate\""
+
     ;; mixed case / non-ASCII
     "'Foo'"                "\"Foo\""
     "'café'"               "\"café\""

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1615,6 +1615,41 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
     (t/is (= #{{:user "alice"} {:user "xtdb"}}
              (set (xt/q tu/*node* "SELECT user FROM docs UNION ALL SELECT user AS user FROM foo"))))))
 
+(t/deftest test-quote-ident
+  (t/are [sql expected]
+    (= [{:x expected}] (xt/q tu/*node* (str "SELECT quote_ident(" sql ") AS x")))
+
+    ;; unquoted pass-through
+    "'foo'"                "foo"
+    "'foo_bar'"            "foo_bar"
+    "'_foo'"               "_foo"
+
+    ;; reserved words
+    "'select'"             "\"select\""
+    "'from'"               "\"from\""
+    "'null'"               "\"null\""
+
+    ;; mixed case / non-ASCII
+    "'Foo'"                "\"Foo\""
+    "'café'"               "\"café\""
+
+    ;; special characters
+    "'foo bar'"            "\"foo bar\""
+    "'foo\"bar'"           "\"foo\"\"bar\""
+    "'\"'"                 "\"\"\"\""
+    "'\"foo\"'"            "\"\"\"foo\"\"\""
+    "'123'"                "\"123\""
+    "'foo$bar'"            "\"foo$bar\""
+    "'$leading'"           "\"$leading\""
+    "'foo;DROP TABLE bar'" "\"foo;DROP TABLE bar\""
+
+    ;; empty string
+    "''"                   "\"\""
+
+    ;; escape syntax
+    "E'foo\\nbar'"         "\"foo\nbar\""
+    "E'foo\\\\bar'"        "\"foo\\bar\""))
+
 (t/deftest test-string-to-array
   (t/are [s delim expected]
     (= [{:x expected}] (xt/q tu/*node* (str "SELECT string_to_array(" s ", " delim ") AS x")))


### PR DESCRIPTION
## Summary
- Adds PostgreSQL-compatible `quote_ident(name)` for identifier quoting
- Returns the identifier unmodified if safe (lowercase, no reserved words, no special chars)
- Otherwise wraps in double quotes with proper `""` escaping
- Uses the SqlLexer vocabulary at load time to detect reserved words

~Flag on this PR is I'm not completely happy with how we build sql-keywords but also can't think of a way around it. If you do please say so!~

I think I've reached the most reasonable solution I can think of for sql-keywords, matching a-zA-Z_+ on literal names of sql lexer vocabulary, there's only one exception on analyze/analyse and should expand with future modifications of vocabulary without issue.