### PR TITLE
refactor(config): bump kaml to 0.104, simplify !Env resolution

### DIFF
--- a/core/src/main/kotlin/xtdb/api/Authenticator.kt
+++ b/core/src/main/kotlin/xtdb/api/Authenticator.kt
@@ -112,8 +112,8 @@ interface Authenticator : AutoCloseable {
         @SerialName("!OpenIdConnect")
         data class OpenIdConnect @JvmOverloads constructor(
             val issuerUrl: URL,
-            @Serializable(with = StringWithEnvVarSerde::class) val clientId: String,
-            @Serializable(with = StringWithEnvVarSerde::class) val clientSecret: String,
+            val clientId: String,
+            val clientSecret: String,
             override var rules: List<MethodRule> = DEFAULT_RULES,
             @Transient var instantSource: InstantSource = InstantSource.system()
         ) : Factory {

--- a/core/src/main/kotlin/xtdb/api/CompactorConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/CompactorConfig.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(DurationSerde::class, IntWithEnvVarSerde::class)
+@file:UseSerializers(DurationSerde::class)
 
 package xtdb.api
 

--- a/core/src/main/kotlin/xtdb/api/FlightSqlConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/FlightSqlConfig.kt
@@ -1,9 +1,6 @@
-@file:UseSerializers(IntWithEnvVarSerde::class)
-
 package xtdb.api
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 
 @Serializable
 data class FlightSqlConfig(

--- a/core/src/main/kotlin/xtdb/api/GarbageCollectorConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/GarbageCollectorConfig.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(IntWithEnvVarSerde::class, DurationSerde::class)
+@file:UseSerializers(DurationSerde::class)
 package xtdb.api
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers

--- a/core/src/main/kotlin/xtdb/api/ServerConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/ServerConfig.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(IntWithEnvVarSerde::class, InetAddressSerde::class)
+@file:UseSerializers(InetAddressSerde::class)
 
 package xtdb.api
 
@@ -18,8 +18,8 @@ data class ServerConfig(
 
     @Serializable
     data class SslSettings(
-        @Serializable(with = PathWithEnvVarSerde::class) val keyStore: Path,
-        @Serializable(with = StringWithEnvVarSerde::class) val keyStorePassword: String
+        @Serializable(with = PathSerde::class) val keyStore: Path,
+        val keyStorePassword: String
     )
 
     fun host(host: InetAddress?) = apply { this.host = host }

--- a/core/src/main/kotlin/xtdb/api/YamlSerde.kt
+++ b/core/src/main/kotlin/xtdb/api/YamlSerde.kt
@@ -2,10 +2,18 @@
 
 package xtdb.api
 
-import com.charleskorn.kaml.*
+import com.charleskorn.kaml.Yaml
+import com.charleskorn.kaml.YamlList
+import com.charleskorn.kaml.YamlMap
+import com.charleskorn.kaml.YamlNode
+import com.charleskorn.kaml.YamlNull
+import com.charleskorn.kaml.YamlScalar
+import com.charleskorn.kaml.YamlTaggedNode
+import com.charleskorn.kaml.yamlScalar
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.modules.SerializersModule
@@ -21,112 +29,34 @@ internal object EnvironmentVariableProvider {
     fun getEnvVariable(name: String): String? = System.getenv(name)
 }
 
-internal fun envFromTaggedNode(taggedNode: YamlTaggedNode): String {
-    if (taggedNode.tag == "!Env") {
-        val value = taggedNode.innerNode.yamlScalar.content
-        return EnvironmentVariableProvider.getEnvVariable(value)
-            ?: throw IllegalArgumentException("Environment variable '$value' not found")
-    }
-    return taggedNode.innerNode.yamlScalar.content
-}
-
-internal fun handleEnvTag(input: YamlInput): String {
-    val currentLocation = input.getCurrentLocation()
-    val scalar = input.node.yamlMap.entries.values.find { it.location == currentLocation }
-
-    return when (scalar) {
-        is YamlTaggedNode -> envFromTaggedNode(scalar.yamlTaggedNode)
-        is YamlScalar -> scalar.content
-        else -> throw IllegalStateException("Expected scalar or tagged node")
-    }
+// Substitutes `!Env VAR` scalars with their resolved environment variable value.
+// Leaves other tags (polymorphic discriminators like `!Local`, `!Kafka`) untouched.
+private fun resolveEnvVars(node: YamlNode): YamlNode = when (node) {
+    is YamlScalar, is YamlNull -> node
+    is YamlList -> node.copy(items = node.items.map(::resolveEnvVars))
+    is YamlMap -> node.copy(entries = node.entries.mapValues { (_, v) -> resolveEnvVars(v) })
+    is YamlTaggedNode ->
+        if (node.tag == "!Env") {
+            val varName = node.innerNode.yamlScalar.content
+            val value = EnvironmentVariableProvider.getEnvVariable(varName)
+                ?: throw IllegalArgumentException("Environment variable '$varName' not found")
+            YamlScalar(value, node.innerNode.path)
+        } else {
+            node.copy(innerNode = resolveEnvVars(node.innerNode))
+        }
 }
 
 /**
  * @suppress
  */
-object PathWithEnvVarSerde : KSerializer<Path> {
-    override val descriptor = PrimitiveSerialDescriptor("PathWithEnvVars", PrimitiveKind.STRING)
+object PathSerde : KSerializer<Path> {
+    override val descriptor = PrimitiveSerialDescriptor("Path", PrimitiveKind.STRING)
 
     override fun serialize(encoder: Encoder, value: Path) {
         throw UnsupportedOperationException("YAML serialization of config is not supported.")
     }
 
-    override fun deserialize(decoder: Decoder): Path {
-        val yamlInput: YamlInput = decoder as YamlInput
-        val str = handleEnvTag(yamlInput)
-        return Paths.get(str)
-    }
-}
-
-/**
- * @suppress
- */
-object StringWithEnvVarSerde : KSerializer<String> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("StringWithEnvVars", PrimitiveKind.STRING)
-
-    override fun serialize(encoder: Encoder, value: String) {
-        throw UnsupportedOperationException("YAML serialization of config is not supported.")
-    }
-
-    override fun deserialize(decoder: Decoder): String {
-        val yamlInput: YamlInput = decoder as YamlInput
-        return handleEnvTag(yamlInput)
-    }
-}
-
-object StringMapWithEnvVarsSerde : KSerializer<Map<String, String>> {
-    @OptIn(
-        kotlinx.serialization.ExperimentalSerializationApi::class,
-        kotlinx.serialization.InternalSerializationApi::class
-    )
-    override val descriptor: SerialDescriptor = buildSerialDescriptor("StringMapWithEnvVarsSerde", StructureKind.MAP)
-
-    override fun serialize(encoder: Encoder, value: Map<String, String>) {
-        throw UnsupportedOperationException("YAML serialization of config is not supported.")
-    }
-
-    override fun deserialize(decoder: Decoder): Map<String, String> {
-        val yamlInput: YamlInput = decoder as YamlInput
-        val currentLocation = yamlInput.getCurrentLocation()
-        val mapNode = yamlInput.node.yamlMap.entries.values.find { it.location == currentLocation }?.yamlMap
-            ?: throw IllegalStateException("Expected map node at current location")
-
-        return mapNode.entries.entries.associate { (keyNode, valueNode): Map.Entry<YamlScalar, YamlNode> ->
-            val key = keyNode.content
-            val value = when (valueNode) {
-                is YamlTaggedNode -> envFromTaggedNode(valueNode.yamlTaggedNode)
-                is YamlScalar -> valueNode.content
-                else -> throw IllegalStateException("Expected scalar or tagged node")
-            }
-            key to value
-        }
-    }
-}
-
-object BooleanWithEnvVarSerde : KSerializer<Boolean> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BooleanWithEnvVars", PrimitiveKind.BOOLEAN)
-
-    override fun serialize(encoder: Encoder, value: Boolean) {
-        throw UnsupportedOperationException("YAML serialization of config is not supported.")
-    }
-
-    override fun deserialize(decoder: Decoder): Boolean {
-        val yamlInput: YamlInput = decoder as YamlInput
-        return handleEnvTag(yamlInput).toBoolean()
-    }
-}
-
-object IntWithEnvVarSerde : KSerializer<Int> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BooleanWithEnvVars", PrimitiveKind.BOOLEAN)
-
-    override fun serialize(encoder: Encoder, value: Int) {
-        throw UnsupportedOperationException("YAML serialization of config is not supported.")
-    }
-
-    override fun deserialize(decoder: Decoder): Int {
-        val yamlInput: YamlInput = decoder as YamlInput
-        return handleEnvTag(yamlInput).toInt()
-    }
+    override fun deserialize(decoder: Decoder): Path = Paths.get(decoder.decodeString())
 }
 
 object InetAddressSerde : KSerializer<InetAddress?> {
@@ -156,5 +86,7 @@ val YAML_SERDE = Yaml(
 /**
  * @suppress
  */
-fun nodeConfig(yamlString: String): Xtdb.Config =
-    YAML_SERDE.decodeFromString<Xtdb.Config>(yamlString)
+fun nodeConfig(yamlString: String): Xtdb.Config {
+    val root = resolveEnvVars(YAML_SERDE.parseToYamlNode(yamlString))
+    return YAML_SERDE.decodeFromYamlNode(root)
+}

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(DurationSerde::class, PathWithEnvVarSerde::class)
+@file:UseSerializers(DurationSerde::class, PathSerde::class)
 
 package xtdb.api.log
 
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.UseSerializers
 import xtdb.DurationSerde
-import xtdb.api.PathWithEnvVarSerde
+import xtdb.api.PathSerde
 import xtdb.api.log.Log.*
 import xtdb.database.proto.DatabaseConfig
 import xtdb.util.MsgIdUtil

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(DurationSerde::class, PathWithEnvVarSerde::class)
+@file:UseSerializers(DurationSerde::class, PathSerde::class)
 
 package xtdb.api.log
 
@@ -10,7 +10,7 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 import xtdb.DurationSerde
-import xtdb.api.PathWithEnvVarSerde
+import xtdb.api.PathSerde
 import xtdb.database.proto.DatabaseConfig
 import xtdb.database.proto.DatabaseConfig.LogCase.*
 import xtdb.util.MsgIdUtil.offsetToMsgId

--- a/core/src/main/kotlin/xtdb/api/metrics/HealthzConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/metrics/HealthzConfig.kt
@@ -1,11 +1,10 @@
-@file:UseSerializers(IntWithEnvVarSerde::class, InetAddressSerde::class)
+@file:UseSerializers(InetAddressSerde::class)
 
 package xtdb.api.metrics
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import xtdb.api.InetAddressSerde
-import xtdb.api.IntWithEnvVarSerde
 import java.net.InetAddress
 
 @Serializable

--- a/core/src/main/kotlin/xtdb/api/metrics/TracerConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/metrics/TracerConfig.kt
@@ -1,14 +1,8 @@
-@file:UseSerializers(StringWithEnvVarSerde::class)
-
 package xtdb.api.metrics
 
 import io.opentelemetry.sdk.trace.SpanProcessor
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
-import kotlinx.serialization.UseSerializers
-import xtdb.DurationSerde
-import xtdb.api.IntWithEnvVarSerde
-import xtdb.api.StringWithEnvVarSerde
 
 @Serializable
 data class TracerConfig(

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(PathWithEnvVarSerde::class)
+@file:UseSerializers(PathSerde::class)
 
 package xtdb.api.storage
 
@@ -10,7 +10,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.ipc.message.ArrowFooter
-import xtdb.api.PathWithEnvVarSerde
+import xtdb.api.PathSerde
 import xtdb.cache.DiskCache
 import xtdb.cache.MemoryCache
 import xtdb.database.DatabaseName

--- a/core/src/main/kotlin/xtdb/cache/DiskCache.kt
+++ b/core/src/main/kotlin/xtdb/cache/DiskCache.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(PathWithEnvVarSerde::class)
+@file:UseSerializers(PathSerde::class)
 package xtdb.cache
 
 import com.github.benmanes.caffeine.cache.RemovalCause
@@ -6,7 +6,7 @@ import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
-import xtdb.api.PathWithEnvVarSerde
+import xtdb.api.PathSerde
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption.ATOMIC_MOVE

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,7 +84,7 @@ kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.10.0" }
 mockk = { group = "io.mockk", name = "mockk", version = "1.14.9" }
-kaml = { group = "com.charleskorn.kaml", name = "kaml", version = "0.56.0" }
+kaml = { group = "com.charleskorn.kaml", name = "kaml", version = "0.104.0" }
 kotest = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
 kotest-props = { group = "io.kotest", name = "kotest-property", version.ref = "kotest" }
 

--- a/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(PathWithEnvVarSerde::class, StringWithEnvVarSerde::class)
+@file:UseSerializers(PathSerde::class)
 
 package xtdb.aws
 
@@ -21,8 +21,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.S3Configuration
 import software.amazon.awssdk.services.s3.model.*
-import xtdb.api.PathWithEnvVarSerde
-import xtdb.api.StringWithEnvVarSerde
+import xtdb.api.PathSerde
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.ObjectStore.Companion.throwMissingKey
 import xtdb.api.storage.ObjectStore.StoredObject
@@ -257,19 +256,19 @@ class S3(
 
         @Serializable
         data class BasicCredentials(
-            @Serializable(StringWithEnvVarSerde::class) val accessKey: String,
-            @Serializable(StringWithEnvVarSerde::class) val secretKey: String
+            val accessKey: String,
+            val secretKey: String
         )
     }
 
     @Serializable
     @SerialName("!S3")
     data class Factory(
-        @Serializable(StringWithEnvVarSerde::class) var region: String? = null,
-        @Serializable(StringWithEnvVarSerde::class) val bucket: String,
-        @Serializable(PathWithEnvVarSerde::class) var prefix: Path? = null,
+        var region: String? = null,
+        val bucket: String,
+        @Serializable(PathSerde::class) var prefix: Path? = null,
         var credentials: BasicCredentials? = null,
-        @Serializable(StringWithEnvVarSerde::class) var endpoint: String? = null,
+        var endpoint: String? = null,
         var pathStyleAccessEnabled: Boolean = false,
         @Transient var s3Configurator: S3Configurator = S3Configurator.Default,
         @Transient var coroutineContext: CoroutineContext = Dispatchers.IO

--- a/modules/azure/src/main/kotlin/xtdb/azure/AzureMonitorMetrics.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/AzureMonitorMetrics.kt
@@ -8,13 +8,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.subclass
 import xtdb.api.module.XtdbModule
-import xtdb.api.StringWithEnvVarSerde
 import xtdb.api.Xtdb
 
 @Serializable
 @SerialName("!AzureMonitor")
 class AzureMonitorMetrics(
-    @Serializable(StringWithEnvVarSerde::class) val connectionString: String,
+    val connectionString: String,
 ) : XtdbModule.Factory {
 
     override val moduleKey = "xtdb.metrics.azure-monitor"

--- a/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(StringWithEnvVarSerde::class, PathWithEnvVarSerde::class)
+@file:UseSerializers(PathSerde::class)
 
 package xtdb.azure
 
@@ -18,8 +18,7 @@ import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.subclass
 import reactor.core.Exceptions
-import xtdb.api.PathWithEnvVarSerde
-import xtdb.api.StringWithEnvVarSerde
+import xtdb.api.PathSerde
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.ObjectStore.Companion.throwMissingKey
 import xtdb.api.storage.ObjectStore.StoredObject

--- a/modules/google-cloud/src/main/kotlin/xtdb/gcp/CloudStorage.kt
+++ b/modules/google-cloud/src/main/kotlin/xtdb/gcp/CloudStorage.kt
@@ -1,4 +1,4 @@
-@file:UseSerializers(StringWithEnvVarSerde::class, PathWithEnvVarSerde::class)
+@file:UseSerializers(PathSerde::class)
 package xtdb.gcp
 
 import clojure.lang.ExceptionInfo
@@ -15,8 +15,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.subclass
-import xtdb.api.PathWithEnvVarSerde
-import xtdb.api.StringWithEnvVarSerde
+import xtdb.api.PathSerde
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.ObjectStore.Companion.throwMissingKey
 import xtdb.api.storage.ObjectStore.StoredObject

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -1,8 +1,6 @@
 @file:UseSerializers(
-    StringMapWithEnvVarsSerde::class,
     DurationSerde::class,
-    StringWithEnvVarSerde::class,
-    PathWithEnvVarSerde::class
+    PathSerde::class
 )
 
 package xtdb.api.log
@@ -30,9 +28,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.Serializer
 import xtdb.DurationSerde
-import xtdb.api.PathWithEnvVarSerde
-import xtdb.api.StringMapWithEnvVarsSerde
-import xtdb.api.StringWithEnvVarSerde
+import xtdb.api.PathSerde
 import xtdb.database.proto.DatabaseConfig
 import xtdb.kafka.proto.KafkaLogConfig
 import xtdb.kafka.proto.kafkaLogConfig


### PR DESCRIPTION
Bumps the kaml YAML library from 0.56.0 → 0.104.0.
We were 48 versions behind and upstream archived in Nov 2025, with 0.104 as the final release.
(A maintained fork, `kotaml`, exists — bumping on the same group id first, the move to kotaml is a separate decision.)

## Why this isn't a one-line bump

0.56 had a latent bug our `!Env` YAML-tag resolution was built on: when a field had a custom `KSerializer`, kaml passed the *parent* `YamlObjectInput` to `deserialize()`, so `input.node` returned the enclosing map.
`handleEnvTag` exploited that — walk the parent's entries by source location, find the scalar at the current location, read its `!Env` tag.

0.104 closes the loophole in `YamlMapLikeInputBase.decodeSerializableValue()` — it now dispatches to the child input correctly.
By then, kaml's `createFor` has already unwrapped a `YamlTaggedNode` to its inner scalar, so our serializer never sees the tag.
No surgical patch recovers this.

## The fix

Resolve `!Env` at the `YamlNode` layer, before kotlinx-serialization runs.
Parse YAML to a node tree, recursively substitute `YamlTaggedNode("!Env", x)` with a plain `YamlScalar(env[x])`, then `decodeFromYamlNode`.
Polymorphic discriminators (`!Local`, `!Kafka`, `!S3`, ...) are preserved — only `!Env` is rewritten.

Consequence: the entire `*WithEnvVarSerde` family (`String`/`Int`/`Boolean`/`Path`/`StringMap`) disappears — default serialization handles the resolved scalars.
`PathSerde` stays as the sole exception (kotlinx-serialization has no built-in `Path` serializer).
`InetAddressSerde` is unrelated (handles `*` → null) and stays.

## Out of scope

The missing-env-var path still throws `IllegalArgumentException` rather than using `xtdb.error`.
Pre-existing behaviour, worth migrating but in a separate, cross-cutting pass.

## Test plan

- [x] `./gradlew :xtdb-core:test --tests 'xtdb.api.YamlSerdeTest'` — 15 tests, all pass
- [x] `./gradlew test` — 1,447 tests, all pass
- [ ] `./gradlew integration-test` — CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)