### PR TITLE
fix(debezium)!: persist txId counter and system-time in offset token

### DIFF
--- a/modules/debezium/src/main/kotlin/xtdb/debezium/KafkaDebeziumLog.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/KafkaDebeziumLog.kt
@@ -188,14 +188,13 @@ class KafkaDebeziumLog @JvmOverloads constructor(
             @Suppress("UNCHECKED_CAST") (valueDeserializer() as Deserializer<Any>)
         ).use { c ->
             // TODO: use partition parameter for multi-partition support
-            val partitionOffsets = afterToken?.let { tok ->
-                val token = tok.unpack(DebeziumOffsetToken::class.java)
-                token.dbzmTopicOffsetsMap[topic]?.offsetsList
-                    ?.mapIndexedNotNull { p, offset ->
-                        if (offset >= 0) TopicPartition(topic, p) to offset else null
-                    }
-                    ?.takeIf { it.isNotEmpty() }
-            }
+            val token = afterToken?.unpack(DebeziumOffsetToken::class.java)
+
+            val partitionOffsets = token?.dbzmTopicOffsetsMap?.get(topic)?.offsetsList
+                ?.mapIndexedNotNull { p, offset ->
+                    if (offset >= 0) TopicPartition(topic, p) to offset else null
+                }
+                ?.takeIf { it.isNotEmpty() }
 
             if (partitionOffsets != null) {
                 c.assign(partitionOffsets.map { it.first })
@@ -206,12 +205,14 @@ class KafkaDebeziumLog @JvmOverloads constructor(
                 c.seekToBeginning(listOf(tp))
             }
 
+            var latestTxId = token?.latestTxId ?: -1L
+
             // Smoothed clock: ensures monotonically increasing system-time across batches.
             // Kafka timestamps are millisecond-precision — consecutive batches can share a timestamp,
             // which would give two transactions the same systemFrom and collapse valid-time history.
             // Mirrors the pattern in indexer.clj's indexTx (default-system-time).
             // TODO: likely superseded by #5445 which restructures the external log pipeline
-            var lastSystemTimeMicros = Long.MIN_VALUE
+            var lastSystemTimeMicros = token?.latestSystemTimeMicros ?: Long.MIN_VALUE
 
             while (currentCoroutineContext().isActive) {
                 val records = runInterruptible(Dispatchers.IO) {
@@ -230,14 +231,12 @@ class KafkaDebeziumLog @JvmOverloads constructor(
                         latestTimestamp = maxOf(latestTimestamp, Instant.ofEpochMilli(consumerRecord.timestamp()))
                     }
 
-                    var systemTimeMicros = latestTimestamp.asMicros
-                    if (systemTimeMicros <= lastSystemTimeMicros) {
-                        systemTimeMicros = lastSystemTimeMicros + 1
-                    }
+                    val systemTimeMicros = maxOf(latestTimestamp.asMicros, lastSystemTimeMicros + 1)
                     lastSystemTimeMicros = systemTimeMicros
 
                     val systemTime = InstantUtil.fromMicros(systemTimeMicros)
-                    val txKey = TransactionKey(maxOffset, systemTime)
+                    val txId = ++latestTxId
+                    val txKey = TransactionKey(txId, systemTime)
 
                     OpenTx(allocator, txKey).use { openTx ->
                         for (consumerRecord in records) {
@@ -249,6 +248,8 @@ class KafkaDebeziumLog @JvmOverloads constructor(
                             dbzmTopicOffsets[topic] = partitionOffsets {
                                 offsets += listOf(maxOffset)
                             }
+                            this.latestTxId = txId
+                            this.latestSystemTimeMicros = systemTimeMicros
                         }, "xtdb.debezium")
 
                         openTx.addTxRow(dbName, openTx.txKey, null)

--- a/modules/debezium/src/main/proto/debezium.proto
+++ b/modules/debezium/src/main/proto/debezium.proto
@@ -27,4 +27,6 @@ message PartitionOffsets {
 
 message DebeziumOffsetToken {
     map<string, PartitionOffsets> dbzm_topic_offsets = 1;
+    int64 latest_tx_id = 2;
+    int64 latest_system_time_micros = 3;
 }

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumIntegrationTest.kt
@@ -439,18 +439,18 @@ class DebeziumIntegrationTest {
                 "DELETE FROM cdc_users WHERE _id = 2",
             )
 
-            // Wait for Alice's update rather than counting transactions,
-            // because the streaming events may batch into fewer transactions than records.
-            awaitCondition("Alice updated") {
-                xtQueryDb(node, "cdc", "SELECT email FROM public.cdc_users WHERE _id = 1")
-                    .firstOrNull()?.get("email") == "alice-new@example.com"
+            // Waiting for the last streaming event (DELETE Bob) guarantees UPDATE Alice is also applied,
+            // since Debezium preserves PG commit order.
+            awaitCondition("Bob deleted") {
+                xtQueryDb(node, "cdc",
+                    "SELECT _valid_to FROM public.cdc_users FOR ALL VALID_TIME WHERE _id = 2"
+                ).any { it["_valid_to"] != null }
             }
 
-            // Bob: deleted — should not appear in current state
-            val bob = xtQueryDb(node, "cdc",
-                "SELECT _id FROM public.cdc_users WHERE _id = 2"
+            val alice = xtQueryDb(node, "cdc",
+                "SELECT email FROM public.cdc_users WHERE _id = 1"
             )
-            assertEquals(0, bob.size, "Bob should be deleted")
+            assertEquals("alice-new@example.com", alice[0]["email"])
         }
     }
 
@@ -488,15 +488,16 @@ class DebeziumIntegrationTest {
                 "DELETE FROM cdc_no_envelope WHERE _id = 2",
             )
 
-            awaitCondition("Alice updated") {
-                xtQueryDb(node, "cdc", "SELECT email FROM public.cdc_no_envelope WHERE _id = 1")
-                    .firstOrNull()?.get("email") == "alice-new@example.com"
+            awaitCondition("Bob deleted") {
+                xtQueryDb(node, "cdc",
+                    "SELECT _valid_to FROM public.cdc_no_envelope FOR ALL VALID_TIME WHERE _id = 2"
+                ).any { it["_valid_to"] != null }
             }
 
-            val bob = xtQueryDb(node, "cdc",
-                "SELECT _id FROM public.cdc_no_envelope WHERE _id = 2"
+            val alice = xtQueryDb(node, "cdc",
+                "SELECT email FROM public.cdc_no_envelope WHERE _id = 1"
             )
-            assertEquals(0, bob.size, "Bob should be deleted")
+            assertEquals("alice-new@example.com", alice[0]["email"])
         }
     }
 
@@ -746,15 +747,16 @@ class DebeziumIntegrationTest {
                 "DELETE FROM cdc_direct WHERE _id = 2",
             )
 
-            awaitCondition("Alice updated") {
-                xtQueryDb(node, "cdc_direct_db", "SELECT email FROM public.cdc_direct WHERE _id = 1")
-                    .firstOrNull()?.get("email") == "alice-new@example.com"
+            awaitCondition("Bob deleted") {
+                xtQueryDb(node, "cdc_direct_db",
+                    "SELECT _valid_to FROM public.cdc_direct FOR ALL VALID_TIME WHERE _id = 2"
+                ).any { it["_valid_to"] != null }
             }
 
-            val bob = xtQueryDb(node, "cdc_direct_db",
-                "SELECT _id FROM public.cdc_direct WHERE _id = 2"
+            val alice = xtQueryDb(node, "cdc_direct_db",
+                "SELECT email FROM public.cdc_direct WHERE _id = 1"
             )
-            assertEquals(0, bob.size, "Bob should be deleted")
+            assertEquals("alice-new@example.com", alice[0]["email"])
 
             // Primary db should have no CDC data
             val primaryRows = xtQuery(node,

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/KafkaDebeziumLogTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/KafkaDebeziumLogTest.kt
@@ -18,7 +18,9 @@ import xtdb.debezium.proto.DebeziumOffsetToken
 import xtdb.debezium.proto.debeziumOffsetToken
 import xtdb.debezium.proto.partitionOffsets
 import xtdb.indexer.OpenTx
+import xtdb.time.InstantUtil.asMicros
 import com.google.protobuf.Any as ProtoAny
+import java.time.Instant
 import java.util.Collections
 import kotlin.time.Duration.Companion.seconds
 
@@ -72,6 +74,8 @@ class KafkaDebeziumLogTest {
     }
 
     data class CapturedTx(
+        val txId: Long,
+        val systemTime: Instant,
         val cdcRows: Int,
         val resumeToken: ExternalSourceToken?,
     )
@@ -81,6 +85,8 @@ class KafkaDebeziumLogTest {
 
         val handler = ExternalSource.TxHandler { openTx, resumeToken ->
             received.add(CapturedTx(
+                txId = openTx.txKey.txId,
+                systemTime = openTx.txKey.systemTime,
                 cdcRows = openTx.tables
                     .filter { (ref, _) -> ref.schemaName != "xt" }
                     .sumOf { (_, table) -> table.txRelation.rowCount },
@@ -95,6 +101,12 @@ class KafkaDebeziumLogTest {
         val debeziumToken = token.unpack(DebeziumOffsetToken::class.java)
         return debeziumToken.dbzmTopicOffsetsMap[topic]?.offsetsList?.firstOrNull()
     }
+
+    private fun resumeTokenTxId(token: ExternalSourceToken?): Long? =
+        token?.unpack(DebeziumOffsetToken::class.java)?.latestTxId
+
+    private fun resumeTokenSystemTimeMicros(token: ExternalSourceToken?): Long? =
+        token?.unpack(DebeziumOffsetToken::class.java)?.latestSystemTimeMicros
 
     @Test
     fun `subscription close cancels cleanly`() = runTest(timeout = 10.seconds) {
@@ -269,5 +281,114 @@ class KafkaDebeziumLogTest {
         log.use {
             assertFailsWith<Exception> { runBlocking { log.onPartitionAssigned(0, null, handler) } }
         }
+    }
+
+    @Test
+    fun `synthetic txId starts at 0 and is persisted in token`() = runTest(timeout = 10.seconds) {
+        val topic = "test-synthetic-txid"
+        produceMessages(topic, listOf(cdcMessage("c", 1, "Alice")))
+
+        val (handler, received) = capturingHandler()
+        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
+        log.use {
+            val job = launch { log.onPartitionAssigned(0, null, handler) }
+            try {
+                while (received.isEmpty()) runInterruptible(Dispatchers.IO) { Thread.sleep(100) }
+            } finally {
+                job.cancelAndJoin()
+            }
+        }
+
+        assertEquals(0L, received[0].txId, "First tx should have synthetic txId=0")
+        assertEquals(0L, resumeTokenTxId(received[0].resumeToken))
+    }
+
+    @Test
+    fun `txId continues incrementing across restarts`() = runTest(timeout = 10.seconds) {
+        val topic = "test-txid-restart"
+        produceMessages(topic, listOf(cdcMessage("c", 1, "Alice")))
+
+        val (handler1, received1) = capturingHandler()
+        val log1 = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
+        log1.use {
+            val job = launch { log1.onPartitionAssigned(0, null, handler1) }
+            try {
+                while (received1.isEmpty()) runInterruptible(Dispatchers.IO) { Thread.sleep(100) }
+            } finally {
+                job.cancelAndJoin()
+            }
+        }
+        assertEquals(0L, received1[0].txId)
+        val resumeToken = received1.last().resumeToken
+
+        produceMessages(topic, listOf(cdcMessage("c", 2, "Bob")))
+
+        val (handler2, received2) = capturingHandler()
+        val log2 = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
+        log2.use {
+            val job = launch { log2.onPartitionAssigned(0, resumeToken, handler2) }
+            try {
+                while (received2.isEmpty()) runInterruptible(Dispatchers.IO) { Thread.sleep(100) }
+            } finally {
+                job.cancelAndJoin()
+            }
+        }
+
+        assertEquals(1L, received2[0].txId, "Should continue from previous txId + 1")
+        assertEquals(1L, resumeTokenTxId(received2[0].resumeToken))
+    }
+
+    @Test
+    fun `system_time is persisted in token in micros`() = runTest(timeout = 10.seconds) {
+        val topic = "test-systime-persist"
+        produceMessages(topic, listOf(cdcMessage("c", 1, "Alice")))
+
+        val (handler, received) = capturingHandler()
+        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
+        log.use {
+            val job = launch { log.onPartitionAssigned(0, null, handler) }
+            try {
+                while (received.isEmpty()) runInterruptible(Dispatchers.IO) { Thread.sleep(100) }
+            } finally {
+                job.cancelAndJoin()
+            }
+        }
+
+        val captured = received[0]
+        assertEquals(
+            captured.systemTime.asMicros,
+            resumeTokenSystemTimeMicros(captured.resumeToken),
+        )
+    }
+
+    @Test
+    fun `system_time smoothing resumes from token`() = runTest(timeout = 10.seconds) {
+        val topic = "test-systime-smooth-restart"
+        produceMessages(topic, listOf(cdcMessage("c", 1, "Alice")))
+
+        // Pretend a previous run committed a tx with system_time in year 3000.
+        // The smoothing should force the next tx's system_time past that, even
+        // though the Kafka record timestamp is present-day.
+        val futureMicros = Instant.parse("3000-01-01T00:00:00Z").asMicros
+        val afterToken = ProtoAny.pack(debeziumOffsetToken {
+            latestSystemTimeMicros = futureMicros
+        }, "xtdb.debezium")
+
+        val (handler, received) = capturingHandler()
+        val log = KafkaDebeziumLog("testdb", kafkaConfig(), topic, MessageFormat.Json)
+        log.use {
+            val job = launch { log.onPartitionAssigned(0, afterToken, handler) }
+            try {
+                while (received.isEmpty()) runInterruptible(Dispatchers.IO) { Thread.sleep(100) }
+            } finally {
+                job.cancelAndJoin()
+            }
+        }
+
+        assertEquals(
+            futureMicros + 1,
+            received[0].systemTime.asMicros,
+            "Smoothing should bump system_time past the token's latestSystemTimeMicros",
+        )
     }
 }


### PR DESCRIPTION
## Summary

Persist the tx id counter and smoothed system-time in `DebeziumOffsetToken` so they survive restarts.

Previously:
- tx id was the max Kafka offset per poll batch
- system-time smoothing was purely in-memory (lost on restart)

Now:
- `latest_tx_id` — synthetic incrementing counter, persisted
- `latest_system_time_micros` — smoothed clock floor, persisted

Full reasoning (including why LSN and Kafka offset don't work) is in the commit message.

**Breaking change:** existing tokens unpack with proto defaults of 0, so first tx after upgrade gets `txId = 1` and smoothing restarts from 0.
Detach and re-attach the Debezium database on upgrade to avoid this.

## Test plan

- [x] `KafkaDebeziumLogTest` — synthetic txId starts at 0
- [x] `KafkaDebeziumLogTest` — txId continues across restart via token
- [x] `KafkaDebeziumLogTest` — system-time persisted in token in micros
- [x] `KafkaDebeziumLogTest` — smoothing resumes from token (year-3000 scenario)
- [x] CI integration tests