### PR TITLE
fix(sql): allow TIME as identifier for Grafana AS time alias

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -147,7 +147,7 @@ identifier
         | 'VARBINARY' | 'BYTEA'
         | 'URI' | 'OID'
         | 'COPY' | 'FORMAT'
-        | 'ATTACH' | 'DETACH' | 'DATABASE' | 'LEVEL'
+        | 'ATTACH' | 'DETACH' | 'DATABASE' | 'LEVEL' | 'TIME'
         | METADATA
         | setFunctionType )
         # RegularIdentifier

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -994,6 +994,16 @@
     (t/is (= [{:x 1.0 :cnt 1} {:x 2.0 :cnt 1} {:x 3.0 :cnt 1}]
              (xt/q tu/*node* "SELECT (FLOOR((_id - 1.0) / 1.0)) * 1.0 + 1.0 AS x, COUNT(*) AS cnt FROM orders GROUP BY (FLOOR((_id - 1.0) / 1.0)) * 1.0 + 1.0 ORDER BY (FLOOR((_id - 1.0) / 1.0)) * 1.0 + 1.0 ASC")))))
 
+(t/deftest test-time-as-identifier
+  (t/testing "TIME as column alias"
+    (t/is (= [{:time 1}]
+             (xt/q tu/*node* "SELECT 1 AS time"))))
+
+  (t/testing "TIME as column name"
+    (xt/execute-tx tu/*node* [[:sql "INSERT INTO time_id_test (_id, time) VALUES (1, 42)"]])
+    (t/is (= [{:time 42}]
+             (xt/q tu/*node* "SELECT time FROM time_id_test")))))
+
 (t/deftest test-order-by-alias
   (t/testing "alias within expression - plan"
     (t/is (=plan-file


### PR DESCRIPTION
Relates to #5170

Required for core grafana functionality, sent in dashboard queries.

Grafana's time-series panel sends queries like \`SELECT recorded_at AS time, value FROM ... ORDER BY time\` with unquoted \`TIME\`.
\`TIME\` is a SQL keyword (time literals, \`WITH TIME ZONE\`), so the parser rejects it as an alias.

Adds \`TIME\` to the \`identifier\` grammar rule, following the same pattern as \`SELECT\`, \`USER\`, \`DATABASE\` etc which are already there.
This allows \`TIME\` as a column alias, column name, or table name — matching PostgreSQL's behaviour where \`TIME\` is a non-reserved keyword.

\`TIME\` in its keyword contexts (\`TIME '14:30'\`, \`WITH TIME ZONE\`) continues to work because ANTLR matches those specific rules before falling through to \`identifier\`.