### PR TITLE
feat(sql): allow subqueries in ORDER BY expressions

### DIFF
--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -2072,7 +2072,7 @@
     (mapv #(.accept ^ParserRuleContext % this) (.columnReference ctx)))
 
   (visitWindowOrderClause [_this ctx]
-    (plan-sort-specification-list (.sortSpecificationList ctx) env scope nil))
+    (:ob-specs (plan-sort-specification-list (.sortSpecificationList ctx) env scope nil)))
 
   (visitWindowFrameClause [_this _ctx]
     (throw (UnsupportedOperationException. "TODO: Window frames currently not supported!")))
@@ -2214,24 +2214,28 @@
                                      {:keys [!id-count] :as env} inner-scope outer-col-syms
                                      & {:keys [gb-expr-to-col select-expr-to-col]
                                         :or {gb-expr-to-col {}, select-expr-to-col {}}}]
-  (let [outer-cols (->> outer-col-syms
+  (let [!subqs (HashMap.)
+        outer-cols (->> outer-col-syms
                         (into {} (mapcat (juxt (juxt identity identity)
                                                (juxt (comp symbol name) identity)))))
-        ob-expr-visitor (->ExprPlanVisitor env
-                                           (reify Scope
-                                             (available-cols [_]
-                                               (set/union (available-cols inner-scope) (set (keys outer-cols))))
+        ob-expr-visitor (map->ExprPlanVisitor
+                         {:env env
+                          :scope (reify Scope
+                                   (available-cols [_]
+                                     (set/union (available-cols inner-scope) (set (keys outer-cols))))
 
-                                             (-find-cols [_ [col-name :as chain] excl-cols]
-                                               (assert col-name)
-                                               (or (when (= 1 (count chain))
-                                                     (when-let [sym (get outer-cols col-name)]
-                                                       (when-not (contains? excl-cols col-name)
-                                                         [sym])))
-                                                   (find-cols inner-scope chain excl-cols)))))]
+                                   (-find-cols [_ [col-name :as chain] excl-cols]
+                                     (assert col-name)
+                                     (or (when (= 1 (count chain))
+                                           (when-let [sym (get outer-cols col-name)]
+                                             (when-not (contains? excl-cols col-name)
+                                               [sym])))
+                                         (find-cols inner-scope chain excl-cols))))
+                          :!subqs !subqs})]
 
-    (-> (.sortSpecification ctx)
-        (->> (mapv (fn [^Sql$SortSpecificationContext sort-spec-ctx]
+    {:ob-specs
+     (-> (.sortSpecification ctx)
+         (->> (mapv (fn [^Sql$SortSpecificationContext sort-spec-ctx]
                      (let [expr (cond-> (-> (.expr sort-spec-ctx) (.accept ob-expr-visitor))
                                  (seq gb-expr-to-col) (->> (w/postwalk #(get gb-expr-to-col % %))))
                            dir (or (some-> (.orderingSpecification sort-spec-ctx)
@@ -2262,16 +2266,20 @@
 
                          (get select-expr-to-col expr) {:order-by-spec [(get select-expr-to-col expr) ob-opts]}
 
-                         :else (let [in-sym (->col-sym (str "_ob" (swap! !id-count inc)))]
-                                 {:order-by-spec [in-sym ob-opts]
-                                  :in-projection {in-sym expr}})))))))))
+                          :else (let [in-sym (->col-sym (str "_ob" (swap! !id-count inc)))]
+                                  {:order-by-spec [in-sym ob-opts]
+                                   :in-projection {in-sym expr}})))))))
+     :subqs (not-empty (into {} !subqs))}))
 
 (defn- plan-order-by [^Sql$OrderByClauseContext ctx env inner-scope outer-col-syms & opts]
   (apply plan-sort-specification-list (.sortSpecificationList ctx) env inner-scope outer-col-syms opts))
 
-(defn- wrap-isolated-ob [plan outer-col-syms ob-specs]
+(defn- wrap-isolated-ob [plan outer-col-syms {:keys [ob-specs subqs]}]
   (let [in-projs (not-empty (into [] (keep :in-projection) ob-specs))]
     (as-> plan plan
+      (cond-> plan
+        subqs (apply-sqs subqs))
+
       (if in-projs
         [:map {:projections in-projs} plan]
         plan)
@@ -2283,10 +2291,13 @@
         [:project {:projections outer-col-syms} plan]
         plan))))
 
-(defn- wrap-integrated-ob [plan projected-cols ob-specs]
+(defn- wrap-integrated-ob [plan projected-cols {:keys [ob-specs subqs]}]
   (let [in-projs (not-empty (into [] (keep :in-projection) ob-specs))
         extend-projs (not-empty (into [] (filter map?) (map :projection projected-cols)))]
     (as-> plan plan
+      (cond-> plan
+        subqs (apply-sqs subqs))
+
       (if extend-projs
         [:map {:projections extend-projs} plan]
         plan)

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -1013,9 +1013,23 @@
     (t/is (= [{:y 11} {:y 21} {:y 31}]
              (xt/q tu/*node* "SELECT x + 1 AS y FROM t ORDER BY y * 2 ASC"))))
 
-  (t/testing "subquery in ORDER BY - not yet supported"
-    (t/is (thrown-with-msg? Exception #"Subqueries are not allowed in this context"
-             (xt/q tu/*node* "SELECT x + 1 AS y FROM t ORDER BY (SELECT 1)")))))
+  (t/testing "subquery in ORDER BY — constant"
+    (t/is (= #{{:y 11} {:y 21} {:y 31}}
+             (set (xt/q tu/*node* "SELECT x + 1 AS y FROM t ORDER BY (SELECT 1)")))))
+
+  (t/testing "subquery in ORDER BY — CASE WHEN ... IN (SELECT ...) pattern"
+    (xt/execute-tx tu/*node* [[:sql "INSERT INTO items (_id, category) VALUES (1, 'a'), (2, 'b'), (3, 'c')"]])
+    (xt/execute-tx tu/*node* [[:sql "INSERT INTO priority (_id, cat) VALUES (1, 'b')"]])
+    (t/is (= [{:category "b"} {:category "a"} {:category "c"}]
+             (xt/q tu/*node* "SELECT category FROM items
+                              ORDER BY CASE WHEN category IN (SELECT cat FROM priority)
+                                THEN 0 ELSE 1 END, category"))))
+
+  (t/testing "subquery in ORDER BY — EXISTS"
+    (t/is (= [{:category "b"} {:category "a"} {:category "c"}]
+             (xt/q tu/*node* "SELECT category FROM items
+                              ORDER BY CASE WHEN EXISTS (SELECT 1 FROM priority WHERE priority.cat = items.category)
+                                THEN 0 ELSE 1 END, category")))))
 
 (t/deftest test-ordered-set-aggregates
   (t/is (=plan-file


### PR DESCRIPTION
Grafana's table discovery query uses `ORDER BY CASE WHEN ... IN (SELECT ...) THEN 0 ELSE 1 END` to sort priority schemas first.
This was rejected with "Subqueries are not allowed in this context" because `plan-sort-specification-list` didn't pass a `!subqs` HashMap to the expression visitor.

Follows the same pattern as `wrap-where`: collect subqueries during expression planning, apply them via `apply-sqs` before the order-by node.
Subqueries in window ORDER BY (`OVER (ORDER BY ...)`) remain rejected — only query-level ORDER BY gains subquery support.

Note: correlated scalar subqueries like `ORDER BY (SELECT -t.x)` require a grammar change (subquery before WrappedExpr in exprPrimary) — deferred to a follow-up.

Relates to #5170