### PR TITLE
fix(aws): reduce heap pressure on S3 upload path

### DIFF
--- a/core/src/main/kotlin/xtdb/util/MemoryUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/MemoryUtil.kt
@@ -3,6 +3,7 @@ package xtdb.util
 
 import io.netty.util.internal.PlatformDependent
 import java.lang.Runtime.getRuntime
+import java.nio.ByteBuffer
 import java.nio.MappedByteBuffer
 import java.nio.channels.ClosedByInterruptException
 import java.nio.channels.FileChannel
@@ -27,3 +28,12 @@ fun toMmapPath(path: Path): MappedByteBuffer =
     } catch (e: ClosedByInterruptException) {
         throw InterruptedException()
     }
+
+fun ByteBuffer.slices(sliceSize: Int): Sequence<ByteBuffer> = sequence {
+    val src = duplicate()
+    while (src.hasRemaining()) {
+        val len = minOf(sliceSize, src.remaining())
+        yield(src.slice().limit(len))
+        src.position(src.position() + len)
+    }
+}

--- a/core/src/main/kotlin/xtdb/util/SystemLogger.kt
+++ b/core/src/main/kotlin/xtdb/util/SystemLogger.kt
@@ -21,6 +21,7 @@ fun Logger.info(message: Supplier<String>) = log(INFO, message)
 fun Logger.info(throwable: Throwable, message: String) = log(INFO, message, throwable)
 
 fun Logger.warn(message: String) = log(WARNING, message)
+fun Logger.warn(message: Supplier<String>) = log(WARNING, message)
 fun Logger.warn(throwable: Throwable, message: String) = log(WARNING, message, throwable)
 
 fun Logger.error(message: String) = log(ERROR, message)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,8 @@ LABEL usage="Example docker-run options for custom logging configuration: \
 --volume .:/config --env JDK_JAVA_OPTIONS='-Dlogback.configurationFile=/config/logback.xml'"
 
 # For healthcheck
-RUN apk add --no-cache wget gcompat
+# wget: healthcheck, gcompat: glibc compat, libgcc: needed by netty-tcnative
+RUN apk add --no-cache wget gcompat libgcc
 
 COPY --from=jlink /build/build/custom-jre /opt/java
 ENV PATH="/opt/java/bin:$PATH"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,9 @@ arrow-adbc = { group = "org.apache.arrow.adbc", name = "adbc-core", version.ref 
 arrow-adbc-driver-manager = { group = "org.apache.arrow.adbc", name = "adbc-driver-manager", version.ref = "arrow-adbc" }
 arrow-adbc-fsql = { group = "org.apache.arrow.adbc", name = "adbc-driver-flight-sql", version.ref = "arrow-adbc" }
 arrow-flight-sql = { group = "org.apache.arrow", name = "flight-sql", version.ref = "arrow" }
+netty-bom = { group = "io.netty", name = "netty-bom", version.ref = "netty" }
 netty-common = { group = "io.netty", name = "netty-common", version.ref = "netty" }
+aws-netty-nio-client = { group = "software.amazon.awssdk", name = "netty-nio-client", version.ref = "aws-sdk" }
 
 roaring-bitmap = { group = "org.roaringbitmap", name = "RoaringBitmap", version = "1.3.0" }
 hppc = { group = "com.carrotsearch", name = "hppc", version = "0.10.0" }

--- a/modules/aws/build.gradle.kts
+++ b/modules/aws/build.gradle.kts
@@ -26,6 +26,10 @@ dependencies {
     api(project(":xtdb-core"))
 
     api(libs.aws.s3)
+    api(libs.aws.netty.nio.client)
+    api(platform(libs.netty.bom))
+    for (classifier in listOf("linux-x86_64", "linux-aarch_64", "osx-x86_64", "osx-aarch_64"))
+        runtimeOnly("io.netty:netty-tcnative-boringssl-static") { artifact { this.classifier = classifier } }
 
     // metrics
     api(libs.micrometer.registry.cloudwatch2)

--- a/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
@@ -12,14 +12,19 @@ import kotlinx.serialization.Transient
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.subclass
+import io.netty.handler.ssl.OpenSsl
+import io.netty.handler.ssl.SslProvider
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.core.FileTransformerConfiguration
 import software.amazon.awssdk.core.async.AsyncRequestBody
 import software.amazon.awssdk.core.async.AsyncResponseTransformer
+import software.amazon.awssdk.core.interceptor.Context
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3AsyncClient
-import software.amazon.awssdk.services.s3.S3Configuration
 import software.amazon.awssdk.services.s3.model.*
 import xtdb.api.PathWithEnvVarSerde
 import xtdb.api.StringWithEnvVarSerde
@@ -33,6 +38,10 @@ import xtdb.aws.s3.S3Configurator
 import xtdb.multipart.IMultipartUpload
 import xtdb.multipart.SupportsMultipart
 import xtdb.util.asPath
+import xtdb.util.logger
+import xtdb.util.slices
+import xtdb.util.trace
+import xtdb.util.warn
 import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.file.Path
@@ -78,13 +87,14 @@ class S3(
         client.close()
     }
 
-    private fun efficientAsyncRequestBody(buf: ByteBuffer): AsyncRequestBody =
-        buf
-            // prevents copying the buffer into a new heap ByteBuffer, as `fromByteBuffer` would do
-            .let(AsyncRequestBody::fromByteBufferUnsafe)
-            // makes the buffer non-replayable, again preventing heap copies for payload-signing or checksum calculations
-            // (couldn't achive this effect by S3 client configuration)
-            .let(AsyncRequestBody::fromPublisher)
+    private fun asyncRequestBody(buf: ByteBuffer): AsyncRequestBody =
+        if (LESS_HEAP_COPIES)
+            // Since LESS_HEAP_COPIES disables chunking, we do our own slicing.
+            // That's because we cannot prevent the Netty TLS layer doing copies, so we need to ensure those are not too big.
+            AsyncRequestBody.fromByteBuffersUnsafe(*buf.slices(256 * 1024).toList().toTypedArray())
+        else
+            // Always prevent fromByteBuffer's heap copy by using fromByteBuffer*Unsafe*
+            AsyncRequestBody.fromByteBufferUnsafe(buf)
 
     override fun startMultipart(k: Path): CompletableFuture<IMultipartUpload<CompletedPart>> = scope.future {
         val s3Key = prefix.resolve(k).toString()
@@ -108,7 +118,7 @@ class S3(
                     val contentLength = buf.remaining().toLong()
                     val partNum = idx + 1
 
-                    val partResp = client.uploadPart(efficientAsyncRequestBody(buf)) {
+                    val partResp = client.uploadPart(asyncRequestBody(buf)) {
                         it.bucket(bucket)
                         it.key(s3Key)
                         it.uploadId(uploadId)
@@ -187,7 +197,7 @@ class S3(
 
             val contentLength = buf.remaining().toLong()
 
-            client.putObject(efficientAsyncRequestBody(buf)) {
+            client.putObject(asyncRequestBody(buf)) {
                 it.bucket(bucket)
                 it.key(s3Key)
                 it.contentLength(contentLength)
@@ -247,6 +257,10 @@ class S3(
 
 
     companion object {
+        private val LOG = S3::class.logger
+
+        private const val LESS_HEAP_COPIES = true
+
         @JvmStatic
         fun s3(bucket: String) = Factory(bucket = bucket)
 
@@ -260,6 +274,25 @@ class S3(
             @Serializable(StringWithEnvVarSerde::class) val accessKey: String,
             @Serializable(StringWithEnvVarSerde::class) val secretKey: String
         )
+
+        /** Logs when the SDK unexpectedly signs the payload or uses chunked encoding, which would indicate heap ByteBuffer allocations on the upload path. */
+        internal object HeapCopyDetector : ExecutionInterceptor {
+            override fun beforeTransmission(context: Context.BeforeTransmission, attrs: ExecutionAttributes) {
+                val headers = context.httpRequest().headers()
+                val contentSha = headers["x-amz-content-sha256"]?.firstOrNull()
+                val contentEncoding = headers["Content-Encoding"]?.firstOrNull()
+
+                fun headersSummary() =
+                    "x-amz-content-sha256=$contentSha, Content-Encoding=$contentEncoding, checksum header is ${headers.keys.firstOrNull { it.startsWith("x-amz-checksum-") }}"
+
+                LOG.trace { "S3 ${context.httpRequest().method().name}: ${headersSummary()}" }
+
+                if (contentEncoding == "aws-chunked"
+                    || (contentSha != null && contentSha != "UNSIGNED-PAYLOAD")) {
+                    LOG.warn { "S3 request using payload signing/chunked encoding: ${headersSummary()}" }
+                }
+            }
+        }
     }
 
     @Serializable
@@ -305,8 +338,27 @@ class S3(
                         }
                         endpoint?.let { endpointOverride(URI(it)) }
 
-                        if (pathStyleAccessEnabled)
-                            serviceConfiguration { it.pathStyleAccessEnabled(true) }
+                        if (LESS_HEAP_COPIES) {
+                            if (OpenSsl.isAvailable()) {
+                                // Netty's OpenSSL (BoringSSL) copies into direct memory, avoids heap copies done by Netty's JDK SslEngineType
+                                httpClient(
+                                    NettyNioAsyncHttpClient.builder()
+                                        .sslProvider(SslProvider.OPENSSL)
+                                        .build()
+                                )
+                            } else {
+                                LOG.warn(OpenSsl.unavailabilityCause(),
+                                    "OpenSSL (BoringSSL) not available for S3 client — TLS will use JDK SSLEngine with heap copies")
+                            }
+                            overrideConfiguration { it.addExecutionInterceptor(HeapCopyDetector) }
+                        }
+
+                        serviceConfiguration {
+                            if (LESS_HEAP_COPIES) {
+                                it.chunkedEncodingEnabled(false) // avoid ChunkedEncodedPublisher, which does heap copies, and can OOM
+                            }
+                            if (pathStyleAccessEnabled) it.pathStyleAccessEnabled(true)
+                        }
 
                         s3Configurator.configureClient(this)
                     }.build()
@@ -355,4 +407,5 @@ class S3(
             builder.subclass(Factory::class)
         }
     }
+
 }

--- a/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
@@ -19,6 +19,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.core.FileTransformerConfiguration
 import software.amazon.awssdk.core.async.AsyncRequestBody
 import software.amazon.awssdk.core.async.AsyncResponseTransformer
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation
 import software.amazon.awssdk.core.interceptor.Context
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor
@@ -275,21 +276,27 @@ class S3(
             @Serializable(StringWithEnvVarSerde::class) val secretKey: String
         )
 
-        /** Logs when the SDK unexpectedly signs the payload or uses chunked encoding, which would indicate heap ByteBuffer allocations on the upload path. */
+        /** Logs when the SDK unexpectedly signs the payload, uses chunked encoding, or computes an integrity checksum — all of which indicate heap ByteBuffer allocations on the upload path. */
         internal object HeapCopyDetector : ExecutionInterceptor {
             override fun beforeTransmission(context: Context.BeforeTransmission, attrs: ExecutionAttributes) {
                 val headers = context.httpRequest().headers()
                 val contentSha = headers["x-amz-content-sha256"]?.firstOrNull()
                 val contentEncoding = headers["Content-Encoding"]?.firstOrNull()
+                val checksumHeader = headers.keys.firstOrNull { it.startsWith("x-amz-checksum-") }
 
                 fun headersSummary() =
-                    "x-amz-content-sha256=$contentSha, Content-Encoding=$contentEncoding, checksum header is ${headers.keys.firstOrNull { it.startsWith("x-amz-checksum-") }}"
+                    "x-amz-content-sha256=$contentSha, Content-Encoding=$contentEncoding, checksum header is $checksumHeader"
 
                 LOG.trace { "S3 ${context.httpRequest().method().name}: ${headersSummary()}" }
 
                 if (contentEncoding == "aws-chunked"
                     || (contentSha != null && contentSha != "UNSIGNED-PAYLOAD")) {
                     LOG.warn { "S3 request using payload signing/chunked encoding: ${headersSummary()}" }
+                }
+
+                // x-amz-checksum-* on a PUT means ChecksumSubscriber ran, thus buffering the whole payload on heap before transmission
+                if (checksumHeader != null && context.httpRequest().method().name == "PUT") {
+                    LOG.warn { "S3 PUT carrying integrity checksum header — buffered ChecksumSubscriber ran: ${headersSummary()}" }
                 }
             }
         }
@@ -350,6 +357,10 @@ class S3(
                                 LOG.warn(OpenSsl.unavailabilityCause(),
                                     "OpenSSL (BoringSSL) not available for S3 client — TLS will use JDK SSLEngine with heap copies")
                             }
+                            // With chunkedEncodingEnabled=false forces to put an integrity checksum -
+                            // ChecksumSubscriber buffers the whole payload onto heap before transmission.
+                            // WHEN_REQUIRED skips that path for operations that don't require a checksum (incl. PutObject).
+                            requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
                             overrideConfiguration { it.addExecutionInterceptor(HeapCopyDetector) }
                         }
 


### PR DESCRIPTION
Closes #5373 

## Context

Production OOMs during S3 `putObject` — heap was exhausted by upload-path allocations during block flushes.
Two layers in the AWS SDK / Netty pipeline make heap copies that compound under load:

1. **SDK's `ChunkedEncodedPublisher`** — allocates 128KB heap buffers per chunk for `aws-chunked` framing.
   Individually small, but adds sustained heap pressure during concurrent block uploads.

2. **Netty's `SslHandler`** — `SslHandlerCoalescingBufferQueue.composeFirst()` coalesces pending channel writes into a buffer for `SSLEngine.wrap()`.
   With JDK's SSLEngine (`SslEngineType.JDK`), this is a **heap** buffer.
   With BoringSSL (`SslEngineType.TCNATIVE`), it's a **direct** buffer.

The original OOM stack trace pointed at `encodeChunk` — but `ChunkedEncodedPublisher` does its own internal chunking at 128KB, so that allocation alone shouldn't OOM.
It was the tipping point on an already heap-stressed JVM, not the root cause.

## Approach

A single `LESS_HEAP_COPIES` flag in `S3.companion` controls three optimizations:

- **Disable `aws-chunked` encoding** — removes `ChunkedEncodedPublisher` from the pipeline entirely.
  The SDK falls back to `UNSIGNED-PAYLOAD` over HTTPS (no per-chunk heap allocations, no signing overhead).

- **Slice upload buffers into 256KB emissions** — since we disabled the SDK's chunking (which bounded writes at 128KB), we do our own slicing via `ByteBuffer.slices()`.
  This keeps Netty's `SslHandler` coalescing queue bounded per write, regardless of upload size.

- **BoringSSL via netty-tcnative** — sets Netty's `SslEngineType` to `TCNATIVE` (`wantsDirectBuffer=true`), so `composeFirst()` allocates direct memory instead of heap.
  Falls back gracefully with a WARN log if BoringSSL isn't available (`OpenSsl.isAvailable()` check).

A `HeapCopyDetector` `ExecutionInterceptor` is installed for observability — TRACE logs S3 request signing headers, WARN if chunked encoding or payload signing is unexpectedly active.

## Dead ends

**AWS CRT HTTP client** — attempted as a drop-in Netty replacement (s2n-tls, no heap copies).
XTDB's upload path uses blocking `.get()` calls on coroutine dispatcher threads.
CRT's limited native connection pool + those blocking threads = thread starvation deadlock on startup.
Pre-requisite for CRT: migrate `.get()` to `.await()` in the upload path — a larger change tracked separately.

## Scope

- This PR reduces heap pressure on the upload path; it doesn't eliminate all heap usage.
- `S3PayloadSigningTest` integration test exists but needs updating for the new `S3` constructor — tracked on #5373.
- The `LESS_HEAP_COPIES` flag is hardcoded `true`; making it configurable is future work if needed.

Refs #5373