### PR TITLE
feat(sql): support generic function calls in FROM clauses

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -540,6 +540,7 @@ tableReference
     | 'LATERAL' subquery tableAlias tableProjection? # LateralDerivedTable
     | 'UNNEST' '(' expr ')' withOrdinality? tableAlias tableProjection? # CollectionDerivedTable
     | generateSeries withOrdinality? tableAlias tableProjection? # GenerateSeriesTable
+    | fn=identifier '(' ( expr (',' expr)* )? ')' withOrdinality? tableAlias tableProjection? # FunctionDerivedTable
     | '(' tableReference ')' # WrappedTableReference
     ;
 

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -25,7 +25,7 @@
            (org.antlr.v4.runtime ParserRuleContext)
            (org.apache.arrow.vector.types.pojo Field)
            (org.apache.commons.codec.binary Hex)
-           (xtdb.antlr Sql$DirectlyExecutableStatementContext Sql$GroupByClauseContext Sql$HavingClauseContext Sql$JoinSpecificationContext Sql$JoinTypeContext Sql$ObjectNameAndValueContext Sql$OrderByClauseContext Sql$QualifiedRenameColumnContext Sql$QueryBodyTermContext Sql$QuerySpecificationContext Sql$QueryTailContext Sql$RenameColumnContext Sql$SearchedWhenClauseContext Sql$SelectClauseContext Sql$SetClauseContext Sql$SimpleWhenClauseContext Sql$SortSpecificationContext Sql$SortSpecificationListContext Sql$WhenOperandContext Sql$WhereClauseContext Sql$WithTimeZoneContext SqlVisitor)
+           (xtdb.antlr Sql$DirectlyExecutableStatementContext Sql$GroupByClauseContext Sql$HavingClauseContext Sql$JoinSpecificationContext Sql$JoinTypeContext Sql$ObjectNameAndValueContext Sql$OrderByClauseContext Sql$QualifiedRenameColumnContext Sql$QueryBodyTermContext Sql$QuerySpecificationContext Sql$QueryTailContext Sql$RenameColumnContext Sql$SearchedWhenClauseContext Sql$SelectClauseContext Sql$SetClauseContext Sql$SetFunctionTypeContext Sql$SimpleWhenClauseContext Sql$SortSpecificationContext Sql$SortSpecificationListContext Sql$WhenOperandContext Sql$WhereClauseContext Sql$WithTimeZoneContext SqlLexer SqlVisitor)
            xtdb.table.TableRef
            xtdb.util.StringUtil))
 
@@ -790,6 +790,38 @@
                        (or (->col-sym (second table-projection))
                            (-> (->col-sym (str "_ordinal." (swap! !id-count inc)))
                                (vary-meta assoc :unnamed-unnest-col? true))))))))
+
+  (visitFunctionDerivedTable [{{:keys [!id-count]} :env} ctx]
+    (let [fn-id-ctx (.fn ctx)]
+      (when (some-> fn-id-ctx ^ParserRuleContext (.getRuleContext Sql$SetFunctionTypeContext 0))
+        (throw (err/incorrect ::aggregate-in-from
+                              "Aggregate functions are not allowed in FROM")))
+
+      (let [fn-name (identifier-sym fn-id-ctx)
+            args (mapv (partial accept-visitor (->ExprPlanVisitor env (or left-scope scope))) (.expr ctx))
+            expr (list* fn-name args)
+
+            table-projection (->table-projection (.tableProjection ctx))
+            table-alias (identifier-sym (.tableAlias ctx))
+            unique-table-alias (symbol (str table-alias "." (swap! !id-count inc)))
+            with-ordinality? (boolean (.withOrdinality ctx))
+            expected-cols (+ 1 (if with-ordinality? 1 0))]
+
+        (if-not (or (nil? table-projection)
+                    (= expected-cols (count table-projection)))
+          (add-err! env (->TableProjectionMismatch table-alias table-projection))
+          (let [col-sym (or (->col-sym (first table-projection))
+                            (->col-sym (str fn-name)))
+                output-cols (cond-> [col-sym]
+                              with-ordinality?
+                              (conj (or (->col-sym (second table-projection))
+                                        (->col-sym (str "_ordinal." (swap! !id-count inc))))))
+                ordinal-sym (when with-ordinality? (second output-cols))
+                plan [:table {:output-cols output-cols
+                              :rows [(cond-> {col-sym expr}
+                                       with-ordinality? (assoc ordinal-sym 1))]}]]
+            (->DerivedTable plan table-alias unique-table-alias
+                            (->insertion-ordered-set output-cols)))))))
 
   (visitWrappedTableReference [this ctx] (-> (.tableReference ctx) (.accept this))))
 

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -2461,6 +2461,72 @@ UNION ALL
            (sql/plan "SELECT x FROM range(1, 4) xs (x)"))
         "RANGE produces the same plan as GENERATE_SERIES"))
 
+(t/deftest test-function-as-from-source
+  (t/testing "scalar function as FROM-clause table source produces single row"
+    (t/is (= [{:val ["a" "b" "c"]}]
+             (xt/q tu/*node* "SELECT s AS val FROM string_to_array('a,b,c', ',') AS t(s)"))))
+
+  (t/testing "cross join range with string_to_array in FROM"
+    (t/is (= [{:i 1, :val "a"} {:i 2, :val "b"} {:i 3, :val "c"}]
+             (xt/q tu/*node* "SELECT i, s[i] AS val FROM range(1, 4) AS xs(i), string_to_array('a,b,c', ',') AS t(s)"))))
+
+  (t/testing "range with computed bounds from array functions"
+    (t/is (= [{:i 1}]
+             (xt/q tu/*node* "SELECT i FROM range(array_lower(string_to_array('public', ','), 1), array_upper(string_to_array('public', ','), 1) + 1) AS xs(i)"))))
+
+  (t/testing "default column name uses function name when no column projection"
+    (t/is (= [{:string-to-array ["a" "b" "c"]}]
+             (xt/q tu/*node* "SELECT * FROM string_to_array('a,b,c', ',') AS t"))))
+
+  (t/testing "function name as explicit column projection"
+    (t/is (= [{:string-to-array ["a" "b"]}]
+             (xt/q tu/*node* "SELECT string_to_array FROM string_to_array('a,b', ',') AS t(string_to_array)"))))
+
+  (t/testing "multiple function sources in FROM"
+    (t/is (= [{:a ["x" "y"], :b ["1" "2"]}]
+             (xt/q tu/*node* "SELECT a, b FROM string_to_array('x,y', ',') AS t1(a), string_to_array('1,2', ',') AS t2(b)"))))
+
+  (t/testing "function in FROM with WITH ORDINALITY"
+    (t/is (= [{:s ["a" "b" "c"], :n 1}]
+             (xt/q tu/*node* "SELECT * FROM string_to_array('a,b,c', ',') WITH ORDINALITY AS t(s, n)"))))
+
+  (t/testing "function in subquery FROM"
+    (t/is (= [{:x ["a" "b"]}]
+             (xt/q tu/*node* "SELECT x FROM (SELECT s AS x FROM string_to_array('a,b', ',') AS t(s)) AS sub"))))
+
+  (t/testing "empty string produces row with empty array"
+    (t/is (= [{:s []}]
+             (xt/q tu/*node* "SELECT s FROM string_to_array('', ',') AS t(s)"))))
+
+  (t/testing "NULL argument produces row with no value"
+    (t/is (= [{}]
+             (xt/q tu/*node* "SELECT s FROM string_to_array(NULL, ',') AS t(s)"))))
+
+  (t/testing "nested function calls as arguments"
+    (t/is (= [{:s ["a" "b" "c"]}]
+             (xt/q tu/*node* "SELECT s FROM string_to_array(concat('a,', concat('b,', 'c')), ',') AS t(s)"))))
+
+  (t/testing "function name disambiguates from table with same name"
+    (xt/execute-tx tu/*node* [[:sql "INSERT INTO string_to_array (_id, val) VALUES (1, 'hello')"]])
+    (t/is (= [{:xt/id 1, :val "hello"}]
+             (xt/q tu/*node* "SELECT * FROM string_to_array"))
+          "bare name resolves to table")
+    (t/is (= [{:s ["a" "b"]}]
+             (xt/q tu/*node* "SELECT s FROM string_to_array('a,b', ',') AS t(s)"))
+          "with parens resolves to function"))
+
+  (t/testing "table projection mismatch errors with too many columns"
+    (t/is (thrown-with-msg? Exception #"Table projection mismatch"
+             (xt/q tu/*node* "SELECT * FROM string_to_array('a,b', ',') AS t(a, b, c)"))))
+
+  (t/testing "WITH ORDINALITY with wrong column count errors"
+    (t/is (thrown-with-msg? Exception #"Table projection mismatch"
+             (xt/q tu/*node* "SELECT * FROM string_to_array('a,b', ',') WITH ORDINALITY AS t(s)"))))
+
+  (t/testing "aggregate functions are rejected in FROM"
+    (t/is (thrown-with-msg? Exception #"Aggregate functions are not allowed in FROM"
+             (xt/q tu/*node* "SELECT x FROM sum(42) AS t(x)")))))
+
 (t/deftest star-goes-at-end-too-3706
   (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo RECORDS {_id: 1, x: 'foo'}"]])
 


### PR DESCRIPTION
Grafana's schema discovery queries use `string_to_array(...)` directly in FROM position.
XTDB only supported UNNEST and GENERATE_SERIES as table-valued functions.

Adds a generic `FunctionDerivedTable` grammar rule that wraps scalar function results as single-row derived tables — equivalent to `(VALUES (fn_call(...))) AS t(col)`.
Default column name uses the function name, WITH ORDINALITY is supported, and aggregates are rejected with a clear error.

Relates to #5170