### PR TITLE
fix(kafka): set linger.ms=0 on Kafka producers

### DIFF
--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -66,6 +66,7 @@ private fun KafkaConfigMap.openProducer() =
             "enable.idempotence" to "true",
             "acks" to "all",
             "compression.type" to "snappy",
+            "linger.ms" to "0",
         ) + this,
         UnitSerializer,
         ByteArraySerializer()
@@ -268,6 +269,7 @@ class KafkaCluster(
                     "enable.idempotence" to "true",
                     "acks" to "all",
                     "compression.type" to "snappy",
+                    "linger.ms" to "0",
                     "transactional.id" to prefixedTxId,
                 ) + kafkaConfigMap,
                 UnitSerializer,


### PR DESCRIPTION
## Context

Kafka 4.0 changed the default `linger.ms` from 0 to 5ms. This means the producer waits 5ms before sending each message, hoping to batch it with others.

XTDB's log producer does synchronous single-message sends — each `appendMessage` sends one record and suspends until the callback fires. There's no concurrent production on the same producer instance, so lingering adds 5ms of dead time per transaction with zero batching benefit.

At scale this is significant: the ingest-tx-overhead benchmark (5000 single-doc transactions) went from ~31s to ~63s after upgrading to kafka-clients 4.1.1.

## Change

Set `linger.ms=0` explicitly on both `openProducer()` and `openAtomicProducer()`. Users can still override via `propertiesMap` if they want batching for some reason.