### PR TITLE
fix: skip attach/detach-db processing on secondaries

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -93,15 +93,19 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 val txKey = TransactionKey(msg.txId, systemTime)
                 if (msg.committed) {
                     when (val dbOp = msg.dbOp) {
-                        is DbOp.Attach -> try {
-                            dbCatalog!!.attach(dbOp.dbName, dbOp.config)
-                        } catch (e: Anomaly.Caller) {
-                            LOG.debug(e) { "[$dbName] follower: attach database '${dbOp.dbName}' failed" }
+                        is DbOp.Attach -> if (dbCatalog != null) {
+                            try {
+                                dbCatalog.attach(dbOp.dbName, dbOp.config)
+                            } catch (e: Anomaly.Caller) {
+                                LOG.debug(e) { "[$dbName] follower: attach database '${dbOp.dbName}' failed" }
+                            }
                         }
-                        is DbOp.Detach -> try {
-                            dbCatalog!!.detach(dbOp.dbName)
-                        } catch (e: Anomaly.Caller) {
-                            LOG.debug(e) { "[$dbName] follower: detach database '${dbOp.dbName}' failed" }
+                        is DbOp.Detach -> if (dbCatalog != null) {
+                            try {
+                                dbCatalog.detach(dbOp.dbName)
+                            } catch (e: Anomaly.Caller) {
+                                LOG.debug(e) { "[$dbName] follower: detach database '${dbOp.dbName}' failed" }
+                            }
                         }
                         null -> {}
                     }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -206,13 +206,15 @@ class LeaderLogProcessor(
 
                     is SourceMessage.AttachDatabase -> {
                         val txKey = TransactionKey(msgId, record.logTimestamp)
-                        val error = try {
-                            dbCatalog!!.attach(msg.dbName, msg.config)
-                            null
-                        } catch (e: Anomaly.Caller) {
-                            LOG.debug(e) { "[$dbName] leader: attach database '${msg.dbName}' failed at $msgId" }
-                            e
-                        }
+                        val error = if (dbCatalog != null) {
+                            try {
+                                dbCatalog.attach(msg.dbName, msg.config)
+                                null
+                            } catch (e: Anomaly.Caller) {
+                                LOG.debug(e) { "[$dbName] leader: attach database '${msg.dbName}' failed at $msgId" }
+                                e
+                            }
+                        } else null
 
                         val resolvedTx = indexer.addTxRow(txKey, error)
                             .let { if (error == null) it.copy(dbOp = DbOp.Attach(msg.dbName, msg.config)) else it }
@@ -228,13 +230,15 @@ class LeaderLogProcessor(
 
                     is SourceMessage.DetachDatabase -> {
                         val txKey = TransactionKey(msgId, record.logTimestamp)
-                        val error = try {
-                            dbCatalog!!.detach(msg.dbName)
-                            null
-                        } catch (e: Anomaly.Caller) {
-                            LOG.debug(e) { "[$dbName] leader: detach database '${msg.dbName}' failed at $msgId" }
-                            e
-                        }
+                        val error = if (dbCatalog != null) {
+                            try {
+                                dbCatalog.detach(msg.dbName)
+                                null
+                            } catch (e: Anomaly.Caller) {
+                                LOG.debug(e) { "[$dbName] leader: detach database '${msg.dbName}' failed at $msgId" }
+                                e
+                            }
+                        } else null
 
                         val resolvedTx = indexer.addTxRow(txKey, error)
                             .let { if (error == null) it.copy(dbOp = DbOp.Detach(msg.dbName)) else it }

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
@@ -309,13 +309,15 @@ class SourceLogProcessor(
 
                     is SourceMessage.AttachDatabase -> {
                         val txKey = TransactionKey(msgId, record.logTimestamp)
-                        val error = try {
-                            dbCatalog!!.attach(msg.dbName, msg.config)
-                            null
-                        } catch (e: Anomaly.Caller) {
-                            LOG.debug(e) { "[$dbName] source: attach database '${msg.dbName}' failed at $msgId" }
-                            e
-                        }
+                        val error = if (dbCatalog != null) {
+                            try {
+                                dbCatalog.attach(msg.dbName, msg.config)
+                                null
+                            } catch (e: Anomaly.Caller) {
+                                LOG.debug(e) { "[$dbName] source: attach database '${msg.dbName}' failed at $msgId" }
+                                e
+                            }
+                        } else null
 
                         indexer.addTxRow(txKey, error)
 
@@ -326,13 +328,15 @@ class SourceLogProcessor(
 
                     is SourceMessage.DetachDatabase -> {
                         val txKey = TransactionKey(msgId, record.logTimestamp)
-                        val error = try {
-                            dbCatalog!!.detach(msg.dbName)
-                            null
-                        } catch (e: Anomaly.Caller) {
-                            LOG.debug(e) { "[$dbName] source: detach database '${msg.dbName}' failed at $msgId" }
-                            e
-                        }
+                        val error = if (dbCatalog != null) {
+                            try {
+                                dbCatalog.detach(msg.dbName)
+                                null
+                            } catch (e: Anomaly.Caller) {
+                                LOG.debug(e) { "[$dbName] source: detach database '${msg.dbName}' failed at $msgId" }
+                                e
+                            }
+                        } else null
 
                         indexer.addTxRow(txKey, error)
 

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -65,15 +65,19 @@ class TransitionLogProcessor(
                 val txKey = TransactionKey(msg.txId, msg.systemTime)
                 if (msg.committed) {
                     when (val dbOp = msg.dbOp) {
-                        is DbOp.Attach -> try {
-                            dbCatalog!!.attach(dbOp.dbName, dbOp.config)
-                        } catch (e: Anomaly.Caller) {
-                            LOG.debug(e) { "[$dbName] transition: attach database '${dbOp.dbName}' failed" }
+                        is DbOp.Attach -> if (dbCatalog != null) {
+                            try {
+                                dbCatalog.attach(dbOp.dbName, dbOp.config)
+                            } catch (e: Anomaly.Caller) {
+                                LOG.debug(e) { "[$dbName] transition: attach database '${dbOp.dbName}' failed" }
+                            }
                         }
-                        is DbOp.Detach -> try {
-                            dbCatalog!!.detach(dbOp.dbName)
-                        } catch (e: Anomaly.Caller) {
-                            LOG.debug(e) { "[$dbName] transition: detach database '${dbOp.dbName}' failed" }
+                        is DbOp.Detach -> if (dbCatalog != null) {
+                            try {
+                                dbCatalog.detach(dbOp.dbName)
+                            } catch (e: Anomaly.Caller) {
+                                LOG.debug(e) { "[$dbName] transition: detach database '${dbOp.dbName}' failed" }
+                            }
                         }
                         null -> {}
                     }

--- a/src/test/clojure/xtdb/sql/multi_db_test.clj
+++ b/src/test/clojure/xtdb/sql/multi_db_test.clj
@@ -361,6 +361,53 @@ ATTACH DATABASE new_db WITH $$
                              (.build))]
           (t/is (= {:_id "secondary"} (jdbc/execute-one! conn ["SELECT * FROM foo"]))))))))
 
+(t/deftest secondary-node-handles-attach-db-in-shared-log
+  (let [xt1-dir (util/->path "target/multi-db/attach-base/xt1")
+        xt1-secondary-dir (util/->path "target/multi-db/attach-base/xt1-secondary")]
+    (util/delete-dir (util/->path "target/multi-db/attach-base"))
+
+    (with-open [xt1 (xtn/start-node {:log [:local {:path (.resolve xt1-dir "log")}]
+                                     :storage [:local {:path (.resolve xt1-dir "objects")}]})]
+
+      ;; write some data to xt1's primary database
+      (xt/submit-tx xt1 [[:put-docs :foo {:xt/id "from-xt1"}]])
+
+      (with-open [xt2 (xtn/start-node)]
+
+        ;; xt2 attaches xt1's primary database as a read-only secondary
+        (jdbc/execute! xt2 ["
+ATTACH DATABASE xt1_db WITH $$
+  log: !Local
+    path: 'target/multi-db/attach-base/xt1/log'
+  storage: !Local
+    path: 'target/multi-db/attach-base/xt1/objects'
+  mode: read-only
+$$"])
+
+        (t/is (= [{:xt/id "from-xt1"}]
+                 (xt/q xt2 "SELECT * FROM xt1_db.foo"))
+              "xt2 can read xt1's data via attached secondary")
+
+        ;; xt1 attaches a new secondary database — this writes an AttachDatabase
+        ;; message into xt1's primary log, which xt2 is also watching
+        (jdbc/execute! xt1 [(format "
+ATTACH DATABASE new_secondary WITH $$
+  log: !Local
+    path: '%s/log'
+  storage: !Local
+    path: '%s/objects'
+$$" xt1-secondary-dir xt1-secondary-dir)])
+
+        ;; sync xt2 so it processes the attach-db message from xt1's log
+        (xt-log/sync-node xt2 #xt/duration "PT5S")
+
+        (t/testing "xt2 still functional after processing xt1's attach-db message"
+          (xt/submit-tx xt1 [[:put-docs :foo {:xt/id "from-xt1", :v 2}]])
+          (xt-log/sync-node xt2 #xt/duration "PT5S")
+
+          (t/is (= [{:xt/id "from-xt1", :v 2}]
+                   (xt/q xt2 "SELECT * FROM xt1_db.foo"))))))))
+
 (t/deftest detach-dormant-database
   (let [node-dir (util/->path "target/multi-db/detach-dormant")]
     (util/delete-dir node-dir)


### PR DESCRIPTION
## Summary

- Non-primary databases watching another node's log NPE on `AttachDatabase`/`DetachDatabase` messages because `dbCatalog` is only present on the primary database's log processors
- Guard the catalog mutation behind `dbCatalog != null` across all four processors: `SourceLogProcessor`, `LeaderLogProcessor`, `FollowerLogProcessor`, and `TransitionLogProcessor`
- Non-primary processors record the message as a committed no-op tx (keeping tx-ids aligned) without attempting the side-effect

## Test plan

- [x] New test `secondary-node-handles-attach-db-in-shared-log` in `multi_db_test.clj` — verified it fails before fix (NPE) and passes after
- [x] Passes in both default and `XTDB_SINGLE_WRITER=true` modes (covering SourceLogProcessor and Leader/FollowerLogProcessor paths respectively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)