### PR TITLE
feat: Add configurable transactional ID prefix to KafkaCluster

### DIFF
--- a/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
@@ -443,6 +443,41 @@ class YamlSerdeTest {
     }
 
     @Test
+    fun testTransactionalIdPrefix() {
+        assertEquals(
+            KafkaCluster.ClusterFactory(bootstrapServers = "localhost:9092"),
+            nodeConfig("""
+                logClusters:
+                  kafkaCluster: !Kafka
+                    bootstrapServers: "localhost:9092"
+            """.trimIndent()).logClusters["kafkaCluster"]
+        )
+
+        assertEquals(
+            KafkaCluster.ClusterFactory(bootstrapServers = "localhost:9092", transactionalIdPrefix = "staging"),
+            nodeConfig("""
+                logClusters:
+                  kafkaCluster: !Kafka
+                    bootstrapServers: "localhost:9092"
+                    transactionalIdPrefix: staging
+            """.trimIndent()).logClusters["kafkaCluster"]
+        )
+
+        mockkObject(EnvironmentVariableProvider)
+        every { EnvironmentVariableProvider.getEnvVariable("XTDB_TX_ID_PREFIX") } returns "from-env"
+        assertEquals(
+            KafkaCluster.ClusterFactory(bootstrapServers = "localhost:9092", transactionalIdPrefix = "from-env"),
+            nodeConfig("""
+                logClusters:
+                  kafkaCluster: !Kafka
+                    bootstrapServers: "localhost:9092"
+                    transactionalIdPrefix: !Env XTDB_TX_ID_PREFIX
+            """.trimIndent()).logClusters["kafkaCluster"]
+        )
+        unmockkObject(EnvironmentVariableProvider)
+    }
+
+    @Test
     fun testTracer() {
         mockkObject(EnvironmentVariableProvider)
         every { EnvironmentVariableProvider.getEnvVariable("XTDB_OTEL_HTTP_ENDPOINT") } returns "http://otelhost:4318/v1/traces"

--- a/modules/kafka/src/main/clojure/xtdb/kafka.clj
+++ b/modules/kafka/src/main/clojure/xtdb/kafka.clj
@@ -5,11 +5,12 @@
   (:import [xtdb.api.log KafkaCluster$ClusterFactory KafkaCluster$LogFactory]))
 
 (defmethod log/->log-cluster-factory ::cluster
-  [_ {:keys [bootstrap-servers poll-duration properties-map properties-file]}]
+  [_ {:keys [bootstrap-servers poll-duration properties-map properties-file transactional-id-prefix]}]
   (cond-> (KafkaCluster$ClusterFactory. bootstrap-servers)
     poll-duration (.pollDuration (time/->duration poll-duration))
     properties-map (.propertiesMap properties-map)
-    properties-file (.propertiesFile (util/->path properties-file))))
+    properties-file (.propertiesFile (util/->path properties-file))
+    transactional-id-prefix (.transactionalIdPrefix transactional-id-prefix)))
 
 (defmethod log/->log-factory ::kafka [_ {:keys [cluster topic replica-cluster replica-topic epoch group-id] :as opts}]
   (let [cluster-str (str (symbol cluster))]

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -118,6 +118,7 @@ class KafkaCluster(
     val kafkaConfigMap: KafkaConfigMap,
     private val pollDuration: Duration,
     val schemaRegistryUrl: String? = null,
+    val transactionalIdPrefix: String? = null,
     coroutineContext: CoroutineContext = Dispatchers.Default
 ) : Log.Cluster {
     val producer = kafkaConfigMap.openProducer()
@@ -136,6 +137,7 @@ class KafkaCluster(
         var propertiesMap: Map<String, String> = emptyMap(),
         var propertiesFile: Path? = null,
         var schemaRegistryUrl: String? = null,
+        var transactionalIdPrefix: String? = null,
         @kotlinx.serialization.Transient var coroutineContext: CoroutineContext = Dispatchers.Default
     ) : Log.Cluster.Factory<KafkaCluster> {
 
@@ -143,6 +145,7 @@ class KafkaCluster(
         fun propertiesMap(propertiesMap: Map<String, String>) = apply { this.propertiesMap = propertiesMap }
         fun propertiesFile(propertiesFile: Path) = apply { this.propertiesFile = propertiesFile }
         fun schemaRegistryUrl(schemaRegistryUrl: String) = apply { this.schemaRegistryUrl = schemaRegistryUrl }
+        fun transactionalIdPrefix(transactionalIdPrefix: String?) = apply { this.transactionalIdPrefix = transactionalIdPrefix }
 
         private val Path.asPropertiesMap: Map<String, String>
             get() =
@@ -155,7 +158,7 @@ class KafkaCluster(
                 .plus(propertiesMap)
                 .plus(propertiesFile?.asPropertiesMap.orEmpty())
 
-        override fun open(): KafkaCluster = KafkaCluster(configMap, pollDuration, schemaRegistryUrl, coroutineContext)
+        override fun open(): KafkaCluster = KafkaCluster(configMap, pollDuration, schemaRegistryUrl, transactionalIdPrefix, coroutineContext)
     }
 
     interface AtomicProducer<M> : Log.AtomicProducer<M> {
@@ -258,12 +261,14 @@ class KafkaCluster(
         }
 
         override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer<M> {
+            private val prefixedTxId = listOfNotNull(transactionalIdPrefix, transactionalId).joinToString("-")
+
             private val producer = KafkaProducer(
                 mapOf(
                     "enable.idempotence" to "true",
                     "acks" to "all",
                     "compression.type" to "snappy",
-                    "transactional.id" to transactionalId,
+                    "transactional.id" to prefixedTxId,
                 ) + kafkaConfigMap,
                 UnitSerializer,
                 ByteArraySerializer()

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -420,14 +420,14 @@
   (let [env-a-topic (str "xtdb.kafka-test.env-a." (random-uuid))
         env-b-topic (str "xtdb.kafka-test.env-b." (random-uuid))]
     (util/with-tmp-dirs #{path-a path-b}
-      (with-open [node-a (xtn/start-node {:tx-id-prefix "env-a"
-                                          :log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
+      (with-open [node-a (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                            :transactional-id-prefix "env-a"}]}
                                           :log [:kafka {:cluster :my-kafka
                                                         :topic env-a-topic}]
                                           :storage [:remote {:object-store [:in-memory {}]}]
                                           :disk-cache {:path path-a}})
-                  node-b (xtn/start-node {:tx-id-prefix "env-b"
-                                          :log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
+                  node-b (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                            :transactional-id-prefix "env-b"}]}
                                           :log [:kafka {:cluster :my-kafka
                                                         :topic env-b-topic}]
                                           :storage [:remote {:object-store [:in-memory {}]}]

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -415,3 +415,56 @@
         (jdbc/execute! xtdb-conn-2 ["INSERT INTO foo RECORDS {_id: 'primary3'}"])
         (t/is (= #{{:_id "primary"} {:_id "primary2"} {:_id "primary3"}}
                  (set (jdbc/execute! xtdb-conn-2 ["SELECT * FROM foo"]))))))))
+
+(t/deftest ^:integration test-tx-id-prefix-prevents-cross-environment-fencing
+  (let [env-a-topic (str "xtdb.kafka-test.env-a." (random-uuid))
+        env-b-topic (str "xtdb.kafka-test.env-b." (random-uuid))]
+    (util/with-tmp-dirs #{path-a path-b}
+      (with-open [node-a (xtn/start-node {:tx-id-prefix "env-a"
+                                          :log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
+                                          :log [:kafka {:cluster :my-kafka
+                                                        :topic env-a-topic}]
+                                          :storage [:remote {:object-store [:in-memory {}]}]
+                                          :disk-cache {:path path-a}})
+                  node-b (xtn/start-node {:tx-id-prefix "env-b"
+                                          :log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
+                                          :log [:kafka {:cluster :my-kafka
+                                                        :topic env-b-topic}]
+                                          :storage [:remote {:object-store [:in-memory {}]}]
+                                          :disk-cache {:path path-b}})]
+        
+        (t/testing "both nodes can transact without fencing each other"
+          (t/is (xt/execute-tx node-a [[:put-docs :docs {:xt/id :from-a}]]))
+          (t/is (xt/execute-tx node-b [[:put-docs :docs {:xt/id :from-b}]]))
+
+          (t/is (xt/execute-tx node-a [[:put-docs :docs {:xt/id :from-a-2}]]))
+          (t/is (xt/execute-tx node-b [[:put-docs :docs {:xt/id :from-b-2}]])))
+
+        (t/testing "each node sees only its own data"
+            (t/is (= #{{:xt/id :from-a} {:xt/id :from-a-2}}
+                     (set (xt/q node-a "SELECT _id FROM docs"))))
+            (t/is (= #{{:xt/id :from-b} {:xt/id :from-b-2}}
+                     (set (xt/q node-b "SELECT _id FROM docs")))))
+
+        (t/testing "attached databases also use the tx-id prefix"
+          (let [test-uuid (random-uuid)]
+            (with-open [conn-a (.build (.createConnectionBuilder node-a))
+                        conn-b (.build (.createConnectionBuilder node-b))]
+              (jdbc/execute! conn-a [(format "ATTACH DATABASE secondary WITH $$
+                 log: !Kafka
+                   cluster: my-kafka
+                   topic: xtdb.kafka-test.env-a-secondary.%s
+                 $$" test-uuid)])
+              (jdbc/execute! conn-b [(format "ATTACH DATABASE secondary WITH $$
+                 log: !Kafka
+                   cluster: my-kafka
+                   topic: xtdb.kafka-test.env-b-secondary.%s
+                 $$" test-uuid)])
+
+              (with-open [sec-a (.build (-> (.createConnectionBuilder node-a) (.database "secondary")))
+                          sec-b (.build (-> (.createConnectionBuilder node-b) (.database "secondary")))]
+                (t/is (xt/submit-tx sec-a [[:put-docs :newdocs {:xt/id :sec-a}]]))
+                (t/is (xt/submit-tx sec-b [[:put-docs :newdocs {:xt/id :sec-b}]]))
+
+                (t/is (= [{:xt/id :sec-a}] (xt/q sec-a "SELECT _id FROM newdocs")))
+                (t/is (= [{:xt/id :sec-b}] (xt/q sec-b "SELECT _id FROM newdocs")))))))))))


### PR DESCRIPTION
Resolves #5447

## Summary

When multiple XTDB environments share a Kafka cluster, their transactional producers collide on the same `transactional.id`, causing `ProducerFencedException`. This PR adds a `transactionalIdPrefix` to `KafkaCluster.ClusterFactory` so each environment can namespace its producer IDs.

- Adds an integration test proving two XTDB nodes sharing a Kafka cluster with different prefixes can transact without fencing each other (including attached databases).
- Adds `transactionalIdPrefix` to `KafkaCluster.ClusterFactory` — the prefix is applied transparently inside `openAtomicProducer`, so core code doesn't need to know about it.
- Configurable via YAML (`transactionalIdPrefix` on the `!Kafka` cluster tag) and EDN (`:transactional-id-prefix` in the cluster opts). Supports `!Env` for environment variables.

## Example YAML config

```yaml
logClusters:
  kafkaCluster: !Kafka
    bootstrapServers: "localhost:9092"
    transactionalIdPrefix: staging
```
