### PR TITLE
fix(sql): parse ScalarSubqueryExpr before WrappedExpr in grammar

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -258,7 +258,8 @@ numericExpr
     ;
 
 exprPrimary
-    : '(' expr ')' #WrappedExpr
+    : subquery # ScalarSubqueryExpr
+    | '(' expr ')' #WrappedExpr
     | literal # LiteralExpr
     | exprPrimary '.' fieldName=identifier #FieldAccess
     | exprPrimary '[' expr ']' #ArrayAccess
@@ -274,7 +275,6 @@ exprPrimary
     | aggregateFunction # AggregateFunctionExpr
     | windowFunctionType 'OVER' windowNameOrSpecification # WindowFunctionExpr
     | nestedWindowFunction # NestedWindowFunctionExpr
-    | subquery # ScalarSubqueryExpr
     | 'NEST_ONE' subquery # NestOneSubqueryExpr
     | 'NEST_MANY' subquery # NestManySubqueryExpr
     | 'CASE' expr simpleWhenClause+ elseClause? 'END' #SimpleCaseExpr

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -1017,6 +1017,23 @@
     (t/is (thrown-with-msg? Exception #"Subqueries are not allowed in this context"
              (xt/q tu/*node* "SELECT x + 1 AS y FROM t ORDER BY (SELECT 1)")))))
 
+(t/deftest test-scalar-subquery-with-expressions
+  (t/testing "non-correlated"
+    (t/is (= [{:v -1}]
+             (xt/q tu/*node* "SELECT (SELECT -1) AS v"))))
+
+  (xt/submit-tx tu/*node* [[:put-docs :t {:xt/id 1 :x 10}]
+                           [:put-docs :t {:xt/id 2 :x 20}]
+                           [:put-docs :t {:xt/id 3 :x 30}]])
+
+  (t/testing "correlated with negation"
+    (t/is (= [{:x 10, :neg -10} {:x 20, :neg -20} {:x 30, :neg -30}]
+             (xt/q tu/*node* "SELECT x, (SELECT -t.x) AS neg FROM t ORDER BY x"))))
+
+  (t/testing "nested"
+    (t/is (= [{:y -10} {:y -20} {:y -30}]
+             (xt/q tu/*node* "SELECT (SELECT (SELECT -t.x)) AS y FROM t ORDER BY x")))))
+
 (t/deftest test-ordered-set-aggregates
   (t/is (=plan-file
          "test-percentile-cont"


### PR DESCRIPTION
Scalar subqueries containing expressions — e.g. `(SELECT -1)`, `(SELECT -t.x)` — were being misparsed as `WrappedExpr`.
ANTLR committed to the `WrappedExpr` alternative and error recovery parsed `SELECT` as a column identifier, producing plans like `(- nil 1)` instead of a scalar subquery — silently returning null.

Simple cases like `(SELECT 1)` and `(SELECT t.x)` were unaffected because ANTLR's lookahead resolved correctly without an operator.

Moves `ScalarSubqueryExpr` above `WrappedExpr` in the `exprPrimary` grammar alternatives so `(SELECT` is always recognised as a subquery.

Relates to #5170