### PR TITLE
feat(sql): add array_lower and array_length functions

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -2079,6 +2079,26 @@
 
                      (.size ~arr)))})
 
+(defmethod codegen-call [:array_lower :list :i64] [_]
+  {:return-type #xt/type :i32
+   :->call-code (fn [[_arr dim]]
+                  `(do
+                     (when-not (= ~dim 1)
+                       (throw (err/unsupported :xtdb.expression/array-dimension-error
+                                               "Unsupported: ARRAY_LOWER for dimension != 1"
+                                               {:dim ~dim})))
+                     (int 1)))})
+
+(defmethod codegen-call [:array_length :list :i64] [_]
+  {:return-type #xt/type :i32
+   :->call-code (fn [[arr dim]]
+                  `(do
+                     (when-not (= ~dim 1)
+                       (throw (err/unsupported :xtdb.expression/array-dimension-error
+                                               "Unsupported: ARRAY_LENGTH for dimension != 1"
+                                               {:dim ~dim})))
+                     (.size ~arr)))})
+
 (defn trim-array-view ^xtdb.arrow.ListValueReader [^long trimmed-value-count ^ListValueReader lst]
   (reify ListValueReader
     (size [_] trimmed-value-count)

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -1179,7 +1179,7 @@
 
 ;; mathy
 (def-sql-fns [octet_length length cardinality] 1 1)
-(def-sql-fns [array_upper] 2 2)
+(def-sql-fns [array_upper array_lower array_length] 2 2)
 (def-sql-fns [abs] 1 1)
 (def-sql-fns [mod] 2 2)
 (def-sql-fns [log] 2 2)

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1653,6 +1653,65 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
     (t/is (= [{}] (xt/q tu/*node* "SELECT string_to_array(NULL, ',') AS x")))
     (t/is (= [{}] (xt/q tu/*node* "SELECT string_to_array(NULL, NULL) AS x")))))
 
+(t/deftest test-array-upper
+  (t/is (= [{:x 2}]
+           (xt/q tu/*node* "SELECT array_upper(ARRAY ['a', 'b'], 1) AS x"))
+        "returns upper bound for multi-element array")
+
+  (t/is (= [{:x 1}]
+           (xt/q tu/*node* "SELECT array_upper(ARRAY ['a'], 1) AS x"))
+        "single-element array returns 1")
+
+  (t/is (= [{:x 0}]
+           (xt/q tu/*node* "SELECT array_upper(ARRAY [], 1) AS x"))
+        "empty array returns 0")
+
+  (t/is (thrown-with-msg? RuntimeException #"dimension != 1"
+           (xt/q tu/*node* "SELECT array_upper(ARRAY ['a', 'b'], 2) AS x"))
+        "dimension 2 throws")
+
+  (t/is (thrown-with-msg? RuntimeException #"dimension != 1"
+           (xt/q tu/*node* "SELECT array_upper(ARRAY ['a', 'b'], 0) AS x"))
+        "dimension 0 throws"))
+
+(t/deftest test-array-lower
+  (t/is (= [{:x 1}]
+           (xt/q tu/*node* "SELECT array_lower(ARRAY ['a', 'b'], 1) AS x"))
+        "returns 1 for dimension 1")
+
+  (t/is (= [{:x 1}]
+           (xt/q tu/*node* "SELECT array_lower(ARRAY ['a'], 1) AS x"))
+        "single-element array still returns 1")
+
+  (t/is (thrown-with-msg? RuntimeException #"dimension != 1"
+           (xt/q tu/*node* "SELECT array_lower(ARRAY ['a', 'b'], 2) AS x"))
+        "dimension 2 throws")
+
+  (t/is (thrown-with-msg? RuntimeException #"dimension != 1"
+           (xt/q tu/*node* "SELECT array_lower(ARRAY ['a', 'b'], 0) AS x"))
+        "dimension 0 throws"))
+
+(t/deftest test-array-length
+  (t/is (= [{:x 2}]
+           (xt/q tu/*node* "SELECT array_length(ARRAY ['a', 'b'], 1) AS x"))
+        "returns the length of a list")
+
+  (t/is (= [{:x 1}]
+           (xt/q tu/*node* "SELECT array_length(ARRAY ['a'], 1) AS x"))
+        "single element returns 1")
+
+  (t/is (= [{:x 5}]
+           (xt/q tu/*node* "SELECT array_length(ARRAY ['a', 'b', 'c', 'd', 'e'], 1) AS x"))
+        "longer array returns correct count")
+
+  (t/is (thrown-with-msg? RuntimeException #"dimension != 1"
+           (xt/q tu/*node* "SELECT array_length(ARRAY ['a', 'b'], 2) AS x"))
+        "dimension 2 throws")
+
+  (t/is (thrown-with-msg? RuntimeException #"dimension != 1"
+           (xt/q tu/*node* "SELECT array_length(ARRAY ['a', 'b'], 0) AS x"))
+        "dimension 0 throws"))
+
 ;; TODO: Add this?
 #_(t/deftest test-random-fn
     (t/is (= true (-> (xt/q tu/*node* "SELECT 0.0 <= random() AS greater") first :greater)))


### PR DESCRIPTION
## Summary
- Adds PostgreSQL-compatible `array_lower(array, dimension)` and `array_length(array, dimension)` for dimension 1
- `array_lower` always returns 1 (PG arrays are 1-indexed, we don't support custom lower bounds)
- `array_length` returns the element count for dimension 1
- Both throw for dimensions other than 1