### PR TITLE
fix(indexer): follower block staleness check skips isFull-triggered blocks

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -78,8 +78,8 @@ class FollowerLogProcessor @JvmOverloads constructor(
         when (this) {
             is ReplicaMessage.ResolvedTx -> txId <= latestSourceMsgId
             is ReplicaMessage.TriesAdded -> sourceMsgId <= latestSourceMsgId
-            is ReplicaMessage.BlockBoundary -> latestProcessedMsgId <= latestSourceMsgId
-            is ReplicaMessage.BlockUploaded -> latestProcessedMsgId <= latestSourceMsgId
+            is ReplicaMessage.BlockBoundary -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
+            is ReplicaMessage.BlockUploaded -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
             is ReplicaMessage.NoOp -> false
         }
 

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -39,16 +39,17 @@ class TransitionLogProcessor(
         private set
 
     private val dbName = dbState.name
+    private val blockCatalog = dbState.blockCatalog
     private val trieCatalog = dbState.trieCatalog
 
     private val allocator = allocator.newChildAllocator("transition-log-processor", 0, Long.MAX_VALUE)
 
-    private val ReplicaMessage.stale get() = 
+    private val ReplicaMessage.stale get() =
         when (this) {
             is ReplicaMessage.ResolvedTx -> txId <= latestSourceMsgId
             is ReplicaMessage.TriesAdded -> sourceMsgId <= latestSourceMsgId
-            is ReplicaMessage.BlockBoundary -> latestProcessedMsgId <= latestSourceMsgId
-            is ReplicaMessage.BlockUploaded -> latestProcessedMsgId <= latestSourceMsgId
+            is ReplicaMessage.BlockBoundary -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
+            is ReplicaMessage.BlockUploaded -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
             is ReplicaMessage.NoOp -> false
         }
 

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -7,10 +7,14 @@ import org.junit.jupiter.api.BeforeEach
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import xtdb.api.TransactionKey
 import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.Watchers
+import xtdb.api.storage.Storage
+import xtdb.block.proto.block
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
@@ -97,7 +101,11 @@ class FollowerLogProcessorTest {
     @Test
     fun `skips stale messages when starting ahead of replica log`() = runTest {
         // simulates MW block with latestProcessedMsgId=1000, no boundaryReplicaMsgId,
-        // replaying a replica log that has old SW-era messages
+        // replaying a replica log that has old SW-era messages.
+        // block catalog starts at block 5 (simulating startup from latest block).
+        val startBlock = block { blockIndex = 5 }
+        blockCatalog = BlockCatalog("test", startBlock)
+        dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(1000)
         val proc = makeProcessor(afterSourceMsgId = 1000)
 
@@ -114,6 +122,31 @@ class FollowerLogProcessorTest {
 
         verify(exactly = 0) { liveIndex.importTx(any()) }
         assert(proc.latestSourceMsgId == 1000L) { "latestSourceMsgId should not have changed" }
+
+        proc.close()
+    }
+
+    @Test
+    fun `block boundary not skipped when isFull triggers on same txId`() = runTest {
+        // Simulates the replica log sequence when isFull() triggers on the leader:
+        // the BlockBoundary's latestProcessedMsgId equals the preceding ResolvedTx's txId.
+        // The follower must still process the block transition.
+        val proc = makeProcessor()
+
+        val blockProto = block { blockIndex = 0 }.toByteArray()
+        every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
+
+        assertNull(blockCatalog.currentBlockIndex, "no block before processing")
+
+        val txId = 100L
+        proc.processRecords(listOf(
+            record(0, ReplicaMessage.ResolvedTx(txId, Instant.now(), true, null, emptyMap())),
+            record(1, ReplicaMessage.BlockBoundary(0, txId)),
+            record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, txId, emptyList())),
+        ))
+
+        assertEquals(0L, blockCatalog.currentBlockIndex,
+            "block catalog should advance to block 0 even when BlockBoundary.latestProcessedMsgId == last txId")
 
         proc.close()
     }

--- a/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
@@ -1,0 +1,77 @@
+package xtdb.indexer
+
+import io.mockk.*
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import xtdb.api.log.Log
+import xtdb.api.log.ReplicaMessage
+import xtdb.api.log.Watchers
+import xtdb.catalog.BlockCatalog
+import xtdb.catalog.TableCatalog
+import xtdb.database.DatabaseState
+import xtdb.storage.BufferPool
+import xtdb.trie.TrieCatalog
+import java.time.Instant
+
+class TransitionLogProcessorTest {
+
+    private lateinit var allocator: RootAllocator
+    private lateinit var bufferPool: BufferPool
+    private lateinit var liveIndex: LiveIndex
+    private lateinit var blockUploader: BlockUploader
+    private lateinit var replicaProducer: Log.AtomicProducer<ReplicaMessage>
+    private lateinit var watchers: Watchers
+    private lateinit var blockCatalog: BlockCatalog
+    private lateinit var tableCatalog: TableCatalog
+    private lateinit var trieCatalog: TrieCatalog
+    private lateinit var dbState: DatabaseState
+
+    @BeforeEach
+    fun setUp() {
+        allocator = RootAllocator()
+        bufferPool = mockk(relaxed = true)
+        liveIndex = mockk(relaxed = true)
+        blockUploader = mockk(relaxed = true)
+        replicaProducer = mockk(relaxed = true)
+        blockCatalog = BlockCatalog("test", null)
+        tableCatalog = mockk(relaxed = true)
+        trieCatalog = mockk(relaxed = true)
+        dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        watchers = Watchers(-1)
+
+        every { bufferPool.epoch } returns 1
+    }
+
+    @AfterEach
+    fun tearDown() {
+        allocator.close()
+    }
+
+    private fun makeProcessor(afterSourceMsgId: Long = -1L) =
+        TransitionLogProcessor(
+            allocator, bufferPool, dbState, liveIndex,
+            blockUploader, replicaProducer,
+            watchers, null, afterSourceMsgId, afterReplicaMsgId = -1L
+        )
+
+    private fun <M> record(offset: Long, message: M) =
+        Log.Record(0, offset, Instant.now(), message)
+
+    @Test
+    fun `block boundary not skipped when isFull triggers on same txId`() = runTest {
+        val proc = makeProcessor()
+
+        val txId = 100L
+        proc.processRecords(listOf(
+            record(0, ReplicaMessage.ResolvedTx(txId, Instant.now(), true, null, emptyMap())),
+            record(1, ReplicaMessage.BlockBoundary(0, txId)),
+        ))
+
+        coVerify { blockUploader.uploadBlock(replicaProducer, 1, any()) }
+
+        proc.close()
+    }
+}

--- a/src/test/clojure/xtdb/read_only_node_test.clj
+++ b/src/test/clojure/xtdb/read_only_node_test.clj
@@ -1,6 +1,7 @@
 (ns xtdb.read-only-node-test
   (:require [clojure.test :as t]
             [xtdb.api :as xt]
+            [xtdb.db-catalog :as db]
             [xtdb.log :as xt-log]
             [xtdb.node :as xtn]
             [xtdb.test-util :as tu]
@@ -109,3 +110,37 @@
           (t/is (= [{:xt/id "b", :y 2}]
                    (xt/q ro-node "SELECT * FROM bar"))
                 "table in live index is visible"))))))
+
+(t/deftest read-only-node-handles-is-full-block-boundary
+  ;; Exercises block processing when isFull() triggers the block (not FlushBlock).
+  ;; In single-writer mode, this exercises the FollowerLogProcessor's stale check
+  ;; which previously dropped BlockBoundary/BlockUploaded when
+  ;; latestProcessedMsgId == latestSourceMsgId.
+  (util/with-tmp-dirs #{node-dir}
+    (let [cfg {:log [:local {:path (.resolve node-dir "log")}]
+               :storage [:local {:path (.resolve node-dir "objects")}]
+               :indexer {:rows-per-block 3}
+               :compactor {:threads 0}}]
+      (with-open [rw-node (xtn/start-node cfg)
+                  ro-node (-> (xtn/->config cfg)
+                              (.readOnlyDatabases true)
+                              (.open))]
+
+        ;; 2 docs + 1 xt.txs row = 3 rows, triggers isFull() with rows-per-block=3
+        (xt/execute-tx rw-node [[:put-docs :foo {:xt/id "a", :x 1}]
+                                [:put-docs :foo {:xt/id "b", :x 2}]])
+
+        ;; this tx lands after the block messages on the replica/source log,
+        ;; so syncing on it guarantees the ro node has processed the block.
+        (xt/execute-tx rw-node [[:put-docs :foo {:xt/id "c", :x 3}]])
+        (xt-log/sync-node ro-node #xt/duration "PT5S")
+
+        (t/is (= #{{:xt/id "a", :x 1} {:xt/id "b", :x 2} {:xt/id "c", :x 3}}
+                 (set (xt/q ro-node "SELECT * FROM foo")))
+              "ro node sees all data after isFull()-triggered block")
+
+        ;; in single-writer mode, the follower's block catalog should advance
+        (when (db/single-writer?)
+          (let [ro-block-cat (.getBlockCatalog (db/primary-db ro-node))]
+            (t/is (= 0 (.getCurrentBlockIndex ro-block-cat))
+                  "follower's block catalog should advance after isFull()-triggered block")))))))


### PR DESCRIPTION
When the leader finishes a block via isFull(), the BlockBoundary's latestProcessedMsgId equals the preceding ResolvedTx's txId. The follower's stale check used `latestProcessedMsgId <= latestSourceMsgId`, which evaluated to `T <= T` — true — silently dropping both the BlockBoundary and BlockUploaded.

This meant the follower never called blockCatalog.refresh, liveIndex.nextBlock, or compactor.signalBlock for these blocks. The block catalog froze at its startup value, causing block-lag to grow steadily (~1 per block) until the healthcheck threshold was crossed.

Followers weren't totally broken because L0 tries are delivered separately via TriesAdded messages on the replica log, so queries still found data. The visible symptom was periodic healthcheck 503s as the block-lag grew past the threshold of 5.

Block messages are block-level events — their staleness should be defined by blockIndex against the block catalog, not by comparing source message watermarks. Same fix applied to TransitionLogProcessor.