### PR TITLE
fix!(sql): disambiguate TRIM grammar to prevent greedy expr matching

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -324,7 +324,7 @@ exprPrimary
          | ',' startPosition=expr (',' stringLength=expr)? )
       ')' # CharacterSubstringFunction
 
-    | 'TRIM' '(' trimSpecification? trimCharacter=expr? 'FROM'? trimSource=expr ')' # TrimFunction
+    | 'TRIM' '(' trimSpecification? (trimCharacter=expr 'FROM' trimSource=expr | 'FROM' trimSource=expr | trimSource=expr) ')' # TrimFunction
 
     | 'URI_SCHEME' '(' expr ')' # UriSchemeFunction
     | 'URI_USER_INFO' '(' expr ')' # UriUserInfoFunction

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -41,7 +41,17 @@
 
     "TRIM(BOTH '😎' FROM foo.a)" '(trim f/a "😎")
 
-    "TRIM('$' FROM foo.a)" '(trim f/a "$")))
+    "TRIM('$' FROM foo.a)" '(trim f/a "$")
+
+    "TRIM(foo.a[1])" '(trim (nth f/a 0) " "))
+
+  (t/testing "TRIM on complex expr — array subscript must not be greedily matched as trimCharacter"
+    (t/is (= [{:val "public"}]
+             (xt/q tu/*node* "SELECT trim(s[1]) AS val FROM (VALUES (string_to_array(' public ', ','))) AS t(s)"))))
+
+  (t/testing "TRIM(expr expr) without FROM keyword is no longer valid"
+    (t/is (thrown? Exception
+             (xt/q tu/*node* "SELECT TRIM('$' '$hello$')")))))
 
 (t/deftest test-like-expr
   (t/are [sql expected] (= expected (plan-expr-with-foo sql))


### PR DESCRIPTION
Relates to #5170

`trim(s[1])` fails with `trim not applicable to types list and list`.
The old grammar `trimCharacter=expr? 'FROM'? trimSource=expr` is ambiguous — ANTLR greedily matches `s` as `trimCharacter`, leaving `[1]` (parsed as an array literal) as `trimSource`.
Both resolve to list types instead of strings.

Simple change in the end: split into explicit alternatives (`trimChar FROM trimSource | FROM trimSource | trimSource`) so the single-arg path is unambiguous.
Grafana's table discovery query uses `trim(s[i])` to strip whitespace from search_path elements.