### PR TITLE
feat(external-source): direct Postgres logical replication CDC source

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,8 @@ junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engi
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junit-launcher" }
 
 pgjdbc = { group = "org.postgresql", name = "postgresql", version = "42.7.10" }
+jdbi-core = { group = "org.jdbi", name = "jdbi3-core", version = "3.49.0" }
+jdbi-kotlin = { group = "org.jdbi", name = "jdbi3-kotlin", version = "3.49.0" }
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
 exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
 exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time", version.ref = "exposed" }

--- a/modules/postgres-cdc/build.gradle.kts
+++ b/modules/postgres-cdc/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    `java-library`
+    alias(libs.plugins.clojurephant)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.protobuf)
+}
+
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+dependencies {
+    api(project(":xtdb-api"))
+    api(project(":xtdb-core"))
+
+    api(kotlin("stdlib"))
+    api(libs.kotlinx.serialization.json)
+    api(libs.protobuf.kotlin)
+
+    implementation(libs.pgjdbc)
+    implementation(libs.jdbi.core)
+    implementation(libs.jdbi.kotlin)
+
+    testImplementation(project(":modules:xtdb-kafka"))
+    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.kafka)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.pgjdbc)
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.asProvider().get()}"
+    }
+
+    generateProtoTasks {
+        all().forEach {
+            it.builtins {
+                create("kotlin")
+            }
+        }
+    }
+}

--- a/modules/postgres-cdc/src/main/kotlin/xtdb/postgres/PgOutputMessage.kt
+++ b/modules/postgres-cdc/src/main/kotlin/xtdb/postgres/PgOutputMessage.kt
@@ -1,0 +1,168 @@
+package xtdb.postgres
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
+/**
+ * Parsed pgoutput logical replication protocol messages.
+ *
+ * See: https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html
+ */
+sealed interface PgOutputMessage {
+
+    data class Relation(
+        val relationId: Int,
+        val schema: String,
+        val table: String,
+        val replicaIdentity: ReplicaIdentity,
+        val columns: List<Column>,
+    ) : PgOutputMessage {
+        data class Column(val name: String, val typeOid: Int)
+    }
+
+    enum class ReplicaIdentity(val code: Char) {
+        DEFAULT('d'),
+        NOTHING('n'),
+        FULL('f'),
+        INDEX('i');
+
+        companion object {
+            fun fromCode(c: Char): ReplicaIdentity =
+                entries.find { it.code == c }
+                    ?: throw UnsupportedOperationException("Unknown replica identity code: '$c'")
+        }
+    }
+
+    data class Begin(val finalLsn: Long, val commitTimestamp: Long, val xid: Int) : PgOutputMessage
+    data class Commit(val commitLsn: Long, val endLsn: Long, val commitTimestamp: Long) : PgOutputMessage
+    data class Insert(val relationId: Int, val values: List<ColumnValue>) : PgOutputMessage
+
+    data class Update(
+        val relationId: Int, val oldValues: List<ColumnValue>?, val newValues: List<ColumnValue>
+    ) : PgOutputMessage
+
+    data class Delete(val relationId: Int, val oldValues: List<ColumnValue>) : PgOutputMessage
+
+    /**
+     * Column value in a data message.
+     * - [Null] for SQL NULL
+     * - [Text] for text-format values (the common case with pgoutput)
+     * - [Unchanged] for TOASTed columns that didn't change
+     */
+    sealed interface ColumnValue {
+        data object Null : ColumnValue
+        data object Unchanged : ColumnValue
+        data class Text(val value: String) : ColumnValue
+    }
+
+    companion object {
+        fun parse(buf: ByteBuffer): PgOutputMessage =
+            when (val type = buf.get().toInt().toChar()) {
+                'R' -> parseRelation(buf)
+                'B' -> parseBegin(buf)
+                'C' -> parseCommit(buf)
+                'I' -> parseInsert(buf)
+                'U' -> parseUpdate(buf)
+                'D' -> parseDelete(buf)
+                else -> throw UnsupportedOperationException(
+                    "Unknown pgoutput message type: '$type' (0x${type.code.toString(16)})"
+                )
+            }
+
+        private fun parseRelation(buf: ByteBuffer): Relation {
+            val relationId = buf.getInt()
+            val schema = buf.readCString()
+            val table = buf.readCString()
+            val replicaIdentity = ReplicaIdentity.fromCode(buf.get().toInt().toChar())
+            val numColumns = buf.getShort().toInt()
+            val columns = (0 until numColumns).map {
+                buf.get() // flags
+                val name = buf.readCString()
+                val typeOid = buf.getInt()
+                buf.getInt() // type modifier
+                Relation.Column(name, typeOid)
+            }
+            return Relation(relationId, schema, table, replicaIdentity, columns)
+        }
+
+        private fun parseBegin(buf: ByteBuffer): Begin {
+            val finalLsn = buf.getLong()
+            val commitTimestamp = buf.getLong()
+            val xid = buf.getInt()
+            return Begin(finalLsn, commitTimestamp, xid)
+        }
+
+        private fun parseCommit(buf: ByteBuffer): Commit {
+            buf.get() // flags
+            val commitLsn = buf.getLong()
+            val endLsn = buf.getLong()
+            val commitTimestamp = buf.getLong()
+            return Commit(commitLsn, endLsn, commitTimestamp)
+        }
+
+        private fun parseInsert(buf: ByteBuffer): Insert {
+            val relationId = buf.getInt()
+            buf.get() // 'N' for new tuple
+            val values = parseTupleData(buf)
+            return Insert(relationId, values)
+        }
+
+        private fun parseUpdate(buf: ByteBuffer): Update {
+            val relationId = buf.getInt()
+            val marker = buf.get().toInt().toChar()
+
+            val oldValues: List<ColumnValue>?
+            val newMarker: Char
+
+            // 'K' = old key, 'O' = old full row, 'N' = new tuple (no old data)
+            if (marker == 'K' || marker == 'O') {
+                oldValues = parseTupleData(buf)
+                newMarker = buf.get().toInt().toChar()
+            } else {
+                oldValues = null
+                newMarker = marker
+            }
+
+            check(newMarker == 'N') { "Expected 'N' marker for new tuple in UPDATE, got '$newMarker'" }
+            val newValues = parseTupleData(buf)
+            return Update(relationId, oldValues, newValues)
+        }
+
+        private fun parseDelete(buf: ByteBuffer): Delete {
+            val relationId = buf.getInt()
+            buf.get() // 'K' or 'O'
+            val oldValues = parseTupleData(buf)
+            return Delete(relationId, oldValues)
+        }
+
+        private fun parseTupleData(buf: ByteBuffer): List<ColumnValue> {
+            val numColumns = buf.getShort().toInt()
+            return (0 until numColumns).map {
+                when (val colType = buf.get().toInt().toChar()) {
+                    'n' -> ColumnValue.Null
+                    'u' -> ColumnValue.Unchanged
+                    't' -> {
+                        val len = buf.getInt()
+                        val bytes = ByteArray(len)
+                        buf.get(bytes)
+                        ColumnValue.Text(String(bytes, StandardCharsets.UTF_8))
+                    }
+
+                    else -> throw UnsupportedOperationException("Unknown column value type: '$colType'")
+                }
+            }
+        }
+
+        private fun ByteBuffer.readCString(): String {
+            val start = position()
+            while (get() != 0.toByte()) { /* scan for null terminator */
+            }
+            val len = position() - start - 1
+            val bytes = ByteArray(len)
+            position(start)
+            get(bytes)
+            get() // consume null terminator
+            return String(bytes, StandardCharsets.UTF_8)
+        }
+    }
+}

--- a/modules/postgres-cdc/src/main/kotlin/xtdb/postgres/PgTypeCoercion.kt
+++ b/modules/postgres-cdc/src/main/kotlin/xtdb/postgres/PgTypeCoercion.kt
@@ -1,0 +1,66 @@
+package xtdb.postgres
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Converts pgoutput text-format column values to appropriate JVM types
+ * based on the PostgreSQL type OID.
+ *
+ * pgoutput always sends values in text format, so we parse from String.
+ */
+object PgTypeCoercion {
+
+    // Well-known PG type OIDs
+    private const val BOOL_OID = 16
+    private const val INT2_OID = 21
+    private const val INT4_OID = 23
+    private const val INT8_OID = 20
+    private const val FLOAT4_OID = 700
+    private const val FLOAT8_OID = 701
+    private const val NUMERIC_OID = 1700
+    private const val TEXT_OID = 25
+    private const val VARCHAR_OID = 1043
+    private const val BPCHAR_OID = 1042
+    private const val NAME_OID = 19
+    private const val DATE_OID = 1082
+    private const val TIMESTAMP_OID = 1114
+    private const val TIMESTAMPTZ_OID = 1184
+    private const val JSON_OID = 114
+    private const val JSONB_OID = 3802
+    private const val UUID_OID = 2950
+
+    fun coerce(text: String, typeOid: Int): Any = when (typeOid) {
+        BOOL_OID -> text == "t"
+        INT2_OID, INT4_OID -> text.toInt()
+        INT8_OID -> text.toLong()
+        FLOAT4_OID -> text.toFloat()
+        FLOAT8_OID -> text.toDouble()
+        NUMERIC_OID -> text.toBigDecimal()
+        DATE_OID -> LocalDate.parse(text)
+        TIMESTAMP_OID -> LocalDateTime.parse(text.replace(' ', 'T'))
+        TIMESTAMPTZ_OID -> parseTimestamptz(text)
+        UUID_OID -> java.util.UUID.fromString(text)
+        // Text-like types (TEXT, VARCHAR, BPCHAR, NAME, JSON, JSONB) stay as String
+        else -> text
+    }
+
+    private fun parseTimestamptz(text: String): Instant {
+        // PG sends timestamptz as e.g. "2024-01-01 00:00:00+00" or "2024-01-01 12:30:00.123456+02"
+        // Normalize to ISO-8601 for Instant.parse
+        val normalized = text
+            .replace(' ', 'T')
+            .let { s ->
+                // PG may omit minutes in tz offset (e.g. "+02" instead of "+02:00")
+                val tzIdx = s.indexOfLast { it == '+' || it == '-' }
+                if (tzIdx > 10) {
+                    val tz = s.substring(tzIdx)
+                    if (tz.length == 3) s + ":00" else s
+                } else s
+            }
+        return Instant.parse(normalized)
+    }
+}

--- a/modules/postgres-cdc/src/main/kotlin/xtdb/postgres/PostgresCdcSource.kt
+++ b/modules/postgres-cdc/src/main/kotlin/xtdb/postgres/PostgresCdcSource.kt
@@ -1,0 +1,460 @@
+package xtdb.postgres
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.runInterruptible
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.subclass
+import org.postgresql.PGConnection
+import org.postgresql.PGProperty
+import org.postgresql.replication.LogSequenceNumber
+import org.postgresql.replication.PGReplicationStream
+import org.slf4j.LoggerFactory
+import xtdb.database.ExternalSource
+import xtdb.database.ExternalSource.TxResult
+import xtdb.database.ExternalSourceToken
+import xtdb.database.proto.DatabaseConfig
+import xtdb.api.log.Log
+import xtdb.api.log.LogClusterAlias
+import xtdb.error.Incorrect
+import xtdb.indexer.OpenTx
+import xtdb.postgres.proto.PostgresCdcSourceConfig
+import xtdb.postgres.proto.PostgresCdcToken
+import xtdb.postgres.proto.postgresCdcSourceConfig
+import xtdb.postgres.proto.postgresCdcToken
+import xtdb.table.TableRef
+import xtdb.time.InstantUtil.asMicros
+import xtdb.util.asIid
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.Handle
+import org.jdbi.v3.core.kotlin.KotlinPlugin
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel.REPEATABLE_READ
+import xtdb.postgres.PgOutputMessage.ColumnValue
+import java.nio.ByteBuffer
+import java.sql.Connection
+import java.sql.Connection.TRANSACTION_REPEATABLE_READ
+import java.sql.DriverManager
+import java.time.Duration
+import java.time.Instant
+import java.util.Properties
+import com.google.protobuf.Any as ProtoAny
+
+private val LOG = LoggerFactory.getLogger(PostgresCdcSource::class.java)
+
+private const val PROTO_TAG = "proto.xtdb.com"
+private const val SNAPSHOT_BATCH_SIZE = 1000
+
+class PostgresCdcSource(
+    private val dbName: String,
+    private val hostname: String,
+    private val port: Int,
+    private val database: String,
+    private val username: String,
+    private val password: String,
+    private val slotName: String,
+    private val publicationName: String,
+    private val schemaIncludeList: List<String>,
+    private val pollDuration: Duration = Duration.ofSeconds(1),
+) : ExternalSource {
+
+    @Serializable
+    @SerialName("!PostgresCdc")
+    data class Factory(
+        val hostname: String,
+        val port: Int = 5432,
+        val database: String,
+        val username: String,
+        val password: String,
+        val slotName: String,
+        val publicationName: String,
+        val schemaIncludeList: List<String> = listOf("public"),
+    ) : ExternalSource.Factory {
+
+        override fun open(dbName: String, clusters: Map<LogClusterAlias, Log.Cluster>): ExternalSource =
+            PostgresCdcSource(
+                dbName, hostname, port, database, username, password,
+                slotName, publicationName, schemaIncludeList,
+            )
+
+        override fun writeTo(dbConfig: DatabaseConfig.Builder) {
+            dbConfig.externalSource = ProtoAny.pack(postgresCdcSourceConfig {
+                hostname = this@Factory.hostname
+                port = this@Factory.port
+                database = this@Factory.database
+                username = this@Factory.username
+                password = this@Factory.password
+                slotName = this@Factory.slotName
+                publicationName = this@Factory.publicationName
+                schemaIncludeList += this@Factory.schemaIncludeList
+            }, PROTO_TAG)
+        }
+
+        class Registration : ExternalSource.Registration {
+            override val protoTag: String get() = "$PROTO_TAG/xtdb.postgres.proto.PostgresCdcSourceConfig"
+
+            override fun fromProto(msg: ProtoAny): ExternalSource.Factory {
+                val config = msg.unpack(PostgresCdcSourceConfig::class.java)
+                return Factory(
+                    hostname = config.hostname,
+                    port = config.port,
+                    database = config.database,
+                    username = config.username,
+                    password = config.password,
+                    slotName = config.slotName,
+                    publicationName = config.publicationName,
+                    schemaIncludeList = config.schemaIncludeListList,
+                )
+            }
+
+            override fun registerSerde(builder: PolymorphicModuleBuilder<ExternalSource.Factory>) {
+                builder.subclass(Factory::class)
+            }
+        }
+    }
+
+    // PGProperty.set() is the correct API here — it resolves the internal property name string.
+    // props[PGProperty.USER] = "..." silently breaks: it puts the enum object as the key,
+    // but pgjdbc looks up by string (e.g. "user"), so the password is never found.
+    private fun openJdbcConnection(): Connection =
+        DriverManager.getConnection(
+            "jdbc:postgresql://$hostname:$port/$database",
+            Properties().also {
+                PGProperty.USER.set(it, username)
+                PGProperty.PASSWORD.set(it, password)
+                PGProperty.ASSUME_MIN_SERVER_VERSION.set(it, "15")
+                PGProperty.REPLICATION.set(it, "database")
+                PGProperty.PREFER_QUERY_MODE.set(it, "simple")
+            })
+
+    private val jdbi: Jdbi by lazy {
+        Jdbi.create("jdbc:postgresql://$hostname:$port/$database", username, password)
+            .installPlugin(KotlinPlugin())
+    }
+
+    override suspend fun onPartitionAssigned(
+        partition: Int,
+        afterToken: ExternalSourceToken?,
+        txIndexer: ExternalSource.TxIndexer,
+    ) {
+        val token = afterToken?.unpack(PostgresCdcToken::class.java)
+
+        try {
+            if (token != null && token.snapshotCompleted) {
+                LOG.info("[$dbName] Resuming streaming from LSN ${LogSequenceNumber.valueOf(token.latestCommittedLsn)}")
+                streamChanges(txIndexer, token.latestCommittedLsn)
+            } else {
+                LOG.info("[$dbName] Starting initial snapshot")
+                val slotLsn = initialSnapshot(txIndexer)
+                LOG.info("[$dbName] Snapshot complete, switching to streaming from LSN ${LogSequenceNumber.valueOf(slotLsn)}")
+                streamChanges(txIndexer, slotLsn)
+            }
+        } catch (e: Exception) {
+            LOG.error("[$dbName] External source failed", e)
+            throw e
+        }
+    }
+
+    /**
+     * Returns the slot LSN for streaming to resume from.
+     */
+    private suspend fun initialSnapshot(txIndexer: ExternalSource.TxIndexer): Long {
+        openJdbcConnection().use { replConn ->
+            val pgReplConn = replConn.unwrap(PGConnection::class.java)
+
+            // Create replication slot and get exported snapshot
+            val slotInfo = pgReplConn.replicationAPI
+                .createReplicationSlot()
+                .logical()
+                .withSlotName(slotName)
+                .withOutputPlugin("pgoutput")
+                .make()
+
+            val snapshotName = slotInfo.snapshotName
+            val slotLsn = slotInfo.consistentPoint.asLong()
+
+            LOG.info("[$dbName] Created slot '$slotName' at LSN ${LogSequenceNumber.valueOf(slotLsn)}, snapshot=$snapshotName")
+
+            // Read tables using the exported snapshot for consistency
+            jdbi.open().use { handle ->
+                handle.begin()
+                try {
+                    handle.transactionIsolationLevel = REPEATABLE_READ
+                    handle.execute("SET TRANSACTION SNAPSHOT '$snapshotName'")
+
+                    val tables = handle.discoverTables()
+
+                    for ((schema, table) in tables) {
+                        val columns = handle.discoverColumns(schema, table)
+                        val fullTableName = "$schema.$table"
+
+                        LOG.info("[$dbName] Snapshotting $fullTableName (${columns.size} columns)")
+
+                        handle.createQuery("SELECT * FROM \"$schema\".\"$table\"")
+                            .setFetchSize(SNAPSHOT_BATCH_SIZE)
+                            .map { rs, _ -> columns.associate { col -> col.name to rs.getObject(col.name) } }
+                            .iterator().use {
+                                it.asSequence()
+                                    .chunked(SNAPSHOT_BATCH_SIZE)
+                                    .forEach { batch ->
+                                        flushSnapshotBatch(txIndexer, slotLsn, schema, table, batch)
+                                    }
+                            }
+
+                        LOG.info("[$dbName] Finished snapshotting $fullTableName")
+                    }
+
+                    // Mark snapshot complete
+                    val completeToken = ProtoAny.pack(postgresCdcToken {
+                        latestCommittedLsn = slotLsn
+                        snapshotCompleted = true
+                    }, PROTO_TAG)
+
+                    txIndexer.indexTx(completeToken) {
+                        TxResult.Committed()
+                    }
+
+                    return slotLsn
+                } finally {
+                    handle.rollback()
+                }
+            }
+        }
+    }
+
+    private data class ColumnInfo(val name: String, val typeOid: Int)
+
+    private fun Handle.discoverTables(): List<Pair<String, String>> =
+        createQuery(
+            """
+            SELECT schemaname, tablename FROM pg_publication_tables
+            WHERE pubname = :pubName AND schemaname IN (<schemas>)
+            ORDER BY schemaname, tablename""".trimIndent()
+        )
+            .bind("pubName", publicationName)
+            .bindList("schemas", schemaIncludeList)
+            .map { rs, _ -> rs.getString("schemaname") to rs.getString("tablename") }
+            .list()
+
+    private fun Handle.discoverColumns(schema: String, table: String): List<ColumnInfo> =
+        createQuery(
+            """
+            SELECT a.attname, a.atttypid::int
+            FROM pg_attribute a
+              JOIN pg_class c ON a.attrelid = c.oid
+              JOIN pg_namespace n ON c.relnamespace = n.oid
+            WHERE n.nspname = :schema AND c.relname = :table
+              AND a.attnum > 0 AND NOT a.attisdropped
+            ORDER BY a.attnum""".trimIndent()
+        )
+            .bind("schema", schema)
+            .bind("table", table)
+            .map { rs, _ -> ColumnInfo(rs.getString("attname"), rs.getInt("atttypid")) }
+            .list()
+
+    private suspend fun streamChanges(txIndexer: ExternalSource.TxIndexer, startLsn: Long) {
+        openJdbcConnection().use { replConn ->
+            val pgReplConn = replConn.unwrap(PGConnection::class.java)
+
+            val stream: PGReplicationStream = pgReplConn.replicationAPI
+                .replicationStream()
+                .logical()
+                .withSlotName(slotName)
+                .withStartPosition(LogSequenceNumber.valueOf(startLsn))
+                .withSlotOption("proto_version", "1")
+                .withSlotOption("publication_names", publicationName)
+                .start()
+
+            val relations = mutableMapOf<Int, PgOutputMessage.Relation>()
+
+            // Accumulated operations within a single PG transaction
+            var currentTxOps = mutableListOf<Pair<PgOutputMessage.Relation, PgOutputMessage>>()
+
+            while (currentCoroutineContext().isActive) {
+                // read() blocks until a message is available; runInterruptible
+                // lets coroutine cancellation interrupt the blocking call.
+                val msg = runInterruptible(Dispatchers.IO) {
+                    stream.read()!!
+                }
+
+                when (val parsed = PgOutputMessage.parse(msg)) {
+                    is PgOutputMessage.Relation -> relations[parsed.relationId] = parsed
+
+                    is PgOutputMessage.Begin -> {
+                        currentTxOps = mutableListOf()
+                    }
+
+                    is PgOutputMessage.Insert, is PgOutputMessage.Update, is PgOutputMessage.Delete -> {
+                        val relationId = when (parsed) {
+                            is PgOutputMessage.Insert -> parsed.relationId
+                            is PgOutputMessage.Update -> parsed.relationId
+                            is PgOutputMessage.Delete -> parsed.relationId
+                        }
+                        val relation = relations[relationId]
+                            ?: error("Relation $relationId not found — missing Relation message before data message")
+                        currentTxOps.add(relation to parsed)
+                    }
+
+                    is PgOutputMessage.Commit -> {
+                        if (currentTxOps.isNotEmpty()) {
+                            val commitLsn = parsed.endLsn
+                            val commitTime = pgTimestampToInstant(parsed.commitTimestamp)
+
+                            val token = ProtoAny.pack(postgresCdcToken {
+                                latestCommittedLsn = commitLsn
+                                snapshotCompleted = true
+                            }, PROTO_TAG)
+
+                            val ops = currentTxOps.toList()
+
+                            txIndexer.indexTx(token, commitTime) { openTx ->
+                                for ((relation, op) in ops) {
+                                    applyStreamingOp(openTx, dbName, relation, op)
+                                }
+                                TxResult.Committed()
+                            }
+                        }
+
+                        // Acknowledge up to the commit LSN
+                        val commitLsn = LogSequenceNumber.valueOf(parsed.endLsn)
+                        runInterruptible(Dispatchers.IO) {
+                            stream.setFlushedLSN(commitLsn)
+                            stream.setAppliedLSN(commitLsn)
+                            stream.forceUpdateStatus()
+                        }
+
+                        currentTxOps = mutableListOf()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun applyStreamingOp(
+        openTx: OpenTx,
+        dbName: String,
+        relation: PgOutputMessage.Relation,
+        op: PgOutputMessage,
+    ) {
+        when (op) {
+            is PgOutputMessage.Insert -> {
+                val row = toRowMap(relation, op.values)
+                writeRow(openTx, dbName, relation.schema, relation.table, "c", row, null)
+            }
+
+            is PgOutputMessage.Update -> {
+                val row = toRowMap(relation, op.newValues)
+                writeRow(openTx, dbName, relation.schema, relation.table, "u", row, null)
+            }
+
+            is PgOutputMessage.Delete -> {
+                val row = toRowMap(relation, op.oldValues)
+                writeRow(openTx, dbName, relation.schema, relation.table, "d", null, row)
+            }
+
+            is PgOutputMessage.Relation, is PgOutputMessage.Begin, is PgOutputMessage.Commit ->
+                error("Unexpected op type in applyStreamingOp: ${op::class.simpleName}")
+        }
+    }
+
+    private fun toRowMap(relation: PgOutputMessage.Relation, values: List<ColumnValue>): Map<String, Any?> =
+        relation.columns
+            .mapIndexedNotNull { idx, col ->
+                values.getOrNull(idx)?.let { colValue ->
+                    col.name to when (colValue) {
+                        is ColumnValue.Null -> null
+                        is ColumnValue.Unchanged ->
+                            throw Incorrect(
+                                buildString {
+                                    appendLine("Received unchanged TOASTed column '${col.name}' on ${relation.schema}.${relation.table}. ")
+                                    appendLine("Set REPLICA IDENTITY FULL on the source table: ")
+                                    appendLine("ALTER TABLE \"${relation.schema}\".\"${relation.table}\" REPLICA IDENTITY FULL")
+                                }
+                            )
+
+                        is ColumnValue.Text -> PgTypeCoercion.coerce(colValue.value, col.typeOid)
+                    }
+                }
+            }
+            .toMap()
+
+    override fun close() = Unit
+
+    private suspend fun flushSnapshotBatch(
+        txIndexer: ExternalSource.TxIndexer,
+        slotLsn: Long,
+        schema: String,
+        table: String,
+        rows: List<Map<String, Any?>>,
+    ) {
+        val token = ProtoAny.pack(postgresCdcToken {
+            latestCommittedLsn = slotLsn
+            snapshotCompleted = false
+        }, PROTO_TAG)
+
+        txIndexer.indexTx(token) { openTx ->
+            for (row in rows) {
+                writeRow(openTx, dbName, schema, table, "r", row, null)
+            }
+            TxResult.Committed()
+        }
+    }
+
+    companion object {
+        // PG epoch is 2000-01-01T00:00:00Z, timestamps are in microseconds
+        private val PG_EPOCH = Instant.parse("2000-01-01T00:00:00Z")
+
+        fun pgTimestampToInstant(pgMicros: Long): Instant =
+            PG_EPOCH.plusNanos(pgMicros * 1000)
+    }
+}
+
+private fun writeRow(
+    openTx: OpenTx,
+    dbName: String,
+    schema: String,
+    table: String,
+    op: String,
+    after: Map<String, Any?>?,
+    before: Map<String, Any?>?,
+) {
+    val openTxTable = openTx.table(TableRef(dbName, schema, table))
+
+    when (op) {
+        "c", "r", "u" -> {
+            requireNotNull(after) { "Missing row data for $op operation" }
+            val docMap = after.toMutableMap()
+
+            val id = docMap["_id"] ?: throw Incorrect("Missing '_id' in row from $schema.$table")
+
+            val explicitValidFrom = (docMap.remove("_valid_from") as? Instant)?.asMicros
+            val explicitValidTo = (docMap.remove("_valid_to") as? Instant)?.asMicros
+
+            if (explicitValidTo != null && explicitValidFrom == null)
+                throw Incorrect("'_valid_to' requires '_valid_from'")
+
+            openTxTable.logPut(
+                ByteBuffer.wrap(id.asIid),
+                explicitValidFrom ?: openTx.systemFrom,
+                explicitValidTo ?: Long.MAX_VALUE,
+            ) { openTxTable.docWriter.writeObject(docMap) }
+        }
+
+        "d" -> {
+            requireNotNull(before) { "Missing 'before' data for delete — check REPLICA IDENTITY on source table" }
+            val id = before["_id"] ?: throw Incorrect("Missing '_id' in 'before' for delete on $schema.$table")
+
+            openTxTable.logDelete(
+                ByteBuffer.wrap(id.asIid),
+                openTx.systemFrom,
+                Long.MAX_VALUE,
+            )
+        }
+
+        else -> throw Incorrect("Unknown CDC op: '$op'")
+    }
+}

--- a/modules/postgres-cdc/src/main/proto/postgres_cdc.proto
+++ b/modules/postgres-cdc/src/main/proto/postgres_cdc.proto
@@ -1,0 +1,25 @@
+edition = "2023";
+
+package xtdb.postgres.proto;
+
+option java_multiple_files = true;
+
+message PostgresCdcSourceConfig {
+    string hostname = 1;
+    int32 port = 2;
+    string database = 3;
+    string username = 4;
+    string password = 5;
+    string slot_name = 6;
+    string publication_name = 7;
+    repeated string schema_include_list = 8;
+}
+
+message PostgresCdcToken {
+    // The raw Debezium-style offset is not needed here — we own the protocol.
+    // The slot's confirmed_flush_lsn tells PG where to resume streaming.
+    // We track the LSN of the last committed transaction in XT.
+    int64 latest_committed_lsn = 1;
+    int64 latest_tx_id = 2;
+    bool snapshot_completed = 3;
+}

--- a/modules/postgres-cdc/src/main/resources/META-INF/services/xtdb.database.ExternalSource$Registration
+++ b/modules/postgres-cdc/src/main/resources/META-INF/services/xtdb.database.ExternalSource$Registration
@@ -1,0 +1,1 @@
+xtdb.postgres.PostgresCdcSource$Factory$Registration

--- a/modules/postgres-cdc/src/test/kotlin/xtdb/postgres/PostgresCdcIntegrationTest.kt
+++ b/modules/postgres-cdc/src/test/kotlin/xtdb/postgres/PostgresCdcIntegrationTest.kt
@@ -222,6 +222,92 @@ class PostgresCdcIntegrationTest {
     }
 
     @Test
+    fun `multi-table snapshot and streaming`() = runTest(timeout = 120.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+        val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS pg_mt_users (_id INT PRIMARY KEY, name TEXT)",
+            "CREATE TABLE IF NOT EXISTS pg_mt_orders (_id INT PRIMARY KEY, user_id INT, amount NUMERIC)",
+            "INSERT INTO pg_mt_users (_id, name) VALUES (1, 'Alice'), (2, 'Bob')",
+            "INSERT INTO pg_mt_orders (_id, user_id, amount) VALUES (1, 1, 99.99)",
+            "CREATE PUBLICATION $pubName FOR TABLE pg_mt_users, pg_mt_orders",
+        )
+
+        openNode(sourceTopic).use { node ->
+            attachPostgresCdc(node, slotName = slotName, publicationName = pubName)
+
+            // Wait for both tables to be snapshotted
+            awaitCondition("both tables snapshotted", timeout = 30.seconds) {
+                runCatching {
+                    xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_mt_users").size == 2 &&
+                        xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_mt_orders").size == 1
+                }.getOrDefault(false)
+            }
+
+            val users = xtQueryDb(node, "cdc", "SELECT _id, name FROM public.pg_mt_users ORDER BY _id")
+            assertEquals("Alice", users[0]["name"])
+            assertEquals("Bob", users[1]["name"])
+
+            val orders = xtQueryDb(node, "cdc", "SELECT _id, user_id, amount FROM public.pg_mt_orders")
+            assertEquals(1, orders.size)
+
+            // Stream changes to both tables in a single PG transaction
+            pgExecute(
+                "BEGIN",
+                "INSERT INTO pg_mt_users (_id, name) VALUES (3, 'Charlie')",
+                "INSERT INTO pg_mt_orders (_id, user_id, amount) VALUES (2, 3, 42.00)",
+                "COMMIT",
+            )
+
+            awaitCondition("streaming changes to both tables", timeout = 30.seconds) {
+                xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_mt_users WHERE _id = 3").isNotEmpty() &&
+                    xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_mt_orders WHERE _id = 2").isNotEmpty()
+            }
+        }
+    }
+
+    @Test
+    fun `schema evolution - add column during streaming`() = runTest(timeout = 120.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+        val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS pg_evolve (_id INT PRIMARY KEY, name TEXT)",
+            "INSERT INTO pg_evolve (_id, name) VALUES (1, 'Alice')",
+            "CREATE PUBLICATION $pubName FOR TABLE pg_evolve",
+        )
+
+        openNode(sourceTopic).use { node ->
+            attachPostgresCdc(node, slotName = slotName, publicationName = pubName)
+
+            awaitCondition("Alice snapshotted", timeout = 30.seconds) {
+                runCatching {
+                    xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_evolve WHERE _id = 1").isNotEmpty()
+                }.getOrDefault(false)
+            }
+
+            // ALTER TABLE in PG while streaming is active
+            pgExecute(
+                "ALTER TABLE pg_evolve ADD COLUMN email TEXT",
+                "INSERT INTO pg_evolve (_id, name, email) VALUES (2, 'Bob', 'bob@example.com')",
+            )
+
+            awaitCondition("Bob with new column appears", timeout = 30.seconds) {
+                val rows = xtQueryDb(node, "cdc", "SELECT _id, email FROM public.pg_evolve WHERE _id = 2")
+                rows.isNotEmpty() && rows[0]["email"] == "bob@example.com"
+            }
+
+            // Alice (pre-evolution row) should have null for the new column
+            val alice = xtQueryDb(node, "cdc", "SELECT _id, name, email FROM public.pg_evolve WHERE _id = 1")
+            assertEquals(1, alice.size)
+            assertEquals(null, alice[0]["email"])
+        }
+    }
+
+    @Test
     fun `snapshot and streaming CDC lifecycle`() = runTest(timeout = 120.seconds) {
         val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
 

--- a/modules/postgres-cdc/src/test/kotlin/xtdb/postgres/PostgresCdcIntegrationTest.kt
+++ b/modules/postgres-cdc/src/test/kotlin/xtdb/postgres/PostgresCdcIntegrationTest.kt
@@ -1,0 +1,272 @@
+package xtdb.postgres
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.testcontainers.containers.Network
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.lifecycle.Startables
+import org.testcontainers.postgresql.PostgreSQLContainer
+import xtdb.api.Xtdb
+import xtdb.api.log.KafkaCluster
+import java.sql.DriverManager
+import java.util.UUID
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+@Tag("integration")
+@EnabledIfEnvironmentVariable(named = "XTDB_SINGLE_WRITER", matches = "true")
+class PostgresCdcIntegrationTest {
+
+    companion object {
+        private val network: Network = Network.newNetwork()
+
+        private val postgres = PostgreSQLContainer("postgres:17-alpine")
+            .withNetwork(network)
+            .withNetworkAliases("postgres")
+            .withDatabaseName("testdb")
+            .withUsername("testuser")
+            .withPassword("testpass")
+            .withCommand("postgres", "-c", "wal_level=logical")
+
+        private val kafka = ConfluentKafkaContainer("confluentinc/cp-kafka:7.8.0")
+            .withNetwork(network)
+            .withNetworkAliases("kafka")
+
+        @JvmStatic
+        @BeforeAll
+        fun beforeAll() {
+            Startables.deepStart(postgres, kafka).join()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            postgres.stop()
+            kafka.stop()
+            network.close()
+        }
+    }
+
+    private fun pgExecute(vararg statements: String) {
+        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { conn ->
+            conn.createStatement().use { stmt ->
+                for (sql in statements) stmt.execute(sql)
+            }
+        }
+    }
+
+    private fun openNode(sourceTopic: String): Xtdb = Xtdb.openNode {
+        server { port = 0 }; flightSql = null
+        logCluster("kafka", KafkaCluster.ClusterFactory(kafka.bootstrapServers))
+        log(KafkaCluster.LogFactory("kafka", sourceTopic))
+    }
+
+    private fun attachPostgresCdc(
+        node: Xtdb,
+        dbName: String = "cdc",
+        slotName: String = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}",
+        publicationName: String = "test_pub",
+    ) {
+        node.getConnection().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute(
+                    """
+                    ATTACH DATABASE $dbName WITH $$
+                        log: !Kafka
+                          cluster: kafka
+                          topic: test-replica-${UUID.randomUUID()}
+                        externalSource: !PostgresCdc
+                          hostname: ${postgres.host}
+                          port: ${postgres.getMappedPort(5432)}
+                          database: testdb
+                          username: testuser
+                          password: testpass
+                          slotName: $slotName
+                          publicationName: $publicationName
+                          schemaIncludeList: [public]
+                    $$""".trimIndent()
+                )
+            }
+        }
+    }
+
+    private fun xtQueryDb(node: Xtdb, dbName: String, sql: String): List<Map<String, Any?>> {
+        return node.createConnectionBuilder().database(dbName).build().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeQuery(sql).use { rs ->
+                    val metadata = rs.metaData
+                    val cols = (1..metadata.columnCount).map { metadata.getColumnName(it) }
+                    buildList {
+                        while (rs.next()) {
+                            add(cols.associateWith { rs.getObject(it) })
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun awaitTxs(node: Xtdb, expected: Int, db: String = "cdc", timeout: Duration = 5.seconds) {
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+        var count = 0L
+        while (System.currentTimeMillis() < deadline) {
+            count = xtQueryDb(node, db, "SELECT count(*) AS cnt FROM xt.txs")[0]["cnt"] as Long
+            if (count >= expected) return
+            runInterruptible { Thread.sleep(200) }
+        }
+        throw AssertionError("Timed out waiting for $expected txs on db '$db' (got $count)")
+    }
+
+    private suspend fun awaitCondition(description: String, timeout: Duration = 10.seconds, check: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+
+        while (System.currentTimeMillis() < deadline) {
+            if (check()) return
+            runInterruptible { Thread.sleep(200) }
+        }
+
+        fail("Timed out waiting for: $description")
+    }
+
+    @Test
+    fun `resume from token after restart`() = runTest(timeout = 180.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+        val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS pg_resume (_id INT PRIMARY KEY, name TEXT)",
+            "INSERT INTO pg_resume (_id, name) VALUES (1, 'Alice')",
+            "CREATE PUBLICATION $pubName FOR TABLE pg_resume",
+        )
+
+        // Phase 1: snapshot + streaming
+        openNode(sourceTopic).use { node ->
+            attachPostgresCdc(node, slotName = slotName, publicationName = pubName)
+
+            // 1 table batch + 1 completion marker = 2 txs
+            awaitTxs(node, 2, db = "cdc")
+
+            val snapshotRows = xtQueryDb(node, "cdc", "SELECT _id, name FROM public.pg_resume ORDER BY _id")
+            assertEquals(1, snapshotRows.size)
+            assertEquals("Alice", snapshotRows[0]["name"])
+
+            // Stream an insert so the token advances beyond the snapshot LSN
+            pgExecute("INSERT INTO pg_resume (_id, name) VALUES (2, 'Bob')")
+
+            awaitCondition("Bob appears", timeout = 30.seconds) {
+                xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_resume WHERE _id = 2").isNotEmpty()
+            }
+        }
+
+        // Insert while node is down — this must appear after restart
+        pgExecute("INSERT INTO pg_resume (_id, name) VALUES (3, 'Charlie')")
+
+        // Phase 2: restart with the same Kafka source topic.
+        // The node replays the ATTACH DATABASE from the source log,
+        // recovers the CDC token (snapshotCompleted=true), and resumes streaming.
+        openNode(sourceTopic).use { node ->
+            awaitCondition("Charlie appears after restart", timeout = 60.seconds) {
+                runCatching {
+                    xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_resume WHERE _id = 3").isNotEmpty()
+                }.getOrDefault(false)
+            }
+
+            val rows = xtQueryDb(node, "cdc", "SELECT _id, name FROM public.pg_resume ORDER BY _id")
+            assertEquals(3, rows.size, "All three rows should be present — no duplication, no loss")
+            assertEquals("Alice", rows[0]["name"])
+            assertEquals("Bob", rows[1]["name"])
+            assertEquals("Charlie", rows[2]["name"])
+        }
+    }
+
+    @Test
+    fun `partial snapshot failure when slot already exists`() = runTest(timeout = 120.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+        val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS pg_partial (_id INT PRIMARY KEY, name TEXT)",
+            "INSERT INTO pg_partial (_id, name) VALUES (1, 'Alice')",
+            "CREATE PUBLICATION $pubName FOR TABLE pg_partial",
+        )
+
+        // Pre-create the replication slot — simulates a previous attempt
+        // that created the slot but crashed before completing the snapshot.
+        pgExecute("SELECT pg_create_logical_replication_slot('$slotName', 'pgoutput')")
+
+        openNode(sourceTopic).use { node ->
+            attachPostgresCdc(node, slotName = slotName, publicationName = pubName)
+
+            // The CDC source will try to CREATE_REPLICATION_SLOT with the same name
+            // and fail because it already exists. Wait long enough for the attempt.
+            runInterruptible { Thread.sleep(10_000) }
+
+            // Snapshot should have failed — no data ingested.
+            val result = runCatching {
+                xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_partial")
+            }
+
+            assertTrue(
+                result.isFailure || result.getOrNull().isNullOrEmpty(),
+                "Snapshot should fail when slot already exists — expected error or no data, got: ${result.getOrNull()}"
+            )
+        }
+    }
+
+    @Test
+    fun `snapshot and streaming CDC lifecycle`() = runTest(timeout = 120.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS pg_cdc_users (_id INT PRIMARY KEY, name TEXT, email TEXT)",
+            "INSERT INTO pg_cdc_users (_id, name, email) VALUES (1, 'Alice', 'alice@example.com')",
+            "CREATE PUBLICATION $pubName FOR TABLE pg_cdc_users",
+        )
+
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+        openNode(sourceTopic).use { node ->
+            attachPostgresCdc(node, publicationName = pubName)
+
+            // Phase 1: snapshot
+            // 1 tx per table + 1 completion marker = 2 txs
+            awaitTxs(node, 2, db = "cdc")
+
+            val snapshotRows = xtQueryDb(
+                node, "cdc",
+                "SELECT _id, name, email FROM public.pg_cdc_users ORDER BY _id"
+            )
+            assertEquals(1, snapshotRows.size, "Snapshot should ingest Alice")
+            assertEquals("alice@example.com", snapshotRows[0]["email"])
+
+            // Phase 2: streaming
+            pgExecute(
+                "INSERT INTO pg_cdc_users (_id, name, email) VALUES (2, 'Bob', 'bob@example.com')",
+                "UPDATE pg_cdc_users SET email = 'alice-new@example.com' WHERE _id = 1",
+            )
+
+            awaitCondition("Alice updated", timeout = 30.seconds) {
+                xtQueryDb(node, "cdc", "SELECT email FROM public.pg_cdc_users WHERE _id = 1")
+                    .firstOrNull()?.get("email") == "alice-new@example.com"
+            }
+
+            val bob = xtQueryDb(node, "cdc", "SELECT email FROM public.pg_cdc_users WHERE _id = 2")
+            assertEquals(1, bob.size)
+            assertEquals("bob@example.com", bob[0]["email"])
+
+            // Phase 3: delete
+            pgExecute("DELETE FROM pg_cdc_users WHERE _id = 2")
+
+            awaitCondition("Bob deleted", timeout = 30.seconds) {
+                xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_cdc_users WHERE _id = 2").isEmpty()
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,10 +14,11 @@ if (file("lang/test-harness").isDirectory) {
 
 include("docker:standalone", "docker:aws", "docker:azure", "docker:google-cloud")
 
-include("modules:kafka", "modules:kafka-connect", "modules:debezium", "modules:aws", "modules:azure", "modules:google-cloud")
+include("modules:kafka", "modules:kafka-connect", "modules:debezium", "modules:postgres-cdc", "modules:aws", "modules:azure", "modules:google-cloud")
 project(":modules:kafka").name = "xtdb-kafka"
 project(":modules:kafka-connect").name = "xtdb-kafka-connect"
 project(":modules:debezium").name = "xtdb-debezium"
+project(":modules:postgres-cdc").name = "xtdb-postgres-cdc"
 project(":modules:aws").name = "xtdb-aws"
 project(":modules:azure").name = "xtdb-azure"
 project(":modules:google-cloud").name = "xtdb-google-cloud"


### PR DESCRIPTION
## Summary

PoC for a direct Postgres CDC source that talks the PG logical replication protocol via pgjdbc, bypassing Debezium entirely.

- Snapshot via `CREATE_REPLICATION_SLOT ... EXPORT_SNAPSHOT` + `SET TRANSACTION SNAPSHOT` on a second connection, batched into XT transactions of 1000 rows
- Snapshot discovers tables from `pg_publication_tables`, respecting the publication boundary
- Streaming via `PGReplicationStream` with `pgoutput` proto_version=1 (contiguous transaction delivery, no interleaving)
- Resume token: `latestCommittedLsn` + `snapshotCompleted` (ESP owns txId assignment)
- Jdbi for query-side SQL, raw pgjdbc for replication connections
- TOAST detection: errors with clear `ALTER TABLE ... REPLICA IDENTITY FULL` message
- Publication must be pre-created by the operator — the source only references `publicationName`, never issues `CREATE PUBLICATION`

See design discussion on #5130 for the Debezium impedance mismatches that motivated this approach.

### Known issues (MVP follow-ups)

- **No automatic retry on stream failure.** If the PG connection drops (e.g. PG restart, network blip), the CDC database enters an error state and the XTDB node must be restarted to recover.
- **Slot cleanup on detach is manual.** Detaching a CDC database does not drop the PG replication slot — `SELECT pg_drop_replication_slot('...')` is the operator's responsibility.
- Partial snapshot = database inoperable (PG exported snapshots are ephemeral; slot already exists on retry)
- Type coverage: arrays/composites/enums fall through as strings

## Test plan

- [x] Integration test: snapshot + streaming insert/update/delete lifecycle (testcontainers Postgres + Kafka)
- [x] Resume from token after restart
- [x] Partial snapshot failure handling
- [x] Multi-table snapshot and streaming
- [x] Schema evolution (ADD COLUMN during streaming)
- [ ] TOAST detection test

Refs #5130

🤖 Generated with [Claude Code](https://claude.com/claude-code)