### PR TITLE
feat(kafka): shared group consumer per KafkaCluster

### DIFF
--- a/core/src/main/kotlin/xtdb/util/IOUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/IOUtil.kt
@@ -21,6 +21,10 @@ fun Iterable<AutoCloseable?>.closeAll() {
     forEach { it?.close() }
 }
 
+fun <T : AutoCloseable> Lazy<T>.close() {
+    if (isInitialized()) value.close()
+}
+
 fun <K, V : AutoCloseable?> Map<K, V>.closeAll() {
     values.closeAll()
 }

--- a/modules/kafka/src/main/clojure/xtdb/kafka.clj
+++ b/modules/kafka/src/main/clojure/xtdb/kafka.clj
@@ -5,18 +5,18 @@
   (:import [xtdb.api.log KafkaCluster$ClusterFactory KafkaCluster$LogFactory]))
 
 (defmethod log/->log-cluster-factory ::cluster
-  [_ {:keys [bootstrap-servers poll-duration properties-map properties-file transactional-id-prefix]}]
+  [_ {:keys [bootstrap-servers poll-duration properties-map properties-file transactional-id-prefix group-id]}]
   (cond-> (KafkaCluster$ClusterFactory. bootstrap-servers)
     poll-duration (.pollDuration (time/->duration poll-duration))
     properties-map (.propertiesMap properties-map)
     properties-file (.propertiesFile (util/->path properties-file))
-    transactional-id-prefix (.transactionalIdPrefix transactional-id-prefix)))
+    transactional-id-prefix (.transactionalIdPrefix transactional-id-prefix)
+    group-id (.groupId group-id)))
 
-(defmethod log/->log-factory ::kafka [_ {:keys [cluster topic replica-cluster replica-topic epoch group-id] :as opts}]
+(defmethod log/->log-factory ::kafka [_ {:keys [cluster topic replica-cluster replica-topic epoch] :as opts}]
   (let [cluster-str (str (symbol cluster))]
     (cond-> (KafkaCluster$LogFactory. cluster-str topic
                                       (or replica-cluster cluster-str)
                                       (or replica-topic (str topic "-replica"))
                                       (boolean (:create-topic? opts true)))
-      epoch (.epoch epoch)
-      group-id (.groupId group-id))))
+      epoch (.epoch epoch))))

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -6,6 +6,12 @@
 package xtdb.api.log
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.selects.onTimeout
+import kotlinx.coroutines.selects.select
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
@@ -15,6 +21,8 @@ import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.KafkaProducer
@@ -35,6 +43,10 @@ import xtdb.kafka.proto.kafkaLogConfig
 import xtdb.util.MsgIdUtil.afterMsgIdToOffset
 import xtdb.util.MsgIdUtil.msgIdToEpoch
 import xtdb.util.MsgIdUtil.msgIdToOffset
+import xtdb.util.close
+import xtdb.util.error
+import xtdb.util.info
+import xtdb.util.logger
 import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant.ofEpochMilli
@@ -42,10 +54,10 @@ import java.util.*
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.resume
 import kotlin.io.path.inputStream
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import xtdb.util.info
-import xtdb.util.logger
 import com.google.protobuf.Any as ProtoAny
 
 private val LOG = KafkaCluster::class.logger
@@ -119,14 +131,186 @@ class KafkaCluster(
     private val pollDuration: Duration,
     val schemaRegistryUrl: String? = null,
     val transactionalIdPrefix: String? = null,
+    private val groupId: String = "xtdb",
     coroutineContext: CoroutineContext = Dispatchers.Default
 ) : Log.Cluster {
     val producer = kafkaConfigMap.openProducer()
     val scope = CoroutineScope(SupervisorJob() + coroutineContext)
 
+    private sealed interface GroupCommand {
+        class Register(val topic: String, val subscription: SharedGroupConsumer.TopicSubscription<*>) : GroupCommand
+        class Unregister(val topic: String, val cont: CancellableContinuation<Unit>) : GroupCommand
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private inner class SharedGroupConsumer : AutoCloseable {
+        private val subscriptions = mutableMapOf<String, TopicSubscription<*>>()
+        private val commandCh = Channel<GroupCommand>(Channel.UNLIMITED)
+
+        private val consumer: KafkaConsumer<Unit, ByteArray> =
+            kafkaConfigMap.plus(mapOf("group.id" to groupId)).openConsumer()
+
+        inner class TopicSubscription<M>(
+            val codec: MessageCodec<M>,
+            val epoch: Int,
+            val listener: Log.SubscriptionListener<M>,
+            var processor: Log.RecordProcessor<M>?,
+        ) {
+            // expecting a load of change here for multi-part.
+
+            suspend fun onPartitionAssigned(tp: TopicPartition) {
+                listener.onPartitionsAssigned(listOf(tp.partition()))
+                    ?.let { tailSpec ->
+                        processor = tailSpec.processor
+                        consumer.seek(tp, afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1)
+                    }
+            }
+
+            suspend fun onPartitionRevoked(tp: TopicPartition) {
+                listener.onPartitionsRevoked(listOf(tp.partition()))
+                processor = null
+            }
+
+            suspend fun processRecords(records: List<ConsumerRecord<*, ByteArray>>) {
+                processor!!.processRecords(
+                    records.mapNotNull { rec ->
+                        codec.decode(rec.value())
+                            ?.let { msg -> Log.Record(epoch, rec.offset(), ofEpochMilli(rec.timestamp()), msg) }
+                    })
+            }
+        }
+
+
+        private inline fun launderInterruptedException(block: () -> Unit) =
+            try {
+                block()
+            } catch (e: InterruptedException) {
+                throw InterruptException(e)
+            }
+
+
+        private fun applySubscriptions() {
+            val topics = subscriptions.keys.toList()
+
+            if (topics.isEmpty()) consumer.unsubscribe()
+            else consumer.subscribe(topics, object : ConsumerRebalanceListener {
+                override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) =
+                    launderInterruptedException {
+                        runBlocking {
+                            for ((topic, tps) in partitions.groupBy { it.topic() }) {
+                                val sub = subscriptions[topic] as? TopicSubscription<Any?> ?: continue
+                                sub.onPartitionAssigned(tps.single())
+                            }
+                        }
+                    }
+
+                override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) =
+                    launderInterruptedException {
+                        runBlocking {
+                            for ((topic, tps) in partitions.groupBy { it.topic() }) {
+                                subscriptions[topic]?.onPartitionRevoked(tps.single())
+                            }
+                        }
+                    }
+            })
+        }
+
+        private fun processCommand(cmd: GroupCommand) {
+            when (cmd) {
+                is GroupCommand.Register -> {
+                    check(cmd.topic !in subscriptions) { "Topic ${cmd.topic} already registered" }
+                    subscriptions[cmd.topic] = cmd.subscription
+                    applySubscriptions()
+                }
+
+                is GroupCommand.Unregister -> {
+                    subscriptions.remove(cmd.topic)?.listener?.onPartitionsRevokedSync(listOf(0))
+                    applySubscriptions()
+                    cmd.cont.resume(Unit)
+                }
+            }
+        }
+
+        private suspend fun KafkaConsumer<*, ByteArray>.pollRecords() =
+            runInterruptible(Dispatchers.IO) {
+                try {
+                    poll(pollDuration)
+                } catch (_: WakeupException) {
+                    ConsumerRecords.empty()
+                } catch (e: InterruptException) {
+                    throw InterruptedException().initCause(e)
+                }
+            }
+
+        private val pollingJob: Job = scope.launch {
+            try {
+                while (isActive) {
+                    select {
+                        commandCh.onReceive { processCommand(it) }
+
+                        if (subscriptions.isNotEmpty()) {
+                            @OptIn(ExperimentalCoroutinesApi::class)
+                            onTimeout(0.milliseconds) {
+                                consumer.pollRecords()?.let { consumerRecords ->
+                                    for ((topic, recs) in consumerRecords.groupBy { it.topic() }) {
+                                        val sub = subscriptions[topic]
+                                            ?: error("Received records for unsubscribed topic $topic")
+
+                                        sub.processRecords(recs)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                LOG.error(e) { "SharedGroupConsumer poll loop failed" }
+                throw e
+            }
+        }
+
+        suspend fun <M> register(
+            topic: String,
+            codec: MessageCodec<M>,
+            epoch: Int,
+            listener: Log.SubscriptionListener<M>
+        ) {
+            commandCh.send(GroupCommand.Register(topic, TopicSubscription(codec, epoch, listener, null)))
+            consumer.wakeup()
+        }
+
+        suspend fun unregister(topic: String) {
+            suspendCancellableCoroutine { cont ->
+                commandCh.trySendBlocking(GroupCommand.Unregister(topic, cont)).getOrThrow()
+                consumer.wakeup()
+            }
+        }
+
+        override fun close() {
+            consumer.wakeup()
+            pollingJob.cancel()
+            commandCh.close()
+            try {
+                runBlocking { withTimeout(30.seconds) { pollingJob.join() } }
+            } finally {
+                check(subscriptions.isEmpty()) { "SharedGroupConsumer closed with active subscriptions: ${subscriptions.keys}" }
+                consumer.close()
+            }
+        }
+    }
+
+    private val _sharedGroupConsumer = lazy { SharedGroupConsumer() }
+    private val sharedGroupConsumer by _sharedGroupConsumer
+
     override fun close() {
-        runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
-        producer.close()
+        try {
+            _sharedGroupConsumer.close()
+        } finally {
+            runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
+            producer.close()
+        }
     }
 
     @Serializable
@@ -138,6 +322,7 @@ class KafkaCluster(
         var propertiesFile: Path? = null,
         var schemaRegistryUrl: String? = null,
         var transactionalIdPrefix: String? = null,
+        var groupId: String = "xtdb",
         @kotlinx.serialization.Transient var coroutineContext: CoroutineContext = Dispatchers.Default
     ) : Log.Cluster.Factory<KafkaCluster> {
 
@@ -145,7 +330,10 @@ class KafkaCluster(
         fun propertiesMap(propertiesMap: Map<String, String>) = apply { this.propertiesMap = propertiesMap }
         fun propertiesFile(propertiesFile: Path) = apply { this.propertiesFile = propertiesFile }
         fun schemaRegistryUrl(schemaRegistryUrl: String) = apply { this.schemaRegistryUrl = schemaRegistryUrl }
-        fun transactionalIdPrefix(transactionalIdPrefix: String?) = apply { this.transactionalIdPrefix = transactionalIdPrefix }
+        fun transactionalIdPrefix(transactionalIdPrefix: String?) =
+            apply { this.transactionalIdPrefix = transactionalIdPrefix }
+
+        fun groupId(groupId: String) = apply { this.groupId = groupId }
 
         private val Path.asPropertiesMap: Map<String, String>
             get() =
@@ -158,7 +346,8 @@ class KafkaCluster(
                 .plus(propertiesMap)
                 .plus(propertiesFile?.asPropertiesMap.orEmpty())
 
-        override fun open(): KafkaCluster = KafkaCluster(configMap, pollDuration, schemaRegistryUrl, transactionalIdPrefix, coroutineContext)
+        override fun open(): KafkaCluster =
+            KafkaCluster(configMap, pollDuration, schemaRegistryUrl, transactionalIdPrefix, groupId, coroutineContext)
     }
 
     interface AtomicProducer<M> : Log.AtomicProducer<M> {
@@ -192,7 +381,6 @@ class KafkaCluster(
         private val codec: MessageCodec<M>,
         private val topic: String,
         override val epoch: Int,
-        private val groupId: String
     ) : Log<M> {
 
         private fun readLatestSubmittedMessage(kafkaConfigMap: KafkaConfigMap): LogOffset =
@@ -343,10 +531,13 @@ class KafkaCluster(
 
         private fun KafkaConsumer<*, ByteArray>.pollRecords(): List<Log.Record<M>> =
             try {
-                poll(pollDuration).records(topic)
+                poll(pollDuration)
+                    .records(topic)
                     .mapNotNull { rec ->
-                        val msg = codec.decode(rec.value()) ?: return@mapNotNull null
-                        Log.Record(epoch, rec.offset(), ofEpochMilli(rec.timestamp()), msg)
+                        Log.Record(
+                            epoch, rec.offset(), ofEpochMilli(rec.timestamp()),
+                            codec.decode(rec.value()) ?: return@mapNotNull null
+                        )
                     }
             } catch (_: WakeupException) {
                 emptyList()
@@ -355,8 +546,7 @@ class KafkaCluster(
             }
 
         override suspend fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) = coroutineScope {
-            val c = kafkaConfigMap.openConsumer()
-            try {
+            kafkaConfigMap.openConsumer().use { c ->
                 val tp = TopicPartition(topic, 0)
                 c.assign(listOf(tp))
                 c.seek(tp, afterMsgIdToOffset(epoch, afterMsgId) + 1)
@@ -365,43 +555,16 @@ class KafkaCluster(
                     val records = runInterruptible(Dispatchers.IO) { c.pollRecords() }
                     if (records.isNotEmpty()) processor.processRecords(records)
                 }
-            } finally {
-                c.close()
             }
         }
 
-        override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>) = coroutineScope {
-            val c = kafkaConfigMap.plus(mapOf("group.id" to groupId)).openConsumer()
+        override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>) {
+            sharedGroupConsumer.register(topic, codec, epoch, listener)
+            LOG.info { "registered group subscription for topic '$topic'" }
             try {
-                val tp = TopicPartition(topic, 0)
-                var currentProcessor: Log.RecordProcessor<M>? = null
-
-                c.subscribe(listOf(topic), object : ConsumerRebalanceListener {
-                    private inline fun launderInterruptedException(block: () -> Unit) =
-                        try { block() } catch (e: InterruptedException) { throw InterruptException(e) }
-
-                    override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) =
-                        launderInterruptedException {
-                            listener.onPartitionsAssignedSync(partitions.map { it.partition() })
-                                ?.let { tailSpec ->
-                                    currentProcessor = tailSpec.processor
-                                    c.seek(tp, afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1)
-                                }
-                        }
-
-                    override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) =
-                        launderInterruptedException {
-                            listener.onPartitionsRevokedSync(partitions.map { it.partition() })
-                            currentProcessor = null
-                        }
-                })
-
-                while (isActive) {
-                    val records = runInterruptible(Dispatchers.IO) { c.pollRecords() }
-                    if (records.isNotEmpty()) currentProcessor?.processRecords(records)
-                }
+                suspendCancellableCoroutine<Unit> { } // wait until cancelled
             } finally {
-                c.close()
+                withContext(NonCancellable) { sharedGroupConsumer.unregister(topic) }
             }
         }
 
@@ -417,14 +580,12 @@ class KafkaCluster(
         var replicaTopic: String = "$topic-replica",
         var autoCreateTopic: Boolean = true,
         var epoch: Int = 0,
-        var groupId: String = "xtdb-$topic"
     ) : Log.Factory {
 
         fun replicaCluster(replicaCluster: LogClusterAlias) = apply { this.replicaCluster = replicaCluster }
         fun replicaTopic(replicaTopic: String) = apply { this.replicaTopic = replicaTopic }
         fun autoCreateTopic(autoCreateTopic: Boolean) = apply { this.autoCreateTopic = autoCreateTopic }
         fun epoch(epoch: Int) = apply { this.epoch = epoch }
-        fun groupId(groupId: String) = apply { this.groupId = groupId }
 
         override fun openSourceLog(clusters: Map<LogClusterAlias, Log.Cluster>): Log<SourceMessage> {
             val clusterAlias = this.cluster
@@ -438,7 +599,7 @@ class KafkaCluster(
                 admin.ensureTopicExists(topic, autoCreateTopic)
             }
 
-            return cluster.KafkaLog(SourceMessage.Codec, topic, epoch, groupId)
+            return cluster.KafkaLog(SourceMessage.Codec, topic, epoch)
         }
 
         override fun openReadOnlySourceLog(clusters: Map<LogClusterAlias, Log.Cluster>) =
@@ -456,7 +617,7 @@ class KafkaCluster(
                 admin.ensureTopicExists(replicaTopic, autoCreateTopic)
             }
 
-            return cluster.KafkaLog(ReplicaMessage.Codec, replicaTopic, epoch, groupId)
+            return cluster.KafkaLog(ReplicaMessage.Codec, replicaTopic, epoch)
         }
 
         override fun openReadOnlyReplicaLog(clusters: Map<LogClusterAlias, Log.Cluster>) =
@@ -469,7 +630,6 @@ class KafkaCluster(
                 this.logClusterAlias = cluster
                 this.replicaClusterAlias = replicaCluster
                 this.replicaTopic = this@LogFactory.replicaTopic
-                this.groupId = this@LogFactory.groupId
             }, "proto.xtdb.com"))
         }
     }
@@ -486,7 +646,6 @@ class KafkaCluster(
                     epoch = it.epoch
                     if (it.hasReplicaClusterAlias()) replicaCluster = it.replicaClusterAlias
                     if (it.hasReplicaTopic()) replicaTopic = it.replicaTopic
-                    if (it.hasGroupId()) groupId = it.groupId
                 }
             }
 

--- a/modules/kafka/src/main/proto/kafka.proto
+++ b/modules/kafka/src/main/proto/kafka.proto
@@ -10,5 +10,5 @@ message KafkaLogConfig {
     int32 epoch = 3;
     string replica_cluster_alias = 4;
     string replica_topic = 5;
-    string group_id = 6;
+    reserved 6; // was group_id, now on the cluster
 }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -10,13 +10,9 @@ import kotlinx.coroutines.test.runTest
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.common.errors.RecordTooLargeException
-import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.testcontainers.kafka.ConfluentKafkaContainer
 import xtdb.api.log.Log.*
 import xtdb.api.storage.Storage
@@ -24,10 +20,13 @@ import xtdb.database.Database
 import xtdb.log.proto.TrieDetails
 import xtdb.log.proto.trieMetadata
 import xtdb.util.asPath
+import xtdb.util.closeAll
 import java.nio.ByteBuffer
 import java.time.Duration
+import java.util.*
 import java.util.Collections.synchronizedList
-import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @Tag("integration")
@@ -87,7 +86,7 @@ class KafkaClusterTest {
 
                             log.appendMessage(SourceMessage.AttachDatabase("foo", databaseConfig))
 
-                            while (synchronized(msgs) { msgs.flatten().size } < 4) delay(100)
+                            while (synchronized(msgs) { msgs.flatten().size } < 4) delay(100.milliseconds)
                         } finally {
                             job.cancelAndJoin()
                         }
@@ -123,7 +122,7 @@ class KafkaClusterTest {
     private fun txMessage(id: Byte) = SourceMessage.LegacyTx(byteArrayOf(-1, id))
 
     @Test
-    fun `readLastMessage returns null when topic is empty`() = runTest(timeout = 30.seconds)  {
+    fun `readLastMessage returns null when topic is empty`() = runTest(timeout = 30.seconds) {
         val topicName = "test-topic-${UUID.randomUUID()}"
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
@@ -138,7 +137,7 @@ class KafkaClusterTest {
     }
 
     @Test
-    fun `readLastMessage returns the message after appending one`() = runTest(timeout = 30.seconds)  {
+    fun `readLastMessage returns the message after appending one`() = runTest(timeout = 30.seconds) {
         val topicName = "test-topic-${UUID.randomUUID()}"
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
@@ -204,80 +203,81 @@ class KafkaClusterTest {
     }
 
     @Test
-    fun `round-trips large replica BlockUploaded message with increased message size`() = runTest(timeout = 60.seconds) {
-        val eightMB = 8 * 1024 * 1024
-        val fourMB = 4 * 1024 * 1024
-        val topicName = "test-topic-${UUID.randomUUID()}"
-        val replicaTopicName = "$topicName-replica"
+    fun `round-trips large replica BlockUploaded message with increased message size`() =
+        runTest(timeout = 60.seconds) {
+            val eightMB = 8 * 1024 * 1024
+            val fourMB = 4 * 1024 * 1024
+            val topicName = "test-topic-${UUID.randomUUID()}"
+            val replicaTopicName = "$topicName-replica"
 
-        val largeMessageContainer = ConfluentKafkaContainer("confluentinc/cp-kafka:7.8.0")
-            .withEnv("KAFKA_MESSAGE_MAX_BYTES", eightMB.toString())
-            .withEnv("KAFKA_REPLICA_FETCH_MAX_BYTES", eightMB.toString())
+            val largeMessageContainer = ConfluentKafkaContainer("confluentinc/cp-kafka:7.8.0")
+                .withEnv("KAFKA_MESSAGE_MAX_BYTES", eightMB.toString())
+                .withEnv("KAFKA_REPLICA_FETCH_MAX_BYTES", eightMB.toString())
 
-        largeMessageContainer.start()
-        try {
-            AdminClient.create(mapOf("bootstrap.servers" to largeMessageContainer.bootstrapServers)).use { admin ->
-                admin.createTopics(
-                    listOf(
-                        NewTopic(replicaTopicName, 1, 1)
-                            .configs(
-                                mapOf(
-                                    "message.timestamp.type" to "LogAppendTime",
-                                    "max.message.bytes" to eightMB.toString()
+            largeMessageContainer.start()
+            try {
+                AdminClient.create(mapOf("bootstrap.servers" to largeMessageContainer.bootstrapServers)).use { admin ->
+                    admin.createTopics(
+                        listOf(
+                            NewTopic(replicaTopicName, 1, 1)
+                                .configs(
+                                    mapOf(
+                                        "message.timestamp.type" to "LogAppendTime",
+                                        "max.message.bytes" to eightMB.toString()
+                                    )
                                 )
-                            )
-                    )
-                ).all().get()
-            }
-
-            val blockUploaded = largeBlockUploaded()
-
-            val msgs = synchronizedList(mutableListOf<List<Record<ReplicaMessage>>>())
-
-            val subscriber = mockk<RecordProcessor<ReplicaMessage>> {
-                coEvery { processRecords(capture(msgs)) } returns Unit
-            }
-
-            KafkaCluster.ClusterFactory(largeMessageContainer.bootstrapServers)
-                .propertiesMap(
-                    mapOf(
-                        "max.request.size" to fourMB.toString(),
-                        "fetch.max.bytes" to fourMB.toString(),
-                        "max.partition.fetch.bytes" to fourMB.toString()
-                    )
-                )
-                .pollDuration(Duration.ofMillis(100))
-                .open().use { cluster ->
-                    KafkaCluster.LogFactory("my-cluster", topicName, autoCreateTopic = false)
-                        .openReplicaLog(mapOf("my-cluster" to cluster))
-                        .use { log ->
-                            val job = launch { log.tailAll(-1, subscriber) }
-                            try {
-                                log.appendMessage(blockUploaded)
-
-                                while (synchronized(msgs) { msgs.flatten().size } < 1) delay(100)
-                            } finally {
-                                job.cancelAndJoin()
-                            }
-                        }
+                        )
+                    ).all().get()
                 }
 
-            val allMsgs = synchronized(msgs) { msgs.flatten() }
-            assertEquals(1, allMsgs.size)
+                val blockUploaded = largeBlockUploaded()
 
-            allMsgs[0].message.let {
-                check(it is ReplicaMessage.BlockUploaded)
-                assertEquals(42, it.blockIndex)
-                assertEquals(100, it.latestProcessedMsgId)
-                assertEquals(Storage.VERSION, it.storageVersion)
-                assertEquals(256, it.tries.size)
-                assertEquals("table-0", it.tries[0].tableName)
-                assertEquals("trie-key-255", it.tries[255].trieKey)
+                val msgs = synchronizedList(mutableListOf<List<Record<ReplicaMessage>>>())
+
+                val subscriber = mockk<RecordProcessor<ReplicaMessage>> {
+                    coEvery { processRecords(capture(msgs)) } returns Unit
+                }
+
+                KafkaCluster.ClusterFactory(largeMessageContainer.bootstrapServers)
+                    .propertiesMap(
+                        mapOf(
+                            "max.request.size" to fourMB.toString(),
+                            "fetch.max.bytes" to fourMB.toString(),
+                            "max.partition.fetch.bytes" to fourMB.toString()
+                        )
+                    )
+                    .pollDuration(Duration.ofMillis(100))
+                    .open().use { cluster ->
+                        KafkaCluster.LogFactory("my-cluster", topicName, autoCreateTopic = false)
+                            .openReplicaLog(mapOf("my-cluster" to cluster))
+                            .use { log ->
+                                val job = launch { log.tailAll(-1, subscriber) }
+                                try {
+                                    log.appendMessage(blockUploaded)
+
+                                    while (synchronized(msgs) { msgs.flatten().size } < 1) delay(100.milliseconds)
+                                } finally {
+                                    job.cancelAndJoin()
+                                }
+                            }
+                    }
+
+                val allMsgs = synchronized(msgs) { msgs.flatten() }
+                assertEquals(1, allMsgs.size)
+
+                allMsgs[0].message.let {
+                    check(it is ReplicaMessage.BlockUploaded)
+                    assertEquals(42, it.blockIndex)
+                    assertEquals(100, it.latestProcessedMsgId)
+                    assertEquals(Storage.VERSION, it.storageVersion)
+                    assertEquals(256, it.tries.size)
+                    assertEquals("table-0", it.tries[0].tableName)
+                    assertEquals("trie-key-255", it.tries[255].trieKey)
+                }
+            } finally {
+                largeMessageContainer.stop()
             }
-        } finally {
-            largeMessageContainer.stop()
         }
-    }
 
     @Test
     fun `large message fails with default producer config`() = runTest(timeout = 60.seconds) {
@@ -297,4 +297,174 @@ class KafkaClusterTest {
                     }
             }
     }
+
+    // SharedGroupConsumer integration tests
+    private suspend fun withClusterAndLogs(
+        topicNames: List<String>,
+        block: suspend (KafkaCluster, List<Log<SourceMessage>>) -> Unit,
+    ) {
+        val cluster =
+            KafkaCluster.ClusterFactory(container.bootstrapServers)
+                .pollDuration(Duration.ofMillis(100))
+                .open()
+
+        cluster.use {
+            val logs = topicNames.map { topic ->
+                KafkaCluster.LogFactory("c", topic).openSourceLog(mapOf("c" to cluster))
+            }
+            try {
+                block(cluster, logs)
+            } finally {
+                logs.closeAll()
+            }
+        }
+    }
+
+    private class TrackingListener(
+        private val afterMsgId: MessageId = -1L,
+    ) : SubscriptionListener<SourceMessage> {
+        val assignedPartitions = CopyOnWriteArrayList<Collection<Int>>()
+        val revokedPartitions = CopyOnWriteArrayList<Collection<Int>>()
+        val records = CopyOnWriteArrayList<Record<SourceMessage>>()
+
+        val isAssigned get() = assignedPartitions.size > revokedPartitions.size
+
+        private val processor = RecordProcessor<SourceMessage> { recs -> records.addAll(recs) }
+
+        override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> {
+            assignedPartitions.add(partitions)
+            return TailSpec(afterMsgId, processor)
+        }
+
+        override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {
+            revokedPartitions.add(partitions)
+        }
+    }
+
+    @Test
+    fun `shared group consumer delivers records to multiple databases`() = runTest(timeout = 60.seconds) {
+        val topic1 = "test-shared-multi-${UUID.randomUUID()}"
+        val topic2 = "test-shared-multi-${UUID.randomUUID()}"
+
+        withClusterAndLogs(listOf(topic1, topic2)) { _, logs ->
+            val (log1, log2) = logs
+            val listener1 = TrackingListener()
+            val listener2 = TrackingListener()
+
+            val job1 = launch { log1.openGroupSubscription(listener1) }
+            val job2 = launch { log2.openGroupSubscription(listener2) }
+
+            while (!listener1.isAssigned || !listener2.isAssigned) delay(100.milliseconds)
+
+            log1.appendMessage(txMessage(1))
+            log2.appendMessage(txMessage(2))
+
+            while (listener1.records.isEmpty() || listener2.records.isEmpty()) delay(100.milliseconds)
+
+            assertEquals(1, listener1.records.size)
+            assertEquals(1, listener2.records.size)
+
+            val msg1 = listener1.records[0].message
+            check(msg1 is SourceMessage.LegacyTx)
+            assertArrayEquals(byteArrayOf(-1, 1), msg1.payload)
+
+            val msg2 = listener2.records[0].message
+            check(msg2 is SourceMessage.LegacyTx)
+            assertArrayEquals(byteArrayOf(-1, 2), msg2.payload)
+
+            job1.cancelAndJoin()
+            job2.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `unsubscribing one database does not affect others`() = runTest(timeout = 60.seconds) {
+        val topic1 = "test-shared-unsub-${UUID.randomUUID()}"
+        val topic2 = "test-shared-unsub-${UUID.randomUUID()}"
+
+        withClusterAndLogs(listOf(topic1, topic2)) { _, logs ->
+            val (log1, log2) = logs
+            val listener1 = TrackingListener()
+            val listener2 = TrackingListener()
+
+            val job1 = launch { log1.openGroupSubscription(listener1) }
+            val job2 = launch { log2.openGroupSubscription(listener2) }
+
+            while (!listener1.isAssigned || !listener2.isAssigned) delay(100.milliseconds)
+
+            job1.cancelAndJoin()
+
+            log2.appendMessage(txMessage(3))
+            while (listener2.records.isEmpty()) delay(100.milliseconds)
+
+            assertEquals(1, listener2.records.size)
+            val msg = listener2.records[0].message
+            check(msg is SourceMessage.LegacyTx)
+            assertArrayEquals(byteArrayOf(-1, 3), msg.payload)
+
+            job2.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `database can resubscribe after unsubscribing`() = runTest(timeout = 60.seconds) {
+        val topic1 = "test-shared-resub-${UUID.randomUUID()}"
+
+        withClusterAndLogs(listOf(topic1)) { _, logs ->
+            val log1 = logs[0]
+
+            val listener1 = TrackingListener()
+            val job1 = launch { log1.openGroupSubscription(listener1) }
+            while (!listener1.isAssigned) delay(100.milliseconds)
+
+            log1.appendMessage(txMessage(1))
+            while (listener1.records.isEmpty()) delay(100.milliseconds)
+            val firstOffset = listener1.records[0].logOffset
+
+            job1.cancelAndJoin()
+            while (listener1.revokedPartitions.isEmpty()) delay(100.milliseconds)
+
+            val listener2 = TrackingListener(afterMsgId = firstOffset)
+            val job2 = launch { log1.openGroupSubscription(listener2) }
+            while (!listener2.isAssigned) delay(100.milliseconds)
+
+            log1.appendMessage(txMessage(2))
+            while (listener2.records.isEmpty()) delay(100.milliseconds)
+
+            assertEquals(1, listener2.records.size)
+            val msg = listener2.records[0].message
+            check(msg is SourceMessage.LegacyTx)
+            assertArrayEquals(byteArrayOf(-1, 2), msg.payload)
+
+            job2.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `shared consumer survives all databases unsubscribing then new one subscribing`() =
+        runTest(timeout = 60.seconds) {
+            val topic1 = "test-shared-drain-${UUID.randomUUID()}"
+            val topic2 = "test-shared-drain-${UUID.randomUUID()}"
+
+            withClusterAndLogs(listOf(topic1, topic2)) { _, logs ->
+                val (log1, log2) = logs
+
+                val listener1 = TrackingListener()
+                val job1 = launch { log1.openGroupSubscription(listener1) }
+                while (!listener1.isAssigned) delay(100.milliseconds)
+
+                job1.cancelAndJoin()
+
+                val listener2 = TrackingListener()
+                val job2 = launch { log2.openGroupSubscription(listener2) }
+                while (!listener2.isAssigned) delay(100.milliseconds)
+
+                log2.appendMessage(txMessage(4))
+                while (listener2.records.isEmpty()) delay(100.milliseconds)
+
+                assertEquals(1, listener2.records.size)
+
+                job2.cancelAndJoin()
+            }
+        }
 }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaLogFactoryTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaLogFactoryTest.kt
@@ -23,7 +23,6 @@ class KafkaLogFactoryTest {
         assertEquals("my-topic-replica", restored.replicaTopic)
         assertEquals("myCluster", restored.replicaCluster)
         assertEquals(0, restored.epoch)
-        assertEquals("xtdb-my-topic", restored.groupId)
     }
 
     @Test
@@ -44,16 +43,6 @@ class KafkaLogFactoryTest {
         val restored = roundTrip(original)
 
         assertEquals("otherCluster", restored.replicaCluster)
-    }
-
-    @Test
-    fun `round-trips groupId`() {
-        val original = KafkaCluster.LogFactory("myCluster", "my-topic")
-            .groupId("my-group")
-
-        val restored = roundTrip(original)
-
-        assertEquals("my-group", restored.groupId)
     }
 
     @Test


### PR DESCRIPTION
## Rationale

In single-writer mode, each database creates its own KafkaConsumer in its own consumer group (`xtdb-$topic`).
Kafka has no visibility into which databases are co-located on the same node, so partition assignment across databases is uncoordinated — leadership distribution across a cluster is essentially random.

With a shared group consumer per KafkaCluster, Kafka sees one consumer per node in a single group subscribing to all source topics.
The CooperativeStickyAssignor can then evenly distribute database leaderships across nodes (e.g. 3 nodes, 6 databases → ~2 leaderships per node).

## Impact

- **Breaking**: all single-writer databases on the same cluster now share consumer group `"xtdb"` (was `"xtdb-$topic"` per database). First deployment after upgrade triggers a one-time rebalance as the old per-database groups are abandoned and the new shared group forms.
- `groupId` moves from `LogFactory` (per-database) to `ClusterFactory` (per-cluster), configurable via `:group-id` on the cluster config.
- `LogFactory.groupId` is removed (proto field 6 reserved).
- `tailAll()` consumers (manual assignment, replica logs, non-single-writer source logs) are unchanged — they don't participate in the group protocol so consolidating them provides no partitioning benefit.

## Implementation notes

- **Poll loop via `select`**: the poll loop uses `select` to prioritise commands (`onReceive`) over Kafka polling (`onTimeout(0)`). When no topics are subscribed, the timeout clause is excluded and the loop parks on the channel — no spin.

- **Register/unregister lifecycle**: `register` sends a command via the channel. `unregister` uses `suspendCancellableCoroutine` — the continuation is carried in the Unregister command and resumed by the poll loop after revocation. `openGroupSubscription` registers, suspends, and unregisters in `finally` with `withContext(NonCancellable)`.

- **Close ordering is RAII**: databases unregister (via coroutine cancellation) before `SharedGroupConsumer.close()` runs. An assertion verifies subscriptions are empty at close time.

- **Lazy initialization**: the SharedGroupConsumer is only created on the first `openGroupSubscription()` call. Nodes not using single-writer mode never create a consumer group.

- **Blocking `onPartitionsAssigned` is accepted**: rebalance callbacks run synchronously inside `poll()`, so a slow leader transition for one database blocks polling for all databases on that consumer. This is acceptable because (a) CooperativeStickyAssignor means only partitions being reassigned trigger callbacks — stable databases are untouched, and (b) followers are hot standbys already mostly caught up on the replica log, so the `awaitReplicaMsgId` during transition should be minimal.

## Test plan

- [x] `KafkaLogFactoryTest` — round-trip serialization without groupId
- [x] `KafkaClusterTest` — 4 shared consumer integration tests with testcontainers:
  - multiple databases on one cluster
  - unsubscribe one, other keeps receiving
  - resubscribe after unsubscribe (with offset resume)
  - drain to zero subscriptions, then new subscriber
- [x] Full `./gradlew :modules:xtdb-kafka:integration-test` with `XTDB_SINGLE_WRITER=true` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)