### PR TITLE
fix(indexer): follower/read-only nodes lose table visibility after block flush

### DIFF
--- a/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
@@ -59,6 +59,22 @@ class TableCatalog(
         )
     }
 
+    fun updateFromBlockMetadata(metadata: Map<TableRef, LiveTable.BlockMetadata>) {
+        val oldTables = state.tables
+
+        val deltaByTable = metadata.mapValues { (_, bm) ->
+            TableMeta(bm.vecTypes, bm.rowCount.toLong(), bm.hllDeltas)
+        }
+
+        val allTableRefs = oldTables.keys + deltaByTable.keys
+        val newTables = allTableRefs.associateWith { mergeTables(oldTables[it], deltaByTable[it]) }
+
+        state = State(
+            blockIdx = blockCatalog.currentBlockIndex,
+            tables = newTables
+        )
+    }
+
     fun finishBlock(
         tableMetadata: Map<TableRef, LiveTable.FinishedBlock>,
         tablePartitions: Map<TableRef, List<Partition>>

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -62,6 +62,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
 
     private val dbName = dbState.name
     private val blockCatalog = dbState.blockCatalog
+    private val tableCatalog = dbState.tableCatalog
     private val trieCatalog = dbState.trieCatalog
     private val liveIndex = dbState.liveIndex
 
@@ -142,6 +143,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
 
                 addTries(msg.tries, record.logTimestamp)
                 blockCatalog.refresh(block)
+                tableCatalog.updateFromBlockMetadata(liveIndex.blockMetadata())
                 liveIndex.nextBlock()
                 compactor.signalBlock()
 

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -117,14 +117,13 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 watchers.notifyMsg(msg.latestProcessedMsgId)
             }
 
-            is ReplicaMessage.BlockUploaded -> {
-                if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch)
-                    addTries(msg.tries, record.logTimestamp)
-                watchers.notifyMsg(msg.latestProcessedMsgId)
-            }
+            is ReplicaMessage.BlockUploaded -> error(
+                "BlockUploaded should be handled by handleRecord, never reaching processRecord directly. msgId=${record.msgId}, blockIndex=${msg.blockIndex.asLexHex}, latestProcessedMsgId=${msg.latestProcessedMsgId}"
+            )
 
             is ReplicaMessage.NoOp -> Unit
         }
+
     }
 
     private suspend fun handleRecord(record: Log.Record<ReplicaMessage>) {
@@ -141,6 +140,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 LOG.debug("[$dbName] block uploaded b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=${record.msgId} (${pendingBlock.bufferedRecords.size} buffered)")
                 val block = parseFrom(bufferPool.getByteArray(blockFilePath(pendingBlockIdx)))
 
+                addTries(msg.tries, record.logTimestamp)
                 blockCatalog.refresh(block)
                 liveIndex.nextBlock()
                 compactor.signalBlock()

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -176,6 +176,9 @@ class LiveIndex private constructor(
 
     fun isFull() = rowCounter.blockRowCount >= rowsPerBlock
 
+    fun blockMetadata(): Map<TableRef, LiveTable.BlockMetadata> =
+        tables.mapNotNull { (table, lt) -> lt.blockMetadata()?.let { table to it } }.toMap()
+
     fun finishBlock(bp: BufferPool, blockIdx: BlockIndex) = tables.finishBlock(bp, blockIdx)
 
     private val skipTxsLogged = AtomicBoolean(false)

--- a/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
@@ -221,6 +221,22 @@ constructor(
 
     fun openSnapshot() = openSnapshot(liveTrie)
 
+    data class BlockMetadata(
+        val vecTypes: Map<FieldName, VectorType>,
+        val rowCount: Int,
+        val hllDeltas: Map<FieldName, HLL>
+    )
+
+    fun blockMetadata(): BlockMetadata? {
+        val rowCount = liveRelation.rowCount
+        if (rowCount == 0) return null
+        return BlockMetadata(
+            vecTypes = liveRelation.types.orEmpty(),
+            rowCount = rowCount,
+            hllDeltas = hllCalculator.build()
+        )
+    }
+
     data class FinishedBlock(
         val vecTypes: Map<FieldName, VectorType>,
         val trieKey: TrieKey,

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
@@ -241,6 +241,7 @@ class SourceLogProcessor(
     private fun enterPendingBlock() {
         val blockIdx = (blockCatalog.currentBlockIndex ?: -1) + 1
         pendingBlockIdx = blockIdx
+        tableCatalog.updateFromBlockMetadata(liveIndex.blockMetadata())
         liveIndex.nextBlock()
         LOG.debug("[$dbName] read-only: waiting for block 'b${blockIdx.asLexHex}' via BlockUploaded...")
     }

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -2,13 +2,14 @@
   (:require [clojure.test :as t]
             [next.jdbc :as jdbc]
             [xtdb.api :as xt]
-            [xtdb.db-catalog :as db]
-            [xtdb.node :as xtn] 
-            [xtdb.test-util :as tu]
-            [xtdb.util :as util])
+            [xtdb.db-catalog :as db] 
+            [xtdb.node :as xtn]
+            [xtdb.test-util :as tu]  
+            [xtdb.util :as util]
+            [clojure.tools.logging :as log])
   (:import org.apache.kafka.common.KafkaException
            org.testcontainers.kafka.ConfluentKafkaContainer
-           org.testcontainers.utility.DockerImageName
+           org.testcontainers.utility.DockerImageName 
            [xtdb.api.log Log]))
 
 (def ^:private ^:dynamic *bootstrap-servers* nil)
@@ -279,8 +280,7 @@
         (t/testing "can finish the block"
           (t/is (nil? (tu/flush-block! node)))))
 
-
-      ;; Restarting the node again with the same new log path and epoch 1
+;; Restarting the node again with the same new log path and epoch 1
       (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
                                                                           :poll-duration "PT2S"
                                                                           :properties-map {}
@@ -382,3 +382,36 @@
 
           (t/testing "shouldn't have flushed another block / re-read the flush block"
             (t/is (= ["l00-rc-b00.arrow"] (tu/read-files-from-bp-path node "tables/public$docs/meta/")))))))))
+
+(t/deftest ^:integration test-implicit-conn-awaiting
+  (let [topic (str "xtdb.kafka-test." (random-uuid))]
+    (util/with-tmp-dirs #{local-disk-path}
+      (with-open [node-1 (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                            :poll-duration "PT2S"}]}
+                                          :log [:kafka {:cluster :my-kafka, :topic topic}]
+                                          :storage [:local {:path local-disk-path}]
+                                          :compactor {:threads 0}})
+                  node-2 (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                            :poll-duration "PT2S"}]}
+                                          :log [:kafka {:cluster :my-kafka, :topic topic}]
+                                          :storage [:local {:path local-disk-path}]
+                                          :compactor {:threads 0}})
+                  xtdb-conn-1 (.build (.createConnectionBuilder node-1))
+                  xtdb-conn-2 (.build (.createConnectionBuilder node-2))]
+        (jdbc/execute! xtdb-conn-1 ["INSERT INTO foo RECORDS {_id: 'primary'}"])
+        (jdbc/execute! xtdb-conn-2 ["INSERT INTO foo RECORDS {_id: 'primary2'}"])
+        (tu/flush-block! node-1)
+
+        (log/info "Testing that both nodes can read from the topic after flush and compact")
+        (log/info "Running query against node 1") 
+        (t/is (= #{{:_id "primary"} {:_id "primary2"}}
+                 (set (jdbc/execute! xtdb-conn-1 ["SELECT * FROM foo"]))))
+
+        (log/info "Running query against node 2") 
+        (t/is (= #{{:_id "primary"} {:_id "primary2"}}
+                 (set (jdbc/execute! xtdb-conn-2 ["SELECT * FROM foo"]))))
+        
+        (log/info "Running second query against node 2")
+        (jdbc/execute! xtdb-conn-2 ["INSERT INTO foo RECORDS {_id: 'primary3'}"])
+        (t/is (= #{{:_id "primary"} {:_id "primary2"} {:_id "primary3"}}
+                 (set (jdbc/execute! xtdb-conn-2 ["SELECT * FROM foo"]))))))))

--- a/src/test/clojure/xtdb/read_only_node_test.clj
+++ b/src/test/clojure/xtdb/read_only_node_test.clj
@@ -3,6 +3,7 @@
             [xtdb.api :as xt]
             [xtdb.log :as xt-log]
             [xtdb.node :as xtn]
+            [xtdb.test-util :as tu]
             [xtdb.util :as util]))
 
 (t/deftest read-only-node-rejects-writes
@@ -41,3 +42,70 @@
         (t/is (= [{:xt/id "from-rw", :v 2}]
                  (xt/q ro-node "SELECT * FROM foo"))
               "read-only node sees updated data from read-write node")))))
+
+(t/deftest read-only-node-sees-data-after-block-flush
+  (util/with-tmp-dirs #{node-dir}
+    (let [cfg {:log [:local {:path (.resolve node-dir "log")}]
+               :storage [:local {:path (.resolve node-dir "objects")}]}]
+      (with-open [rw-node (xtn/start-node cfg)
+                  ro-node (-> (xtn/->config cfg)
+                              (.readOnlyDatabases true)
+                              (.open))]
+
+        (xt/submit-tx rw-node [[:put-docs :foo {:xt/id "a", :x 1}]])
+        (tu/flush-block! rw-node)
+        (xt-log/sync-node ro-node #xt/duration "PT5S")
+
+        (t/is (= [{:xt/id "a", :x 1}]
+                 (xt/q ro-node "SELECT * FROM foo"))
+              "ro node sees data after first block flush")
+
+        (xt/submit-tx rw-node [[:put-docs :foo {:xt/id "b", :x 2, :y "hello"}]])
+        (tu/flush-block! rw-node)
+        (xt-log/sync-node ro-node #xt/duration "PT5S")
+
+        (t/is (= #{{:xt/id "a", :x 1} {:xt/id "b", :x 2, :y "hello"}}
+                 (set (xt/q ro-node "SELECT * FROM foo")))
+              "ro node sees all data after second block flush")))))
+
+(t/deftest read-only-node-updates-table-catalog-on-block-flush
+  (util/with-tmp-dirs #{node-dir}
+    (let [cfg {:log [:local {:path (.resolve node-dir "log")}]
+               :storage [:local {:path (.resolve node-dir "objects")}]}]
+      (with-open [rw-node (xtn/start-node cfg)
+                  ro-node (-> (xtn/->config cfg)
+                              (.readOnlyDatabases true)
+                              (.open))]
+
+        (xt/execute-tx rw-node [[:put-docs :foo {:xt/id "a", :x 1}]])
+        (tu/flush-block! rw-node)
+
+        (xt/execute-tx rw-node [[:put-docs :bar {:xt/id "b", :y 2}]])
+
+        (t/is (= [{:xt/id "b", :y 2}]
+                 (xt/q ro-node "SELECT * FROM bar"))
+              "table in live index is visible")
+        (t/is (= [{:xt/id "a", :x 1}]
+                 (xt/q ro-node "SELECT * FROM foo"))
+              "table flushed to block while ro node was running is visible")))))
+
+(t/deftest read-only-node-loads-table-catalog-at-startup
+  (util/with-tmp-dirs #{node-dir}
+    (let [cfg {:log [:local {:path (.resolve node-dir "log")}]
+               :storage [:local {:path (.resolve node-dir "objects")}]}]
+      (with-open [rw-node (xtn/start-node cfg)]
+
+        (xt/execute-tx rw-node [[:put-docs :foo {:xt/id "a", :x 1}]])
+        (tu/flush-block! rw-node)
+
+        (xt/execute-tx rw-node [[:put-docs :bar {:xt/id "b", :y 2}]])
+
+        (with-open [ro-node (-> (xtn/->config cfg)
+                                (.readOnlyDatabases true)
+                                (.open))] 
+          (t/is (= [{:xt/id "a", :x 1}]
+                   (xt/q ro-node "SELECT * FROM foo"))
+                "table from block flushed before startup is visible")
+          (t/is (= [{:xt/id "b", :y 2}]
+                   (xt/q ro-node "SELECT * FROM bar"))
+                "table in live index is visible"))))))


### PR DESCRIPTION
Github actions runs: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Afeat%2Ffix-single-writer-awaiting 

## Context

Follower and read-only nodes silently lose visibility of tables after a block flush (#5405).
Queries return empty results for tables whose data has been flushed to a block, while tables still in the live index work fine.
This affects single-writer deployments where the follower processes `BlockUploaded` messages, and read-only source nodes that enter the pending-block path.

## Root cause

`LiveIndex.buildSchema()` merges two sources of table metadata: `tableCatalog.types` (from finished blocks) and `snap.allColumnTypes` (from the live index).
When a block transition happens, `liveIndex.nextBlock()` clears the live tables — but neither `FollowerLogProcessor` nor the read-only `SourceLogProcessor` path ever updated `tableCatalog`.
The leader/source paths correctly called `tableCatalog.finishBlock()`, but followers had no reference to `tableCatalog` at all.

Result: `buildSchema()` returns an empty map, `table-info` is empty at planning time, and tables resolve to `xt/not_found`.

## Approach

We considered `tableCatalog.refresh()` but it pulls all table-block files from storage — too heavy for a hot path.
Instead, we extract the metadata (vecTypes, rowCount, HLLs) from the live index *before* `nextBlock()` clears it, and merge it in-memory.

This required:
- `LiveTable.blockMetadata()` / `LiveIndex.blockMetadata()` — lightweight metadata extraction without writing tries to storage (unlike `finishBlock`)
- `TableCatalog.updateFromBlockMetadata()` — merges the delta into the in-memory state without building `TableBlock` protos (the source already wrote those)
- Calling this in both `FollowerLogProcessor`'s `BlockUploaded` handler and `SourceLogProcessor.enterPendingBlock()`

Also includes an earlier fix for an `addTries` race condition on the follower, and test coverage for both the Kafka multi-node and read-only node scenarios.

Resolves #5405

🤖 Generated with [Claude Code](https://claude.com/claude-code)