### PR TITLE
feat(sql): add current_setting('search_path') support

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1394,6 +1394,7 @@
 (defn current-setting [setting-name]
   (case setting-name
     "server_version_num" "160000"
+    "search_path" (str/join ", " explicit-search-path)
     (throw (err/unsupported ::unsupported-setting (str "Setting not supported: " setting-name)
                             {:setting-name setting-name}))))
 

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1031,7 +1031,11 @@
     "LOCALTIMESTAMP()" '(local-timestamp)
     "LOCALTIMESTAMP(6)" '(local-timestamp 6)))
 
-(t/deftest test-current-setting-server-version-num
+(t/deftest test-current-setting
+  (t/is (= [{:v "public"}]
+           (xt/q tu/*node* "SELECT current_setting('search_path') AS v"))
+        "search_path returns PG-compatible default")
+
   (t/is (= [{:v "160000"}]
            (xt/q tu/*node* "SELECT current_setting('server_version_num') AS v")))
 


### PR DESCRIPTION
## Summary
- Returns `'"$user", public'` for `current_setting('search_path')` to match PostgreSQL defaults
- Grafana's PostgreSQL plugin queries this during table discovery