### PR TITLE
feat(sql): add parse_ident function

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1630,6 +1630,73 @@
 (defmethod codegen-call [:string_to_array :null :null] [_]
   {:return-type #xt/type :null, :->call-code (constantly nil)})
 
+(defn- scan-quoted-ident
+  "Scans a quoted identifier starting after the opening quote at position `start`.
+  Returns [parsed-string position-after-closing-quote]."
+  ^clojure.lang.IPersistentVector [^String s ^long start]
+  (let [len (.length s)
+        sb (StringBuilder.)]
+    (loop [j start]
+      (when (>= j len)
+        (throw (err/incorrect :xtdb.expression/unterminated-quoted-identifier
+                              (str "unterminated quoted identifier in: " s)
+                              {:input s})))
+      (let [c (.charAt s j)]
+        (if (= c \")
+          (if (and (< (inc j) len) (= (.charAt s (inc j)) \"))
+            (do (.append sb \") (recur (+ j 2)))
+            [(.toString sb) (inc j)])
+          (do (.append sb c) (recur (inc j))))))))
+
+(defn parse-ident ^xtdb.arrow.ListValueReader [^String s]
+  (let [len (.length s)]
+    (when (zero? len)
+      (throw (err/incorrect :xtdb.expression/zero-length-identifier
+                            (str "zero-length identifier in: " s)
+                            {:input s})))
+    (loop [i 0, parts [], after-dot? false]
+      (if (>= i len)
+        (if after-dot?
+          (throw (err/incorrect :xtdb.expression/zero-length-identifier
+                                (str "zero-length identifier in: " s)
+                                {:input s}))
+          (strings->list-reader (into-array String parts)))
+
+        (if (= (.charAt s i) \")
+          ;; quoted identifier
+          (let [[part next-i] (scan-quoted-ident s (inc i))
+                next-i (long next-i)]
+            (when (zero? (.length ^String part))
+              (throw (err/incorrect :xtdb.expression/empty-quoted-identifier
+                                    (str "quoted identifier must not be empty in: " s)
+                                    {:input s})))
+            (let [parts (conj parts part)]
+              (if (>= next-i len)
+                (strings->list-reader (into-array String parts))
+                (if (= (.charAt s next-i) \.)
+                  (recur (inc next-i) parts true)
+                  (throw (err/incorrect :xtdb.expression/unexpected-character-in-identifier
+                                        (str "unexpected character after quoted identifier in: " s)
+                                        {:input s}))))))
+
+          ;; unquoted identifier — scan to next dot, fold to lowercase
+          (let [dot-idx (.indexOf s (int \.) i)
+                end (if (neg? dot-idx) len dot-idx)
+                part (.toLowerCase (.substring s i end) java.util.Locale/ROOT)]
+            (when (zero? (.length part))
+              (throw (err/incorrect :xtdb.expression/zero-length-identifier
+                                    (str "zero-length identifier in: " s)
+                                    {:input s})))
+            (let [parts (conj parts part)]
+              (if (neg? dot-idx)
+                (strings->list-reader (into-array String parts))
+                (recur (inc end) parts true)))))))))
+
+(defmethod codegen-call [:parse_ident :utf8] [_]
+  {:return-type #xt/type [:list :utf8]
+   :->call-code (fn [[s]]
+                  `(parse-ident (resolve-string ~s)))})
+
 (defmethod codegen-call [:overlay :varbinary :varbinary :int :int] [_]
   {:return-type #xt/type :varbinary
    :->call-code (fn [[target replacement from len]]

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -1199,7 +1199,7 @@
 (def-sql-fns [str] 1 Long/MAX_VALUE)
 (def-sql-fns [format] 1 Long/MAX_VALUE)
 (def-sql-fns [namespace local_name reverse] 1 1)
-(def-sql-fns [quote_ident] 1 1)
+(def-sql-fns [quote_ident parse_ident] 1 1)
 (def-sql-fns [string_to_array] 2 2)
 
 ;; system info

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1654,6 +1654,46 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
     "E'foo\\nbar'"         "\"foo\nbar\""
     "E'foo\\\\bar'"        "\"foo\\bar\""))
 
+(t/deftest test-parse-ident
+  (t/are [sql expected]
+    (= [{:x expected}] (xt/q tu/*node* (str "SELECT parse_ident(" sql ") AS x")))
+
+    ;; case folding
+    "'FOO'"                          ["foo"]
+    "'public.foo'"                   ["public" "foo"]
+    "'select.from'"                  ["select" "from"]
+
+    ;; quoted identifiers
+    "'\"Foo\".\"Bar\"'"              ["Foo" "Bar"]
+    "'\"foo\"\"bar\"'"               ["foo\"bar"]
+    "'public.\"My Table\"'"          ["public" "My Table"]
+    "'\"foo bar\"'"                  ["foo bar"]
+    "'\"has.dot\"'"                  ["has.dot"]
+    "'schema.\"has.dot\"'"           ["schema" "has.dot"]
+    "'\"\"\"nested\"\"\"'"           ["\"nested\""]
+    "'\"\"\"\"'"                     ["\""]
+    "'\"café\"'"                     ["café"]
+
+    ;; deeply nested / alternating
+    "'a.b.c.d'"                      ["a" "b" "c" "d"]
+    "'a.\"B\".c.\"D\"'"              ["a" "B" "c" "D"])
+
+  (t/testing "error cases"
+    (t/are [sql pattern]
+      (thrown-with-msg? RuntimeException pattern
+        (xt/q tu/*node* (str "SELECT parse_ident(" sql ") AS x")))
+
+      "'\"foo'"              #"unterminated quoted identifier"
+      "'foo..bar'"           #"zero-length identifier"
+      "'\"foo\"bar'"         #"unexpected character after quoted identifier"
+      "'\"\"'"               #"quoted identifier must not be empty"
+      "'.foo'"               #"zero-length identifier"
+      "'foo.'"               #"zero-length identifier"
+      "''"                   #"zero-length identifier"
+      "'\"foo\".'"           #"zero-length identifier"
+      "'foo.\"\".bar'"       #"quoted identifier must not be empty"
+      "'\"foo\" .bar'"       #"unexpected character")))
+
 (t/deftest test-string-to-array
   (t/are [s delim expected]
     (= [{:x expected}] (xt/q tu/*node* (str "SELECT string_to_array(" s ", " delim ") AS x")))


### PR DESCRIPTION
## Summary
- Adds PostgreSQL-compatible `parse_ident(qualified_name)` for splitting qualified identifiers
- Splits by `.`, handles double-quoted identifiers with `""` escape sequences
- Folds unquoted parts to lowercase, preserves case in quoted parts
- Uses `err/incorrect` for all error cases (unterminated quotes, empty identifiers, unexpected characters)
- Depends on `strings->list-reader` from #5412