### PR TITLE
feat(sql): implicit utf8-to-temporal coercion in comparisons

### DIFF
--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -1024,6 +1024,18 @@
   (defmethod expr/codegen-call [:compare t :date] [{[t1 _] :arg-types, :as expr}]
     (-> expr (recall-with-cast2 t1 [:timestamp-local :micro]))))
 
+;; implicit utf8 → temporal coercion for comparisons
+;; PG implicitly casts string literals to temporal types in comparison contexts.
+;; e.g. Grafana's $__timeFilter macro: `recorded_at BETWEEN '2026-01-01T00:00:00Z' AND '2026-01-02T00:00:00Z'`
+;; where recorded_at is a timestamp-tz column and the strings are utf8 literals.
+(doseq [f-kw [:< :<= :> :>= :compare :=== :null_eq]
+        temporal-type [:timestamp-tz :timestamp-local :date :time-local]]
+  (defmethod expr/codegen-call [f-kw temporal-type :utf8] [{[t1 _] :arg-types, :as expr}]
+    (-> expr (recall-with-cast2 t1 t1)))
+
+  (defmethod expr/codegen-call [f-kw :utf8 temporal-type] [{[_ t2] :arg-types, :as expr}]
+    (-> expr (recall-with-cast2 t2 t2))))
+
 (defmethod expr/codegen-call [:compare :time-local :time-local] [{[t1 t2] :arg-types, :as expr}]
   (let [time-unit1 (st/time-type->unit t1)
         time-unit2 (st/time-type->unit t2)]

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1949,6 +1949,56 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
   (t/is (= [{:v #xt/zoned-date-time "2021-10-21T12:34+01:00"}]
            (xt/q tu/*node* "SELECT TIMESTAMP WITH TIME ZONE '2021-10-21T12:34:00+01:00' v"))))
 
+(t/deftest test-implicit-utf8-to-temporal-coercion
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO ts_tz (_id, t) VALUES (1, TIMESTAMP '2026-01-15 10:00:00+00:00')"]])
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO ts_local (_id, t) VALUES (1, TIMESTAMP '2026-01-15 10:00:00')"]])
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO date_test (_id, d) VALUES (1, DATE '2026-03-15')"]])
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO time_test (_id, t) VALUES (1, TIME '14:30:00')"]])
+
+  (t/testing "timestamp-tz"
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_tz WHERE t >= '2026-01-15T09:00:00Z'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_tz WHERE t > '2026-01-15T09:00:00Z'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_tz WHERE t < '2026-01-15T11:00:00Z'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_tz WHERE '2026-01-15T09:00:00Z' <= t")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_tz WHERE t BETWEEN '2026-01-15T09:00:00Z' AND '2026-01-15T11:00:00Z'")))
+    (t/is (= [] (xt/q tu/*node* "SELECT _id AS id FROM ts_tz WHERE t >= '2026-01-15T11:00:00Z'"))))
+
+  (t/testing "timestamp-local"
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_local WHERE t >= '2026-01-15T09:00:00'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_local WHERE t > '2026-01-15T09:00:00'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_local WHERE t < '2026-01-15T11:00:00'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_local WHERE '2026-01-15T09:00:00' <= t")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_local WHERE t BETWEEN '2026-01-15T09:00:00' AND '2026-01-15T11:00:00'")))
+    (t/is (= [] (xt/q tu/*node* "SELECT _id AS id FROM ts_local WHERE t >= '2026-01-15T11:00:00'"))))
+
+  (t/testing "date"
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM date_test WHERE d >= '2026-03-14'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM date_test WHERE d > '2026-03-14'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM date_test WHERE d < '2026-03-16'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM date_test WHERE '2026-03-16' > d")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM date_test WHERE d BETWEEN '2026-03-14' AND '2026-03-16'")))
+    (t/is (= [] (xt/q tu/*node* "SELECT _id AS id FROM date_test WHERE d >= '2026-03-16'"))))
+
+  (t/testing "time-local"
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM time_test WHERE t >= '14:00:00'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM time_test WHERE t > '14:00:00'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM time_test WHERE t < '15:00:00'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM time_test WHERE '15:00:00' > t")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM time_test WHERE t BETWEEN '14:00:00' AND '15:00:00'")))
+    (t/is (= [] (xt/q tu/*node* "SELECT _id AS id FROM time_test WHERE t >= '15:00:00'"))))
+
+  (t/testing "malformed string"
+    (t/is (thrown-with-msg? Exception #"could not be parsed"
+             (xt/q tu/*node* "SELECT _id FROM ts_tz WHERE t >= 'not-a-timestamp'")))
+    (t/is (thrown-with-msg? Exception #"invalid format for type date"
+             (xt/q tu/*node* "SELECT _id FROM date_test WHERE d >= 'not-a-date'")))
+    (t/is (thrown-with-msg? Exception #"invalid format for type time"
+             (xt/q tu/*node* "SELECT _id FROM time_test WHERE t >= 'not-a-time'"))))
+
+  (t/testing "empty string"
+    (t/is (thrown-with-msg? Exception #"could not be parsed"
+             (xt/q tu/*node* "SELECT _id FROM ts_tz WHERE t >= ''")))))
+
 (t/deftest test-timezone-single-word-syntax
   ;; Tests that both TIME ZONE (two words) and TIMEZONE (single word) variants work
   (t/testing "TIMESTAMP WITH TIMEZONE (single word)"


### PR DESCRIPTION
Relates to #5170

Grafana's \`\$__timeFilter\` macro expands to bare ISO strings in temporal comparisons:
\`recorded_at BETWEEN '2026-01-01T00:00:00Z' AND '2026-01-02T00:00:00Z'\`

This is NOT strictly required for grafana compatibility (i.e. table/column discovery).

PG implicitly casts these to the temporal type of the other operand.
Without this, XTDB rejects the comparison as a type mismatch.

Registers codegen-call methods for each comparison operator and temporal type pair (timestamp-tz, timestamp-local, date, time-local) in both operand orderings, casting the utf8 side to match via \`recall-with-cast2\`.
Malformed strings produce clear parse errors at runtime ("could not be parsed" / "invalid format for type").