### PR TITLE
tidy(catalog): remove TableCatalog's constructor dependency on BlockCatalog

### DIFF
--- a/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
@@ -21,7 +21,6 @@ import xtdb.util.toHLL
 import java.nio.ByteBuffer
 
 class TableCatalog(
-    private val blockCatalog: BlockCatalog,
     private val bufferPool: BufferPool
 ) {
 
@@ -50,7 +49,9 @@ class TableCatalog(
     val types: Map<TableRef, Map<ColumnName, VectorType>>
         get() = state.tables.mapValues { (_, meta) -> meta.vecTypes }
 
-    fun refresh(blockIndex: Long) {
+    fun refresh(blockCatalog: BlockCatalog) {
+        val blockIndex = blockCatalog.currentBlockIndex ?: return
+
         if (state.blockIdx?.let { blockIndex <= it } ?: false) return
 
         state = State(
@@ -59,7 +60,7 @@ class TableCatalog(
         )
     }
 
-    fun updateFromBlockMetadata(metadata: Map<TableRef, LiveTable.BlockMetadata>) {
+    fun updateFromBlockMetadata(blockIndex: Long?, metadata: Map<TableRef, LiveTable.BlockMetadata>) {
         val oldTables = state.tables
 
         val deltaByTable = metadata.mapValues { (_, bm) ->
@@ -70,12 +71,13 @@ class TableCatalog(
         val newTables = allTableRefs.associateWith { mergeTables(oldTables[it], deltaByTable[it]) }
 
         state = State(
-            blockIdx = blockCatalog.currentBlockIndex,
+            blockIdx = blockIndex,
             tables = newTables
         )
     }
 
     fun finishBlock(
+        blockIndex: Long?,
         tableMetadata: Map<TableRef, LiveTable.FinishedBlock>,
         tablePartitions: Map<TableRef, List<Partition>>
     ): Map<TableRef, TableBlock> {
@@ -89,7 +91,7 @@ class TableCatalog(
         val newTables = allTableRefs.associateWith { mergeTables(oldTables[it], deltaByTable[it]) }
 
         state = State(
-            blockIdx = blockCatalog.currentBlockIndex,
+            blockIdx = blockIndex,
             tables = newTables
         )
 

--- a/core/src/main/kotlin/xtdb/database/DatabaseState.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseState.kt
@@ -43,8 +43,8 @@ data class DatabaseState(
 
             val blockCatalog = BlockCatalog(dbName, bufferPool.latestBlock)
 
-            val tableCatalog = TableCatalog(blockCatalog, bufferPool).also {
-                it.refresh(blockCatalog.currentBlockIndex ?: -1)
+            val tableCatalog = TableCatalog(bufferPool).also {
+                it.refresh(blockCatalog)
             }
 
             val trieCatalog = trieCatalogFactory.open(bufferPool, blockCatalog)

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -66,7 +66,7 @@ class BlockUploader(
         val allTables = finishedBlocks.keys + blockCatalog.allTables
         val tablePartitions = allTables.associateWith { trieCatalog.getPartitions(it) }
 
-        val tableBlocks = tableCatalog.finishBlock(finishedBlocks, tablePartitions)
+        val tableBlocks = tableCatalog.finishBlock(blockCatalog.currentBlockIndex, finishedBlocks, tablePartitions)
 
         for ((table, tableBlock) in tableBlocks) {
             val path = BlockCatalog.tableBlockPath(table, blockIdx)

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -143,7 +143,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
 
                 addTries(msg.tries, record.logTimestamp)
                 blockCatalog.refresh(block)
-                tableCatalog.updateFromBlockMetadata(liveIndex.blockMetadata())
+                tableCatalog.updateFromBlockMetadata(blockCatalog.currentBlockIndex, liveIndex.blockMetadata())
                 liveIndex.nextBlock()
                 compactor.signalBlock()
 

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
@@ -212,7 +212,7 @@ class SourceLogProcessor(
         val allTables = finishedBlocks.keys + blockCatalog.allTables
         val tablePartitions = allTables.associateWith { trieCatalog.getPartitions(it) }
 
-        val tableBlocks = tableCatalog.finishBlock(finishedBlocks, tablePartitions)
+        val tableBlocks = tableCatalog.finishBlock(blockCatalog.currentBlockIndex, finishedBlocks, tablePartitions)
 
         for ((table, tableBlock) in tableBlocks) {
             val path = BlockCatalog.tableBlockPath(table, blockIdx)
@@ -241,7 +241,7 @@ class SourceLogProcessor(
     private fun enterPendingBlock() {
         val blockIdx = (blockCatalog.currentBlockIndex ?: -1) + 1
         pendingBlockIdx = blockIdx
-        tableCatalog.updateFromBlockMetadata(liveIndex.blockMetadata())
+        tableCatalog.updateFromBlockMetadata(blockCatalog.currentBlockIndex, liveIndex.blockMetadata())
         liveIndex.nextBlock()
         LOG.debug("[$dbName] read-only: waiting for block 'b${blockIdx.asLexHex}' via BlockUploaded...")
     }

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -91,7 +91,7 @@ class LeaderLogProcessorTest {
             every { getPartitions(any()) } returns emptyList()
         }
         val tableCatalog = mockk<TableCatalog>(relaxed = true) {
-            every { finishBlock(any(), any()) } returns emptyMap()
+            every { finishBlock(any(), any(), any()) } returns emptyMap()
         }
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
         val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
@@ -153,7 +153,7 @@ class LeaderLogProcessorTest {
             every { getPartitions(any()) } returns emptyList()
         }
         val tableCatalog = mockk<TableCatalog>(relaxed = true) {
-            every { finishBlock(any(), any()) } returns mapOf(
+            every { finishBlock(any(), any(), any()) } returns mapOf(
                 tableRef to TableBlock.getDefaultInstance()
             )
         }


### PR DESCRIPTION
TableCatalog held a BlockCatalog reference from instantiation, but only needed it transiently — in `refresh` (to load tables from storage) and in `finishBlock` (to record the current block index in state).

`refresh` now takes `BlockCatalog` as a parameter since it genuinely needs it for `loadTablesFromStorage`.
`finishBlock` takes `Long?` — the only value it extracted was `currentBlockIndex`, and passing it directly avoids coupling to the full BlockCatalog lifecycle.