### PR TITLE
fix(kafka): pin kafka-clients version to prevent Confluent override

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,6 +120,17 @@ allprojects {
         maven { url = uri("https://packages.confluent.io/maven/") }
     }
 
+    // Confluent publishes kafka-clients with a higher version number (7.8.0-ccs)
+    // than Apache's (4.1.1), causing silent version override via the Confluent Maven repo.
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.apache.kafka" && requested.name == "kafka-clients") {
+                useVersion(libs.versions.kafka.get())
+                because("pin to Apache kafka-clients; Confluent's 7.8.0-ccs silently overrides 4.1.1")
+            }
+        }
+    }
+
     if (plugins.hasPlugin("java-library")) {
         java {
             withSourcesJar()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,6 +130,20 @@ allprojects {
         maven { url = uri("https://packages.confluent.io/maven/") }
     }
 
+    // Confluent publishes kafka-clients as 7.8.0-ccs (Confluent Platform versioning), numerically
+    // higher than Apache's 4.1.1 — so via the Confluent repo Gradle silently overrides our declared
+    // client. Pin it back across every configuration in every module. This catches our own
+    // classpaths (runtime AND test); the transitive `exclude`s in modules/kafka additionally keep
+    // the override out of the published POM, which a resolutionStrategy alone does not do.
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.apache.kafka" && requested.name == "kafka-clients") {
+                useVersion(libs.versions.kafka.get())
+                because("pin to Apache kafka-clients; Confluent's 7.8.0-ccs silently overrides it")
+            }
+        }
+    }
+
     tasks.withType<ShadowJar> {
         transform(Log4j2PluginsCacheFileTransformer())
     }

--- a/modules/kafka/build.gradle.kts
+++ b/modules/kafka/build.gradle.kts
@@ -42,7 +42,10 @@ dependencies {
     // Bundle the two common ones so they work out of the box; operators wanting others
     // (e.g. JsonSchema) add the converter jar to their own classpath.
     runtimeOnly(libs.kafka.connect.json)
-    runtimeOnly(libs.kafka.connect.avro.converter)
+    // Confluent artifacts declare their own kafka-clients:7.8.0-ccs. Exclude it here so the
+    // exclusion travels in the published POM and downstream consumers of xtdb-kafka don't
+    // inherit the override (the root resolutionStrategy fixes our build but not theirs).
+    runtimeOnly(libs.kafka.connect.avro.converter) { exclude(group = "org.apache.kafka", module = "kafka-clients") }
 
     implementation(libs.kotlinx.coroutines)
 
@@ -51,8 +54,8 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.kafka)
-    testImplementation(libs.kafka.avro.serializer)
-    testImplementation(libs.kafka.json.schema.serializer)
+    testImplementation(libs.kafka.avro.serializer) { exclude(group = "org.apache.kafka", module = "kafka-clients") }
+    testImplementation(libs.kafka.json.schema.serializer) { exclude(group = "org.apache.kafka", module = "kafka-clients") }
     testImplementation(libs.kafka.connect.json.schema.converter)
 }
 


### PR DESCRIPTION
## Context

The `xtdb-kafka` module bundles Confluent artifacts (the avro / json-schema serializers and the connect avro converter) for out-of-the-box converter support.
Each of those declares its own `kafka-clients:7.8.0-ccs` — Confluent's fork, versioned to Confluent Platform (7.x) rather than Apache (4.x).

Because `7.8.0` is numerically higher than our declared `4.1.1`, Gradle's default "highest wins" conflict resolution silently swaps our client for Confluent's the moment any Confluent artifact reaches the graph (via the Confluent Maven repo).
This meant our benchmarks, dev classpath, **and test classpath** were running against the Confluent 7.x client instead of Apache 4.1.

The swap was not benign: it changed producer behaviour enough to move the ingest benchmarks ~40%, which masked a real `linger.ms` regression — see #5452.

## Change

Two complementary mechanisms — neither is sufficient alone (verified per-configuration):

- **Root `resolutionStrategy`** pins `kafka-clients` to the version catalog across every configuration in every module, including the test classpaths.
  An exclude alone leaves `testRuntimeClasspath`/`testCompileClasspath` on ccs, because the test-scoped avro / json-schema serializers pull it by paths a single runtime exclude doesn't cover.
- **`exclude`s on the Confluent dependencies** keep the override out of the published POM, so downstream consumers of `xtdb-kafka` don't re-inherit it.
  A `resolutionStrategy` does not travel in the POM; an `exclude` does.

A blanket `configurations.all { exclude(kafka-clients) }` was rejected — it also strips our own declared client, leaving `kafka-clients` absent entirely.

## Test plan

- All four `:modules:xtdb-kafka` configurations (`{runtime,compile,testRuntime,testCompile}Classpath`) resolve `kafka-clients` to `4.1.1`.
- The published POM declares `kafka-clients:4.1.1` (compile) plus the runtime `<exclusion>` on the avro converter.
- `:modules:xtdb-kafka` compiles clean (main + test).

Refs #5452