### PR TITLE
feat(kafka): poison watchers on leader transition failure

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -250,7 +250,7 @@ class Database(
                         )
                     }
 
-                    val lp = LogProcessor(procFactory, storage, state, blockUploader, scope, base.meterRegistry)
+                    val lp = LogProcessor(procFactory, storage, state, watchers, blockUploader, scope, base.meterRegistry)
                     processor = lp
 
                     if (!readOnly) {

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -228,12 +228,12 @@ class Database(
                                 val demux = ExternalSource.Demux(leaderProc, extSource, 0, afterToken, txHandler)
                                 object : LogProcessor.LeaderSystem {
                                     override val proc get() = demux
-                                    override fun close() { demux.close(); extSource.close(); leaderProc.close() }
+                                    override fun close() { demux.close(); extSource.close(); leaderProc.close(); replicaProducer.close() }
                                 }
                             } else {
                                 object : LogProcessor.LeaderSystem {
                                     override val proc get() = leaderProc
-                                    override fun close() = leaderProc.close()
+                                    override fun close() { leaderProc.close(); replicaProducer.close() }
                                 }
                             }
                         }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -9,8 +9,10 @@ import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
+import xtdb.error.Interrupted
 import xtdb.util.closeOnCatch
 import xtdb.util.debug
+import xtdb.util.error
 import xtdb.util.info
 import xtdb.util.logger
 
@@ -20,6 +22,7 @@ class LogProcessor(
     private val procFactory: ProcessorFactory,
     dbStorage: DatabaseStorage,
     private val dbState: DatabaseState,
+    private val watchers: Watchers,
     private val blockUploader: BlockUploader,
     private val scope: CoroutineScope,
     meterRegistry: MeterRegistry? = null,
@@ -120,44 +123,54 @@ class LogProcessor(
             is FollowerSystem -> {
                 LOG.info("[$dbName] partitions assigned: $partitions — transitioning to leader")
 
-                replicaLog.openAtomicProducer("${dbState.name}-leader").closeOnCatch { replicaProducer ->
-                    val followerProc = oldSys.proc
+                try {
+                    replicaLog.openAtomicProducer("${dbState.name}-leader").closeOnCatch { replicaProducer ->
+                        val followerProc = oldSys.proc
 
-                    // Send a NoOp to get a known msgId we can await —
-                    // we can't use latestSubmittedMsgId because Kafka's endOffsets
-                    // includes transaction marker offsets that consumers never deliver.
-                    val replayTarget = replicaProducer.withTx { it.appendMessage(ReplicaMessage.NoOp) }.await().msgId
+                        // Send a NoOp to get a known msgId we can await —
+                        // we can't use latestSubmittedMsgId because Kafka's endOffsets
+                        // includes transaction marker offsets that consumers never deliver.
+                        val replayTarget = replicaProducer.withTx { it.appendMessage(ReplicaMessage.NoOp) }.await().msgId
 
-                    followerProc.awaitReplicaMsgId(replayTarget)
-                    LOG.debug("[$dbName] transition: closing follower system")
-                    oldSys.close()
+                        followerProc.awaitReplicaMsgId(replayTarget)
+                        LOG.debug("[$dbName] transition: closing follower system")
+                        oldSys.close()
 
-                    val pendingBlock = followerProc.pendingBlock
+                        val pendingBlock = followerProc.pendingBlock
 
-                    procFactory.openTransition(
-                        replicaProducer,
-                        followerProc.latestSourceMsgId,
-                        followerProc.latestReplicaMsgId
-                    )
-                        .use { transition ->
-                            if (pendingBlock != null) {
-                                LOG.debug("[$dbName] transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
-                                blockUploader.uploadBlock(
-                                    replicaProducer, pendingBlock.boundaryMsgId, pendingBlock.boundaryMessage,
-                                )
-                                LOG.debug("[$dbName] transition: replaying ${pendingBlock.bufferedRecords.size} buffered records through transition processor")
-                                transition.processRecords(pendingBlock.bufferedRecords)
+                        procFactory.openTransition(
+                            replicaProducer,
+                            followerProc.latestSourceMsgId,
+                            followerProc.latestReplicaMsgId
+                        )
+                            .use { transition ->
+                                if (pendingBlock != null) {
+                                    LOG.debug("[$dbName] transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
+                                    blockUploader.uploadBlock(
+                                        replicaProducer, pendingBlock.boundaryMsgId, pendingBlock.boundaryMessage,
+                                    )
+                                    LOG.debug("[$dbName] transition: replaying ${pendingBlock.bufferedRecords.size} buffered records through transition processor")
+                                    transition.processRecords(pendingBlock.bufferedRecords)
+                                }
+
+                                val latestSourceMsgId = transition.latestSourceMsgId
+                                LOG.debug("[$dbName] transition: opening leader processor")
+
+                                val sys = procFactory.openLeaderSystem(replicaProducer, latestSourceMsgId, replayTarget)
+                                this.sys = sys
+
+                                LOG.info("[$dbName] leader startup complete, resuming after $latestSourceMsgId")
+                                Log.TailSpec(latestSourceMsgId, sys.proc)
                             }
-
-                            val latestSourceMsgId = transition.latestSourceMsgId
-                            LOG.debug("[$dbName] transition: opening leader processor")
-
-                            val sys = procFactory.openLeaderSystem(replicaProducer, latestSourceMsgId, replayTarget)
-                            this.sys = sys
-
-                            LOG.info("[$dbName] leader startup complete, resuming after $latestSourceMsgId")
-                            Log.TailSpec(latestSourceMsgId, sys.proc)
-                        }
+                    }
+                } catch (e: InterruptedException) {
+                    throw e
+                } catch (e: Interrupted) {
+                    throw e
+                } catch (e: Throwable) {
+                    LOG.error(e, "[$dbName] transition: failed to transition to leader")
+                    watchers.notifyError(e)
+                    throw e
                 }
             }
         }

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -161,7 +161,7 @@ class LogProcessorSimTest : SimulationTestBase(), LogProcessor.ProcessorFactory 
             afterSourceMsgId, afterReplicaMsgId
         )
 
-    fun openLogProcessor(scope: CoroutineScope) = LogProcessor(this, dbStorage, dbState, blockUploader, scope)
+    fun openLogProcessor(scope: CoroutineScope) = LogProcessor(this, dbStorage, dbState, watchers, blockUploader, scope)
 
     private fun emptyTx(): SourceMessage.Tx =
         SourceMessage.Tx(

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -112,7 +112,7 @@ class LogProcessorTest {
         val scope = CoroutineScope(SupervisorJob())
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader, scope
+            dbStorage, dbState, watchers, blockUploader, scope
         )
 
         val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
@@ -136,7 +136,7 @@ class LogProcessorTest {
         val scope = CoroutineScope(SupervisorJob())
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader, scope
+            dbStorage, dbState, watchers, blockUploader, scope
         )
 
         val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
@@ -168,7 +168,7 @@ class LogProcessorTest {
         val scope = CoroutineScope(SupervisorJob())
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader, scope
+            dbStorage, dbState, watchers, blockUploader, scope
         )
 
         val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
@@ -203,7 +203,7 @@ class LogProcessorTest {
         val scope = CoroutineScope(SupervisorJob())
         val logProc = LogProcessor(
             procFactory(allocator, bufferPool, dbState, dbStorage, watchers),
-            dbStorage, dbState, blockUploader, scope
+            dbStorage, dbState, watchers, blockUploader, scope
         )
 
         val job = scope.launch { sourceLog.openGroupSubscription(logProc) }


### PR DESCRIPTION
## Context

In single-writer mode, the Kafka replica producer can fail for several reasons — fencing (another node opened a producer with the same transactional.id), transaction timeout, broker restart, network partition.
When this happens during leader processing, we have a correctness problem: `LeaderLogProcessor` calls `indexer.indexTx` (updating the live index) *before* `appendToReplica` (writing to the replica log).
If the replica commit fails, the live index has state that isn't on the replica log.

This PR makes sure the node is marked failed in all replica producer failure paths, so the process supervisor restarts it and the live index rebuilds from a clean slate.

Supersedes #5459 — that PR tried to recover in-process by stepping down to follower, but that leaves the dirty live index behind.
When the new leader re-processes the same source transaction, the follower's `liveIndex.importTx` double-applies it.
Killing the node forces a clean restart: the live index rebuilds from the last persisted block and catches up from the replica log.

## What was already correct

`LeaderLogProcessor.processRecords` already catches `appendToReplica` failures and calls \`watchers.notifyError\`.
The top-level \`CoroutineExceptionHandler\` in \`Database.kt\` also poisons watchers for any uncaught exception in the subscription scope.

So failures during normal processing are handled.

## What was missing

\`LogProcessor.onPartitionsAssigned\` also interacts with the replica producer — NoOp send during transition, block upload for pending blocks — but had no explicit error handling.
Failures propagated to the top-level handler, which poisons watchers implicitly via the scope.

This worked, but was fragile: any future refactor that caught exceptions earlier in the chain silently broke the poisoning.
And the error path produced no contextual logging.

The first commit adds an explicit catch in \`onPartitionsAssigned\` mirroring the pattern in \`LeaderLogProcessor.processRecords\` — log with context for real errors, let cancellation propagate quietly.

## Resource leak fix

The second commit fixes a pre-existing resource leak: \`LeaderSystem.close()\` didn't close the replica producer.
Every \`onPartitionsRevoked\` leaked the Kafka producer.

## Scope

Out of scope: testing the full fencing recovery path end-to-end.
The correctness argument (kill rather than recover) makes this less critical — we're relying on the supervisor to restart, which is a well-trodden operational pattern.

Resolves #5446

🤖 Generated with [Claude Code](https://claude.com/claude-code)