### PR TITLE
feat(sql): coerce string literals to temporal types in comparisons

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -680,6 +680,38 @@
                           ~(f #xt/type :null nil)
                           ~(f #xt/type :bool `(not (== -1 ~l-sym ~r-sym))))))))}))
 
+(def ^:private comparison-ops #{:< :<= :> :>= :== :<>})
+
+(defn- try-coerce-utf8-literal-to-temporal
+  "When a utf8 string literal is compared against a date-time type, coerces the
+  literal to the temporal type before dispatch — so operators only see temporal+temporal."
+  [{:keys [f] :as expr} arg-types emitted-args]
+  (when (and (comparison-ops f) (= 2 (count arg-types)))
+    (let [ea (vec emitted-args)
+          type-head (fn [t] (types/col-type-head (st/render-type t)))
+          date-time? (fn [th] (isa? types/col-type-hierarchy th :date-time))
+          coerce (fn [utf8-idx temporal-idx]
+                   (let [target-type (nth arg-types temporal-idx)
+                         {cast-ret :return-type, cast-bb :batch-bindings, cast-cc :->call-code}
+                         (codegen-cast {:source-type (nth arg-types utf8-idx) :target-type target-type})
+                         new-arg-types (assoc (vec arg-types) utf8-idx cast-ret)
+                         {ret :return-type, bb :batch-bindings, cc :->call-code}
+                         (codegen-call (assoc expr :args emitted-args :arg-types new-arg-types))]
+                     {:return-type ret
+                      :batch-bindings (vec (concat cast-bb bb))
+                      :->call-code (fn [args]
+                                     (cc (update (vec args) utf8-idx (fn [a] (cast-cc [a])))))}))]
+      (cond
+        (and (= :utf8 (type-head (nth arg-types 0)))
+             (date-time? (type-head (nth arg-types 1)))
+             (contains? (nth ea 0) :literal))
+        (coerce 0 1)
+
+        (and (date-time? (type-head (nth arg-types 0)))
+             (= :utf8 (type-head (nth arg-types 1)))
+             (contains? (nth ea 1) :literal))
+        (coerce 1 0)))))
+
 (defn- codegen-call* [{:keys [f emitted-args] :as expr}]
   (let [shortcut-null? (shortcut-null-args? f)
 
@@ -694,9 +726,10 @@
                              (MapEntry/create arg-types
                                               (if (or (not shortcut-null?)
                                                       (every? #(not= #xt/type :null %) arg-types))
-                                                (codegen-call (assoc expr
-                                                                     :args emitted-args
-                                                                     :arg-types arg-types))
+                                                (or (try-coerce-utf8-literal-to-temporal expr arg-types emitted-args)
+                                                    (codegen-call (assoc expr
+                                                                         :args emitted-args
+                                                                         :arg-types arg-types)))
                                                 {:return-type #xt/type :null, :->call-code (constantly nil)})))
                            (into {}))
 

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1959,6 +1959,41 @@ SELECT DATE_BIN(INTERVAL 'P1D', TIMESTAMP '2020-01-01T00:00:00Z'),
   (t/is (= [{:v #xt/zoned-date-time "2021-10-21T12:34+01:00"}]
            (xt/q tu/*node* "SELECT TIMESTAMP WITH TIME ZONE '2021-10-21T12:34:00+01:00' v"))))
 
+(t/deftest test-implicit-string-literal-to-temporal-coercion-in-comparisons
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO ts_tz (_id, t) VALUES (1, TIMESTAMP '2026-01-15 10:00:00+00:00')"]])
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO ts_local (_id, t) VALUES (1, TIMESTAMP '2026-01-15 10:00:00')"]])
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO date_test (_id, d) VALUES (1, DATE '2026-03-15')"]])
+  (t/testing "timestamp-tz"
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_tz WHERE t >= '2026-01-15T09:00:00Z'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_tz WHERE '2026-01-15T09:00:00Z' <= t")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_tz WHERE t BETWEEN '2026-01-15T09:00:00Z' AND '2026-01-15T11:00:00Z'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_tz WHERE t = '2026-01-15T10:00:00Z'")))
+    (t/is (= [] (xt/q tu/*node* "SELECT _id AS id FROM ts_tz WHERE t >= '2026-01-15T11:00:00Z'"))))
+
+  (t/testing "timestamp-local"
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_local WHERE t >= '2026-01-15T09:00:00'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM ts_local WHERE t BETWEEN '2026-01-15T09:00:00' AND '2026-01-15T11:00:00'")))
+    (t/is (= [] (xt/q tu/*node* "SELECT _id AS id FROM ts_local WHERE t >= '2026-01-15T11:00:00'"))))
+
+  (t/testing "date"
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM date_test WHERE d >= '2026-03-14'")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM date_test WHERE '2026-03-16' > d")))
+    (t/is (= [{:id 1}] (xt/q tu/*node* "SELECT _id AS id FROM date_test WHERE d BETWEEN '2026-03-14' AND '2026-03-16'")))
+    (t/is (= [] (xt/q tu/*node* "SELECT _id AS id FROM date_test WHERE d >= '2026-03-16'"))))
+
+  (t/testing "malformed string literal"
+    (t/is (thrown-with-msg? Exception #"could not be parsed"
+             (xt/q tu/*node* "SELECT _id FROM ts_tz WHERE t >= 'not-a-timestamp'")))
+    (t/is (thrown-with-msg? Exception #"invalid format for type date"
+             (xt/q tu/*node* "SELECT _id FROM date_test WHERE d >= 'not-a-date'"))))
+
+  (t/testing "non-literal utf8 values are not coerced"
+    (xt/execute-tx tu/*node* [[:sql "INSERT INTO strings (_id, s) VALUES (1, '2026-01-15T10:00:00Z')"]])
+    (t/is (thrown? Exception
+             (xt/q tu/*node* "SELECT _id FROM ts_tz WHERE t >= (SELECT s FROM strings WHERE _id = 1)")))
+    (t/is (thrown? Exception
+             (xt/q tu/*node* "SELECT _id FROM date_test WHERE d >= (SELECT s FROM strings WHERE _id = 1)")))))
+
 (t/deftest test-timezone-single-word-syntax
   ;; Tests that both TIME ZONE (two words) and TIMEZONE (single word) variants work
   (t/testing "TIMESTAMP WITH TIMEZONE (single word)"


### PR DESCRIPTION
Bare string literals like '2026-01-01' are now resolved to the temporal type of the other operand in comparison expressions. This matches how DuckDB (STRING_LITERAL) and CockroachDB (StrVal) treat untyped string constants — the literal adapts to context rather than being committed to VARCHAR/utf8.

The coercion lives in codegen-call* rather than as operator-specific codegen-call multimethod methods — multimethod dispatch is committed once matched on types, so non-literal utf8 values would also match with no way to fall through to default dispatch (which produces the type error). codegen-call* lets us try 
  the coercion and fall back naturally.

=== is excluded because UPDATE uses it for change detection on polymorphic columns where utf8 and temporal can coexist — coercing there would mask real type differences.

Gated to user-facing comparison ops only (<, <=, >, >=, =, <>) — predicates return booleans so the coercion can't change what gets stored, unlike COALESCE or GREATEST where it would silently alter the result type. Internal operators (compare, compare_nulls_first, compare_nulls_last, null_eq) are excluded —     
  their operands are always column refs from sorting/grouping, never literals.

Primary motivation is Grafana compatibility: its $__timeFilter macro expands to bare ISO strings in temporal comparisons.                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                          
  Relates to #5170       