### PR TITLE
test(indexer): add deterministic simulation test for LogProcessor state machine

### DIFF
--- a/core/src/test/kotlin/xtdb/DeterministicDispatcher.kt
+++ b/core/src/test/kotlin/xtdb/DeterministicDispatcher.kt
@@ -12,7 +12,7 @@ class DeterministicDispatcher(private val rand: Random) : CoroutineDispatcher() 
     private data class DispatchJob(val context: CoroutineContext, val block: Runnable)
 
 
-    private val jobs = mutableSetOf<DispatchJob>()
+    private val jobs = mutableListOf<DispatchJob>()
 
     @Volatile
     private var running = false
@@ -22,9 +22,9 @@ class DeterministicDispatcher(private val rand: Random) : CoroutineDispatcher() 
 
         if (!running) {
             running = true
-            while (true) {
-                val job = jobs.randomOrNull(rand) ?: break
-                jobs.remove(job)
+            while (jobs.isNotEmpty()) {
+                val idx = rand.nextInt(jobs.size)
+                val job = jobs.removeAt(idx)
                 job.block.run()
             }
             running = false

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -1,0 +1,222 @@
+package xtdb.indexer
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import xtdb.RepeatableSimulationTest
+import xtdb.SimulationTestBase
+import xtdb.api.TransactionKey
+import xtdb.api.log.*
+import xtdb.api.log.Log
+import xtdb.api.log.MessageId
+import xtdb.api.log.ReplicaMessage
+import xtdb.catalog.BlockCatalog
+import xtdb.catalog.TableCatalog
+import xtdb.compactor.Compactor
+import xtdb.database.DatabaseState
+import xtdb.database.DatabaseStorage
+import xtdb.storage.BufferPool
+import xtdb.trie.TrieCatalog
+import xtdb.tx.TxOp
+import xtdb.tx.toArrowBytes
+import xtdb.util.debug
+import xtdb.util.logger
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.time.Duration.Companion.seconds
+
+private val LOG = LogProcessorSimTest::class.logger
+
+@Tag("property")
+class LogProcessorSimTest : SimulationTestBase(), LogProcessor.ProcessorFactory {
+
+    private lateinit var allocator: RootAllocator
+    private lateinit var bp: BufferPool
+    private lateinit var srcLog: SimLog<SourceMessage>
+    private lateinit var replicaLog: SimLog<ReplicaMessage>
+    private lateinit var dbStorage: DatabaseStorage
+    private lateinit var dbState: DatabaseState
+    private lateinit var watchers: Watchers
+    private lateinit var indexer: Indexer.ForDatabase
+    private lateinit var blockUploader: BlockUploader
+
+    @BeforeEach
+    fun setUp() {
+        allocator = RootAllocator()
+        bp = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
+
+        val dbName = "test-db"
+
+        this.srcLog = SimLog("src", dispatcher, rand)
+        this.replicaLog = SimLog("replica", dispatcher, rand)
+        this.dbStorage = DatabaseStorage(srcLog, replicaLog, null, bp, null)
+
+        // isFull returns true every N txs, triggering block finishing
+        val fullEvery = rand.nextInt(2, 5)
+        var txCount = 0
+
+        val liveIndex = mockk<LiveIndex>(relaxed = true) {
+            every { latestCompletedTx } returns null
+            every { isFull() } answers { ++txCount % fullEvery == 0 }
+        }
+
+        this.dbState = DatabaseState(
+            dbName,
+            BlockCatalog(dbName, null),
+            mockk<TableCatalog>(relaxed = true),
+            mockk<TrieCatalog>(relaxed = true),
+            liveIndex
+        )
+
+        this.watchers = Watchers(-1)
+        this.indexer = simIndexer()
+        this.blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        indexer.close()
+        replicaLog.close()
+        srcLog.close()
+        allocator.close()
+    }
+
+    /**
+     * Simulates the Indexer — ~30% random abort rate, no actual SQL indexing.
+     */
+    private fun simIndexer() = object : Indexer.ForDatabase {
+        override fun indexTx(
+            msgId: MessageId, msgTimestamp: Instant, txOps: xtdb.arrow.VectorReader?,
+            systemTime: Instant?, defaultTz: ZoneId?, user: String?, userMetadata: Any?
+        ): ReplicaMessage.ResolvedTx =
+            ReplicaMessage.ResolvedTx(
+                txId = msgId,
+                systemTime = systemTime ?: msgTimestamp,
+                committed = rand.nextFloat() > 0.3f,
+                error = null,
+                tableData = emptyMap()
+            )
+
+        override fun addTxRow(txKey: TransactionKey, error: Throwable?): ReplicaMessage.ResolvedTx =
+            ReplicaMessage.ResolvedTx(
+                txId = txKey.txId,
+                systemTime = txKey.systemTime,
+                committed = error == null,
+                error = error,
+                tableData = emptyMap()
+            )
+
+        override fun close() {}
+    }
+
+    override fun openLeaderSystem(
+        replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+        afterSourceMsgId: MessageId,
+        afterReplicaMsgId: MessageId,
+    ): LogProcessor.LeaderSystem {
+        val proc = LeaderLogProcessor(
+            allocator, dbStorage, replicaProducer,
+            dbState, indexer, watchers,
+            emptySet(), null, blockUploader,
+            afterSourceMsgId, afterReplicaMsgId
+        )
+        return object : LogProcessor.LeaderSystem {
+            override val proc get() = proc
+            override fun close() = proc.close()
+        }
+    }
+
+    override fun openTransition(
+        replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+        afterSourceMsgId: MessageId,
+        afterReplicaMsgId: MessageId,
+    ): LogProcessor.TransitionProcessor =
+        TransitionLogProcessor(
+            allocator, bp, dbState, dbState.liveIndex,
+            blockUploader,
+            replicaProducer, watchers, null,
+            afterSourceMsgId, afterReplicaMsgId
+        )
+
+    override fun openFollower(
+        pendingBlock: PendingBlock?,
+        afterSourceMsgId: MessageId,
+        afterReplicaMsgId: MessageId,
+    ): LogProcessor.FollowerProcessor =
+        FollowerLogProcessor(
+            allocator, bp, dbState,
+            mockk<Compactor.ForDatabase>(relaxed = true),
+            watchers, null, pendingBlock,
+            afterSourceMsgId, afterReplicaMsgId
+        )
+
+    fun openLogProcessor(scope: CoroutineScope) = LogProcessor(this, dbStorage, dbState, blockUploader, scope)
+
+    private fun emptyTx(): SourceMessage.Tx =
+        SourceMessage.Tx(
+            txOps = emptyList<TxOp>().toArrowBytes(allocator),
+            systemTime = null,
+            defaultTz = ZoneId.of("UTC"),
+            user = null,
+            userMetadata = null
+        )
+
+    @RepeatableSimulationTest
+    fun `single node processes txs and flush-blocks with rebalances`(@Suppress("unused") iteration: Int) =
+        runTest(timeout = 5.seconds) {
+            val logProcScope = CoroutineScope(dispatcher + Job())
+            openLogProcessor(logProcScope).use { logProc ->
+                val groupJob = launch(dispatcher) { srcLog.openGroupSubscription(logProc) }
+
+                launch(dispatcher) {
+                    val totalActions = rand.nextInt(5, 20)
+                    LOG.debug("test: will perform $totalActions actions")
+                    repeat(totalActions) { _ ->
+                        yield()
+
+                        when (rand.nextInt(3)) {
+                            0 -> srcLog.appendMessage(emptyTx())
+                            1 -> srcLog.appendMessage(SourceMessage.FlushBlock(null))
+                            2 -> srcLog.rebalanceTrigger.send(Unit)
+                        }
+                    }
+                    val lastSrcMsgId = srcLog.latestSubmittedMsgId
+                    if (lastSrcMsgId >= 0) watchers.awaitSource(lastSrcMsgId)
+                }.join()
+
+                groupJob.cancel()
+                logProcScope.cancel()
+
+                val sourceTxIds = srcLog.topic
+                    .filter { it.message is SourceMessage.Tx || it.message is SourceMessage.LegacyTx }
+                    .map { it.msgId }
+
+                val replicaTxIds = replicaLog.topic
+                    .map { it.message }
+                    .filterIsInstance<ReplicaMessage.ResolvedTx>()
+                    .map { it.txId }
+
+                assertEquals(sourceTxIds, replicaTxIds, "every source tx should appear on the replica, in order")
+
+                assertEquals(replicaTxIds, replicaTxIds.sorted(), "replica txIds should be monotonically increasing")
+
+                assertEquals(replicaTxIds.size, replicaTxIds.toSet().size, "replica should have no duplicate txIds")
+
+                val replicaMessages = replicaLog.topic.map { it.message }
+                val boundaries = replicaMessages.filterIsInstance<ReplicaMessage.BlockBoundary>().map { it.blockIndex }
+                val uploads = replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>().map { it.blockIndex }
+                assertEquals(boundaries, uploads, "every BlockBoundary should have a matching BlockUploaded")
+            }
+        }
+}

--- a/core/src/test/kotlin/xtdb/indexer/SimLog.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLog.kt
@@ -1,0 +1,256 @@
+package xtdb.indexer
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import xtdb.api.log.Log
+import xtdb.api.log.LogOffset
+import xtdb.api.log.MessageId
+import xtdb.util.MsgIdUtil
+import kotlin.coroutines.coroutineContext
+import xtdb.util.debug
+import xtdb.util.logger
+import java.time.Instant
+import kotlin.coroutines.CoroutineContext
+import kotlin.random.Random
+
+private val LOG = SimLog::class.logger
+
+internal class SimLog<M>(private val name: String, ctx: CoroutineContext, private val rand: Random) : Log<M> {
+    override val epoch: Int get() = 0
+
+    override var latestSubmittedOffset: LogOffset = -1
+        private set
+
+    /**
+     * A consumer that participates in leader election (Kafka consumer group semantics).
+     */
+    class GroupConsumer<M>(val listener: Log.SubscriptionListener<M>) {
+        var tailSpec: Log.TailSpec<M>? = null
+        var nextOffset = 0
+    }
+
+    /**
+     * A plain consumer that receives all records independently (not part of the consumer group).
+     * Used by the replica log's follower subscription via Log.tailAll.
+     */
+    class PlainConsumer<M>(val proc: Log.RecordProcessor<M>, var nextOffset: Int, val job: Job)
+
+    val groupConsumers = mutableSetOf<GroupConsumer<M>>()
+    val plainConsumers = mutableSetOf<PlainConsumer<M>>()
+
+    val topic = mutableListOf<Log.Record<M>>()
+
+    val wakeLeader = Channel<Unit>(Channel.CONFLATED)
+    val wakePlainConsumers = Channel<Unit>(Channel.CONFLATED)
+    val rebalanceTrigger = Channel<Unit>(Channel.CONFLATED)
+
+    var leader: GroupConsumer<M>? = null
+
+    val job = Job()
+    private val scope = CoroutineScope(ctx + job)
+
+    /**
+     * Delivers records to the current group leader.
+     */
+    suspend fun processMessagesLoop() {
+        while (true) {
+            wakeLeader.receive()
+            yield()
+
+            this.leader?.let { leader ->
+                val tailSpec = leader.tailSpec
+                    ?: run {
+                        LOG.debug("$name/processMessages: leader has no tail spec, skipping")
+                        return@let
+                    }
+
+                val nextOffset = leader.nextOffset
+                val lag = topic.size - nextOffset
+
+                if (lag > 0) {
+                    val messageCount = rand.nextInt(1, lag + 1)
+                    LOG.debug("$name/processMessages: delivering $messageCount group record(s) [$nextOffset..${nextOffset + messageCount - 1}] (lag=$lag)")
+                    tailSpec.processor.processRecords(topic.subList(nextOffset, nextOffset + messageCount).toList())
+                    leader.nextOffset += messageCount
+                }
+
+                if (leader.nextOffset < topic.size)
+                    wakeLeader.send(Unit)
+            }
+        }
+    }
+
+    /**
+     * Delivers records to all plain (non-group) consumers.
+     */
+    suspend fun plainConsumerLoop() {
+        while (true) {
+            wakePlainConsumers.receive()
+            yield()
+
+            for (consumer in plainConsumers.toList()) {
+                if (!consumer.job.isActive) continue
+                val nextOffset = consumer.nextOffset
+                val lag = topic.size - nextOffset
+                if (lag > 0) {
+                    val messageCount = rand.nextInt(1, lag + 1)
+                    LOG.debug("$name/plainConsumer: delivering $messageCount record(s) [$nextOffset..${nextOffset + messageCount - 1}] (lag=$lag)")
+                    consumer.proc.processRecords(topic.subList(nextOffset, nextOffset + messageCount).toList())
+                    consumer.nextOffset += messageCount
+                }
+            }
+
+            if (plainConsumers.any { it.job.isActive && it.nextOffset < topic.size })
+                wakePlainConsumers.send(Unit)
+        }
+    }
+
+    /**
+     * Handles leader election — reacts to consumer join/leave events.
+     */
+    suspend fun chooseLeaderLoop() {
+        while (true) {
+            rebalanceTrigger.receive()
+            yield()
+
+            LOG.debug("$name/chooseLeader: rebalance triggered (${groupConsumers.size} consumers)")
+
+            leader?.let { old ->
+                LOG.debug("$name/chooseLeader: revoking old leader")
+                old.listener.onPartitionsRevoked(listOf(0))
+                old.tailSpec = null
+                leader = null
+            }
+
+            if (groupConsumers.isNotEmpty()) {
+                val newLeader = groupConsumers.random(rand)
+                LOG.debug("$name/chooseLeader: assigning new leader")
+                val tailSpec = newLeader.listener.onPartitionsAssigned(listOf(0))
+                newLeader.tailSpec = tailSpec
+                if (tailSpec != null) {
+                    val startOffset = (MsgIdUtil.afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1).toInt()
+                    newLeader.nextOffset = startOffset
+                }
+                leader = newLeader
+                wakeLeader.send(Unit)
+            } else {
+                LOG.debug("$name/chooseLeader: no consumers, no leader elected")
+            }
+        }
+    }
+
+    init {
+        LOG.debug("$name: starting loops")
+        scope.launch(CoroutineName("SimLog/processMessages")) { processMessagesLoop() }
+        scope.launch(CoroutineName("SimLog/plainConsumers")) { plainConsumerLoop() }
+        scope.launch(CoroutineName("SimLog/chooseLeader")) { chooseLeaderLoop() }
+    }
+
+    private fun appendSync(message: M): Log.MessageMetadata {
+        val offset = ++latestSubmittedOffset
+        val ts = Instant.now()
+        LOG.debug("$name/append: offset=$offset message=${message!!::class.simpleName}")
+        topic += Log.Record(epoch, offset, ts, message)
+        wakeLeader.trySend(Unit)
+        wakePlainConsumers.trySend(Unit)
+        return Log.MessageMetadata(epoch, offset, ts)
+    }
+
+    override suspend fun appendMessage(message: M): Log.MessageMetadata =
+        appendSync(message)
+
+    override fun openAtomicProducer(transactionalId: String) = object : Log.AtomicProducer<M> {
+        override fun openTx() = object : Log.AtomicProducer.Tx<M> {
+            private val buffer = mutableListOf<Pair<M, CompletableDeferred<Log.MessageMetadata>>>()
+            private var isOpen = true
+
+            override fun appendMessage(message: M): CompletableDeferred<Log.MessageMetadata> {
+                check(isOpen) { "Transaction already closed" }
+                return CompletableDeferred<Log.MessageMetadata>()
+                    .also { buffer.add(message to it) }
+            }
+
+            override fun commit() {
+                check(isOpen) { "Transaction already closed" }
+                isOpen = false
+                LOG.debug("$name/atomicProducer($transactionalId): committing ${buffer.size} message(s)")
+                for ((message, res) in buffer) {
+                    res.complete(appendSync(message))
+                }
+            }
+
+            override fun abort() {
+                check(isOpen) { "Transaction already closed" }
+                isOpen = false
+                LOG.debug("$name/atomicProducer($transactionalId): aborting ${buffer.size} message(s)")
+                buffer.clear()
+            }
+
+            override fun close() {
+                if (isOpen) abort()
+            }
+        }
+
+        override fun close() {}
+    }
+
+    override fun readLastMessage(): M? = topic.lastOrNull()?.message
+
+    override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId): Sequence<Log.Record<M>> {
+        val fromOffset = MsgIdUtil.msgIdToOffset(fromMsgId).toInt()
+        val toOffset = MsgIdUtil.msgIdToOffset(toMsgId).toInt()
+        return topic.subList(fromOffset.coerceAtLeast(0), toOffset.coerceAtMost(topic.size)).asSequence()
+    }
+
+    override suspend fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) {
+        val startOffset = (MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId) + 1).toInt()
+        LOG.debug("$name/tailAll: startOffset=$startOffset topicSize=${topic.size}")
+        val consumer = PlainConsumer(processor, startOffset, coroutineContext.job)
+        plainConsumers += consumer
+
+        if (consumer.nextOffset < topic.size)
+            wakePlainConsumers.trySend(Unit)
+
+        try {
+            awaitCancellation()
+        } finally {
+            LOG.debug("$name/tailAll: closing plain subscription")
+            plainConsumers -= consumer
+        }
+    }
+
+    private fun newGroupConsumer(listener: Log.SubscriptionListener<M>): GroupConsumer<M> {
+        LOG.debug("$name: new group consumer joining (total will be ${groupConsumers.size + 1})")
+        return GroupConsumer(listener).also {
+            groupConsumers += it
+            rebalanceTrigger.trySend(Unit)
+        }
+    }
+
+    private fun groupConsumerClosed(c: GroupConsumer<M>) {
+        LOG.debug("$name: group consumer leaving (total will be ${groupConsumers.size - 1})")
+        groupConsumers -= c
+        rebalanceTrigger.trySend(Unit)
+    }
+
+    override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>) {
+        val consumer = newGroupConsumer(listener)
+        try {
+            awaitCancellation()
+        } finally {
+            LOG.debug("$name/groupSubscription: closing")
+            groupConsumerClosed(consumer)
+        }
+    }
+
+    override fun close() {
+        LOG.debug("$name: closing")
+        job.cancel()
+        runBlocking {
+            LOG.debug("$name: waiting for loops to finish")
+            job.join()
+            LOG.debug("$name: loops finished")
+        }
+        LOG.debug("$name: closed")
+    }
+}


### PR DESCRIPTION
SimLog simulates Kafka's consumer group and plain consumer semantics, driven by a DeterministicDispatcher that explores random interleavings from a reproducible seed.

The test exercises a single node cycling through leader → transition → follower states via random rebalances, interleaved with tx submissions and flush-block requests.
The indexer stub randomly aborts ~30% of txs.

Assertions verify:
- every source tx appears on the replica, in order
- replica txIds are monotonically increasing with no duplicates
- every BlockBoundary has a matching BlockUploaded

Also includes:
- DeterministicDispatcher fix: mutableSetOf → mutableListOf with removeAt to avoid ConcurrentModificationException during drain