### PR TITLE
feat(kafka): handle ProducerFencedException in single-writer mode

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -139,6 +139,12 @@ interface Log<M> : AutoCloseable {
     interface AtomicProducer<M> : AutoCloseable {
         fun openTx(): Tx<M>
 
+        /**
+         * Returns true if the given exception (or any in its cause chain) indicates
+         * that this producer has been fenced by a newer producer with the same transactional.id.
+         */
+        fun isProducerFenced(e: Throwable): Boolean = false
+
         interface Tx<M> : AutoCloseable {
             fun appendMessage(message: M): CompletableDeferred<MessageMetadata>
             fun commit()

--- a/core/src/main/kotlin/xtdb/api/log/StepDownException.kt
+++ b/core/src/main/kotlin/xtdb/api/log/StepDownException.kt
@@ -1,0 +1,8 @@
+package xtdb.api.log
+
+/**
+ * Thrown by a [Log.RecordProcessor] to signal that the processor has been fenced
+ * and the subscription should continue polling (to receive rebalance callbacks)
+ * rather than terminating.
+ */
+class StepDownException(cause: Throwable) : Exception("Processor stepped down", cause)

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -228,12 +228,14 @@ class Database(
                                 val demux = ExternalSource.Demux(leaderProc, extSource, 0, afterToken, txHandler)
                                 object : LogProcessor.LeaderSystem {
                                     override val proc get() = demux
-                                    override fun close() { demux.close(); extSource.close(); leaderProc.close() }
+                                    override fun isProducerFenced(e: Throwable) = replicaProducer.isProducerFenced(e)
+                                    override fun close() { demux.close(); extSource.close(); leaderProc.close(); replicaProducer.close() }
                                 }
                             } else {
                                 object : LogProcessor.LeaderSystem {
                                     override val proc get() = leaderProc
-                                    override fun close() = leaderProc.close()
+                                    override fun isProducerFenced(e: Throwable) = replicaProducer.isProducerFenced(e)
+                                    override fun close() { leaderProc.close(); replicaProducer.close() }
                                 }
                             }
                         }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -305,6 +305,10 @@ class LeaderLogProcessor(
             } catch (e: Interrupted) {
                 throw e
             } catch (e: Throwable) {
+                if (replicaProducer.isProducerFenced(e)) {
+                    LOG.warn("[$dbName] leader: producer fenced while processing msgId $msgId — stepping down")
+                    throw e
+                }
                 LOG.error(
                     e,
                     "[$dbName] leader: failed to process log record with msgId $msgId (${record.message::class.simpleName})"

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -13,6 +13,7 @@ import xtdb.util.closeOnCatch
 import xtdb.util.debug
 import xtdb.util.info
 import xtdb.util.logger
+import xtdb.util.warn
 
 private val LOG = LogProcessor::class.logger
 
@@ -68,6 +69,7 @@ class LogProcessor(
 
     interface LeaderSystem : SubSystem {
         val proc: LeaderProcessor
+        fun isProducerFenced(e: Throwable): Boolean = false
     }
 
     private class FollowerSystem(val proc: FollowerProcessor, private val job: Job) : SubSystem {
@@ -120,7 +122,8 @@ class LogProcessor(
             is FollowerSystem -> {
                 LOG.info("[$dbName] partitions assigned: $partitions — transitioning to leader")
 
-                replicaLog.openAtomicProducer("${dbState.name}-leader").closeOnCatch { replicaProducer ->
+                val replicaProducer = replicaLog.openAtomicProducer("${dbState.name}-leader")
+                try {
                     val followerProc = oldSys.proc
 
                     // Send a NoOp to get a known msgId we can await —
@@ -152,12 +155,25 @@ class LogProcessor(
                             val latestSourceMsgId = transition.latestSourceMsgId
                             LOG.debug("[$dbName] transition: opening leader processor")
 
-                            val sys = procFactory.openLeaderSystem(replicaProducer, latestSourceMsgId, replayTarget)
-                            this.sys = sys
+                            val leaderSys = procFactory.openLeaderSystem(replicaProducer, latestSourceMsgId, replayTarget)
+                            this.sys = leaderSys
 
                             LOG.info("[$dbName] leader startup complete, resuming after $latestSourceMsgId")
-                            Log.TailSpec(latestSourceMsgId, sys.proc)
+                            Log.TailSpec(latestSourceMsgId, FencingAwareProcessor(leaderSys))
                         }
+                } catch (e: Throwable) {
+                    replicaProducer.close()
+                    if (replicaProducer.isProducerFenced(e)) {
+                        LOG.warn("[$dbName] fenced during leader transition — reverting to follower")
+                        val followerProc = oldSys.proc
+                        this.sys = openFollowerSystem(
+                            followerProc.latestSourceMsgId,
+                            followerProc.latestReplicaMsgId,
+                            followerProc.pendingBlock
+                        )
+                        return null
+                    }
+                    throw e
                 }
             }
         }
@@ -178,6 +194,22 @@ class LogProcessor(
 
             is FollowerSystem -> {
                 LOG.debug("[$dbName] partitions revoked: $partitions — already follower, no transition needed")
+            }
+        }
+    }
+
+    private inner class FencingAwareProcessor(
+        private val leaderSys: LeaderSystem
+    ) : Log.RecordProcessor<SourceMessage> {
+        override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+            try {
+                leaderSys.proc.processRecords(records)
+            } catch (e: Throwable) {
+                if (leaderSys.isProducerFenced(e)) {
+                    LOG.warn("[$dbName] producer fenced — stepping down")
+                    throw StepDownException(e)
+                }
+                throw e
             }
         }
     }

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -396,6 +396,24 @@ config {
 -- after a transition. This is safe because:
 --   - FlushBlock is a CAS on expected_block_idx; stale flushes fail the check.
 --   - TriesAdded is idempotent; addTries tolerates duplicates.
+--
+-- == Fencing Recovery ==
+--
+-- If the leader's transactional producer is fenced during normal operation
+-- (ProducerFencedException, InvalidProducerEpochException, or
+-- OutOfOrderSequenceException), the processor throws StepDownException.
+-- The subscription loop catches this and nulls out the processor,
+-- then continues polling. The in-progress rebalance fires
+-- onPartitionsRevoked on the next poll, which triggers the normal
+-- TransitionToFollower path.
+--
+-- The replica log remains consistent because the fenced transaction was
+-- never committed — Kafka rejected it. The new leader will re-process
+-- any source records that the fenced leader failed to commit.
+--
+-- If fencing occurs during leader transition (onPartitionsAssigned),
+-- the transition is aborted and the node remains as follower.
+-- The old follower's watermarks are used to open a new follower system.
 
 -- == Transition Safety ==
 --
@@ -517,6 +535,26 @@ rule TransitionToFollower {
             from_replica: leader.latest_replica_msg_id,
             pending_block: leader.pending_block
         )
+}
+
+rule ProducerFenced {
+    -- The leader's transactional producer has been fenced by a newer producer.
+    -- This happens when another node has been assigned the partition and opened
+    -- its own producer during a consumer group rebalance, or when a transaction
+    -- times out on the broker.
+    -- See: indexer/LogProcessor.kt (FencingAwareProcessor), api/log/StepDownException.kt
+    when: ProducerFencedException during leader processRecords
+    requires: log_processor.mode is Leader
+
+    ensures:
+        -- FencingAwareProcessor catches the exception and throws StepDownException.
+        -- The subscription loop catches StepDownException and nulls out the processor.
+        -- The in-progress rebalance fires onPartitionsRevoked on the next poll,
+        -- which triggers the normal TransitionToFollower path.
+        -- Watchers are NOT notified of the error (this is a graceful recovery).
+        -- The fenced transaction was never committed to the replica log.
+        -- The new leader will re-process the source records.
+        throw StepDownException
 }
 
 ---- Rules: Transaction Submission

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -22,9 +22,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.InterruptException
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
-import org.apache.kafka.common.errors.WakeupException
+import org.apache.kafka.common.errors.*
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.serialization.Deserializer
@@ -176,6 +174,17 @@ class KafkaCluster(
         }
 
         companion object {
+            fun isKafkaProducerFenced(e: Throwable): Boolean {
+                var current: Throwable? = e
+                while (current != null) {
+                    if (current is ProducerFencedException ||
+                        current is InvalidProducerEpochException ||
+                        current is OutOfOrderSequenceException) return true
+                    current = current.cause
+                }
+                return false
+            }
+
             inline fun <M, R> AtomicProducer<M>.withTx(block: (Tx<M>) -> R): R =
                 openTx().use { tx ->
                     try {
@@ -281,6 +290,8 @@ class KafkaCluster(
                 UnitSerializer,
                 ByteArraySerializer()
             ).also { it.initTransactions() }
+
+            override fun isProducerFenced(e: Throwable) = AtomicProducer.isKafkaProducerFenced(e)
 
             override fun openTx(): AtomicProducer.Tx<M> {
                 producer.beginTransaction()
@@ -402,7 +413,13 @@ class KafkaCluster(
 
                 while (isActive) {
                     val records = runInterruptible(Dispatchers.IO) { c.pollRecords() }
-                    if (records.isNotEmpty()) currentProcessor?.processRecords(records)
+                    if (records.isNotEmpty()) {
+                        try {
+                            currentProcessor?.processRecords(records)
+                        } catch (_: StepDownException) {
+                            currentProcessor = null
+                        }
+                    }
                 }
             } finally {
                 c.close()

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
@@ -2,9 +2,7 @@ package xtdb.api.log
 
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -15,8 +13,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertArrayEquals
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -297,5 +294,34 @@ class KafkaAtomicProducerTest {
             val records = c2.poll(Duration.ofSeconds(2))
             assertEquals(0, records.count(), "No records should be re-delivered — offsets were committed")
         }
+    }
+
+    @Test
+    fun `second producer with same transactional id fences the first`() = runTest(timeout = 60.seconds) {
+        val topicName = "test-topic-${UUID.randomUUID()}"
+
+        KafkaCluster.ClusterFactory(container.bootstrapServers)
+            .pollDuration(Duration.ofMillis(100))
+            .open().use { cluster ->
+                KafkaCluster.LogFactory("my-cluster", topicName)
+                    .openSourceLog(mapOf("my-cluster" to cluster)).use { log ->
+                        val producer1 = log.openAtomicProducer("same-tx-id")
+
+                        // Commit succeeds before fencing
+                        producer1.withTx { tx -> tx.appendMessage(txMessage(1)) }
+
+                        // Second producer with the same transactional.id fences producer1
+                        val producer2 = log.openAtomicProducer("same-tx-id")
+
+                        // producer1 is now fenced — next commit should throw
+                        val e = assertThrows(Exception::class.java) {
+                            producer1.withTx { tx -> tx.appendMessage(txMessage(2)) }
+                        }
+                        assertTrue(producer1.isProducerFenced(e), "Should be recognized as a fencing exception")
+
+                        producer1.close()
+                        producer2.close()
+                    }
+            }
     }
 }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaProducerFencingTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaProducerFencingTest.kt
@@ -1,0 +1,254 @@
+package xtdb.api.log
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.*
+import org.apache.arrow.memory.RootAllocator
+import org.apache.kafka.common.errors.InvalidProducerEpochException
+import org.apache.kafka.common.errors.OutOfOrderSequenceException
+import org.apache.kafka.common.errors.ProducerFencedException
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import xtdb.catalog.BlockCatalog
+import xtdb.catalog.TableCatalog
+import xtdb.compactor.Compactor
+import xtdb.database.DatabaseState
+import xtdb.database.DatabaseStorage
+import xtdb.api.storage.Storage
+import xtdb.indexer.*
+import xtdb.storage.BufferPool
+import xtdb.trie.TrieCatalog
+import java.time.InstantSource
+import java.util.concurrent.TimeUnit
+
+private class FenceableProducer<M>(private val delegate: Log.AtomicProducer<M>) : Log.AtomicProducer<M> {
+    @Volatile
+    var fenced = false
+
+    override fun isProducerFenced(e: Throwable) = KafkaCluster.AtomicProducer.isKafkaProducerFenced(e)
+
+    override fun openTx(): Log.AtomicProducer.Tx<M> {
+        if (fenced) throw ProducerFencedException("simulated fencing")
+        val tx = delegate.openTx()
+        return object : Log.AtomicProducer.Tx<M> {
+            override fun appendMessage(message: M) = tx.appendMessage(message)
+            override fun commit() {
+                if (fenced) throw ProducerFencedException("simulated fencing")
+                tx.commit()
+            }
+
+            override fun abort() = tx.abort()
+            override fun close() = tx.close()
+        }
+    }
+
+    override fun close() = delegate.close()
+}
+
+private class FenceableReplicaLog(
+    private val delegate: InMemoryLog<ReplicaMessage>
+) : Log<ReplicaMessage> by delegate {
+    var fenceableProducer: FenceableProducer<ReplicaMessage>? = null
+        private set
+
+    override fun openAtomicProducer(transactionalId: String): Log.AtomicProducer<ReplicaMessage> {
+        val producer = FenceableProducer(delegate.openAtomicProducer(transactionalId))
+        fenceableProducer = producer
+        return producer
+    }
+}
+
+@Timeout(30, unit = TimeUnit.SECONDS)
+class KafkaProducerFencingTest {
+
+    private lateinit var allocator: RootAllocator
+
+    @BeforeEach
+    fun setUp() {
+        allocator = RootAllocator()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        allocator.close()
+    }
+
+    private fun mockBufferPool(epoch: Int = 0) =
+        mockk<BufferPool>(relaxed = true) { every { this@mockk.epoch } returns epoch }
+
+    private fun dbState(name: String = "test-db") =
+        DatabaseState(
+            name,
+            BlockCatalog(name, null),
+            mockk<TableCatalog>(relaxed = true),
+            mockk<TrieCatalog>(relaxed = true),
+            mockk(relaxed = true)
+        )
+
+    private fun procFactory(
+        bufferPool: BufferPool,
+        dbState: DatabaseState,
+        dbStorage: DatabaseStorage,
+        watchers: Watchers,
+    ) = object : LogProcessor.ProcessorFactory {
+        override fun openLeaderSystem(
+            replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+            afterSourceMsgId: MessageId,
+            afterReplicaMsgId: MessageId,
+        ): LogProcessor.LeaderSystem {
+            val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
+            val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
+            val leaderProc = LeaderLogProcessor(
+                allocator, dbStorage, replicaProducer,
+                dbState, mockk(relaxed = true), watchers,
+                emptySet(), null, blockUploader, afterSourceMsgId, afterReplicaMsgId
+            )
+            return object : LogProcessor.LeaderSystem {
+                override val proc get() = leaderProc
+                override fun isProducerFenced(e: Throwable) = replicaProducer.isProducerFenced(e)
+                override fun close() { leaderProc.close(); replicaProducer.close() }
+            }
+        }
+
+        override fun openTransition(
+            replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+            afterSourceMsgId: MessageId,
+            afterReplicaMsgId: MessageId,
+        ): LogProcessor.TransitionProcessor =
+            TransitionLogProcessor(
+                allocator, bufferPool, dbState, dbState.liveIndex,
+                BlockUploader(dbStorage, dbState, mockk(relaxed = true), null),
+                replicaProducer, watchers, dbCatalog = null,
+                afterSourceMsgId = afterSourceMsgId,
+                afterReplicaMsgId = afterReplicaMsgId,
+            )
+
+        override fun openFollower(
+            pendingBlock: PendingBlock?,
+            afterSourceMsgId: MessageId,
+            afterReplicaMsgId: MessageId,
+        ): LogProcessor.FollowerProcessor =
+            FollowerLogProcessor(
+                allocator, bufferPool, dbState,
+                mockk(relaxed = true), watchers, null, pendingBlock,
+                afterSourceMsgId, afterReplicaMsgId,
+            )
+    }
+
+    @Test
+    fun `fencing during leader transition reverts to follower`() = runBlocking {
+        val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val bufferPool = mockBufferPool()
+        val dbState = dbState()
+
+        val alwaysFencedReplicaLog = object : Log<ReplicaMessage> by replicaLog {
+            override fun openAtomicProducer(transactionalId: String): Log.AtomicProducer<ReplicaMessage> {
+                val producer = FenceableProducer(replicaLog.openAtomicProducer(transactionalId))
+                producer.fenced = true
+                return producer
+            }
+        }
+
+        val dbStorage = DatabaseStorage(sourceLog, alwaysFencedReplicaLog, bufferPool, null)
+        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
+        val watchers = Watchers(-1)
+
+        val scope = CoroutineScope(SupervisorJob())
+        val logProc = LogProcessor(
+            procFactory(bufferPool, dbState, dbStorage, watchers),
+            dbStorage, dbState, blockUploader, scope
+        )
+
+        val tailSpec = logProc.onPartitionsAssigned(listOf(0))
+        assertEquals(null, tailSpec)
+
+        logProc.close()
+        sourceLog.close()
+        replicaLog.close()
+    }
+
+    private fun triesAddedMessage() = SourceMessage.TriesAdded(Storage.VERSION, 0, emptyList())
+
+    @Test
+    fun `fencing during processRecords does not poison watchers`() = runBlocking {
+        val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val fenceableReplicaLog = FenceableReplicaLog(replicaLog)
+        val bufferPool = mockBufferPool()
+        val dbState = dbState()
+        val dbStorage = DatabaseStorage(sourceLog, fenceableReplicaLog, bufferPool, null)
+        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
+        val watchers = Watchers(-1)
+
+        val scope = CoroutineScope(SupervisorJob())
+        val logProc = LogProcessor(
+            procFactory(bufferPool, dbState, dbStorage, watchers),
+            dbStorage, dbState, blockUploader, scope
+        )
+
+        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
+
+        val firstMsgId = sourceLog.appendMessage(triesAddedMessage()).msgId
+        watchers.awaitSource(firstMsgId)
+
+        fenceableReplicaLog.fenceableProducer!!.fenced = true
+        sourceLog.appendMessage(triesAddedMessage())
+
+        // InMemoryLog doesn't catch StepDownException so the subscription dies,
+        // but watchers should not be poisoned — LeaderLogProcessor skips notifyError for fencing.
+        job.join()
+
+        assertEquals(null, watchers.exception)
+
+        logProc.close()
+        sourceLog.close()
+        replicaLog.close()
+    }
+
+    @Test
+    fun `non-fencing exceptions poison watchers`() = runBlocking {
+        val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val fenceableReplicaLog = FenceableReplicaLog(replicaLog)
+        val bufferPool = mockBufferPool()
+        val dbState = dbState()
+        val dbStorage = DatabaseStorage(sourceLog, fenceableReplicaLog, bufferPool, null)
+        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
+        val watchers = Watchers(-1)
+
+        val scope = CoroutineScope(SupervisorJob())
+        val logProc = LogProcessor(
+            procFactory(bufferPool, dbState, dbStorage, watchers),
+            dbStorage, dbState, blockUploader, scope
+        )
+
+        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
+
+        val firstMsgId = sourceLog.appendMessage(triesAddedMessage()).msgId
+        watchers.awaitSource(firstMsgId)
+
+        sourceLog.appendMessage(SourceMessage.Tx(ByteArray(0), null, java.time.ZoneId.of("UTC"), null, null))
+
+        job.join()
+
+        assertNotEquals(null, watchers.exception)
+
+        logProc.close()
+        sourceLog.close()
+        replicaLog.close()
+    }
+
+    @Test
+    fun `isProducerFenced recognizes all fencing exception types`() {
+        val producer = FenceableProducer(InMemoryLog<ReplicaMessage>(InstantSource.system(), 0).openAtomicProducer("test"))
+
+        assertTrue(producer.isProducerFenced(ProducerFencedException("fenced")))
+        assertTrue(producer.isProducerFenced(InvalidProducerEpochException("stale epoch")))
+        assertTrue(producer.isProducerFenced(OutOfOrderSequenceException("sequence gap")))
+        assertTrue(producer.isProducerFenced(RuntimeException("wrapper", ProducerFencedException("nested"))))
+        assertFalse(producer.isProducerFenced(RuntimeException("unrelated")))
+
+        producer.close()
+    }
+}


### PR DESCRIPTION
## Summary

In single-writer mode, Kafka's transactional producer can be fenced when another node opens a producer with the same `transactional.id` during a consumer group rebalance, or when a transaction times out on the broker.
Previously this propagated unhandled and crashed the node.

A fenced leader now throws `StepDownException`, which the subscription loop catches — nulling out the processor and continuing to poll.
The in-progress rebalance fires `onPartitionsRevoked` on the next `poll()`, which handles the actual follower transition via the existing path.

Fencing during leader transition (`onPartitionsAssigned`) is handled separately — the exception fires inside `poll()` itself, so the subscription loop can't catch it.
The transition catch reverts to follower using the old follower's watermarks.

## Key decisions

**Step down, don't crash.**
The fenced producer is dead regardless, but the node can continue as a follower serving reads and be re-elected via the next rebalance.

**`StepDownException` as a signal, not self-managed step-down.**
Originally `FencingAwareProcessor` managed the transition itself (closing the leader, opening a follower, absorbing records).
Simplified to just throwing `StepDownException` — the subscription loop catches it, and the existing `onPartitionsRevoked` path handles the real transition.
This avoids duplicating step-down logic.

**No `enforceRebalance`.**
Fencing only occurs when a rebalance is already in progress (another node opened a producer after being assigned the partition).
The in-progress rebalance handles reassignment — forcing another is redundant.

**`LeaderLogProcessor` skips `watchers.notifyError` for fencing.**
Without this, clients waiting on transaction confirmations would be poisoned during a graceful recovery.

## Also fixes

`LeaderSystem.close()` now closes the `replicaProducer` — previously leaked on every `onPartitionsRevoked`.

## Test gap

No test that `FencingAwareProcessor` converts fencing to `StepDownException`.
`InMemoryLog`'s subscription loop doesn't catch `StepDownException` (only `KafkaCluster`'s does), and a real Kafka integration test has no clean observable signal for "the exception was caught" without timing hacks.
Covered by code review for now.

Resolves #5446

🤖 Generated with [Claude Code](https://claude.com/claude-code)