### PR TITLE
refactor(indexer): split external-source processor from LLP

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -207,39 +207,33 @@ class Database(
                             afterSourceMsgId: MessageId,
                             afterReplicaMsgId: MessageId,
                         ): LogProcessor.LeaderSystem {
-                            val leaderProc = LeaderLogProcessor(
-                                allocator, storage, replicaProducer, state,
-                                indexerForDb, watchers,
-                                indexerConfig.skipTxs.toSet(),
-                                dbCatalog, blockUploader,
-                                afterSourceMsgId, afterReplicaMsgId,
-                                indexerConfig.flushDuration,
-                                base.meterRegistry,
-                            )
-
                             val extFactory = dbConfig.externalSource
 
                             return if (extFactory != null) {
-                                val extSource = extFactory.open(dbName, base.logClusters)
-                                val liveIndex = state.liveIndex
+                                val leaderProc = ExternalSourceProcessor(
+                                    storage, replicaProducer, state,
+                                    watchers, blockUploader,
+                                    afterSourceMsgId, afterReplicaMsgId,
+                                    extSource = extFactory.open(dbName, base.logClusters),
+                                    afterToken = state.blockCatalog.externalSourceToken,
+                                    flushTimeout = indexerConfig.flushDuration,
+                                )
 
-                                val txHandler = ExternalSource.TxHandler { openTx, resumeToken ->
-                                    val tableData = openTx.serializeTableData()
-                                    liveIndex.commitTx(openTx)
-                                    leaderProc.handleExternalTx(ResolvedTx(
-                                        txId = openTx.txKey.txId, systemTime = openTx.txKey.systemTime,
-                                        committed = null, error = null, tableData = tableData,
-                                        externalSourceToken = resumeToken,
-                                    ))
-                                }
-
-                                val afterToken = state.blockCatalog.externalSourceToken
-                                val demux = ExternalSource.Demux(leaderProc, extSource, 0, afterToken, txHandler)
                                 object : LogProcessor.LeaderSystem {
-                                    override val proc get() = demux
-                                    override fun close() { demux.close(); extSource.close(); leaderProc.close(); replicaProducer.close() }
+                                    override val proc get() = leaderProc
+                                    override fun close() { leaderProc.close(); replicaProducer.close() }
                                 }
                             } else {
+                                val leaderProc = LeaderLogProcessor(
+                                    allocator, storage, replicaProducer, state,
+                                    indexerForDb, watchers,
+                                    indexerConfig.skipTxs.toSet(),
+                                    dbCatalog, blockUploader,
+                                    afterSourceMsgId, afterReplicaMsgId,
+                                    indexerConfig.flushDuration,
+                                    base.meterRegistry,
+                                )
+
                                 object : LogProcessor.LeaderSystem {
                                     override val proc get() = leaderProc
                                     override fun close() { leaderProc.close(); replicaProducer.close() }

--- a/core/src/main/kotlin/xtdb/database/ExternalSource.kt
+++ b/core/src/main/kotlin/xtdb/database/ExternalSource.kt
@@ -1,23 +1,13 @@
 package xtdb.database
 
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
-import xtdb.api.log.SourceMessage
 import xtdb.database.proto.DatabaseConfig
-import xtdb.indexer.LeaderLogProcessor
-import xtdb.indexer.LogProcessor.LeaderProcessor
 import xtdb.indexer.OpenTx
 import java.util.*
-import kotlin.coroutines.CoroutineContext
 import com.google.protobuf.Any as ProtoAny
 
 typealias ExternalSourceToken = ProtoAny
@@ -62,41 +52,5 @@ interface ExternalSource : AutoCloseable {
         fun fromProto(msg: ProtoAny): Factory
         fun registerSerde(builder: PolymorphicModuleBuilder<Factory>)
         val serializersModule: SerializersModule get() = SerializersModule {}
-    }
-
-    class Demux @JvmOverloads constructor(
-        private val leaderLogProcessor: LeaderLogProcessor,
-        private val externalSource: ExternalSource,
-        private val partition: Int,
-        private val afterToken: ExternalSourceToken?,
-        private val txHandler: TxHandler,
-        ctx: CoroutineContext = Dispatchers.Default
-    ) : LeaderProcessor by leaderLogProcessor {
-
-        private val lock = Mutex()
-
-        private val scope = CoroutineScope(ctx)
-
-        private val job = scope.launch {
-            try {
-                externalSource.onPartitionAssigned(partition, afterToken, TxHandler { openTx, resumeToken ->
-                    lock.withLock { txHandler.handleTx(openTx, resumeToken) }
-                })
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                leaderLogProcessor.notifyError(e)
-            }
-        }
-
-        override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
-            lock.withLock { leaderLogProcessor.processRecords(records) }
-        }
-
-        override fun close() {
-            // cancel without join: the coroutine suspends on every iteration (Kafka poll / mutex acquire),
-            // so cancellation is near-instant. A blocking join would deadlock inside runTest's virtual time.
-            job.cancel()
-        }
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/ExternalSourceProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ExternalSourceProcessor.kt
@@ -1,0 +1,212 @@
+package xtdb.indexer
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import xtdb.api.log.*
+import xtdb.api.log.Log.AtomicProducer.Companion.withTx
+import xtdb.api.log.ReplicaMessage.BlockBoundary
+import xtdb.api.log.ReplicaMessage.TriesAdded
+import xtdb.api.storage.Storage
+import xtdb.database.DatabaseState
+import xtdb.database.DatabaseStorage
+import xtdb.database.ExternalSource
+import xtdb.database.ExternalSourceToken
+import xtdb.error.Interrupted
+import xtdb.table.TableRef
+import xtdb.util.StringUtil.asLexHex
+import xtdb.util.debug
+import xtdb.util.error
+import xtdb.util.logger
+import xtdb.util.trace
+import java.time.Duration
+import kotlin.coroutines.CoroutineContext
+
+private val LOG = ExternalSourceProcessor::class.logger
+
+class ExternalSourceProcessor(
+    dbStorage: DatabaseStorage,
+    private val replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+    private val dbState: DatabaseState,
+    private val watchers: Watchers,
+    private val blockUploader: BlockUploader,
+    afterSourceMsgId: MessageId,
+    afterReplicaMsgId: MessageId,
+    private val extSource: ExternalSource,
+    afterToken: ExternalSourceToken?,
+    partition: Int = 0,
+    flushTimeout: Duration = Duration.ofMinutes(5),
+    ctx: CoroutineContext = Dispatchers.Default,
+) : LogProcessor.LeaderProcessor {
+
+    init {
+        require(dbState.name != "xtdb") {
+            "ExternalSourceProcessor cannot run on the primary 'xtdb' database — primary handles AttachDatabase / DetachDatabase which external-source DBs never see."
+        }
+    }
+
+    private val dbName = dbState.name
+    private val sourceLog = dbStorage.sourceLog
+    private val bufferPool = dbStorage.bufferPool
+    private val liveIndex = dbState.liveIndex
+
+    private val blockCatalog = dbState.blockCatalog
+    private val trieCatalog = dbState.trieCatalog
+
+    override var pendingBlock: PendingBlock? = null
+        private set
+
+    override var latestSourceMsgId: MessageId = afterSourceMsgId
+        private set
+
+    override var latestReplicaMsgId: MessageId = afterReplicaMsgId
+        private set
+
+    private val blockFlusher = BlockFlusher(flushTimeout, blockCatalog)
+
+    // Serialises the two input streams — source-log records (via [processRecords]) and external-source txs
+    // (via the subscription coroutine below).
+    // The transactional Kafka producer (replicaProducer) is not safe for concurrent `withTx`, so both paths
+    // must hold this lock before touching it.
+    private val mutex = Mutex()
+
+    private val extJob = CoroutineScope(ctx).launch {
+        try {
+            extSource.onPartitionAssigned(partition, afterToken) { openTx, resumeToken ->
+                handleExternalTx(openTx, resumeToken)
+            }
+
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            watchers.notifyError(e)
+        }
+    }
+
+    private suspend fun maybeFlushBlock() {
+        if (blockFlusher.checkBlockTimeout(blockCatalog, liveIndex)) {
+            val flushMessage = SourceMessage.FlushBlock(blockCatalog.currentBlockIndex ?: -1)
+            blockFlusher.flushedTxId = sourceLog.appendMessage(flushMessage).msgId
+        }
+    }
+
+    private suspend fun appendToReplica(message: ReplicaMessage): Log.MessageMetadata =
+        replicaProducer.withTx { tx -> tx.appendMessage(message) }.await()
+            .also { latestReplicaMsgId = it.msgId }
+
+    private suspend fun finishBlock(latestProcessedMsgId: MessageId, externalSourceToken: ExternalSourceToken?) {
+        val boundaryMsg =
+            BlockBoundary((blockCatalog.currentBlockIndex ?: -1) + 1, latestProcessedMsgId, externalSourceToken)
+
+        val boundaryMsgId = appendToReplica(boundaryMsg).msgId
+        LOG.debug("[$dbName] block boundary b${boundaryMsg.blockIndex.asLexHex}: source=$latestProcessedMsgId, replica=$boundaryMsgId")
+
+        pendingBlock = PendingBlock(boundaryMsgId, boundaryMsg)
+
+        latestReplicaMsgId = blockUploader.uploadBlock(replicaProducer, boundaryMsgId, boundaryMsg)
+        pendingBlock = null
+    }
+
+    suspend fun handleExternalTx(openTx: OpenTx, resumeToken: ExternalSourceToken?) {
+        val txKey = openTx.txKey
+        val tableData = openTx.serializeTableData()
+
+        mutex.withLock {
+            liveIndex.commitTx(openTx)
+
+            val resolvedTx = ReplicaMessage.ResolvedTx(
+                txKey.txId, txKey.systemTime, committed = null, error = null, tableData, dbOp = null, resumeToken
+            )
+
+            appendToReplica(resolvedTx)
+
+            // No TransactionResult to publish, but the resume token must still advance
+            // so that block flushes persist the correct external source position.
+            watchers.updateExternalSourceToken(resolvedTx.externalSourceToken)
+
+            if (liveIndex.isFull())
+                finishBlock(latestSourceMsgId, resolvedTx.externalSourceToken)
+        }
+    }
+
+    override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+        maybeFlushBlock()
+
+        for (record in records) {
+            mutex.withLock {
+                val msgId = record.msgId
+                LOG.trace { "[${dbName}] external: message $msgId (${record.message::class.simpleName})" }
+
+                try {
+                    when (val msg = record.message) {
+                        is SourceMessage.FlushBlock -> {
+                            val expectedBlockIdx = msg.expectedBlockIdx
+                            if (expectedBlockIdx != null && expectedBlockIdx == (blockCatalog.currentBlockIndex
+                                    ?: -1L)
+                            ) {
+                                finishBlock(msgId, watchers.externalSourceToken)
+                            }
+                            latestSourceMsgId = msgId
+                            watchers.notifyMsg(msgId)
+                        }
+
+                        is SourceMessage.TriesAdded -> {
+                            if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch) {
+                                msg.tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
+                                    trieCatalog.addTries(
+                                        TableRef.parse(dbState.name, tableName),
+                                        tries,
+                                        record.logTimestamp
+                                    )
+                                }
+                            }
+
+                            appendToReplica(
+                                TriesAdded(
+                                    msg.storageVersion, msg.storageEpoch, msg.tries,
+                                    sourceMsgId = msgId
+                                )
+                            )
+
+                            latestSourceMsgId = msgId
+                            watchers.notifyMsg(msgId)
+                        }
+
+                        // TODO this one's going before release
+                        is SourceMessage.BlockUploaded -> {
+                            latestSourceMsgId = msgId
+                            watchers.notifyMsg(msgId)
+                        }
+
+                        // User txs and catalog mutations can't appear on an external-source DB's source log:
+                        // - Tx / LegacyTx are blocked at Database.submitTxBlocking (see #5443)
+                        // - AttachDatabase / DetachDatabase only target the primary DB, never external-source secondaries
+                        is SourceMessage.Tx, is SourceMessage.LegacyTx,
+                        is SourceMessage.AttachDatabase, is SourceMessage.DetachDatabase ->
+                            error("[${dbName}] external-source DB received unexpected source message: ${msg::class.simpleName}")
+                    }
+                } catch (e: InterruptedException) {
+                    throw e
+                } catch (e: Interrupted) {
+                    throw e
+                } catch (e: Throwable) {
+                    LOG.error(
+                        e,
+                        "[${dbName}] external: failed to process log record with msgId $msgId (${record.message::class.simpleName})"
+                    )
+                    watchers.notifyError(e)
+                    throw e
+                }
+            }
+        }
+    }
+
+    override fun close() {
+        // HACK: we cancel without joining because a blocking join deadlocks under runTest's virtual time.
+        extJob.cancel()
+        extSource.close()
+    }
+}

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -181,30 +181,6 @@ class LeaderLogProcessor(
             finishBlock(txId, resolvedTx.externalSourceToken)
     }
 
-    suspend fun handleExternalTx(resolvedTx: ReplicaMessage.ResolvedTx) {
-        appendToReplica(resolvedTx)
-
-        val txKey = TransactionKey(resolvedTx.txId, resolvedTx.systemTime)
-        val result = when (resolvedTx.committed) {
-            true -> TransactionResult.Committed(txKey)
-            false -> TransactionResult.Aborted(txKey, resolvedTx.error)
-            null -> null
-        }
-
-        if (result != null) {
-            watchers.notifyTx(result, latestSourceMsgId, resolvedTx.externalSourceToken)
-        } else {
-            // No TransactionResult to publish, but the resume token must still advance
-            // so that block flushes persist the correct external source position.
-            watchers.updateExternalSourceToken(resolvedTx.externalSourceToken)
-        }
-
-        if (liveIndex.isFull())
-            finishBlock(latestSourceMsgId, resolvedTx.externalSourceToken)
-    }
-
-    fun notifyError(exception: Throwable) = watchers.notifyError(exception)
-
     override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
         maybeFlushBlock()
 

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -3,6 +3,7 @@ package xtdb.database
 import com.google.protobuf.StringValue
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import xtdb.api.TransactionResult
+import xtdb.api.TransactionKey
 import xtdb.api.log.InMemoryLog
 import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
@@ -26,6 +27,7 @@ import xtdb.tx.TxOpts
 import java.time.Instant
 import java.time.InstantSource
 import java.time.ZoneId
+import kotlin.coroutines.CoroutineContext
 import com.google.protobuf.Any as ProtoAny
 
 class ExternalSourceTest {
@@ -45,12 +47,39 @@ class ExternalSourceTest {
         allocator.close()
     }
 
+    /**
+     * Simple in-memory ExternalSource for testing.
+     * Send signals to [channel] to trigger txHandler.handleTx with a mock OpenTx.
+     */
+    class InMemoryExternalSource(
+        val channel: Channel<Unit> = Channel(100)
+    ) : ExternalSource {
+        private var nextTxId = 0L
+
+        override suspend fun onPartitionAssigned(partition: Int, afterToken: ExternalSourceToken?, txHandler: ExternalSource.TxHandler) {
+            for (signal in channel) {
+                val openTx = mockk<OpenTx>(relaxed = true) {
+                    every { txKey } returns TransactionKey(nextTxId++, Instant.now())
+                    every { serializeTableData() } returns emptyMap()
+                }
+                txHandler.handleTx(openTx, null)
+            }
+        }
+
+        override fun close() {
+            channel.close()
+        }
+    }
+
     private fun leaderProc(
         sourceLog: InMemoryLog<SourceMessage> = InMemoryLog(InstantSource.system(), 0),
         replicaLog: InMemoryLog<ReplicaMessage> = InMemoryLog(InstantSource.system(), 0),
         liveIndex: LiveIndex = mockk(relaxed = true),
         watchers: Watchers = Watchers(-1),
-    ): LeaderLogProcessor {
+        extSource: ExternalSource = InMemoryExternalSource(),
+        afterToken: ExternalSourceToken? = null,
+        ctx: CoroutineContext,
+    ): ExternalSourceProcessor {
         val blockCatalog = BlockCatalog("test", null)
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
         val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
@@ -60,83 +89,56 @@ class ExternalSourceTest {
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
 
-        return LeaderLogProcessor(
-            allocator, dbStorage, replicaProducer,
-            dbState, mockk(relaxed = true), watchers,
-            emptySet(), null, blockUploader, afterSourceMsgId = -1, afterReplicaMsgId = -1
+        return ExternalSourceProcessor(
+            dbStorage, replicaProducer, dbState, watchers, blockUploader,
+            afterSourceMsgId = -1, afterReplicaMsgId = -1,
+            extSource = extSource, afterToken = afterToken, ctx = ctx,
         )
     }
 
-    /**
-     * Simple in-memory ExternalSource for testing.
-     * Send signals to [channel] to trigger txHandler.handleTx with a mock OpenTx.
-     */
-    class InMemoryExternalSource(
-        val channel: Channel<Unit> = Channel(100)
-    ) : ExternalSource {
+    @Test
+    fun `handleExternalTx appends ResolvedTx to replica log`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(-1)
+        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers, ctx = coroutineContext)
 
-        override suspend fun onPartitionAssigned(partition: Int, afterToken: ExternalSourceToken?, txHandler: ExternalSource.TxHandler) {
-            for (signal in channel) {
-                txHandler.handleTx(mockk(relaxed = true), null)
+        try {
+            val openTx = mockk<OpenTx>(relaxed = true) {
+                every { txKey } returns TransactionKey(0L, Instant.now())
+                every { serializeTableData() } returns emptyMap()
             }
-        }
+            lp.handleExternalTx(openTx, resumeToken = null)
 
-        override fun close() {
-            channel.close()
+            assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have received a message")
+
+            val replicaMessages = mutableListOf<ReplicaMessage>()
+            val job = launch { replicaLog.tailAll(-1) { records ->
+                replicaMessages.addAll(records.map { it.message })
+            } }
+            delay(200)
+            job.cancelAndJoin()
+
+            assertEquals(1, replicaMessages.size)
+            val resolved = replicaMessages[0] as ReplicaMessage.ResolvedTx
+            // external-source path always produces committed=null (tx-indexer branch will revisit)
+            assertEquals(null, resolved.committed)
+            assertEquals(0L, resolved.txId)
+        } finally {
+            lp.close()
         }
     }
 
     @Test
-    fun `handleExternalTx appends to replica log and notifies watchers`() = runTest {
+    fun `subscription routes external events through commitTx and handleExternalTx`() = runTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val watchers = Watchers(-1)
-        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
-
-        val now = Instant.now()
-        lp.handleExternalTx(
-            ReplicaMessage.ResolvedTx(
-                txId = 0, systemTime = now,
-                committed = true, error = null,
-                tableData = emptyMap(),
-            )
-        )
-
-        assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have received a message")
-
-        val replicaMessages = mutableListOf<ReplicaMessage>()
-        val job = launch { replicaLog.tailAll(-1) { records ->
-            replicaMessages.addAll(records.map { it.message })
-        } }
-        delay(200)
-        job.cancelAndJoin()
-
-        assertEquals(1, replicaMessages.size)
-        val resolved = replicaMessages[0] as ReplicaMessage.ResolvedTx
-        assertEquals(true, resolved.committed)
-        assertEquals(0, resolved.txId)
-    }
-
-    @Test
-    fun `Demux routes external events to txHandler`() = runTest {
-        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
-        val watchers = Watchers(-1)
-        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
-
+        val liveIndex = mockk<LiveIndex>(relaxed = true)
         val extSource = InMemoryExternalSource()
-        val events = mutableListOf<String>()
 
-        val txHandler = ExternalSource.TxHandler { _, _ ->
-            events.add("handled")
-            lp.handleExternalTx(
-                ReplicaMessage.ResolvedTx(
-                    txId = 0, systemTime = Instant.now(),
-                    committed = true, error = null,
-                    tableData = emptyMap(),
-                )
-            )
-        }
-
-        val demux = ExternalSource.Demux(lp, extSource, 0, null, txHandler, coroutineContext)
+        val lp = leaderProc(
+            replicaLog = replicaLog, watchers = watchers, liveIndex = liveIndex,
+            extSource = extSource, ctx = coroutineContext
+        )
 
         try {
             extSource.channel.send(Unit)
@@ -144,100 +146,61 @@ class ExternalSourceTest {
 
             delay(500)
 
-            assertEquals(2, events.size)
+            verify(exactly = 2) { liveIndex.commitTx(any()) }
             assertTrue(replicaLog.latestSubmittedOffset >= 1, "replica log should have 2 messages")
         } finally {
-            demux.close()
+            lp.close()
         }
     }
 
     @Test
-    fun `Demux routes source records to leader processor`() = runTest {
+    fun `processRecords flows source records through the leader processor`() = runTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val liveIndex = mockk<LiveIndex>(relaxed = true) {
             every { latestCompletedTx } returns null
         }
-        val lp = leaderProc(replicaLog = replicaLog, liveIndex = liveIndex)
-
-        val extSource = InMemoryExternalSource()
-        val txHandler = ExternalSource.TxHandler { _, _ -> }
-
-        val demux = ExternalSource.Demux(lp, extSource, 0, null, txHandler, coroutineContext)
+        val lp = leaderProc(replicaLog = replicaLog, liveIndex = liveIndex, ctx = coroutineContext)
 
         try {
             val now = Instant.now()
 
-            demux.processRecords(listOf(
+            lp.processRecords(listOf(
                 Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
             ))
 
             delay(500)
 
-            assertTrue(replicaLog.latestSubmittedOffset >= 0, "source records should flow through demux to leader")
+            assertTrue(replicaLog.latestSubmittedOffset >= 0, "source records should flow through to the leader")
         } finally {
-            demux.close()
+            lp.close()
         }
     }
 
     @Test
-    fun `handleExternalTx with aborted transaction`() = runTest {
-        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+    fun `handleExternalTx threads resumeToken to watchers`() = runTest {
         val watchers = Watchers(-1)
-        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
+        val lp = leaderProc(watchers = watchers, ctx = coroutineContext)
 
-        val now = Instant.now()
-        lp.handleExternalTx(
-            ReplicaMessage.ResolvedTx(
-                txId = 0, systemTime = now,
-                committed = false, error = RuntimeException("bad data"),
-                tableData = emptyMap(),
-            )
-        )
+        try {
+            val token = ProtoAny.pack(StringValue.of("kafka-offset:42"))
+            val openTx = mockk<OpenTx>(relaxed = true) {
+                every { txKey } returns TransactionKey(0L, Instant.now())
+                every { serializeTableData() } returns emptyMap()
+            }
 
-        val result = watchers.awaitTx(0)
-        assertNotNull(result)
-        assertInstanceOf(TransactionResult.Aborted::class.java, result)
+            lp.handleExternalTx(openTx, resumeToken = token)
 
-        val replicaMessages = mutableListOf<ReplicaMessage>()
-        val job = launch { replicaLog.tailAll(-1) { records ->
-            replicaMessages.addAll(records.map { it.message })
-        } }
-        delay(200)
-        job.cancelAndJoin()
-
-        assertEquals(1, replicaMessages.size)
-        val resolved = replicaMessages[0] as ReplicaMessage.ResolvedTx
-        assertEquals(false, resolved.committed)
+            val watcherToken = watchers.externalSourceToken
+            assertNotNull(watcherToken)
+            assertEquals("kafka-offset:42", watcherToken!!.unpack(StringValue::class.java).value)
+        } finally {
+            lp.close()
+        }
     }
 
     @Test
-    fun `handleExternalTx threads externalSourceToken to watchers`() = runTest {
-        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+    fun `error in external source propagates to watchers`() = runTest {
         val watchers = Watchers(-1)
-        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
-
-        val token = ProtoAny.pack(StringValue.of("kafka-offset:42"))
-        val now = Instant.now()
-
-        lp.handleExternalTx(
-            ReplicaMessage.ResolvedTx(
-                txId = 0, systemTime = now,
-                committed = true, error = null,
-                tableData = emptyMap(),
-                externalSourceToken = token,
-            )
-        )
-
-        val watcherToken = watchers.externalSourceToken
-        assertNotNull(watcherToken)
-        assertEquals("kafka-offset:42", watcherToken!!.unpack(StringValue::class.java).value)
-    }
-
-    @Test
-    fun `Demux error in external source propagates to watchers`() = runTest {
-        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
-        val watchers = Watchers(-1)
-        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
 
         val failingSource = object : ExternalSource {
             override suspend fun onPartitionAssigned(partition: Int, afterToken: ExternalSourceToken?, txHandler: ExternalSource.TxHandler) {
@@ -246,16 +209,32 @@ class ExternalSourceTest {
             override fun close() {}
         }
 
-        val txHandler = ExternalSource.TxHandler { _, _ -> }
-
-        val demux = ExternalSource.Demux(lp, failingSource, 0, null, txHandler, coroutineContext)
+        val lp = leaderProc(watchers = watchers, extSource = failingSource, ctx = coroutineContext)
 
         try {
             delay(500)
-
             assertNotNull(watchers.exception, "watchers should be in failed state")
         } finally {
-            demux.close()
+            lp.close()
+        }
+    }
+
+    @Test
+    fun `error in commitTx propagates to watchers`() = runTest {
+        val watchers = Watchers(-1)
+        val liveIndex = mockk<LiveIndex>(relaxed = true) {
+            every { commitTx(any()) } throws RuntimeException("commit failed")
+        }
+
+        val extSource = InMemoryExternalSource()
+        val lp = leaderProc(watchers = watchers, liveIndex = liveIndex, extSource = extSource, ctx = coroutineContext)
+
+        try {
+            extSource.channel.send(Unit)
+            delay(500)
+            assertNotNull(watchers.exception, "watchers should be in failed state")
+        } finally {
+            lp.close()
         }
     }
 
@@ -279,30 +258,5 @@ class ExternalSourceTest {
             db.submitTxBlocking(emptyList(), TxOpts(defaultTz = ZoneId.of("UTC")))
         }
         assertTrue(ex.message!!.contains("external source"), "message mentions external source")
-    }
-
-    @Test
-    fun `Demux error in txHandler propagates to watchers`() = runTest {
-        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
-        val watchers = Watchers(-1)
-        val lp = leaderProc(replicaLog = replicaLog, watchers = watchers)
-
-        val extSource = InMemoryExternalSource()
-
-        val txHandler = ExternalSource.TxHandler { _, _ ->
-            throw RuntimeException("handler failed")
-        }
-
-        val demux = ExternalSource.Demux(lp, extSource, 0, null, txHandler, coroutineContext)
-
-        try {
-            extSource.channel.send(Unit)
-
-            delay(500)
-
-            assertNotNull(watchers.exception, "watchers should be in failed state")
-        } finally {
-            demux.close()
-        }
     }
 }


### PR DESCRIPTION
Now that external-source databases can't receive Tx/LegacyTx messages on their source log (#5443), a big chunk of LeaderLogProcessor is unreachable when a DB has an external source configured.
Branching inside a single class hides that; splitting it into two types makes the unreachability structural and lets us fold the Demux shim away.

Behaviour-preserving throughout.

## ExternalSourceProcessor

External-source DBs only see control messages on their source log: FlushBlock (from their own timer), TriesAdded (from the compactor), BlockUploaded.
Tx / LegacyTx are blocked at `Database.submitTxBlocking`; AttachDatabase / DetachDatabase are primary-only and external-source DBs are always secondaries.

With the unreachable branches gone, the supporting machinery goes too:
- `resolveTx`, `handleResolvedTx`, `notifyTx` were only called from the Tx/LegacyTx paths.
- The child BufferAllocator only existed to decode Tx/LegacyTx payloads.
- `indexer`, `skipTxs`, `dbCatalog` constructor params were only consumed by the removed branches.
- `meterRegistry` was already dead weight (accepted, never used).

The `when` keeps explicit branches for the now-illegal message types, failing loudly rather than silently falling through.
`require(dbState.name != "xtdb")` makes the "secondary-only" precondition structural.

## LeaderLogProcessor

`handleExternalTx` and `notifyError` had exactly one caller — `ExternalSource.Demux`, which now targets ESP — so LLP becomes internal-source-only by construction.

`externalSourceToken` plumbing through `notifyTx` / `finishBlock` stays for now because `SourceMessage.Tx` still carries the field in its proto.
Removing the field is a separate PR.

## Folding Demux

Demux was a mutex-plus-LeaderProcessor-delegate shim whose only job was to serialise two input streams against a shared `replicaProducer`.
Now that ESP is the only thing Demux ever wraps, the indirection is pure overhead — ESP owns the subscription coroutine and the mutex directly.

Lock granularity is scoped tight:
- `processRecords` takes the lock per-record so source-log batches don't block external txs for a whole batch.
- `handleExternalTx(openTx, resumeToken)` takes the lock around the full commit-then-append-then-maybe-finish flow — these steps must be atomic w.r.t. a concurrent FlushBlock → finishBlock → uploadBlock in processRecords, because uploadBlock drains liveIndex blocks.

Known race in `close()`: cancels without join.
On a leadership rebalance (not just node shutdown) this can split an in-flight Kafka transaction between `beginTransaction()` and `commitTransaction()`, leaving the producer in a weird state.
Fixing it needs structured concurrency so the coroutine reaches a quiescent point before transport-level resources go away — deliberately out of scope; the comment in `close()` spells it out.


Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>