### PR TITLE
tidy!(sql): require table alias before column projection in BaseTable grammar

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -532,7 +532,7 @@ fromClause : 'FROM' tableReference (',' tableReference)* ;
 /// §7.6 <table reference>
 
 tableReference
-    : fromTableRef (querySystemTimePeriodSpecification | queryValidTimePeriodSpecification)* tableAlias? tableProjection? # BaseTable
+    : fromTableRef (querySystemTimePeriodSpecification | queryValidTimePeriodSpecification)* (tableAlias tableProjection?)? # BaseTable
     | tableReference joinType? 'JOIN' tableReference joinSpecification # JoinTable
     | tableReference 'CROSS' 'JOIN' tableReference # CrossJoinTable
     | tableReference 'NATURAL' joinType? 'JOIN' tableReference # NaturalJoinTable


### PR DESCRIPTION
Previously `tableAlias?` and `tableProjection?` were independently optional on `BaseTable`, so `FROM foo(x)` parsed as table `foo` with column projection `(x)` and no alias.
This is non-standard — in standard SQL and PostgreSQL, column projection is always part of the alias clause (`FROM foo AS f(x)`), and bare `FROM foo(x)` is unambiguously a function call.

The independent optionals were a legacy of early XTDB where base relations required explicit column declarations.
No existing tests rely on projection-without-alias.

This also unblocks a cleaner grammar for function-calls-in-FROM (#5429): without this fix, `FROM fn(arg)` is ambiguous between BaseTable (table + projection) and a function call, because ANTLR's ALL(*) prediction sees both alternatives as viable.