### PR TITLE
feat!(debezium): Avro message format with Schema Registry support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,6 +117,7 @@ allprojects {
     repositories {
         mavenCentral()
         maven { url = uri("https://repo.clojars.org/") }
+        maven { url = uri("https://packages.confluent.io/maven/") }
     }
 
     if (plugins.hasPlugin("java-library")) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,80 @@ services:
       - KAFKA_ENABLE_KRAFT=yes
       - KAFKA_PROCESS_ROLES=broker,controller
       - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+      - KAFKA_LISTENERS=EXTERNAL://:9092,INTERNAL://:19092,CONTROLLER://:9093
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT
+      - KAFKA_ADVERTISED_LISTENERS=EXTERNAL://localhost:9092,INTERNAL://kafka:19092
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
       - KAFKA_BROKER_ID=1
       - KAFKA_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093
       - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
       - CLUSTER_ID=q1Sh-9_ISia_zwGINzRvyQ
+
+  schema-registry:
+    image: 'confluentinc/cp-schema-registry:7.8.0'
+    ports:
+      - '8081:8081'
+    environment:
+      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
+      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:19092
+      - SCHEMA_REGISTRY_LISTENERS=http://0.0.0.0:8081
+    depends_on:
+      - kafka
+
+  debezium-connect:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM confluentinc/cp-kafka-connect:7.8.0
+        RUN mkdir -p /usr/share/confluent-hub-components/debezium-postgresql && cd /usr/share/confluent-hub-components/debezium-postgresql && curl -sL 'https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/3.0.2.Final/debezium-connector-postgres-3.0.2.Final-plugin.tar.gz' | tar xz
+    ports:
+      - '8083:8083'
+    environment:
+      - CONNECT_BOOTSTRAP_SERVERS=kafka:19092
+      - CONNECT_REST_PORT=8083
+      - CONNECT_REST_ADVERTISED_HOST_NAME=debezium-connect
+      - CONNECT_GROUP_ID=debezium-connect
+      - CONNECT_CONFIG_STORAGE_TOPIC=debezium_configs
+      - CONNECT_OFFSET_STORAGE_TOPIC=debezium_offsets
+      - CONNECT_STATUS_STORAGE_TOPIC=debezium_statuses
+      - CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR=1
+      - CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR=1
+      - CONNECT_STATUS_STORAGE_REPLICATION_FACTOR=1
+      - CONNECT_KEY_CONVERTER=org.apache.kafka.connect.storage.StringConverter
+      - CONNECT_VALUE_CONVERTER=io.confluent.connect.avro.AvroConverter
+      - CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+      - CONNECT_INTERNAL_KEY_CONVERTER=org.apache.kafka.connect.json.JsonConverter
+      - CONNECT_INTERNAL_VALUE_CONVERTER=org.apache.kafka.connect.json.JsonConverter
+      - CONNECT_PLUGIN_PATH=/usr/share/java,/usr/share/confluent-hub-components
+      - CONNECT_SCHEDULED_REBALANCE_MAX_DELAY_MS=0
+    depends_on:
+      - kafka
+      - schema-registry
+
+  # Avro CDC demo: PostgreSQL → Debezium (Avro) → Schema Registry → Kafka → XTDB
+  # Usage:
+  #   docker-compose up cdc-postgres debezium-connect schema-registry xtdb-avro
+  #   Then register the Debezium connector (see modules/debezium/README or CLAUDE.md)
+  #   and ATTACH DATABASE in XTDB:
+  #     ATTACH DATABASE cdc WITH $$
+  #       log: !Kafka { cluster: kafka, topic: cdc-replica }
+  #       externalLog: !Debezium
+  #         messageFormat: !Avro {}
+  #         log: !Kafka { logCluster: kafka, tableTopic: testdb.public.<table> }
+  #     $$
+
+  cdc-postgres:
+    image: 'postgres:17-alpine'
+    ports:
+      - '5433:5432'
+    environment:
+      POSTGRES_DB: testdb
+      POSTGRES_USER: testuser
+      POSTGRES_PASSWORD: testpass
+    command: ['postgres', '-c', 'wal_level=logical']
 
   minio:
     image: minio/minio:latest

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ clojure = "1.12.0"
 exposed = "0.61.0"
 google-cloud-storage = "2.60.0"
 guava = "33.4.7-jre"
+confluent = "7.8.0"
 kafka = "4.1.1"
 kotest = "6.1.11"
 kotlin = "2.3.0"
@@ -151,6 +152,7 @@ guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 # Kafka
 kafka-clients = { group = "org.apache.kafka", name = "kafka-clients", version.ref = "kafka" }
 kafka-connect-api = { group = "org.apache.kafka", name = "connect-api", version.ref = "kafka" }
+kafka-avro-serializer = { group = "io.confluent", name = "kafka-avro-serializer", version.ref = "confluent" }
 
 # Dev/test dependencies
 jovial = { group = "dev.clojurephant", name = "jovial", version = "0.4.3" }

--- a/modules/debezium/build.gradle.kts
+++ b/modules/debezium/build.gradle.kts
@@ -17,8 +17,12 @@ dependencies {
     api(libs.kotlinx.serialization.json)
     api(libs.protobuf.kotlin)
 
+    implementation(libs.kafka.avro.serializer)
+
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.kafka)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.pgjdbc)
 }

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumLog.kt
@@ -12,7 +12,7 @@ import xtdb.debezium.proto.DebeziumSourceConfig.LogCase.*
 sealed interface DebeziumLog : ExternalLog<DebeziumMessage> {
 
     interface Factory {
-        fun openLog(dbName: String, clusters: Map<LogClusterAlias, Log.Cluster>): DebeziumLog
+        fun openLog(dbName: String, clusters: Map<LogClusterAlias, Log.Cluster>, messageFormat: MessageFormat): DebeziumLog
 
         companion object {
             val serializersModule = SerializersModule {

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumSource.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumSource.kt
@@ -20,8 +20,11 @@ import com.google.protobuf.Any as ProtoAny
 
 @Serializable
 @SerialName("!Debezium")
-data class DebeziumSource(val log: DebeziumLog.Factory) : ExternalLog.Factory {
-    override fun open(dbName: String, clusters: Map<LogClusterAlias, Log.Cluster>) = log.openLog(dbName, clusters)
+data class DebeziumSource(
+    val log: DebeziumLog.Factory,
+    val messageFormat: MessageFormat,
+) : ExternalLog.Factory {
+    override fun open(dbName: String, clusters: Map<LogClusterAlias, Log.Cluster>) = log.openLog(dbName, clusters, messageFormat)
 
     override fun openProcessor(llp: LeaderLogProcessor, dbState: DatabaseState): MessageProcessor<DebeziumMessage> {
         val dbName = dbState.name
@@ -54,6 +57,9 @@ data class DebeziumSource(val log: DebeziumLog.Factory) : ExternalLog.Factory {
             when (val l = log) {
                 is KafkaDebeziumLog.Factory -> kafkaLog = l.toProto()
             }
+            if (messageFormat is MessageFormat.Avro) {
+                avro = true
+            }
         }, "proto.xtdb.com")
     }
 
@@ -62,7 +68,11 @@ data class DebeziumSource(val log: DebeziumLog.Factory) : ExternalLog.Factory {
 
         override fun fromProto(msg: ProtoAny): ExternalLog.Factory {
             val config = msg.unpack(DebeziumSourceConfigProto::class.java)
-            return DebeziumSource(log = DebeziumLog.Factory.fromProto(config))
+            val format = when (config.messageFormatCase) {
+                DebeziumSourceConfigProto.MessageFormatCase.AVRO -> MessageFormat.Avro
+                else -> MessageFormat.Json
+            }
+            return DebeziumSource(log = DebeziumLog.Factory.fromProto(config), messageFormat = format)
         }
 
         override fun registerSerde(builder: PolymorphicModuleBuilder<ExternalLog.Factory>) {

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/KafkaDebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/KafkaDebeziumLog.kt
@@ -3,13 +3,14 @@ package xtdb.debezium
 import kotlinx.coroutines.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.*
 import org.apache.arrow.memory.RootAllocator
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.InterruptException
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.Deserializer
 import org.slf4j.LoggerFactory
@@ -38,13 +39,6 @@ import java.time.Instant
 
 private val LOG = LoggerFactory.getLogger(KafkaDebeziumLog::class.java)
 
-private fun JsonElement.toJvmValue(): Any? = when (this) {
-    is JsonNull -> null
-    is JsonPrimitive -> if (isString) content else booleanOrNull ?: longOrNull ?: doubleOrNull ?: content
-    is JsonArray -> map { it.toJvmValue() }
-    is JsonObject -> entries.associate { (k, v) -> k to v.toJvmValue() }
-}
-
 private fun parseValidTimeMicros(value: Any?, field: String): Long? = when (value) {
     null -> null
     is String -> try {
@@ -60,6 +54,7 @@ class KafkaDebeziumLog @JvmOverloads constructor(
     private val dbName: String,
     private val kafkaConfig: Map<String, String>,
     private val topic: String,
+    private val messageFormat: MessageFormat,
     private val pollDuration: Duration = Duration.ofSeconds(1),
 ) : DebeziumLog {
 
@@ -75,15 +70,31 @@ class KafkaDebeziumLog @JvmOverloads constructor(
         val logCluster: LogClusterAlias, val tableTopic: String,
     ) : DebeziumLog.Factory {
 
-        override fun openLog(dbName: String, clusters: Map<LogClusterAlias, Log.Cluster>): DebeziumLog {
+        override fun openLog(dbName: String, clusters: Map<LogClusterAlias, Log.Cluster>, messageFormat: MessageFormat): DebeziumLog {
             val cluster =
                 requireNotNull(clusters[logCluster] as? KafkaCluster) { "missing Kafka cluster: '${logCluster}'" }
+
+            if (messageFormat is MessageFormat.Avro) {
+                requireNotNull(cluster.schemaRegistryUrl) {
+                    "schemaRegistryUrl must be set on Kafka cluster '${logCluster}' when using Avro message format"
+                }
+            }
 
             AdminClient.create(cluster.kafkaConfigMap).use { admin ->
                 admin.ensureTopicExists(tableTopic, autoCreate = false)
             }
 
-            return KafkaDebeziumLog(dbName, cluster.kafkaConfigMap, tableTopic)
+            val kafkaConfig = when (messageFormat) {
+                is MessageFormat.Json -> cluster.kafkaConfigMap
+                is MessageFormat.Avro -> cluster.kafkaConfigMap.plus(
+                    mapOf(
+                        KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG to cluster.schemaRegistryUrl!!,
+                        KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG to "false",
+                    )
+                )
+            }
+
+            return KafkaDebeziumLog(dbName, kafkaConfig, tableTopic, messageFormat)
         }
 
         fun toProto(): KafkaDebeziumLogConfig = kafkaDebeziumLogConfig {
@@ -102,33 +113,33 @@ class KafkaDebeziumLog @JvmOverloads constructor(
 
     val epoch: Int get() = 0
 
-    private fun writeCdcJson(bytes: ByteArray, dbName: String, openTx: OpenTx) {
-        val envelope = try {
-            Json.parseToJsonElement(String(bytes)).jsonObject
-        } catch (e: IllegalArgumentException) {
-            throw Incorrect("Invalid CDC message: ${e.message}", cause = e)
-        }
+    private fun valueDeserializer(): Deserializer<*> = when (messageFormat) {
+        is MessageFormat.Json -> ByteArrayDeserializer()
+        // KafkaConsumer doesn't call configure() on deserializer instances passed to the constructor,
+        // so we configure it manually with the Schema Registry URL from kafkaConfig.
+        is MessageFormat.Avro -> KafkaAvroDeserializer().also { it.configure(kafkaConfig, false) }
+    }
 
-        val payload = envelope["payload"]?.jsonObject ?: envelope
-
-        val op = payload["op"]?.jsonPrimitive?.content
+    @Suppress("UNCHECKED_CAST")
+    private fun writeCdcPayload(payload: Map<String, Any?>, dbName: String, openTx: OpenTx) {
+        val op = payload["op"] as? String
             ?: throw Incorrect("Missing 'op' in payload")
 
-        val source = payload["source"]?.jsonObject
+        val source = payload["source"] as? Map<String, Any?>
             ?: throw Incorrect("Missing 'source' in payload")
-        val schema = source["schema"]?.jsonPrimitive?.content
+        val schema = source["schema"] as? String
             ?: throw Incorrect("Missing 'source.schema' in payload")
-        val table = source["table"]?.jsonPrimitive?.content
+        val table = source["table"] as? String
             ?: throw Incorrect("Missing 'source.table' in payload")
 
         val openTxTable = openTx.table(TableRef(dbName, schema, table))
 
         when (op) {
             "c", "r", "u" -> {
-                val after = payload["after"]?.jsonObject
+                val after = payload["after"] as? Map<String, Any?>
                     ?: throw Incorrect("Missing 'after' for put op")
 
-                val docMap = after.entries.associate { (k, v) -> k to v.toJvmValue() }.toMutableMap()
+                val docMap = after.toMutableMap()
 
                 val id = docMap["_id"] ?: throw Incorrect("Missing '_id' in document")
 
@@ -147,10 +158,10 @@ class KafkaDebeziumLog @JvmOverloads constructor(
             }
 
             "d" -> {
-                val before = payload["before"]?.takeUnless { it is JsonNull }?.jsonObject
+                val before = payload["before"]?.let { it as? Map<String, Any?> }
                     ?: throw Incorrect("Missing 'before' for delete — check REPLICA IDENTITY on source table")
 
-                val id = before["_id"]?.toJvmValue()
+                val id = before["_id"]
                     ?: throw Incorrect("Missing '_id' in 'before' for delete")
 
                 openTxTable.logDelete(
@@ -165,7 +176,7 @@ class KafkaDebeziumLog @JvmOverloads constructor(
     }
 
     override suspend fun tailAll(afterToken: ExternalSourceToken?, processor: MessageProcessor<DebeziumMessage>) {
-        KafkaConsumer(
+        KafkaConsumer<Unit, Any>(
             kafkaConfig.plus(
                 mapOf(
                     ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false",
@@ -174,7 +185,7 @@ class KafkaDebeziumLog @JvmOverloads constructor(
                 )
             ),
             UnitDeserializer,
-            ByteArrayDeserializer()
+            @Suppress("UNCHECKED_CAST") (valueDeserializer() as Deserializer<Any>)
         ).use { c ->
             val partitionOffsets = afterToken?.let { tok ->
                 val token = tok.unpack(DebeziumOffsetToken::class.java)
@@ -219,7 +230,7 @@ class KafkaDebeziumLog @JvmOverloads constructor(
                     OpenTx(allocator, txKey).use { openTx ->
                         for (consumerRecord in records) {
                             val value = consumerRecord.value() ?: continue
-                            writeCdcJson(value, dbName, openTx)
+                            writeCdcPayload(messageFormat.decode(value), dbName, openTx)
                         }
 
                         val offsets = debeziumOffsetToken {

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/MessageFormat.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/MessageFormat.kt
@@ -1,0 +1,81 @@
+package xtdb.debezium
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.*
+import org.apache.avro.generic.GenericArray
+import org.apache.avro.generic.GenericEnumSymbol
+import org.apache.avro.generic.GenericFixed
+import org.apache.avro.generic.GenericRecord
+import org.apache.avro.util.Utf8
+import xtdb.error.Incorrect
+import java.nio.ByteBuffer
+
+private fun jsonToJvmValue(el: Any?): Any? = when (el) {
+    null, is JsonNull -> null
+    is JsonPrimitive -> if (el.isString) el.content else el.booleanOrNull ?: el.longOrNull ?: el.doubleOrNull ?: el.content
+    is JsonArray -> el.map { jsonToJvmValue(it) }
+    is JsonObject -> el.entries.associate { (k, v) -> k to jsonToJvmValue(v) }
+    else -> el
+}
+
+private fun avroToJvmValue(value: Any?): Any? = when (value) {
+    null -> null
+    is GenericRecord -> value.schema.fields.associate { field ->
+        field.name() to avroToJvmValue(value.get(field.name()))
+    }
+    is GenericEnumSymbol<*> -> value.toString()
+    is GenericFixed -> value.bytes().copyOf()
+    is GenericArray<*> -> value.map { avroToJvmValue(it) }
+    is ByteBuffer -> ByteArray(value.remaining()).also { value.duplicate().get(it) }
+    is Utf8 -> value.toString()
+    is CharSequence -> value.toString()
+    is Map<*, *> -> value.entries.associate { (k, v) -> k.toString() to avroToJvmValue(v) }
+    else -> value // primitives: Int, Long, Float, Double, Boolean
+}
+
+/**
+ * Decodes raw Kafka consumer values into CDC payload maps.
+ *
+ * Json expects ByteArray (from ByteArrayDeserializer).
+ * Avro expects GenericRecord (from KafkaAvroDeserializer).
+ */
+@Serializable
+sealed interface MessageFormat {
+    fun decode(value: Any): Map<String, Any?>
+
+    @Serializable
+    @SerialName("!Json")
+    data object Json : MessageFormat {
+        override fun decode(value: Any): Map<String, Any?> {
+            val bytes = value as? ByteArray
+                ?: throw Incorrect("Expected ByteArray for JSON message format, got ${value::class.simpleName}")
+
+            val payload = try {
+                val envelope = kotlinx.serialization.json.Json
+                    .parseToJsonElement(String(bytes, Charsets.UTF_8))
+                    .jsonObject
+
+                // Auto-detect JsonConverter envelope (schemas.enable=true wraps in {schema, payload}).
+                envelope["payload"]?.jsonObject ?: envelope
+            } catch (e: RuntimeException) {
+                throw Incorrect("Invalid CDC message: ${e.message}", cause = e)
+            }
+
+            return payload.entries.associate { (k, v) -> k to jsonToJvmValue(v) }
+        }
+    }
+
+    @Serializable
+    @SerialName("!Avro")
+    data object Avro : MessageFormat {
+        override fun decode(value: Any): Map<String, Any?> {
+            val record = value as? GenericRecord
+                ?: throw Incorrect("Expected GenericRecord for Avro message format, got ${value::class.simpleName}")
+
+            return record.schema.fields.associate { field ->
+                field.name() to avroToJvmValue(record.get(field.name()))
+            }
+        }
+    }
+}

--- a/modules/debezium/src/main/proto/debezium.proto
+++ b/modules/debezium/src/main/proto/debezium.proto
@@ -15,6 +15,10 @@ message DebeziumSourceConfig {
     oneof log {
         KafkaDebeziumLogConfig kafka_log = 1;
     }
+
+    oneof message_format {
+        bool avro = 10;
+    }
 }
 
 message PartitionOffsets {

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/AvroConsumerTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/AvroConsumerTest.kt
@@ -1,0 +1,532 @@
+package xtdb.debezium
+
+import io.confluent.kafka.serializers.KafkaAvroSerializer
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.generic.GenericData
+import org.apache.avro.generic.GenericRecordBuilder
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.StringSerializer
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.lifecycle.Startables
+import xtdb.api.Xtdb
+import xtdb.api.log.IngestionStoppedException
+import xtdb.api.log.KafkaCluster
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Integration test for Avro message format with Confluent Schema Registry.
+ *
+ * Produces CDC-shaped Avro records (mimicking Debezium's Avro converter output)
+ * via KafkaAvroSerializer → Schema Registry → Kafka, then verifies XTDB consumes
+ * them correctly with MessageFormat.Avro and KafkaAvroDeserializer.
+ */
+@Tag("integration")
+@EnabledIfEnvironmentVariable(named = "XTDB_SINGLE_WRITER", matches = "true")
+class AvroConsumerTest {
+
+    private lateinit var network: Network
+    private lateinit var kafka: ConfluentKafkaContainer
+    private lateinit var schemaRegistry: GenericContainer<*>
+
+    @BeforeEach
+    fun setUp() {
+        network = Network.newNetwork()
+
+        kafka = ConfluentKafkaContainer("confluentinc/cp-kafka:7.8.0")
+            .withNetwork(network)
+            .withNetworkAliases("kafka")
+            .withListener("kafka:19092")
+
+        schemaRegistry = GenericContainer("confluentinc/cp-schema-registry:7.8.0")
+            .withNetwork(network)
+            .withNetworkAliases("schema-registry")
+            .withExposedPorts(8081)
+            .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+            .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "kafka:19092")
+            .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:8081")
+            .waitingFor(Wait.forHttp("/subjects").forPort(8081).forStatusCode(200))
+            .dependsOn(kafka)
+
+        Startables.deepStart(kafka, schemaRegistry).join()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        schemaRegistry.stop()
+        kafka.stop()
+        network.close()
+    }
+
+    private fun schemaRegistryUrl() =
+        "http://${schemaRegistry.host}:${schemaRegistry.getMappedPort(8081)}"
+
+    private fun createTopic(topic: String) {
+        AdminClient.create(mapOf("bootstrap.servers" to kafka.bootstrapServers)).use { admin ->
+            admin.createTopics(listOf(NewTopic(topic, 1, 1.toShort()))).all().get()
+        }
+    }
+
+    // -- Avro schemas matching Debezium's CDC envelope structure --
+
+    private val sourceSchema = SchemaBuilder.record("Source")
+        .namespace("xtdb.debezium.test")
+        .fields()
+        .requiredString("schema")
+        .requiredString("table")
+        .optionalLong("lsn")
+        .endRecord()
+
+    private fun docSchema(name: String, vararg extraFields: Pair<String, org.apache.avro.Schema>) =
+        SchemaBuilder.record(name)
+            .namespace("xtdb.debezium.test")
+            .fields()
+            .apply {
+                requiredLong("_id")
+                requiredString("name")
+                for ((fieldName, fieldSchema) in extraFields) {
+                    name(fieldName).type(fieldSchema).noDefault()
+                }
+            }
+            .endRecord()
+
+    private fun envelopeSchema(name: String, docSchema: org.apache.avro.Schema) =
+        SchemaBuilder.record(name)
+            .namespace("xtdb.debezium.test")
+            .fields()
+            .requiredString("op")
+            .name("source").type(sourceSchema).noDefault()
+            .name("before").type().unionOf().nullType().and().type(docSchema).endUnion().nullDefault()
+            .name("after").type().unionOf().nullType().and().type(docSchema).endUnion().nullDefault()
+            .endRecord()
+
+    private fun cdcRecord(
+        envelope: org.apache.avro.Schema,
+        op: String,
+        schema: String,
+        table: String,
+        before: GenericData.Record? = null,
+        after: GenericData.Record? = null,
+    ): GenericData.Record = GenericRecordBuilder(envelope)
+        .set("op", op)
+        .set("source", GenericRecordBuilder(sourceSchema)
+            .set("schema", schema)
+            .set("table", table)
+            .set("lsn", 1L)
+            .build())
+        .set("before", before)
+        .set("after", after)
+        .build()
+
+    private fun openAvroProducer(): KafkaProducer<String, Any> =
+        KafkaProducer(
+            mapOf(
+                "bootstrap.servers" to kafka.bootstrapServers,
+                "key.serializer" to StringSerializer::class.java.name,
+                "value.serializer" to KafkaAvroSerializer::class.java.name,
+                KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG to schemaRegistryUrl(),
+                "acks" to "all",
+            ),
+        )
+
+    private fun openNodeOnSourceTopic(
+        sourceTopic: String,
+        kafkaProperties: Map<String, String> = emptyMap(),
+    ): Xtdb = Xtdb.openNode {
+        server { port = 0 }; flightSql = null
+        logCluster("kafka", KafkaCluster.ClusterFactory(kafka.bootstrapServers)
+            .schemaRegistryUrl(schemaRegistryUrl())
+            .propertiesMap(kafkaProperties))
+        log(KafkaCluster.LogFactory("kafka", sourceTopic))
+    }
+
+    private fun attachAvroDebeziumDb(node: Xtdb, debeziumTopic: String, dbName: String = "cdc") {
+        node.getConnection().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("""ATTACH DATABASE $dbName WITH $$
+                    log: !Kafka
+                      cluster: kafka
+                      topic: test-replica-${UUID.randomUUID()}
+                    externalLog: !Debezium
+                      messageFormat: !Avro {}
+                      log: !Kafka
+                        logCluster: kafka
+                        tableTopic: $debeziumTopic
+                $$""")
+            }
+        }
+    }
+
+    private suspend fun awaitTxs(node: Xtdb, expected: Int, db: String = "cdc", timeout: Long = 15_000) {
+        val deadline = System.currentTimeMillis() + timeout
+        var count = 0L
+        while (System.currentTimeMillis() < deadline) {
+            count = xtQueryDb(node, db, "SELECT count(*) AS cnt FROM xt.txs")[0]["cnt"] as Long
+            if (count >= expected) return
+            delay(200)
+        }
+        throw AssertionError("Timed out waiting for $expected txs on db '$db' (got $count)")
+    }
+
+    private fun xtQueryDb(node: Xtdb, dbName: String, sql: String): List<Map<String, Any?>> {
+        return node.createConnectionBuilder().database(dbName).build().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeQuery(sql).use { rs ->
+                    val metadata = rs.metaData
+                    val cols = (1..metadata.columnCount).map { metadata.getColumnName(it) }
+                    buildList {
+                        while (rs.next()) {
+                            add(cols.associateWith { rs.getObject(it) })
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun database(node: Xtdb, dbName: String) =
+        (node as Xtdb.XtdbInternal).dbCatalog.databaseOrNull(dbName)
+            ?: throw AssertionError("Database '$dbName' does not exist")
+
+    @Test
+    fun `Avro CDC events are ingested into XTDB via Schema Registry`() = runTest(timeout = 120.seconds) {
+        val topic = "testdb.public.avro_users"
+        createTopic(topic)
+
+        val userDoc = docSchema("UserValue")
+        val envelope = envelopeSchema("UserEnvelope", userDoc)
+
+        fun userRecord(id: Long, name: String) =
+            GenericRecordBuilder(userDoc).set("_id", id).set("name", name).build()
+
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+        // max.poll.records=1 ensures each CDC event is a separate transaction,
+        // preserving per-event valid-time history for assertions.
+        openNodeOnSourceTopic(sourceTopic, mapOf("max.poll.records" to "1")).use { node ->
+            attachAvroDebeziumDb(node, topic)
+
+            openAvroProducer().use { producer ->
+                // snapshot: Alice
+                producer.send(ProducerRecord(topic, "1",
+                    cdcRecord(envelope, "r", "public", "avro_users",
+                        after = userRecord(1L, "Alice")))).get()
+
+                // insert: Bob
+                producer.send(ProducerRecord(topic, "2",
+                    cdcRecord(envelope, "c", "public", "avro_users",
+                        after = userRecord(2L, "Bob")))).get()
+
+                // update: Alice
+                producer.send(ProducerRecord(topic, "1",
+                    cdcRecord(envelope, "u", "public", "avro_users",
+                        after = userRecord(1L, "Alice-updated")))).get()
+
+                // delete: Bob
+                producer.send(ProducerRecord(topic, "2",
+                    cdcRecord(envelope, "d", "public", "avro_users",
+                        before = userRecord(2L, "Bob")))).get()
+            }
+
+            // snapshot(Alice) + insert(Bob) + update(Alice) + delete(Bob)
+            awaitTxs(node, 4)
+
+            val history = xtQueryDb(node, "cdc",
+                """SELECT _id, name, _valid_from, _valid_to
+                   FROM public.avro_users
+                   FOR ALL VALID_TIME
+                   ORDER BY _id, _valid_from"""
+            )
+
+            assertEquals(3, history.size, "Expected 3 history rows (2 Alice + 1 Bob)")
+
+            // Alice: snapshot then update
+            assertEquals(1L, (history[0]["_id"] as Number).toLong())
+            assertEquals("Alice", history[0]["name"])
+            assertTrue(history[0]["_valid_to"] != null, "Snapshot row should be superseded")
+
+            assertEquals(1L, (history[1]["_id"] as Number).toLong())
+            assertEquals("Alice-updated", history[1]["name"])
+            assertNull(history[1]["_valid_to"], "Updated row should be current")
+
+            // Bob: inserted then deleted
+            assertEquals(2L, (history[2]["_id"] as Number).toLong())
+            assertEquals("Bob", history[2]["name"])
+            assertTrue(history[2]["_valid_to"] != null, "Bob should have valid_to from DELETE")
+        }
+    }
+
+    @Test
+    fun `Avro CDC multiple records ingested`() = runTest(timeout = 120.seconds) {
+        val topic = "testdb.public.avro_batch"
+        createTopic(topic)
+
+        val batchDoc = docSchema("BatchValue")
+        val envelope = envelopeSchema("BatchEnvelope", batchDoc)
+
+        fun record(id: Long, name: String) =
+            GenericRecordBuilder(batchDoc).set("_id", id).set("name", name).build()
+
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+
+        openNodeOnSourceTopic(sourceTopic).use { node ->
+            attachAvroDebeziumDb(node, topic, dbName = "avro_batch")
+
+            openAvroProducer().use { producer ->
+                producer.send(ProducerRecord(topic, "1",
+                    cdcRecord(envelope, "c", "public", "avro_batch",
+                        after = record(1L, "first")))).get()
+
+                producer.send(ProducerRecord(topic, "2",
+                    cdcRecord(envelope, "c", "public", "avro_batch",
+                        after = record(2L, "second")))).get()
+            }
+
+            awaitTxs(node, 1, db = "avro_batch")
+
+            val rows = xtQueryDb(node, "avro_batch",
+                "SELECT _id, name FROM public.avro_batch ORDER BY _id"
+            )
+
+            assertEquals(2, rows.size)
+            assertEquals("first", rows[0]["name"])
+            assertEquals("second", rows[1]["name"])
+        }
+    }
+
+    @Test
+    fun `Avro CDC with additional column types`() = runTest(timeout = 120.seconds) {
+        val topic = "testdb.public.avro_typed"
+        createTopic(topic)
+
+        val typedDoc = docSchema("TypedValue",
+            "score" to SchemaBuilder.builder().doubleType(),
+            "active" to SchemaBuilder.builder().booleanType(),
+        )
+        val envelope = envelopeSchema("TypedEnvelope", typedDoc)
+
+        val doc = GenericRecordBuilder(typedDoc)
+            .set("_id", 1L)
+            .set("name", "Alice")
+            .set("score", 3.14)
+            .set("active", true)
+            .build()
+
+        openAvroProducer().use { producer ->
+            producer.send(ProducerRecord(topic, "1",
+                cdcRecord(envelope, "c", "public", "avro_typed", after = doc))).get()
+        }
+
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+        openNodeOnSourceTopic(sourceTopic).use { node ->
+            attachAvroDebeziumDb(node, topic, dbName = "avro_typed")
+
+            awaitTxs(node, 1, db = "avro_typed")
+
+            val rows = xtQueryDb(node, "avro_typed",
+                "SELECT _id, name, score, active FROM public.avro_typed"
+            )
+
+            assertEquals(1, rows.size)
+            assertEquals(1L, (rows[0]["_id"] as Number).toLong())
+            assertEquals("Alice", rows[0]["name"])
+            assertEquals(3.14, (rows[0]["score"] as Number).toDouble(), 0.001)
+            assertEquals(true, rows[0]["active"])
+        }
+    }
+
+    // -- Error case tests: verify Avro-decoded maps trigger the same errors as JSON --
+
+    @Test
+    fun `Avro CDC without _id halts ingestion`() = runTest(timeout = 120.seconds) {
+        val topic = "testdb.public.avro_no_id"
+        createTopic(topic)
+
+        // Doc schema without _id — just has "id" (wrong name)
+        val noIdDoc = SchemaBuilder.record("NoIdValue")
+            .namespace("xtdb.debezium.test")
+            .fields()
+            .requiredLong("id")
+            .requiredString("name")
+            .endRecord()
+        val envelope = envelopeSchema("NoIdEnvelope", noIdDoc)
+
+        val doc = GenericRecordBuilder(noIdDoc)
+            .set("id", 1L)
+            .set("name", "Alice")
+            .build()
+
+        openAvroProducer().use { producer ->
+            producer.send(ProducerRecord(topic, "1",
+                cdcRecord(envelope, "c", "public", "avro_no_id", after = doc))).get()
+        }
+
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+        openNodeOnSourceTopic(sourceTopic).use { node ->
+            attachAvroDebeziumDb(node, topic, dbName = "avro_no_id")
+
+            assertThrows<IngestionStoppedException> {
+                runBlocking { database(node, "avro_no_id").watchers.awaitTx(Long.MAX_VALUE) }
+            }
+
+            val rows = xtQueryDb(node, "avro_no_id",
+                "SELECT * FROM public.avro_no_id FOR ALL VALID_TIME"
+            )
+            assertEquals(0, rows.size, "No rows should be ingested — records lack _id")
+        }
+    }
+
+    @Test
+    fun `Avro CDC with _valid_to but no _valid_from halts ingestion`() = runTest(timeout = 120.seconds) {
+        val topic = "testdb.public.avro_bad_vt"
+        createTopic(topic)
+
+        val vtDoc = SchemaBuilder.record("BadVtValue")
+            .namespace("xtdb.debezium.test")
+            .fields()
+            .requiredLong("_id")
+            .requiredString("name")
+            .name("_valid_from").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+            .name("_valid_to").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+            .endRecord()
+        val envelope = envelopeSchema("BadVtEnvelope", vtDoc)
+
+        // First: a valid record so the database gets created
+        val validDoc = GenericRecordBuilder(vtDoc)
+            .set("_id", 1L)
+            .set("name", "valid")
+            .set("_valid_from", "2024-01-01T00:00:00Z")
+            .set("_valid_to", null)
+            .build()
+
+        // Second: _valid_to without _valid_from — should halt
+        val badDoc = GenericRecordBuilder(vtDoc)
+            .set("_id", 2L)
+            .set("name", "bad")
+            .set("_valid_from", null)
+            .set("_valid_to", "2025-01-01T00:00:00Z")
+            .build()
+
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+        openNodeOnSourceTopic(sourceTopic, mapOf("max.poll.records" to "1")).use { node ->
+            attachAvroDebeziumDb(node, topic, dbName = "avro_bad_vt")
+
+            openAvroProducer().use { producer ->
+                producer.send(ProducerRecord(topic, "1",
+                    cdcRecord(envelope, "c", "public", "avro_bad_vt", after = validDoc))).get()
+                producer.send(ProducerRecord(topic, "2",
+                    cdcRecord(envelope, "c", "public", "avro_bad_vt", after = badDoc))).get()
+            }
+
+            // First record ingested OK
+            awaitTxs(node, 1, db = "avro_bad_vt")
+
+            // Second record halts ingestion
+            assertThrows<IngestionStoppedException> {
+                runBlocking { database(node, "avro_bad_vt").watchers.awaitTx(Long.MAX_VALUE) }
+            }
+
+            val rows = xtQueryDb(node, "avro_bad_vt",
+                "SELECT _id, name FROM public.avro_bad_vt ORDER BY _id"
+            )
+            assertEquals(1, rows.size, "Only valid record should be ingested")
+            assertEquals("valid", rows[0]["name"])
+        }
+    }
+
+    // -- Valid time tests: verify Avro-decoded _valid_from/_valid_to are honoured --
+
+    @Test
+    fun `Avro CDC with valid time bounds`() = runTest(timeout = 120.seconds) {
+        val topic = "testdb.public.avro_vt"
+        createTopic(topic)
+
+        val vtDoc = SchemaBuilder.record("VtValue")
+            .namespace("xtdb.debezium.test")
+            .fields()
+            .requiredLong("_id")
+            .requiredString("name")
+            .name("_valid_from").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+            .name("_valid_to").type().unionOf().nullType().and().stringType().endUnion().nullDefault()
+            .endRecord()
+        val envelope = envelopeSchema("VtEnvelope", vtDoc)
+
+        // Both bounds set
+        val bounded = GenericRecordBuilder(vtDoc)
+            .set("_id", 1L).set("name", "bounded")
+            .set("_valid_from", "2024-01-01T00:00:00Z")
+            .set("_valid_to", "2025-01-01T00:00:00Z")
+            .build()
+
+        // Only _valid_from
+        val fromOnly = GenericRecordBuilder(vtDoc)
+            .set("_id", 2L).set("name", "from-only")
+            .set("_valid_from", "2024-06-01T00:00:00Z")
+            .set("_valid_to", null)
+            .build()
+
+        // Neither — system-assigned
+        val neither = GenericRecordBuilder(vtDoc)
+            .set("_id", 3L).set("name", "neither")
+            .set("_valid_from", null)
+            .set("_valid_to", null)
+            .build()
+
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+        openNodeOnSourceTopic(sourceTopic, mapOf("max.poll.records" to "1")).use { node ->
+            attachAvroDebeziumDb(node, topic, dbName = "avro_vt")
+
+            openAvroProducer().use { producer ->
+                producer.send(ProducerRecord(topic, "1",
+                    cdcRecord(envelope, "c", "public", "avro_vt", after = bounded))).get()
+                producer.send(ProducerRecord(topic, "2",
+                    cdcRecord(envelope, "c", "public", "avro_vt", after = fromOnly))).get()
+                producer.send(ProducerRecord(topic, "3",
+                    cdcRecord(envelope, "c", "public", "avro_vt", after = neither))).get()
+            }
+
+            awaitTxs(node, 3, db = "avro_vt")
+
+            val rows = xtQueryDb(node, "avro_vt",
+                """SELECT _id, name, _valid_from, _valid_to
+                   FROM public.avro_vt
+                   FOR ALL VALID_TIME
+                   ORDER BY _id"""
+            )
+
+            assertEquals(3, rows.size)
+
+            // Both bounds set
+            assertEquals(1L, (rows[0]["_id"] as Number).toLong())
+            assertEquals("bounded", rows[0]["name"])
+            assertTrue(rows[0]["_valid_from"] != null, "Should have valid_from")
+            assertTrue(rows[0]["_valid_to"] != null, "Should have valid_to")
+
+            // Only valid_from
+            assertEquals(2L, (rows[1]["_id"] as Number).toLong())
+            assertEquals("from-only", rows[1]["name"])
+            assertTrue(rows[1]["_valid_from"] != null, "Should have valid_from")
+            assertNull(rows[1]["_valid_to"], "Should have no valid_to")
+
+            // Neither — system-assigned valid_from, no valid_to
+            assertEquals(3L, (rows[2]["_id"] as Number).toLong())
+            assertEquals("neither", rows[2]["name"])
+            assertTrue(rows[2]["_valid_from"] != null, "Should have system-assigned valid_from")
+            assertNull(rows[2]["_valid_to"], "Should have no valid_to")
+        }
+    }
+}

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/AvroE2eTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/AvroE2eTest.kt
@@ -1,0 +1,296 @@
+package xtdb.debezium
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.*
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.images.builder.ImageFromDockerfile
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.lifecycle.Startables
+import org.testcontainers.postgresql.PostgreSQLContainer
+import xtdb.api.Xtdb
+import xtdb.api.log.KafkaCluster
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.sql.DriverManager
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * End-to-end integration test for the full Avro CDC pipeline:
+ * PostgreSQL → Debezium Connect (Avro converter) → Schema Registry → Kafka → XTDB
+ *
+ * Uses Confluent's cp-kafka-connect image (which includes the Avro converter)
+ * with the Debezium PostgreSQL connector installed via Maven archive.
+ */
+@Tag("integration")
+@EnabledIfEnvironmentVariable(named = "XTDB_SINGLE_WRITER", matches = "true")
+class AvroE2eTest {
+
+    private lateinit var network: Network
+    private lateinit var postgres: PostgreSQLContainer
+    private lateinit var kafka: ConfluentKafkaContainer
+    private lateinit var schemaRegistry: GenericContainer<*>
+    private lateinit var debeziumConnect: GenericContainer<*>
+
+    private val httpClient: HttpClient = HttpClient.newHttpClient()
+
+    companion object {
+        // Confluent Connect image with Debezium PostgreSQL connector added.
+        // Built once and cached by Docker for subsequent runs.
+        private val connectImage = ImageFromDockerfile()
+            .withDockerfileFromBuilder { builder ->
+                builder
+                    .from("confluentinc/cp-kafka-connect:7.8.0")
+                    .run("mkdir -p /usr/share/confluent-hub-components/debezium-postgresql && cd /usr/share/confluent-hub-components/debezium-postgresql && curl -sL 'https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/3.0.2.Final/debezium-connector-postgres-3.0.2.Final-plugin.tar.gz' | tar xz")
+                    .build()
+            }
+    }
+
+    @BeforeEach
+    fun setUp() {
+        network = Network.newNetwork()
+
+        postgres = PostgreSQLContainer("postgres:17-alpine")
+            .withNetwork(network)
+            .withNetworkAliases("postgres")
+            .withDatabaseName("testdb")
+            .withUsername("testuser")
+            .withPassword("testpass")
+            .withCommand("postgres", "-c", "wal_level=logical")
+
+        kafka = ConfluentKafkaContainer("confluentinc/cp-kafka:7.8.0")
+            .withNetwork(network)
+            .withNetworkAliases("kafka")
+            .withListener("kafka:19092")
+
+        schemaRegistry = GenericContainer("confluentinc/cp-schema-registry:7.8.0")
+            .withNetwork(network)
+            .withNetworkAliases("schema-registry")
+            .withExposedPorts(8081)
+            .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+            .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "kafka:19092")
+            .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:8081")
+            .waitingFor(Wait.forHttp("/subjects").forPort(8081).forStatusCode(200))
+            .dependsOn(kafka)
+
+        debeziumConnect = GenericContainer(connectImage)
+            .withNetwork(network)
+            .withExposedPorts(8083)
+            .withEnv("CONNECT_BOOTSTRAP_SERVERS", "kafka:19092")
+            .withEnv("CONNECT_REST_PORT", "8083")
+            .withEnv("CONNECT_GROUP_ID", "debezium-avro-connect")
+            .withEnv("CONNECT_CONFIG_STORAGE_TOPIC", "debezium_avro_configs")
+            .withEnv("CONNECT_OFFSET_STORAGE_TOPIC", "debezium_avro_offsets")
+            .withEnv("CONNECT_STATUS_STORAGE_TOPIC", "debezium_avro_statuses")
+            .withEnv("CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR", "1")
+            .withEnv("CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR", "1")
+            .withEnv("CONNECT_STATUS_STORAGE_REPLICATION_FACTOR", "1")
+            .withEnv("CONNECT_KEY_CONVERTER", "org.apache.kafka.connect.storage.StringConverter")
+            .withEnv("CONNECT_VALUE_CONVERTER", "io.confluent.connect.avro.AvroConverter")
+            .withEnv("CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL", "http://schema-registry:8081")
+            .withEnv("CONNECT_REST_ADVERTISED_HOST_NAME", "debezium-connect")
+            .withEnv("CONNECT_PLUGIN_PATH", "/usr/share/java,/usr/share/confluent-hub-components")
+            // Internal converter for config/offset/status topics
+            .withEnv("CONNECT_INTERNAL_KEY_CONVERTER", "org.apache.kafka.connect.json.JsonConverter")
+            .withEnv("CONNECT_INTERNAL_VALUE_CONVERTER", "org.apache.kafka.connect.json.JsonConverter")
+            .waitingFor(Wait.forHttp("/connectors").forPort(8083).forStatusCode(200))
+            .dependsOn(kafka, schemaRegistry)
+
+        Startables.deepStart(postgres, kafka, schemaRegistry, debeziumConnect).join()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        debeziumConnect.stop()
+        schemaRegistry.stop()
+        kafka.stop()
+        postgres.stop()
+        network.close()
+    }
+
+    private fun schemaRegistryUrl() =
+        "http://${schemaRegistry.host}:${schemaRegistry.getMappedPort(8081)}"
+
+    private fun connectUrl() =
+        "http://${debeziumConnect.host}:${debeziumConnect.getMappedPort(8083)}"
+
+    private suspend fun registerConnectorAndAwait(
+        schemas: String = "public",
+        extraConfig: Map<String, String> = emptyMap(),
+    ) {
+        fun isConnectorRunning(): Boolean {
+            try {
+                val resp = httpClient.send(
+                    HttpRequest.newBuilder()
+                        .uri(URI.create("${connectUrl()}/connectors/test-connector/status"))
+                        .GET()
+                        .build(),
+                    HttpResponse.BodyHandlers.ofString()
+                )
+                if (resp.statusCode() != 200) return false
+                val status = Json.parseToJsonElement(resp.body()).jsonObject
+                val connectorState = status["connector"]?.jsonObject?.get("state")?.jsonPrimitive?.content
+                val taskState = status["tasks"]?.jsonArray?.firstOrNull()?.jsonObject?.get("state")?.jsonPrimitive?.content
+                return connectorState == "RUNNING" && taskState == "RUNNING"
+            } catch (_: Exception) {
+                return false
+            }
+        }
+
+        val connectorConfig = buildJsonObject {
+            put("name", "test-connector")
+            putJsonObject("config") {
+                put("connector.class", "io.debezium.connector.postgresql.PostgresConnector")
+                put("tasks.max", "1")
+                put("database.hostname", "postgres")
+                put("database.port", "5432")
+                put("database.user", "testuser")
+                put("database.password", "testpass")
+                put("database.dbname", "testdb")
+                put("topic.prefix", "testdb")
+                put("schema.include.list", schemas)
+                put("plugin.name", "pgoutput")
+                for ((k, v) in extraConfig) put(k, v)
+            }
+        }
+
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("${connectUrl()}/connectors"))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(connectorConfig.toString()))
+            .build()
+
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        assertTrue(response.statusCode() in 200..201, "Failed to register connector: ${response.body()}")
+
+        while (!isConnectorRunning()) delay(500)
+    }
+
+    private fun pgExecute(vararg statements: String) {
+        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { conn ->
+            conn.createStatement().use { stmt ->
+                for (sql in statements) stmt.execute(sql)
+            }
+        }
+    }
+
+    private fun openNodeOnSourceTopic(
+        sourceTopic: String,
+        kafkaProperties: Map<String, String> = emptyMap(),
+    ): Xtdb = Xtdb.openNode {
+        server { port = 0 }; flightSql = null
+        logCluster("kafka", KafkaCluster.ClusterFactory(kafka.bootstrapServers)
+            .schemaRegistryUrl(schemaRegistryUrl())
+            .propertiesMap(kafkaProperties))
+        log(KafkaCluster.LogFactory("kafka", sourceTopic))
+    }
+
+    private fun attachAvroDebeziumDb(
+        node: Xtdb,
+        debeziumTopic: String,
+        dbName: String = "cdc",
+    ) {
+        node.getConnection().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("""ATTACH DATABASE $dbName WITH $$
+                    log: !Kafka
+                      cluster: kafka
+                      topic: test-replica-${UUID.randomUUID()}
+                    externalLog: !Debezium
+                      messageFormat: !Avro {}
+                      log: !Kafka
+                        logCluster: kafka
+                        tableTopic: $debeziumTopic
+                $$""")
+            }
+        }
+    }
+
+    private suspend fun awaitTxs(node: Xtdb, expected: Int, db: String = "cdc", timeout: Long = 30_000) {
+        val deadline = System.currentTimeMillis() + timeout
+        var count = 0L
+        while (System.currentTimeMillis() < deadline) {
+            count = xtQueryDb(node, db, "SELECT count(*) AS cnt FROM xt.txs")[0]["cnt"] as Long
+            if (count >= expected) return
+            delay(200)
+        }
+        throw AssertionError("Timed out waiting for $expected txs on db '$db' (got $count)")
+    }
+
+    private fun xtQueryDb(node: Xtdb, dbName: String, sql: String): List<Map<String, Any?>> {
+        return node.createConnectionBuilder().database(dbName).build().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeQuery(sql).use { rs ->
+                    val metadata = rs.metaData
+                    val cols = (1..metadata.columnCount).map { metadata.getColumnName(it) }
+                    buildList {
+                        while (rs.next()) {
+                            add(cols.associateWith { rs.getObject(it) })
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Avro CDC from Debezium Connect ingested into XTDB`() = runTest(timeout = 120.seconds) {
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS cdc_avro (_id INT PRIMARY KEY, name TEXT, email TEXT)",
+            "INSERT INTO cdc_avro (_id, name, email) VALUES (1, 'Alice', 'alice@example.com')",
+        )
+
+        registerConnectorAndAwait(extraConfig = mapOf(
+            "key.converter" to "org.apache.kafka.connect.storage.StringConverter",
+            "value.converter" to "io.confluent.connect.avro.AvroConverter",
+            "value.converter.schema.registry.url" to "http://schema-registry:8081",
+        ))
+
+        pgExecute(
+            "INSERT INTO cdc_avro (_id, name, email) VALUES (2, 'Bob', 'bob@example.com')",
+            "UPDATE cdc_avro SET email = 'alice-new@example.com' WHERE _id = 1",
+            "DELETE FROM cdc_avro WHERE _id = 2",
+        )
+
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+        openNodeOnSourceTopic(sourceTopic, mapOf("max.poll.records" to "1")).use { node ->
+            attachAvroDebeziumDb(node, "testdb.public.cdc_avro")
+
+            // snapshot(Alice) + insert(Bob) + update(Alice) + delete(Bob)
+            awaitTxs(node, 4)
+
+            val history = xtQueryDb(node, "cdc",
+                """SELECT _id, name, email, _valid_from, _valid_to
+                   FROM public.cdc_avro
+                   FOR ALL VALID_TIME
+                   ORDER BY _id, _valid_from"""
+            )
+
+            assertEquals(3, history.size, "Expected 3 history rows (2 Alice + 1 Bob)")
+
+            // Alice: snapshot row then updated row
+            assertEquals(1L, (history[0]["_id"] as Number).toLong())
+            assertEquals("alice@example.com", history[0]["email"])
+            assertTrue(history[0]["_valid_to"] != null, "Snapshot row should be superseded")
+
+            assertEquals(1L, (history[1]["_id"] as Number).toLong())
+            assertEquals("alice-new@example.com", history[1]["email"])
+            assertNull(history[1]["_valid_to"], "Updated row should be current")
+
+            // Bob: inserted then deleted
+            assertEquals(2L, (history[2]["_id"] as Number).toLong())
+            assertEquals("bob@example.com", history[2]["email"])
+            assertTrue(history[2]["_valid_to"] != null, "Bob should have valid_to from DELETE")
+        }
+    }
+}

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
@@ -179,6 +179,7 @@ class DebeziumIntegrationTest {
                       cluster: kafka
                       topic: test-replica-${UUID.randomUUID()}$storageYaml
                     externalLog: !Debezium
+                      messageFormat: !Json {}
                       log: !Kafka
                         logCluster: kafka
                         tableTopic: $debeziumTopic

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumSourceTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumSourceTest.kt
@@ -18,7 +18,8 @@ class DebeziumSourceTest {
             log = KafkaDebeziumLog.Factory(
                 logCluster = "my-cluster",
                 tableTopic = "cdc.public.users",
-            )
+            ),
+            messageFormat = MessageFormat.Json,
         )
 
         val restored = protoRoundTrip(original)
@@ -40,6 +41,7 @@ class DebeziumSourceTest {
     fun `YAML round-trips DebeziumSource with KafkaDebeziumLog`() {
         val yaml = """
             externalLog: !Debezium
+              messageFormat: !Json {}
               log: !Kafka
                 logCluster: my-cluster
                 tableTopic: cdc.public.users
@@ -51,6 +53,7 @@ class DebeziumSourceTest {
 
         assertEquals("my-cluster", log.logCluster)
         assertEquals("cdc.public.users", log.tableTopic)
+        assertEquals(MessageFormat.Json, source.messageFormat)
     }
 
     @Test
@@ -60,12 +63,70 @@ class DebeziumSourceTest {
     }
 
     @Test
+    fun `proto round-trips DebeziumSource with Avro message format`() {
+        val original = DebeziumSource(
+            log = KafkaDebeziumLog.Factory(
+                logCluster = "my-cluster",
+                tableTopic = "cdc.public.users",
+            ),
+            messageFormat = MessageFormat.Avro,
+        )
+
+        val restored = protoRoundTrip(original)
+        assertEquals(MessageFormat.Avro, restored.messageFormat)
+    }
+
+    @Test
+    fun `proto round-trips DebeziumSource with Json message format`() {
+        val original = DebeziumSource(
+            log = KafkaDebeziumLog.Factory(
+                logCluster = "my-cluster",
+                tableTopic = "cdc.public.users",
+            ),
+            messageFormat = MessageFormat.Json,
+        )
+
+        val restored = protoRoundTrip(original)
+        assertEquals(MessageFormat.Json, restored.messageFormat)
+    }
+
+    @Test
+    fun `YAML round-trips DebeziumSource with Avro message format`() {
+        val yaml = """
+            externalLog: !Debezium
+              messageFormat: !Avro {}
+              log: !Kafka
+                logCluster: my-cluster
+                tableTopic: cdc.public.users
+        """.trimIndent()
+
+        val config = Database.Config.fromYaml(yaml)
+        val source = config.externalLog as DebeziumSource
+        assertEquals(MessageFormat.Avro, source.messageFormat)
+    }
+
+    @Test
+    fun `YAML requires messageFormat`() {
+        val yaml = """
+            externalLog: !Debezium
+              log: !Kafka
+                logCluster: my-cluster
+                tableTopic: cdc.public.users
+        """.trimIndent()
+
+        assertThrows(Exception::class.java) {
+            Database.Config.fromYaml(yaml)
+        }
+    }
+
+    @Test
     fun `external source is nullable in Config`() {
         val config = Database.Config()
         assertNull(config.externalLog)
 
         val withSource = config.externalSource(DebeziumSource(
-            log = KafkaDebeziumLog.Factory("cluster", "topic")
+            log = KafkaDebeziumLog.Factory("cluster", "topic"),
+            messageFormat = MessageFormat.Json,
         ))
         assertNotNull(withSource.externalLog)
 

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/KafkaDebeziumLogTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/KafkaDebeziumLogTest.kt
@@ -93,7 +93,7 @@ class KafkaDebeziumLogTest {
         produceMessages(topic, listOf(cdcMessage("c", 1, "Alice")))
 
         val (subscriber, received) = capturingProcessor()
-        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic)
+        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
         log.use {
             val job = launch { log.tailAll(null, subscriber) }
             while (received.isEmpty()) runInterruptible(Dispatchers.IO) { Thread.sleep(100) }
@@ -112,7 +112,7 @@ class KafkaDebeziumLogTest {
         produceMessages(topic, listOf(cdcMessage("c", 1, "Alice")))
 
         val (subscriber, received) = capturingProcessor()
-        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic)
+        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
 
         val job = launch { log.tailAll(null, subscriber) }
         while (received.isEmpty()) runInterruptible(Dispatchers.IO) { Thread.sleep(100) }
@@ -134,7 +134,7 @@ class KafkaDebeziumLogTest {
         produceMessages(topic, listOf(cdcMessage("c", 1, "Alice"), null))
 
         val (subscriber, received) = capturingProcessor()
-        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic)
+        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
         log.use {
             val tailJob = launch { log.tailAll(null, subscriber) }
             try {
@@ -167,7 +167,7 @@ class KafkaDebeziumLogTest {
         }, "xtdb.debezium")
 
         val (subscriber, received) = capturingProcessor()
-        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic)
+        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
         log.use {
             val tailJob = launch { log.tailAll(token, subscriber) }
             try {
@@ -196,7 +196,7 @@ class KafkaDebeziumLogTest {
         ))
 
         val (subscriber, received) = capturingProcessor()
-        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic)
+        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
         log.use {
             val tailJob = launch { log.tailAll(null, subscriber) }
             try {
@@ -225,7 +225,7 @@ class KafkaDebeziumLogTest {
         ))
 
         val (subscriber, received) = capturingProcessor()
-        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic)
+        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
         log.use {
             val tailJob = launch { log.tailAll(null, subscriber) }
             try {
@@ -246,7 +246,7 @@ class KafkaDebeziumLogTest {
         produceMessages(topic, listOf("not json at all"))
 
         val (subscriber, _) = capturingProcessor()
-        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic)
+        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
         log.use {
             assertFailsWith<Exception> { runBlocking { log.tailAll(null, subscriber) } }
         }
@@ -261,7 +261,7 @@ class KafkaDebeziumLogTest {
         ))
 
         val (subscriber, _) = capturingProcessor()
-        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic)
+        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
         log.use {
             assertFailsWith<Exception> { runBlocking { log.tailAll(null, subscriber) } }
         }

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/MessageFormatTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/MessageFormatTest.kt
@@ -1,0 +1,208 @@
+package xtdb.debezium
+
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.generic.GenericData
+import org.apache.avro.generic.GenericRecordBuilder
+import org.apache.avro.util.Utf8
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import xtdb.error.Incorrect
+
+class MessageFormatTest {
+
+    // -- Json format tests --
+
+    @Test
+    fun `Json decode produces map from valid CDC envelope`() {
+        val json = """{"op":"c","source":{"schema":"public","table":"t"},"after":{"_id":1,"name":"Alice"}}"""
+        val payload = MessageFormat.Json.decode(json.toByteArray())
+
+        assertEquals("c", payload["op"])
+        @Suppress("UNCHECKED_CAST")
+        val after = payload["after"] as Map<String, Any?>
+        assertEquals(1L, after["_id"])
+        assertEquals("Alice", after["name"])
+    }
+
+    @Test
+    fun `Json decode unwraps payload envelope`() {
+        val json = """{"payload":{"op":"c","source":{"schema":"public","table":"t"},"after":{"_id":1}}}"""
+        val payload = MessageFormat.Json.decode(json.toByteArray())
+        assertEquals("c", payload["op"])
+    }
+
+    @Test
+    fun `Json decode rejects non-ByteArray`() {
+        val ex = assertThrows(Incorrect::class.java) {
+            MessageFormat.Json.decode("not a byte array")
+        }
+        assertTrue(ex.message!!.contains("ByteArray"))
+    }
+
+    @Test
+    fun `Json decode rejects invalid JSON`() {
+        assertThrows(Incorrect::class.java) {
+            MessageFormat.Json.decode("not json".toByteArray())
+        }
+    }
+
+    // -- Avro format tests --
+
+    private val sourceSchema = SchemaBuilder.record("Source")
+        .fields()
+        .requiredString("schema")
+        .requiredString("table")
+        .optionalLong("lsn")
+        .endRecord()
+
+    private val docSchema = SchemaBuilder.record("Doc")
+        .fields()
+        .requiredLong("_id")
+        .requiredString("name")
+        .endRecord()
+
+    private val envelopeSchema = SchemaBuilder.record("Envelope")
+        .fields()
+        .requiredString("op")
+        .name("source").type(sourceSchema).noDefault()
+        .name("before").type().unionOf().nullType().and().type(docSchema).endUnion().nullDefault()
+        .name("after").type().unionOf().nullType().and().type(docSchema).endUnion().nullDefault()
+        .endRecord()
+
+    private fun cdcRecord(
+        op: String,
+        schema: String = "public",
+        table: String = "users",
+        before: GenericData.Record? = null,
+        after: GenericData.Record? = null,
+    ): GenericData.Record = GenericRecordBuilder(envelopeSchema)
+        .set("op", op)
+        .set("source", GenericRecordBuilder(sourceSchema)
+            .set("schema", schema)
+            .set("table", table)
+            .set("lsn", 42L)
+            .build())
+        .set("before", before)
+        .set("after", after)
+        .build()
+
+    private fun doc(id: Long, name: String): GenericData.Record =
+        GenericRecordBuilder(docSchema)
+            .set("_id", id)
+            .set("name", name)
+            .build()
+
+    @Test
+    fun `Avro decode produces map from create op`() {
+        val record = cdcRecord("c", after = doc(1L, "Alice"))
+        val payload = MessageFormat.Avro.decode(record)
+
+        assertEquals("c", payload["op"])
+        @Suppress("UNCHECKED_CAST")
+        val source = payload["source"] as Map<String, Any?>
+        assertEquals("public", source["schema"])
+        assertEquals("users", source["table"])
+
+        @Suppress("UNCHECKED_CAST")
+        val after = payload["after"] as Map<String, Any?>
+        assertEquals(1L, after["_id"])
+        assertEquals("Alice", after["name"])
+    }
+
+    @Test
+    fun `Avro decode produces map from delete op`() {
+        val record = cdcRecord("d", before = doc(3L, "to-delete"))
+        val payload = MessageFormat.Avro.decode(record)
+
+        assertEquals("d", payload["op"])
+        @Suppress("UNCHECKED_CAST")
+        val before = payload["before"] as Map<String, Any?>
+        assertEquals(3L, before["_id"])
+    }
+
+    @Test
+    fun `Avro decode converts Utf8 to String`() {
+        val record = cdcRecord("c", after = doc(1L, "hello"))
+        val payload = MessageFormat.Avro.decode(record)
+
+        @Suppress("UNCHECKED_CAST")
+        val after = payload["after"] as Map<String, Any?>
+        assertInstanceOf(String::class.java, after["name"])
+    }
+
+    @Test
+    fun `Avro decode handles arrays`() {
+        val arrayDocSchema = SchemaBuilder.record("ArrayDoc")
+            .fields()
+            .requiredLong("_id")
+            .name("tags").type().array().items().stringType().noDefault()
+            .endRecord()
+
+        val arrayEnvelopeSchema = SchemaBuilder.record("ArrayEnvelope")
+            .fields()
+            .requiredString("op")
+            .name("source").type(sourceSchema).noDefault()
+            .name("before").type().unionOf().nullType().and().type(arrayDocSchema).endUnion().nullDefault()
+            .name("after").type().unionOf().nullType().and().type(arrayDocSchema).endUnion().nullDefault()
+            .endRecord()
+
+        val afterRecord = GenericData.Record(arrayDocSchema)
+        afterRecord.put("_id", 1L)
+        afterRecord.put("tags", GenericData.Array(arrayDocSchema.getField("tags").schema(), listOf(Utf8("a"), Utf8("b"))))
+
+        val envelope = GenericRecordBuilder(arrayEnvelopeSchema)
+            .set("op", "c")
+            .set("source", GenericRecordBuilder(sourceSchema).set("schema", "public").set("table", "t").set("lsn", 1L).build())
+            .set("before", null)
+            .set("after", afterRecord)
+            .build()
+
+        val payload = MessageFormat.Avro.decode(envelope)
+        @Suppress("UNCHECKED_CAST")
+        val after = payload["after"] as Map<String, Any?>
+        assertEquals(listOf("a", "b"), after["tags"])
+    }
+
+    @Test
+    fun `Avro decode converts enum symbols to strings`() {
+        val opEnum = SchemaBuilder.enumeration("OpEnum")
+            .namespace("xtdb.debezium.test")
+            .symbols("c", "r", "u", "d")
+
+        val enumEnvelopeSchema = SchemaBuilder.record("EnumEnvelope")
+            .namespace("xtdb.debezium.test")
+            .fields()
+            .name("op").type(opEnum).noDefault()
+            .name("source").type(sourceSchema).noDefault()
+            .name("before").type().unionOf().nullType().and().type(docSchema).endUnion().nullDefault()
+            .name("after").type().unionOf().nullType().and().type(docSchema).endUnion().nullDefault()
+            .endRecord()
+
+        val record = GenericRecordBuilder(enumEnvelopeSchema)
+            .set("op", GenericData.EnumSymbol(opEnum, "c"))
+            .set("source", GenericRecordBuilder(sourceSchema)
+                .set("schema", "public").set("table", "t").set("lsn", 1L).build())
+            .set("before", null)
+            .set("after", doc(1L, "Alice"))
+            .build()
+
+        val payload = MessageFormat.Avro.decode(record)
+        assertEquals("c", payload["op"])
+        assertInstanceOf(String::class.java, payload["op"])
+    }
+
+    @Test
+    fun `Avro decode rejects non-GenericRecord`() {
+        val ex = assertThrows(Incorrect::class.java) {
+            MessageFormat.Avro.decode("not a record")
+        }
+        assertTrue(ex.message!!.contains("GenericRecord"))
+    }
+
+    @Test
+    fun `Avro decode passes through unknown ops`() {
+        val record = cdcRecord("x", after = doc(1L, "Alice"))
+        val payload = MessageFormat.Avro.decode(record)
+        assertEquals("x", payload["op"])
+    }
+}

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -117,6 +117,7 @@ fun AdminClient.ensureTopicExists(topic: String, autoCreate: Boolean) {
 class KafkaCluster(
     val kafkaConfigMap: KafkaConfigMap,
     private val pollDuration: Duration,
+    val schemaRegistryUrl: String? = null,
     coroutineContext: CoroutineContext = Dispatchers.Default
 ) : Log.Cluster {
     val producer = kafkaConfigMap.openProducer()
@@ -134,12 +135,14 @@ class KafkaCluster(
         var pollDuration: Duration = Duration.ofSeconds(1),
         var propertiesMap: Map<String, String> = emptyMap(),
         var propertiesFile: Path? = null,
+        var schemaRegistryUrl: String? = null,
         @kotlinx.serialization.Transient var coroutineContext: CoroutineContext = Dispatchers.Default
     ) : Log.Cluster.Factory<KafkaCluster> {
 
         fun pollDuration(pollDuration: Duration) = apply { this.pollDuration = pollDuration }
         fun propertiesMap(propertiesMap: Map<String, String>) = apply { this.propertiesMap = propertiesMap }
         fun propertiesFile(propertiesFile: Path) = apply { this.propertiesFile = propertiesFile }
+        fun schemaRegistryUrl(schemaRegistryUrl: String) = apply { this.schemaRegistryUrl = schemaRegistryUrl }
 
         private val Path.asPropertiesMap: Map<String, String>
             get() =
@@ -152,7 +155,7 @@ class KafkaCluster(
                 .plus(propertiesMap)
                 .plus(propertiesFile?.asPropertiesMap.orEmpty())
 
-        override fun open(): KafkaCluster = KafkaCluster(configMap, pollDuration, coroutineContext)
+        override fun open(): KafkaCluster = KafkaCluster(configMap, pollDuration, schemaRegistryUrl, coroutineContext)
     }
 
     interface AtomicProducer<M> : Log.AtomicProducer<M> {


### PR DESCRIPTION
Resolves #5205

## Context

Debezium CDC messages can be serialized as Avro (via Confluent Schema Registry) instead of JSON.
This is common in production Kafka deployments where schema evolution and compact wire format matter.

## Approach

Two layers: **decode** (format-specific) and **write** (format-agnostic).

`MessageFormat` is a sealed interface with `Json` and `Avro` implementations.
Each converts the raw Kafka consumer value into a `Map<String, Any?>` — JSON parses bytes, Avro walks `GenericRecord` fields recursively (converting `Utf8` → `String`, `GenericFixed` → `ByteArray`, etc.).
`writeCdcPayload` takes the resulting map and writes directly into `OpenTx`, preserving the Arrow-direct pipeline from the previous refactor.

Config ownership: `schemaRegistryUrl` lives on `KafkaCluster` (cluster-level infrastructure), `messageFormat` lives on `DebeziumSource` (describes how Debezium serializes, independent of transport).
At open-time, `KafkaDebeziumLog.Factory` validates the registry URL is present for Avro and configures `KafkaAvroDeserializer` with `SPECIFIC_AVRO_READER=false` (we want `GenericRecord`, not generated classes).

## Breaking change

`messageFormat` is now a required field on `DebeziumSource` — no default.
For infrastructure running national-scale CDC pipelines, silently defaulting to JSON when a user meant Avro is the kind of misconfiguration that should fail at config time, not at runtime with mysterious empty results.
Proto deserialization still defaults to Json for backwards compatibility with already-persisted configs.

## Dead ends

The integration test caught a real bug: `KafkaConsumer` doesn't call `configure()` on deserializer instances passed to its constructor.
`KafkaAvroDeserializer` never received the Schema Registry URL, silently producing zero records.
Fix: explicitly call `configure(kafkaConfig, false)` after construction.
Unit tests with hand-built `GenericRecord` objects couldn't catch this — it only manifests with real wire format bytes through a real Schema Registry.

## Test plan

- Unit tests: `MessageFormatTest` (Json + Avro decode, error cases, type conversions), `DebeziumSourceTest` (proto + YAML round-trips for both formats, required-field validation)
- Integration test: `AvroIntegrationTest` — Testcontainers with Kafka + Confluent Schema Registry, 6 tests:
  - Full CDC lifecycle (snapshot, insert, update, delete with per-event valid-time history)
  - Multi-batch ingestion
  - Additional column types (double, boolean)
  - Missing `_id` halts ingestion (error parity with JSON path)
  - `_valid_to` without `_valid_from` halts ingestion (error parity with JSON path)
  - Valid time bounds: both set, from-only, neither (system-assigned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)