### PR TITLE
feat(debezium): add DebeziumEngineSource for direct Postgres CDC

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ exposed = "0.61.0"
 google-cloud-storage = "2.60.0"
 guava = "33.4.7-jre"
 confluent = "7.8.0"
+debezium = "3.2.2.Final"
 kafka = "4.1.1"
 kotest = "6.1.11"
 kotlin = "2.3.0"
@@ -152,7 +153,13 @@ guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 # Kafka
 kafka-clients = { group = "org.apache.kafka", name = "kafka-clients", version.ref = "kafka" }
 kafka-connect-api = { group = "org.apache.kafka", name = "connect-api", version.ref = "kafka" }
+kafka-connect-runtime = { group = "org.apache.kafka", name = "connect-runtime", version.ref = "kafka" }
 kafka-avro-serializer = { group = "io.confluent", name = "kafka-avro-serializer", version.ref = "confluent" }
+
+# Debezium
+debezium-api = { group = "io.debezium", name = "debezium-api", version.ref = "debezium" }
+debezium-embedded = { group = "io.debezium", name = "debezium-embedded", version.ref = "debezium" }
+debezium-connector-postgres = { group = "io.debezium", name = "debezium-connector-postgres", version.ref = "debezium" }
 
 # Dev/test dependencies
 jovial = { group = "dev.clojurephant", name = "jovial", version = "0.4.3" }

--- a/modules/debezium/build.gradle.kts
+++ b/modules/debezium/build.gradle.kts
@@ -19,6 +19,12 @@ dependencies {
 
     implementation(libs.kafka.avro.serializer)
 
+    implementation(libs.debezium.api)
+    implementation(libs.debezium.embedded)
+    implementation(libs.debezium.connector.postgres)
+    implementation(libs.kafka.connect.api)
+    implementation(libs.kafka.connect.runtime)
+
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.testcontainers)

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/CdcPayload.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/CdcPayload.kt
@@ -1,0 +1,114 @@
+package xtdb.debezium
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.longOrNull
+import xtdb.error.Incorrect
+import xtdb.indexer.OpenTx
+import xtdb.table.TableRef
+import xtdb.time.InstantUtil.asMicros
+import xtdb.util.asIid
+import java.nio.ByteBuffer
+import java.time.DateTimeException
+import java.time.Instant
+
+// JSON → plain JVM values.  Used by MessageFormat.Json (ByteArray input) and
+// DebeziumEngineSource (String input) — kept here rather than duplicated.
+internal fun parseCdcEnvelope(json: String): Map<String, Any?> {
+    val envelope = try {
+        Json.parseToJsonElement(json).jsonObject
+    } catch (e: RuntimeException) {
+        throw Incorrect("Invalid CDC message: ${e.message}", cause = e)
+    }
+
+    // Auto-detect Kafka Connect JsonConverter envelope (`{schema, payload}`).
+    val payload = envelope["payload"]?.let {
+        (it as? JsonObject) ?: throw Incorrect("'payload' was not a JSON object")
+    } ?: envelope
+
+    return payload.entries.associate { (k, v) -> k to jsonToJvmValue(v) }
+}
+
+internal fun jsonToJvmValue(el: Any?): Any? = when (el) {
+    null, is JsonNull -> null
+    is JsonPrimitive -> if (el.isString) el.content else el.booleanOrNull ?: el.longOrNull ?: el.doubleOrNull ?: el.content
+    is JsonArray -> el.map { jsonToJvmValue(it) }
+    is JsonObject -> el.entries.associate { (k, v) -> k to jsonToJvmValue(v) }
+    else -> el
+}
+
+// Shared CDC payload handling for the Debezium sources (both Kafka and embedded engine).
+// Both sources ultimately receive the same Debezium envelope shape —
+// { op, before, after, source: { schema, table, lsn, txId, snapshot, ... } } — so the
+// write path into XTDB is the same. Transport-specific code lives in each source.
+
+internal fun parseValidTimeMicros(value: Any?, field: String): Long? = when (value) {
+    null -> null
+    is String -> try {
+        Instant.parse(value).asMicros
+    } catch (_: DateTimeException) {
+        throw Incorrect("Invalid ISO-8601 timestamp for '$field': $value")
+    }
+
+    else -> throw Incorrect("'$field' must be a TIMESTAMPTZ string, got ${value::class.simpleName}")
+}
+
+@Suppress("UNCHECKED_CAST")
+internal fun writeCdcPayload(payload: Map<String, Any?>, dbName: String, openTx: OpenTx) {
+    val op = payload["op"] as? String
+        ?: throw Incorrect("Missing 'op' in payload")
+
+    val source = payload["source"] as? Map<String, Any?>
+        ?: throw Incorrect("Missing 'source' in payload")
+    val schema = source["schema"] as? String
+        ?: throw Incorrect("Missing 'source.schema' in payload")
+    val table = source["table"] as? String
+        ?: throw Incorrect("Missing 'source.table' in payload")
+
+    val openTxTable = openTx.table(TableRef(dbName, schema, table))
+
+    when (op) {
+        "c", "r", "u" -> {
+            val after = payload["after"] as? Map<String, Any?>
+                ?: throw Incorrect("Missing 'after' for put op")
+
+            val docMap = after.toMutableMap()
+
+            val id = docMap["_id"] ?: throw Incorrect("Missing '_id' in document")
+
+            val explicitValidFrom = parseValidTimeMicros(docMap.remove("_valid_from"), "_valid_from")
+            val explicitValidTo = parseValidTimeMicros(docMap.remove("_valid_to"), "_valid_to")
+
+            if (explicitValidTo != null && explicitValidFrom == null)
+                throw Incorrect("'_valid_to' requires '_valid_from'")
+
+            openTxTable.logPut(
+                ByteBuffer.wrap(id.asIid),
+                explicitValidFrom ?: openTx.systemFrom,
+                explicitValidTo ?: Long.MAX_VALUE,
+            ) { openTxTable.docWriter.writeObject(docMap) }
+        }
+
+        "d" -> {
+            val before = payload["before"]?.let { it as? Map<String, Any?> }
+                ?: throw Incorrect("Missing 'before' for delete — check REPLICA IDENTITY on source table")
+
+            val id = before["_id"]
+                ?: throw Incorrect("Missing '_id' in 'before' for delete")
+
+            openTxTable.logDelete(
+                ByteBuffer.wrap(id.asIid),
+                openTx.systemFrom,
+                Long.MAX_VALUE,
+            )
+        }
+
+        else -> throw Incorrect("Unknown CDC op: '$op'")
+    }
+}

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumEngineOffsetStore.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumEngineOffsetStore.kt
@@ -1,0 +1,126 @@
+package xtdb.debezium
+
+import com.google.protobuf.ByteString
+import org.apache.kafka.connect.runtime.WorkerConfig
+import org.apache.kafka.connect.storage.OffsetBackingStore
+import org.apache.kafka.connect.util.Callback
+import xtdb.debezium.proto.DebeziumOffsetEntry
+import xtdb.debezium.proto.debeziumOffsetEntry
+import java.nio.ByteBuffer
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Future
+
+// An in-memory `OffsetBackingStore` for embedded Debezium that lets us smuggle
+// initial state in and read Debezium's writes back out, neither of which the
+// engine's standard classname-based config supports.
+//
+// Debezium instantiates this class via reflection (no-arg ctor) and then calls
+// `configure(WorkerConfig)`.  To bridge the instance back to our code, we pass an
+// instance id through the engine's properties; `configure` looks up a pre-registered
+// handle by that id so the outside can reach `snapshotEntries()`.
+//
+// The map lives only in memory: durability comes from the resumeToken being persisted
+// atomically with the XTDB data, then fed back at the next `onPartitionAssigned`.
+class DebeziumEngineOffsetStore : OffsetBackingStore {
+
+    companion object {
+        const val INSTANCE_ID_CONFIG = "xtdb.debezium.engine.offset-store.instance-id"
+
+        // Registry of seeded state + live handles keyed by instance id.
+        // The ExternalSource sets up an entry before the engine starts and removes it
+        // when the engine stops.  Concurrent by construction — many sources could run
+        // in the same JVM (tests, multi-db deployments).
+        private val seeds = ConcurrentHashMap<String, List<DebeziumOffsetEntry>>()
+        private val handles = ConcurrentHashMap<String, DebeziumEngineOffsetStore>()
+
+        // Registers seed state for a fresh engine instance and returns a token that
+        // both identifies it in Debezium config and gives the caller a way to later
+        // obtain the live handle via `handleFor(id)`.
+        fun register(seed: List<DebeziumOffsetEntry>): String {
+            val id = UUID.randomUUID().toString()
+            seeds[id] = seed
+            return id
+        }
+
+        fun unregister(instanceId: String) {
+            seeds.remove(instanceId)
+            handles.remove(instanceId)
+        }
+
+        // The live handle, populated once Debezium has instantiated and configured the store.
+        // Null before the engine starts.
+        fun handleFor(instanceId: String): DebeziumEngineOffsetStore? = handles[instanceId]
+    }
+
+    private lateinit var instanceId: String
+
+    // Thread-safe: Debezium's engine thread calls set(); our ChangeConsumer thread calls snapshotEntries().
+    private val data = ConcurrentHashMap<ByteBuffer, ByteBuffer>()
+
+    override fun configure(config: WorkerConfig) {
+        val id = config.originalsStrings()[INSTANCE_ID_CONFIG]
+        require(!id.isNullOrBlank()) {
+            "missing or blank $INSTANCE_ID_CONFIG in WorkerConfig — DebeziumEngineOffsetStore requires a non-blank value"
+        }
+        instanceId = id
+
+        seeds.remove(instanceId)?.forEach { entry ->
+            data[copyOf(entry.key.asReadOnlyByteBuffer())] = copyOf(entry.value.asReadOnlyByteBuffer())
+        }
+
+        handles[instanceId] = this
+    }
+
+    override fun start() {}
+
+    override fun stop() {
+        handles.remove(instanceId, this)
+    }
+
+    override fun get(keys: Collection<ByteBuffer>): Future<Map<ByteBuffer, ByteBuffer>> =
+        CompletableFuture.completedFuture(
+            buildMap {
+                for (k in keys) {
+                    // Normalise the key and return independent views so callers can never
+                    // observe or mutate the position/limit of buffers stored in `data`.
+                    // Read-only protects the bytes; `duplicate()` gives each caller its
+                    // own position/limit state.
+                    val normalisedKey = copyOf(k)
+                    data[normalisedKey]?.let { put(normalisedKey, it.duplicate()) }
+                }
+            }
+        )
+
+    override fun set(values: Map<ByteBuffer, ByteBuffer>, callback: Callback<Void>?): Future<Void> {
+        for ((k, v) in values) {
+            // Deep-copy the bytes: Debezium reuses buffers, and we hold onto them beyond this call.
+            data[copyOf(k)] = copyOf(v)
+        }
+        callback?.onCompletion(null, null)
+        return CompletableFuture.completedFuture(null)
+    }
+
+    // Required by the Kafka Connect OffsetBackingStore interface (added in newer versions)
+    // for external consumers querying "what partitions does this connector know about?"
+    // We don't surface that information — Debezium embedded doesn't need it, and we have
+    // no external consumers of this store.
+    override fun connectorPartitions(connectorName: String): MutableSet<MutableMap<String, Any>> =
+        mutableSetOf()
+
+    // Snapshot of current state for inclusion in a resumeToken.
+    fun snapshotEntries(): List<DebeziumOffsetEntry> =
+        data.map { (k, v) ->
+            debeziumOffsetEntry {
+                key = ByteString.copyFrom(k.duplicate())
+                value = ByteString.copyFrom(v.duplicate())
+            }
+        }
+}
+
+private fun copyOf(buf: ByteBuffer): ByteBuffer {
+    val bytes = ByteArray(buf.remaining())
+    buf.duplicate().get(bytes)
+    return ByteBuffer.wrap(bytes).asReadOnlyBuffer()
+}

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumEngineSource.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumEngineSource.kt
@@ -1,0 +1,411 @@
+package xtdb.debezium
+
+import io.debezium.connector.postgresql.PostgresConnector
+import io.debezium.engine.ChangeEvent
+import io.debezium.engine.DebeziumEngine
+import io.debezium.engine.format.Json
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.subclass
+import org.apache.arrow.memory.RootAllocator
+import org.slf4j.LoggerFactory
+import xtdb.api.TransactionKey
+import xtdb.api.log.Log
+import xtdb.api.log.LogClusterAlias
+import xtdb.database.ExternalSource
+import xtdb.database.ExternalSourceToken
+import xtdb.database.proto.DatabaseConfig
+import xtdb.debezium.proto.DebeziumEngineOffsetToken
+import xtdb.debezium.proto.DebeziumEngineSourceConfig
+import xtdb.debezium.proto.DebeziumEngineSourceConfig.BackendCase
+import xtdb.debezium.proto.debeziumEngineOffsetToken
+import xtdb.debezium.proto.debeziumEngineSourceConfig
+import xtdb.debezium.proto.postgresBackendConfig
+import xtdb.indexer.Indexer.Companion.addTxRow
+import xtdb.indexer.OpenTx
+import xtdb.time.InstantUtil
+import java.time.Instant
+import java.util.Properties
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import com.google.protobuf.Any as ProtoAny
+
+private val LOG = LoggerFactory.getLogger(DebeziumEngineSource::class.java)
+
+// Consumes CDC events via an embedded Debezium engine — reads directly from the source
+// DB, no Kafka in between.  Connector-specific bits (Postgres, MySQL, …) are held in
+// `Factory.backend` as a polymorphic value.
+//
+// One source transaction maps to one XTDB transaction.  Boundary detection is by
+// `source.txId` change on streaming events.  Snapshot events are batched into
+// fixed-size chunks since they share a position and aren't naturally grouped.
+//
+// Exactly-once-at-sink: the `resumeToken` is committed atomically with each XTDB tx.
+// On restart we dedup replays by comparing the event's source position against
+// `last_applied_lsn`.
+class DebeziumEngineSource(
+    private val dbName: String,
+    private val cfg: Factory,
+) : ExternalSource {
+
+    private val allocator = RootAllocator()
+
+    /**
+     * Config for a Debezium source consuming CDC via an embedded engine.
+     * The connector-specific details live in `backend` — currently `!Postgres` only.
+     */
+    @Serializable
+    @SerialName("!DebeziumEngine")
+    data class Factory(
+        val backend: Backend,
+        val snapshotChunkSize: Int = 1000,
+        val offsetFlushIntervalMs: Long = 1000L,
+    ) : ExternalSource.Factory {
+
+        override fun open(dbName: String, clusters: Map<LogClusterAlias, Log.Cluster>): ExternalSource =
+            // Embedded engine talks to the source DB directly; no `Log.Cluster` involvement.
+            DebeziumEngineSource(dbName, this)
+
+        override fun writeTo(dbConfig: DatabaseConfig.Builder) {
+            dbConfig.externalSource = ProtoAny.pack(debeziumEngineSourceConfig {
+                snapshotChunkSize = this@Factory.snapshotChunkSize
+                offsetFlushIntervalMs = this@Factory.offsetFlushIntervalMs
+                when (val b = backend) {
+                    is Backend.Postgres -> postgres = postgresBackendConfig {
+                        hostname = b.hostname
+                        user = b.user
+                        password = b.password
+                        database = b.database
+                        publicationName = b.publicationName
+                        slotName = b.slotName
+                        tableIncludeList = b.tableIncludeList
+                        port = b.port
+                    }
+                }
+            }, "proto.xtdb.com")
+        }
+
+        class Registration : ExternalSource.Registration {
+            override val protoTag: String
+                get() = "proto.xtdb.com/xtdb.debezium.proto.DebeziumEngineSourceConfig"
+
+            override fun fromProto(msg: ProtoAny): ExternalSource.Factory {
+                val config = msg.unpack(DebeziumEngineSourceConfig::class.java)
+                val backend = when (config.backendCase) {
+                    BackendCase.POSTGRES -> Backend.Postgres(
+                        hostname = config.postgres.hostname,
+                        user = config.postgres.user,
+                        password = config.postgres.password,
+                        database = config.postgres.database,
+                        publicationName = config.postgres.publicationName,
+                        slotName = config.postgres.slotName,
+                        tableIncludeList = config.postgres.tableIncludeList,
+                        port = config.postgres.port,
+                    )
+
+                    BackendCase.BACKEND_NOT_SET, null ->
+                        error("DebeziumEngineSourceConfig missing required `backend`")
+                }
+                return Factory(
+                    backend = backend,
+                    snapshotChunkSize = config.snapshotChunkSize,
+                    offsetFlushIntervalMs = config.offsetFlushIntervalMs,
+                )
+            }
+
+            override fun registerSerde(builder: PolymorphicModuleBuilder<ExternalSource.Factory>) {
+                builder.subclass(Factory::class)
+            }
+        }
+    }
+
+    /**
+     * Connector-specific config — one variant per supported Debezium connector.
+     * Responsible for knowing how to stamp its own properties onto the engine's `Properties`.
+     */
+    @Serializable
+    sealed interface Backend {
+        fun applyEngineProperties(props: Properties)
+
+        @Serializable
+        @SerialName("!Postgres")
+        data class Postgres(
+            val hostname: String,
+            val user: String,
+            val password: String,
+            val database: String,
+            // Publication is created on the source DB first (it defines which tables emit CDC);
+            // the replication slot is our consumer's handle, created by Debezium against it.
+            val publicationName: String,
+            val slotName: String,
+            val tableIncludeList: String,
+            val port: Int = 5432,
+        ) : Backend {
+            override fun applyEngineProperties(props: Properties) {
+                props.setProperty("connector.class", PostgresConnector::class.java.name)
+                props.setProperty("database.hostname", hostname)
+                props.setProperty("database.port", port.toString())
+                props.setProperty("database.user", user)
+                props.setProperty("database.password", password)
+                props.setProperty("database.dbname", database)
+                // Namespace identifier — feeds the `server` key in the OffsetBackingStore
+                // partition and the `topic` field on records (even though nothing's produced
+                // to Kafka in embedded mode).
+                props.setProperty("topic.prefix", "xtdb-$database")
+
+                props.setProperty("plugin.name", "pgoutput")
+                props.setProperty("slot.name", slotName)
+                props.setProperty("publication.name", publicationName)
+                props.setProperty("publication.autocreate.mode", "disabled")
+                props.setProperty("table.include.list", tableIncludeList)
+            }
+        }
+    }
+
+    override suspend fun onPartitionAssigned(
+        partition: Int,
+        afterToken: ExternalSourceToken?,
+        txHandler: ExternalSource.TxHandler,
+    ) = coroutineScope {
+        val token = afterToken?.unpack(DebeziumEngineOffsetToken::class.java)
+        val offsetStoreId = DebeziumEngineOffsetStore.register(token?.debeziumOffsetsList.orEmpty())
+        try {
+            val completion = CompletableDeferred<Throwable?>()
+
+            val engine = DebeziumEngine.create(Json::class.java)
+                .using(buildEngineProperties(cfg, offsetStoreId))
+                .using(DebeziumEngine.CompletionCallback { success, msg, err ->
+                    completion.complete(
+                        when {
+                            success -> null
+                            err != null -> err
+                            else -> RuntimeException(msg ?: "Debezium engine failed with no error")
+                        }
+                    )
+                })
+                .notifying(ChangeConsumer(dbName, allocator, offsetStoreId, txHandler, token, cfg.snapshotChunkSize))
+                .build()
+
+            val executor = Executors.newSingleThreadExecutor { r ->
+                Thread(r, "xtdb-debezium-engine-$dbName").apply { isDaemon = true }
+            }
+
+            try {
+                executor.execute(engine)
+                val err = completion.await()
+                if (err != null) throw err
+            } finally {
+                withContext(NonCancellable) {
+                    runCatching { engine.close() }
+                    executor.shutdown()
+                    if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                        LOG.warn("Debezium engine didn't terminate in 30s; forcing shutdown")
+                        executor.shutdownNow()
+                    }
+                }
+            }
+        } finally {
+            DebeziumEngineOffsetStore.unregister(offsetStoreId)
+        }
+    }
+
+    override fun close() {
+        allocator.close()
+    }
+}
+
+// Engine properties: engine-level config here, connector-level config delegated to the backend.
+// No Kafka-broker settings because nothing is produced to Kafka in embedded mode.
+private fun buildEngineProperties(cfg: DebeziumEngineSource.Factory, offsetStoreId: String): Properties =
+    Properties().apply {
+        setProperty("name", "xtdb-debezium-engine-${offsetStoreId.take(8)}")
+
+        // In-memory offset store; the store instance is bridged through a static registry
+        // keyed by `offsetStoreId` because Debezium instantiates OffsetBackingStore via reflection.
+        setProperty("offset.storage", DebeziumEngineOffsetStore::class.java.name)
+        setProperty(DebeziumEngineOffsetStore.INSTANCE_ID_CONFIG, offsetStoreId)
+        setProperty("offset.flush.interval.ms", cfg.offsetFlushIntervalMs.toString())
+
+        // Snapshot once, stream forever, fail loudly on slot/binlog loss.
+        setProperty("snapshot.mode", "initial")
+
+        // Records delivered to our callback as JSON strings; payload only, no envelope.
+        setProperty("key.converter", "org.apache.kafka.connect.json.JsonConverter")
+        setProperty("value.converter", "org.apache.kafka.connect.json.JsonConverter")
+        setProperty("key.converter.schemas.enable", "false")
+        setProperty("value.converter.schemas.enable", "false")
+
+        cfg.backend.applyEngineProperties(this)
+    }
+
+// Engine callback.  Runs on the engine's own thread; blocks synchronously while we
+// commit to XTDB (via `runBlocking`) so Debezium doesn't poll the next batch until
+// this one is durably applied.
+private class ChangeConsumer(
+    private val dbName: String,
+    private val allocator: RootAllocator,
+    private val offsetStoreId: String,
+    private val txHandler: ExternalSource.TxHandler,
+    initialToken: DebeziumEngineOffsetToken?,
+    private val snapshotChunkSize: Int,
+) : DebeziumEngine.ChangeConsumer<ChangeEvent<String, String>> {
+
+    // Dedup high-water mark: any streaming event whose `source.lsn` is at or below this value
+    // has already been durably applied to XTDB.  Starts at 0 on fresh begin; the `> 0` guard
+    // in the dedup check prevents accidentally skipping pre-first-commit events.
+    //
+    // NOTE: the field is currently Postgres-LSN-shaped; when MySQL arrives we'll need to
+    // generalise this into a per-backend `SourcePosition`.
+    private var lastAppliedLsn: Long = initialToken?.lastAppliedLsn ?: 0L
+
+    // Our XTDB-side monotonic txId counter.  Source XIDs wrap; we mint our own.
+    private var latestTxId: Long = initialToken?.latestTxId ?: -1L
+
+    // Smoothed clock: enforces monotonic system-time across txs.  Source ts_ms is millisecond-
+    // precision; back-to-back events can collide, which would give two XTDB txs the same
+    // systemFrom and collapse valid-time history.
+    private var lastSystemTimeMicros: Long = initialToken?.latestSystemTimeMicros ?: Long.MIN_VALUE
+
+    override fun handleBatch(
+        records: MutableList<ChangeEvent<String, String>>,
+        committer: DebeziumEngine.RecordCommitter<ChangeEvent<String, String>>,
+    ) {
+        var streamingTx: StreamingTx? = null
+        val snapshotBuf: MutableList<ParsedRecord> = mutableListOf()
+
+        for (record in records) {
+            val p = classify(record)
+            if (p == null) {
+                // Not a data event (heartbeat, schema change, tombstone) — ack and skip.
+                committer.markProcessed(record)
+                continue
+            }
+
+            // Real Postgres LSNs are > 0; the `lastAppliedLsn > 0` guard prevents deduping
+            // on cold start where the high-water mark hasn't been set yet.
+            if (lastAppliedLsn > 0L && p.lsn in 1..lastAppliedLsn) {
+                committer.markProcessed(record)
+                continue
+            }
+
+            if (p.isSnapshot) {
+                streamingTx?.let {
+                    flushXtdbTxn(it.events, committer, isSnapshot = false)
+                    streamingTx = null
+                }
+                snapshotBuf.add(p)
+                if (snapshotBuf.size >= snapshotChunkSize) {
+                    flushXtdbTxn(snapshotBuf.toList(), committer, isSnapshot = true)
+                    snapshotBuf.clear()
+                }
+            } else {
+                if (snapshotBuf.isNotEmpty()) {
+                    flushXtdbTxn(snapshotBuf.toList(), committer, isSnapshot = true)
+                    snapshotBuf.clear()
+                }
+                val pending = streamingTx
+                if (pending != null && pending.txId != p.txId) {
+                    flushXtdbTxn(pending.events, committer, isSnapshot = false)
+                    streamingTx = null
+                }
+                val accumulator = streamingTx ?: StreamingTx(p.txId, mutableListOf()).also { streamingTx = it }
+                accumulator.events.add(p)
+            }
+        }
+
+        // End-of-batch flush.  Snapshot: always safe.  Streaming: flushing a partial source
+        // txn is rare — pgoutput delivers txns contiguously — and on retry, dedup by LSN
+        // drops events we already committed.
+        if (snapshotBuf.isNotEmpty()) flushXtdbTxn(snapshotBuf.toList(), committer, isSnapshot = true)
+        streamingTx?.let { flushXtdbTxn(it.events, committer, isSnapshot = false) }
+
+        committer.markBatchFinished()
+    }
+
+    // One record → ParsedRecord, or null if this isn't a data event (heartbeat, schema change,
+    // tombstone).  Non-data records still get acked by the caller so Debezium advances.
+    private fun classify(record: ChangeEvent<String, String>): ParsedRecord? {
+        val value = record.value() ?: return null
+        val payload = parseCdcEnvelope(value)
+        val source = payload["source"] as? Map<*, *> ?: return null
+        if (payload["op"] !is String) return null
+
+        val lsn = (source["lsn"] as? Number)?.toLong() ?: return null
+        val snapshotFlag = source["snapshot"]
+        val isSnapshot = snapshotFlag != null && snapshotFlag.toString() != "false"
+
+        return ParsedRecord(
+            record = record,
+            payload = payload,
+            lsn = lsn,
+            // Postgres emits this as "txId" in JSON; tolerate lowercase as defensive coding.
+            txId = (source["txId"] as? Number)?.toLong() ?: (source["txid"] as? Number)?.toLong(),
+            isSnapshot = isSnapshot,
+            tsMs = (source["ts_ms"] as? Number)?.toLong() ?: 0L,
+        )
+    }
+
+    private fun flushXtdbTxn(
+        records: List<ParsedRecord>,
+        committer: DebeziumEngine.RecordCommitter<ChangeEvent<String, String>>,
+        isSnapshot: Boolean,
+    ) {
+        if (records.isEmpty()) return
+
+        val maxTsMs = records.maxOf { it.tsMs }
+        val tsMicros = maxOf(
+            Instant.ofEpochMilli(maxTsMs).let { it.epochSecond * 1_000_000L + it.nano / 1_000L },
+            lastSystemTimeMicros + 1,
+        )
+        val systemTime = InstantUtil.fromMicros(tsMicros)
+        val txId = ++latestTxId
+        val txKey = TransactionKey(txId, systemTime)
+        val maxEventLsn = records.maxOf { it.lsn }
+
+        val offsetStore = DebeziumEngineOffsetStore.handleFor(offsetStoreId)
+        val currentOffsets = offsetStore?.snapshotEntries().orEmpty()
+
+        val resumeToken: ExternalSourceToken = ProtoAny.pack(
+            debeziumEngineOffsetToken {
+                debeziumOffsets += currentOffsets
+                lastAppliedLsn = if (isSnapshot) this@ChangeConsumer.lastAppliedLsn else maxEventLsn
+                latestTxId = txId
+                latestSystemTimeMicros = tsMicros
+            },
+            "xtdb.debezium",
+        )
+
+        OpenTx(allocator, txKey).use { openTx ->
+            for (p in records) writeCdcPayload(p.payload, dbName, openTx)
+            openTx.addTxRow(dbName, openTx.txKey, null)
+            runBlocking { txHandler.handleTx(openTx, resumeToken) }
+        }
+
+        // Promote in-memory watermarks only after `handleTx` has returned successfully,
+        // outside the `use` block so a close-throws can't leave them ahead of durable state.
+        lastSystemTimeMicros = tsMicros
+        if (!isSnapshot) lastAppliedLsn = maxEventLsn
+
+        for (p in records) committer.markProcessed(p.record)
+    }
+}
+
+// Parsed form of a Debezium record — decode once, pass around instead of re-parsing JSON.
+private class ParsedRecord(
+    val record: ChangeEvent<String, String>,
+    val payload: Map<String, Any?>,
+    val lsn: Long,
+    val txId: Long?,
+    val isSnapshot: Boolean,
+    val tsMs: Long,
+)
+
+// Pairs a source txn's buffered events with its txId so they can only be set and cleared
+// as a unit.  Making illegal states unrepresentable.
+private class StreamingTx(val txId: Long?, val events: MutableList<ParsedRecord>)

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumKafkaSource.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumKafkaSource.kt
@@ -30,28 +30,13 @@ import xtdb.debezium.proto.DebeziumKafkaSourceConfig.MessageFormatCase
 import xtdb.error.Incorrect
 import xtdb.indexer.Indexer.Companion.addTxRow
 import xtdb.indexer.OpenTx
-import xtdb.table.TableRef
 import xtdb.time.InstantUtil
 import xtdb.time.InstantUtil.asMicros
-import xtdb.util.asIid
-import java.nio.ByteBuffer
-import java.time.DateTimeException
 import java.time.Duration
 import java.time.Instant
 import com.google.protobuf.Any as ProtoAny
 
 private val LOG = LoggerFactory.getLogger(DebeziumKafkaSource::class.java)
-
-private fun parseValidTimeMicros(value: Any?, field: String): Long? = when (value) {
-    null -> null
-    is String -> try {
-        Instant.parse(value).asMicros
-    } catch (_: DateTimeException) {
-        throw Incorrect("Invalid ISO-8601 timestamp for '$field': $value")
-    }
-
-    else -> throw Incorrect("'$field' must be a TIMESTAMPTZ string, got ${value::class.simpleName}")
-}
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DebeziumKafkaSource @JvmOverloads constructor(
@@ -143,60 +128,6 @@ class DebeziumKafkaSource @JvmOverloads constructor(
             override fun registerSerde(builder: PolymorphicModuleBuilder<ExternalSource.Factory>) {
                 builder.subclass(Factory::class)
             }
-        }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun writeCdcPayload(payload: Map<String, Any?>, dbName: String, openTx: OpenTx) {
-        val op = payload["op"] as? String
-            ?: throw Incorrect("Missing 'op' in payload")
-
-        val source = payload["source"] as? Map<String, Any?>
-            ?: throw Incorrect("Missing 'source' in payload")
-        val schema = source["schema"] as? String
-            ?: throw Incorrect("Missing 'source.schema' in payload")
-        val table = source["table"] as? String
-            ?: throw Incorrect("Missing 'source.table' in payload")
-
-        val openTxTable = openTx.table(TableRef(dbName, schema, table))
-
-        when (op) {
-            "c", "r", "u" -> {
-                val after = payload["after"] as? Map<String, Any?>
-                    ?: throw Incorrect("Missing 'after' for put op")
-
-                val docMap = after.toMutableMap()
-
-                val id = docMap["_id"] ?: throw Incorrect("Missing '_id' in document")
-
-                val explicitValidFrom = parseValidTimeMicros(docMap.remove("_valid_from"), "_valid_from")
-                val explicitValidTo = parseValidTimeMicros(docMap.remove("_valid_to"), "_valid_to")
-
-                if (explicitValidTo != null && explicitValidFrom == null)
-                    throw Incorrect("'_valid_to' requires '_valid_from'")
-
-                openTxTable.logPut(
-                    ByteBuffer.wrap(id.asIid),
-                    explicitValidFrom ?: openTx.systemFrom,
-                    explicitValidTo ?: Long.MAX_VALUE,
-                ) { openTxTable.docWriter.writeObject(docMap) }
-            }
-
-            "d" -> {
-                val before = payload["before"]?.let { it as? Map<String, Any?> }
-                    ?: throw Incorrect("Missing 'before' for delete — check REPLICA IDENTITY on source table")
-
-                val id = before["_id"]
-                    ?: throw Incorrect("Missing '_id' in 'before' for delete")
-
-                openTxTable.logDelete(
-                    ByteBuffer.wrap(id.asIid),
-                    openTx.systemFrom,
-                    Long.MAX_VALUE,
-                )
-            }
-
-            else -> throw Incorrect("Unknown CDC op: '$op'")
         }
     }
 

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/MessageFormat.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/MessageFormat.kt
@@ -2,7 +2,6 @@ package xtdb.debezium
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.*
 import org.apache.avro.generic.GenericArray
 import org.apache.avro.generic.GenericEnumSymbol
 import org.apache.avro.generic.GenericFixed
@@ -10,14 +9,6 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.avro.util.Utf8
 import xtdb.error.Incorrect
 import java.nio.ByteBuffer
-
-private fun jsonToJvmValue(el: Any?): Any? = when (el) {
-    null, is JsonNull -> null
-    is JsonPrimitive -> if (el.isString) el.content else el.booleanOrNull ?: el.longOrNull ?: el.doubleOrNull ?: el.content
-    is JsonArray -> el.map { jsonToJvmValue(it) }
-    is JsonObject -> el.entries.associate { (k, v) -> k to jsonToJvmValue(v) }
-    else -> el
-}
 
 private fun avroToJvmValue(value: Any?): Any? = when (value) {
     null -> null
@@ -50,19 +41,7 @@ sealed interface MessageFormat {
         override fun decode(value: Any): Map<String, Any?> {
             val bytes = value as? ByteArray
                 ?: throw Incorrect("Expected ByteArray for JSON message format, got ${value::class.simpleName}")
-
-            val payload = try {
-                val envelope = kotlinx.serialization.json.Json
-                    .parseToJsonElement(String(bytes, Charsets.UTF_8))
-                    .jsonObject
-
-                // Auto-detect JsonConverter envelope (schemas.enable=true wraps in {schema, payload}).
-                envelope["payload"]?.jsonObject ?: envelope
-            } catch (e: RuntimeException) {
-                throw Incorrect("Invalid CDC message: ${e.message}", cause = e)
-            }
-
-            return payload.entries.associate { (k, v) -> k to jsonToJvmValue(v) }
+            return parseCdcEnvelope(String(bytes, Charsets.UTF_8))
         }
     }
 

--- a/modules/debezium/src/main/proto/debezium.proto
+++ b/modules/debezium/src/main/proto/debezium.proto
@@ -23,3 +23,70 @@ message DebeziumOffsetToken {
     int64 latest_tx_id = 2;
     int64 latest_system_time_micros = 3;
 }
+
+message DebeziumEngineSourceConfig {
+    // Number of snapshot records bundled into one XTDB transaction during initial snapshot.
+    int32 snapshot_chunk_size = 1;
+
+    // Debezium offset flush interval in millis — controls how often we acknowledge position
+    // to the source.  Shorter = smaller replay window; longer = fewer round-trips.
+    int64 offset_flush_interval_ms = 2;
+
+    // Connector-specific config — everything that differs between Postgres / MySQL / etc.
+    oneof backend {
+        PostgresBackendConfig postgres = 3;
+    }
+}
+
+message PostgresBackendConfig {
+    string hostname = 1;
+    string user = 2;
+    string password = 3;
+
+    // Postgres database to connect to (maps to `database.dbname`).
+    string database = 4;
+
+    // Publication name — must exist on the source DB, and declares the tables that emit CDC.
+    // Created first; the replication slot is created against it.
+    string publication_name = 5;
+
+    // Logical replication slot name.  Our consumer's handle on the source WAL.
+    // Must be unique per XTDB database pulling from this source.
+    string slot_name = 6;
+
+    // Comma-separated list of fully-qualified table names to include, e.g. "public.orders,public.customers".
+    string table_include_list = 7;
+
+    int32 port = 8;
+}
+
+message DebeziumOffsetEntry {
+    // A single entry in Debezium's OffsetBackingStore map.
+    // Keys and values are opaque to us — Debezium writes whatever shape it uses internally
+    // (currently Kafka Connect JSON blobs).  We round-trip them verbatim.
+    bytes key = 1;
+    bytes value = 2;
+}
+
+message DebeziumEngineOffsetToken {
+    // Debezium's OffsetBackingStore state.  Fed back into our in-memory store on restart
+    // so the engine knows where to resume reading from the Postgres replication slot.
+    // MUST be present (can be empty repeated on first start) — if we hand Debezium an empty
+    // offset map with snapshot already done, it will interpret that as "no previous state"
+    // and trigger a fresh snapshot.
+    repeated DebeziumOffsetEntry debezium_offsets = 1;
+
+    // High-water mark for dedup: any streaming event whose source.lsn is <= this value
+    // has already been atomically applied to XTDB and must be dropped on replay.
+    // Our precise dedup guard — needed because Debezium's offset in this token may be
+    // slightly stale relative to the true last-committed XTDB state (flush interval window).
+    uint64 last_applied_lsn = 2;
+
+    // Our XTDB-side monotonic txId counter (same pattern as DebeziumKafkaSource).
+    // Source txIds wrap; we mint our own and persist the high-water mark.
+    int64 latest_tx_id = 3;
+
+    // Latest system_time (microseconds) we've stamped on an XTDB tx.
+    // Used to smooth past ts_ms collisions at the millisecond boundary.
+    int64 latest_system_time_micros = 4;
+}

--- a/modules/debezium/src/main/resources/META-INF/services/xtdb.database.ExternalSource$Registration
+++ b/modules/debezium/src/main/resources/META-INF/services/xtdb.database.ExternalSource$Registration
@@ -1,1 +1,2 @@
 xtdb.debezium.DebeziumKafkaSource$Factory$Registration
+xtdb.debezium.DebeziumEngineSource$Factory$Registration

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumEngineOffsetStoreTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumEngineOffsetStoreTest.kt
@@ -1,0 +1,159 @@
+package xtdb.debezium
+
+import com.google.protobuf.ByteString
+import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.connect.runtime.WorkerConfig
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import xtdb.debezium.proto.DebeziumOffsetEntry
+import xtdb.debezium.proto.debeziumOffsetEntry
+import java.nio.ByteBuffer
+
+class DebeziumEngineOffsetStoreTest {
+
+    private fun configFor(id: String): WorkerConfig {
+        val defs = ConfigDef()
+            .define(DebeziumEngineOffsetStore.INSTANCE_ID_CONFIG, ConfigDef.Type.STRING, "", ConfigDef.Importance.LOW, "")
+        return object : WorkerConfig(defs, mapOf(DebeziumEngineOffsetStore.INSTANCE_ID_CONFIG to id)) {}
+    }
+
+    private fun entry(key: String, value: String) = debeziumOffsetEntry {
+        this.key = ByteString.copyFromUtf8(key)
+        this.value = ByteString.copyFromUtf8(value)
+    }
+
+    private fun buf(s: String): ByteBuffer = ByteBuffer.wrap(s.toByteArray()).asReadOnlyBuffer()
+
+    private fun ByteBuffer.asUtf8(): String {
+        val bytes = ByteArray(remaining())
+        duplicate().get(bytes)
+        return String(bytes, Charsets.UTF_8)
+    }
+
+    @Test
+    fun `bootstrap from seed and retrieve via get`() {
+        val seed = listOf(entry("k1", "v1"), entry("k2", "v2"))
+        val id = DebeziumEngineOffsetStore.register(seed)
+
+        val store = DebeziumEngineOffsetStore()
+        store.configure(configFor(id))
+
+        val retrieved = store.get(listOf(buf("k1"), buf("k2"), buf("missing"))).get()
+
+        assertEquals(2, retrieved.size)
+        assertEquals("v1", retrieved[buf("k1")]!!.asUtf8())
+        assertEquals("v2", retrieved[buf("k2")]!!.asUtf8())
+
+        store.stop()
+        DebeziumEngineOffsetStore.unregister(id)
+    }
+
+    @Test
+    fun `set writes persist and appear in snapshot`() {
+        val id = DebeziumEngineOffsetStore.register(emptyList())
+        val store = DebeziumEngineOffsetStore()
+        store.configure(configFor(id))
+
+        store.set(mapOf(buf("alpha") to buf("one"), buf("beta") to buf("two")), null).get()
+
+        val snap = store.snapshotEntries()
+        assertEquals(2, snap.size)
+
+        val asMap = snap.associate { it.key.toStringUtf8() to it.value.toStringUtf8() }
+        assertEquals("one", asMap["alpha"])
+        assertEquals("two", asMap["beta"])
+
+        store.stop()
+        DebeziumEngineOffsetStore.unregister(id)
+    }
+
+    @Test
+    fun `set overwrites existing entries`() {
+        val id = DebeziumEngineOffsetStore.register(listOf(entry("k", "old")))
+        val store = DebeziumEngineOffsetStore()
+        store.configure(configFor(id))
+
+        store.set(mapOf(buf("k") to buf("new")), null).get()
+
+        val snap = store.snapshotEntries().associate { it.key.toStringUtf8() to it.value.toStringUtf8() }
+        assertEquals("new", snap["k"])
+
+        store.stop()
+        DebeziumEngineOffsetStore.unregister(id)
+    }
+
+    @Test
+    fun `handleFor returns configured store and null after stop`() {
+        val id = DebeziumEngineOffsetStore.register(emptyList())
+        val store = DebeziumEngineOffsetStore()
+        store.configure(configFor(id))
+
+        assertNotNull(DebeziumEngineOffsetStore.handleFor(id))
+
+        store.stop()
+        assertNull(DebeziumEngineOffsetStore.handleFor(id))
+
+        DebeziumEngineOffsetStore.unregister(id)
+    }
+
+    @Test
+    fun `multiple concurrent instances don't collide`() {
+        val id1 = DebeziumEngineOffsetStore.register(listOf(entry("x", "1")))
+        val id2 = DebeziumEngineOffsetStore.register(listOf(entry("x", "2")))
+
+        val store1 = DebeziumEngineOffsetStore().also { it.configure(configFor(id1)) }
+        val store2 = DebeziumEngineOffsetStore().also { it.configure(configFor(id2)) }
+
+        assertEquals("1", store1.snapshotEntries().single().value.toStringUtf8())
+        assertEquals("2", store2.snapshotEntries().single().value.toStringUtf8())
+
+        // Writes to one don't bleed into the other.
+        store1.set(mapOf(buf("y") to buf("from1")), null).get()
+        assertTrue(store2.snapshotEntries().none { it.key.toStringUtf8() == "y" })
+
+        store1.stop(); store2.stop()
+        DebeziumEngineOffsetStore.unregister(id1)
+        DebeziumEngineOffsetStore.unregister(id2)
+    }
+
+    @Test
+    fun `get returns independent buffer views per call`() {
+        // Without duplicating the stored value, advancing position on one retrieved buffer
+        // would corrupt the stored buffer and poison later reads.
+        val id = DebeziumEngineOffsetStore.register(listOf(entry("k", "hello")))
+        val store = DebeziumEngineOffsetStore()
+        store.configure(configFor(id))
+
+        val first = store.get(listOf(buf("k"))).get()[buf("k")]!!
+        first.position(first.limit())  // exhaust the first view
+        assertEquals(0, first.remaining())
+
+        val second = store.get(listOf(buf("k"))).get()[buf("k")]!!
+        assertEquals(5, second.remaining())
+        assertEquals("hello", second.asUtf8())
+
+        store.stop()
+        DebeziumEngineOffsetStore.unregister(id)
+    }
+
+    @Test
+    fun `blank instance id in config is rejected`() {
+        val store = DebeziumEngineOffsetStore()
+        val thrown = runCatching { store.configure(configFor("   ")) }.exceptionOrNull()
+        assertNotNull(thrown)
+        assertTrue(thrown!!.message!!.contains(DebeziumEngineOffsetStore.INSTANCE_ID_CONFIG))
+    }
+
+    @Test
+    fun `missing instance id in config is rejected`() {
+        val store = DebeziumEngineOffsetStore()
+        val emptyConfig = object : WorkerConfig(ConfigDef(), emptyMap<String, String>()) {}
+
+        val thrown = runCatching { store.configure(emptyConfig) }.exceptionOrNull()
+        assertNotNull(thrown)
+        assertTrue(thrown!!.message!!.contains(DebeziumEngineOffsetStore.INSTANCE_ID_CONFIG))
+    }
+}

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumEngineSourceTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumEngineSourceTest.kt
@@ -1,0 +1,235 @@
+package xtdb.debezium
+
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.testcontainers.postgresql.PostgreSQLContainer
+import xtdb.database.ExternalSource
+import xtdb.database.ExternalSourceToken
+import xtdb.debezium.proto.DebeziumEngineOffsetToken
+import java.sql.Connection
+import java.util.Collections
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
+
+@Tag("integration")
+class DebeziumEngineSourceTest {
+
+    companion object {
+        private val postgres = PostgreSQLContainer("postgres:17-alpine")
+            .withDatabaseName("testdb")
+            .withUsername("testuser")
+            .withPassword("testpass")
+            .withCommand("postgres", "-c", "wal_level=logical", "-c", "max_replication_slots=10", "-c", "max_wal_senders=10")
+
+        @JvmStatic
+        @BeforeAll
+        fun beforeAll() {
+            postgres.start()
+
+            withConn { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute(
+                        """
+                        CREATE TABLE public.items (
+                            _id TEXT PRIMARY KEY,
+                            name TEXT NOT NULL
+                        );
+                        """.trimIndent()
+                    )
+                    stmt.execute("CREATE PUBLICATION test_pub FOR TABLE public.items;")
+                }
+            }
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            postgres.stop()
+        }
+
+        private fun <R> withConn(block: (Connection) -> R): R =
+            postgres.createConnection("").use(block)
+    }
+
+    private fun uniqueSlot(): String =
+        "xtdb_test_slot_" + UUID.randomUUID().toString().replace("-", "").take(16)
+
+    private fun factory(slot: String) = DebeziumEngineSource.Factory(
+        backend = DebeziumEngineSource.Backend.Postgres(
+            hostname = postgres.host,
+            user = postgres.username,
+            password = postgres.password,
+            database = postgres.databaseName,
+            publicationName = "test_pub",
+            slotName = slot,
+            tableIncludeList = "public.items",
+            port = postgres.firstMappedPort,
+        ),
+        snapshotChunkSize = 10,
+        offsetFlushIntervalMs = 100L,
+    )
+
+    private data class CapturedTx(
+        val txId: Long,
+        val cdcRows: Int,
+        val resumeToken: ExternalSourceToken?,
+    )
+
+    private fun capturingHandler(): Pair<ExternalSource.TxHandler, MutableList<CapturedTx>> {
+        val received = Collections.synchronizedList(mutableListOf<CapturedTx>())
+        val handler = ExternalSource.TxHandler { openTx, resumeToken ->
+            received.add(
+                CapturedTx(
+                    txId = openTx.txKey.txId,
+                    cdcRows = openTx.tables
+                        .filter { (ref, _) -> ref.schemaName != "xt" }
+                        .sumOf { (_, table) -> table.txRelation.rowCount },
+                    resumeToken = resumeToken,
+                )
+            )
+        }
+        return handler to received
+    }
+
+    private fun execSql(sql: String) {
+        withConn { conn -> conn.createStatement().use { it.execute(sql) } }
+    }
+
+    private fun dropSlotQuietly(slot: String) {
+        runCatching {
+            withConn { conn ->
+                conn.createStatement().use { it.execute("SELECT pg_drop_replication_slot('$slot')") }
+            }
+        }
+    }
+
+    private fun clearTable() {
+        runCatching { execSql("DELETE FROM public.items") }
+    }
+
+    @Test
+    fun `snapshot and streaming events flow from postgres`() = runBlocking(Dispatchers.Default) {
+        val slot = uniqueSlot()
+        clearTable()
+        try {
+            // Pre-populate — these will come through via the initial snapshot.
+            execSql("INSERT INTO public.items VALUES ('snap-1', 'Alice'), ('snap-2', 'Bob')")
+
+            val (handler, received) = capturingHandler()
+            val source = factory(slot).open("testdb", emptyMap())
+
+            source.use {
+                val job = launch { source.onPartitionAssigned(0, null, handler) }
+                try {
+                    // Wait for snapshot phase to emit both pre-inserted rows.
+                    withTimeout(30.seconds) {
+                        while (received.sumOf { it.cdcRows } < 2) delay(250)
+                    }
+
+                    val rowsAfterSnapshot = received.sumOf { it.cdcRows }
+
+                    // New inserts — these flow as streaming events.
+                    execSql("INSERT INTO public.items VALUES ('live-1', 'Carol')")
+
+                    withTimeout(30.seconds) {
+                        while (received.sumOf { it.cdcRows } < rowsAfterSnapshot + 1) delay(250)
+                    }
+
+                    assertTrue(received.sumOf { it.cdcRows } >= 3, "expected at least 3 CDC rows across snapshot + streaming")
+
+                    // Every committed tx should carry a non-null resumeToken that decodes to our proto.
+                    for (tx in received) {
+                        assertNotNull(tx.resumeToken, "resumeToken should be set for each tx")
+                        val decoded = tx.resumeToken!!.unpack(DebeziumEngineOffsetToken::class.java)
+                        // latestTxId is monotonic across txns.
+                        assertEquals(tx.txId, decoded.latestTxId)
+                    }
+
+                    // Last token should have some Debezium offset state captured.
+                    val lastToken = received.last().resumeToken!!.unpack(DebeziumEngineOffsetToken::class.java)
+                    assertTrue(
+                        lastToken.debeziumOffsetsList.isNotEmpty(),
+                        "last token should contain Debezium offset map — was empty",
+                    )
+                } finally {
+                    job.cancelAndJoin()
+                }
+            }
+        } finally {
+            dropSlotQuietly(slot)
+            clearTable()
+        }
+    }
+
+    @Test
+    fun `resume from token skips already-applied events`() = runBlocking(Dispatchers.Default) {
+        val slot = uniqueSlot()
+        clearTable()
+        try {
+            execSql("INSERT INTO public.items VALUES ('r-1', 'First')")
+
+            val (handler1, received1) = capturingHandler()
+            val source1 = factory(slot).open("testdb", emptyMap())
+
+            var firstToken: ExternalSourceToken? = null
+            source1.use {
+                val job = launch { source1.onPartitionAssigned(0, null, handler1) }
+                try {
+                    withTimeout(30.seconds) {
+                        while (received1.sumOf { it.cdcRows } < 1) delay(250)
+                    }
+
+                    // Add a streaming event so we have a non-trivial last LSN in the resumeToken.
+                    execSql("INSERT INTO public.items VALUES ('r-2', 'Second')")
+                    withTimeout(30.seconds) {
+                        while (received1.sumOf { it.cdcRows } < 2) delay(250)
+                    }
+
+                    firstToken = received1.last().resumeToken
+                    assertNotNull(firstToken)
+                } finally {
+                    job.cancelAndJoin()
+                }
+            }
+            val capturedToken = firstToken!!
+
+            // Resume with the token.  Inserts made while stopped should still arrive,
+            // but previously-applied ones should be deduped.
+            execSql("INSERT INTO public.items VALUES ('r-3', 'Third')")
+
+            val (handler2, received2) = capturingHandler()
+            val source2 = factory(slot).open("testdb", emptyMap())
+            source2.use {
+                val job = launch { source2.onPartitionAssigned(0, capturedToken, handler2) }
+                try {
+                    withTimeout(30.seconds) {
+                        while (received2.sumOf { it.cdcRows } < 1) delay(250)
+                    }
+
+                    // We should see exactly the new row, not the two earlier ones.
+                    // (Debezium may replay from slot position; our LSN dedup filters them.)
+                    assertTrue(
+                        received2.sumOf { it.cdcRows } >= 1,
+                        "should see the post-resume insert",
+                    )
+
+                    // Confirm the resumed txId continues from the first session.
+                    val firstDecoded = capturedToken.unpack(DebeziumEngineOffsetToken::class.java)
+                    val lastDecoded = received2.last().resumeToken!!.unpack(DebeziumEngineOffsetToken::class.java)
+                    assertTrue(
+                        lastDecoded.latestTxId > firstDecoded.latestTxId,
+                        "resumed session should advance latestTxId past the first session's",
+                    )
+                } finally {
+                    job.cancelAndJoin()
+                }
+            }
+        } finally {
+            dropSlotQuietly(slot)
+            clearTable()
+        }
+    }
+}

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/ParseCdcEnvelopeTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/ParseCdcEnvelopeTest.kt
@@ -1,0 +1,81 @@
+package xtdb.debezium
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.assertThrows
+import xtdb.error.Incorrect
+
+class ParseCdcEnvelopeTest {
+
+    @Test
+    fun `bare payload without schema envelope`() {
+        val json = """{"op":"c","after":{"_id":1,"name":"Alice"},"source":{"schema":"public","table":"users"}}"""
+
+        val out = parseCdcEnvelope(json)
+
+        assertEquals("c", out["op"])
+        @Suppress("UNCHECKED_CAST")
+        val source = out["source"] as Map<String, Any?>
+        assertEquals("public", source["schema"])
+        assertEquals("users", source["table"])
+    }
+
+    @Test
+    fun `schema-payload envelope is unwrapped`() {
+        val json = """
+            {
+              "schema": {"type":"struct", "fields": []},
+              "payload": {"op":"c","after":{"_id":1},"source":{"schema":"s","table":"t"}}
+            }
+        """.trimIndent()
+
+        val out = parseCdcEnvelope(json)
+
+        assertEquals("c", out["op"])
+    }
+
+    @Test
+    fun `nested arrays and objects convert to jvm values`() {
+        val json = """{"op":"u","arr":[1,2,3],"nested":{"a":true,"b":null}}"""
+
+        val out = parseCdcEnvelope(json)
+
+        @Suppress("UNCHECKED_CAST")
+        val arr = out["arr"] as List<Any?>
+        assertEquals(listOf(1L, 2L, 3L), arr)
+
+        @Suppress("UNCHECKED_CAST")
+        val nested = out["nested"] as Map<String, Any?>
+        assertEquals(true, nested["a"])
+        assertNull(nested["b"])
+    }
+
+    @Test
+    fun `number types preserve long and double correctly`() {
+        val json = """{"intVal": 42, "longVal": 9999999999, "doubleVal": 3.14}"""
+
+        val out = parseCdcEnvelope(json)
+
+        assertEquals(42L, out["intVal"])
+        assertEquals(9999999999L, out["longVal"])
+        assertEquals(3.14, out["doubleVal"])
+    }
+
+    @Test
+    fun `invalid json rejected with Incorrect error`() {
+        val bad = """{"op":"c","malformed"""
+
+        val err = assertThrows<Incorrect> { parseCdcEnvelope(bad) }
+        assertTrue(err.message!!.contains("Invalid CDC message"))
+    }
+
+    @Test
+    fun `non-object payload is rejected`() {
+        val bad = """{"schema": {}, "payload": ["not","an","object"]}"""
+
+        val err = assertThrows<Incorrect> { parseCdcEnvelope(bad) }
+        assertTrue(err.message!!.contains("'payload' was not a JSON object"))
+    }
+}


### PR DESCRIPTION
Adds `!DebeziumEngine` as a sibling to `!DebeziumKafka` on `ExternalSource.Factory`.
Reads Postgres CDC directly via the embedded Debezium engine and a logical replication slot — no Kafka between XTDB and the source DB.

## Why

XTDB is bitemporal — ordering is load-bearing for the sink, not a nice-to-have.
The previous `!DebeziumKafka` path consumes CDC that's already been fanned out across Kafka topics and partitions, and that architecture is fundamentally at odds with meaningful replay semantics in two distinct ways.

**Snapshot replay has no natural ordering.**
Initial-snapshot events all share a single LSN (the `pg_export_snapshot` position) and fan out across table topics, with each topic partitioned by PK.
Across partitions Kafka gives no ordering guarantee; across topics there's none at all.
Per-key ordering holds by construction — Debezium keys by PK — but that's the ceiling.
The best a consumer can do is either (a) buffer the entire snapshot before applying and sort by some canonical key, infeasible at production scale, or (b) apply events as they arrive in arbitrary order and rely on per-key convergence.
`!DebeziumKafka` does (b).
For a sink that stamps each incoming event with a `system_time`, the result is arbitrary valid-time ordering for facts that are conceptually "existing state as of LSN X".
Streaming events after the snapshot then add deltas on top of that arbitrary baseline.

**Source-txn atomicity is expensive to reassemble.**
A single source txn spreads across partitions and tables on the Kafka side.
Reassembling it requires correlating data events with `BEGIN`/`END` markers from the transaction-metadata topic, counting events per table from the `END` envelope's `data_collections`.
The mechanism is internally consistent but the costs compound: throughput collapses to "slowest partition × txn size", atomicity-across-tables requires consuming every topic that could participate, and any partition lag stalls every open txn touching that partition.
For the many-small-transactions workload we care about, the cost dominates the benefit.

**Embedded sidesteps both.**
The Debezium engine delivers events in source commit order, in a single in-process stream, with snapshot events arriving as a contiguous block followed by streaming.
One source txn maps cleanly to one XTDB txn, boundary-detected by `source.txId` change.
Snapshot events are batched into fixed-size XTDB txns — still arbitrary within a chunk, inherent to snapshot scan order, but the chunks themselves are serial with a clean switchover to streaming.

## Shape

Config is polymorphic so future connectors (MySQL, etc.) slot in without reshaping the outer type:

```yaml
externalSource: !DebeziumEngine
  backend: !Postgres
    hostname: ...
    publicationName: xtdb_pub       # created first on source
    slotName: xtdb_slot             # our consumer's handle
    tableIncludeList: public.orders,public.customers
  snapshotChunkSize: 1000
  offsetFlushIntervalMs: 1000
```

Engine-level config (`snapshotChunkSize`, `offsetFlushIntervalMs`) lives on the outer `Factory`.
Connector-specific config lives on `backend` — a sealed interface with `Postgres` as its one variant.
Each variant knows how to stamp its own properties onto Debezium's `Properties`.

## Exactly-once-at-sink

Two mechanisms combined:

1. `handleTx(openTx, resumeToken)` commits the XTDB tx and the resume token atomically via the existing `ExternalSource` framework.
2. Per-event `source.lsn` compared against `last_applied_lsn` in the stored token filters replays on restart.

The `offset.flush.interval.ms=1000` setting keeps Debezium's slot acknowledgement near-real-time, bounding the replay window without making it strictly zero — dedup is the safety net.

## Snapshot handling

`snapshot.mode=initial`: snapshot once, stream forever, fail loudly on slot loss.
This deliberately rejects `when_needed` — silently re-snapshotting would produce a valid-time gap in XTDB's bitemporal history for the outage window, which we'd rather surface as an operator-visible failure than absorb.

Initial snapshot events share an LSN so they can't be LSN-deduped.
Debezium doesn't resume interrupted initial snapshots anyway — mid-snapshot crash restarts the scan from the beginning and idempotent re-application handles the overlap.

## The OffsetBackingStore dance

Debezium 3.2.2's `OffsetBackingStore` is instantiated reflectively (`offset.storage=<classname>` + no-arg ctor); no `using(OffsetBackingStore)` builder overload exists.
But we need to inject state from the resumeToken at startup and read Debezium's writes back for the next resumeToken.

Bridge: a static registry keyed by a generated UUID passed through Debezium's config map.
Engine instantiates our class, `configure()` pulls seed state and registers the live handle, callers reach it via `handleFor(id)`.
In-memory only; durability comes from the framework's atomic token commit.

## Behaviour-preserving tidy on the way in

The first commit (`tidy(debezium): extract CDC payload helpers`) moves `writeCdcPayload`, `parseValidTimeMicros`, `parseCdcEnvelope`, and `jsonToJvmValue` out of `DebeziumKafkaSource` and `MessageFormat` into a shared `CdcPayload.kt`.
Pure refactor — both sources receive the same Debezium envelope shape and the same apply path, better to have one copy than three.
Reviewable independently.

## Debezium version bump

3.2.2.Final (was 3.0.2.Final for the Kafka-based integration test).
Earlier 3.0.x throws `NoSuchMethodError` on `SourceTask.commitRecord(SourceRecord)` against Kafka 4.1.x — that overload was removed.
3.2 is the first Debezium line compiled against Kafka 4.

## Known follow-ups

- **MySQL generalisation not done.**
  `ChangeConsumer.classify` extracts `source.lsn` directly (MySQL has no LSN — it's `(file, pos)` or GTID), `writeCdcPayload` routes via `source.schema` (MySQL uses `db`), and `last_applied_lsn` in the proto is a `uint64`.
  The connector-agnostic parts (engine lifecycle, offset store, batch-processing skeleton, envelope parsing) are already ~60–70% of the code and will factor out cleanly when a second concrete backend lands.
  YAGNI until then.
- **No user-facing docs yet** (`dev/doc/` or equivalent).
  Should add before this is pitched as production-ready.
- **Password is a plain String on the Factory**, not routed through `StringWithEnvVarSerde`.
  Existing `!DebeziumKafka` doesn't face this because credentials flow through the referenced Kafka cluster config; here they're direct.
  Worth wiring before exposing this to users.
- **Single-partition only** per `ExternalSource.onPartitionAssigned`, matching `DebeziumKafkaSource`.
  Not a real limitation for Postgres — one replication slot is a singleton source stream anyway.

## Test plan

- [x] Unit tests: offset store bootstrap/snapshot/overwrite/isolation + envelope parser (31 passing)
- [x] Integration tests against TestContainers Postgres 17: snapshot+streaming flow, resume-from-token dedup (2 passing in 16s)
- [x] No reflection / boxed math warnings
- [ ] Manual smoke test against a non-trivial production-like schema
- [ ] Longer-soak test to validate snapshot chunk boundaries and slot advancement under load