### PR TITLE
ISSUE #3055: Missing functions from the docs

### DIFF
--- a/docs/src/content/docs/reference/main/stdlib.md
+++ b/docs/src/content/docs/reference/main/stdlib.md
@@ -9,6 +9,7 @@ XTDB provides a rich standard library of predicates and functions:
 - [String functions](/reference/main/stdlib/string)
 - [Temporal functions](/reference/main/stdlib/temporal)
 - [Aggregate functions](/reference/main/stdlib/aggregates)
+- [Collection functions](/reference/main/stdlib/collections)
 - [Other functions](/reference/main/stdlib/other)
 
 The following control structures are available in XTDB:

--- a/docs/src/content/docs/reference/main/stdlib/collections.md
+++ b/docs/src/content/docs/reference/main/stdlib/collections.md
@@ -1,0 +1,38 @@
+---
+title: Collection functions
+---
+
+:::note
+- SQL array subscripts are 1-based.
+- XTQL `nth` indexes are 0-based.
+- Unless otherwise specified, if any argument is null, the result will be null.
+:::
+
+`CARDINALITY(list)`
+: returns the number of elements in the list.
+
+`TRIM_ARRAY(array, n)`
+: returns a copy of `array` with the last `n` elements removed.
+
+`array[idx]` | XTQL `(nth array idx)`
+: returns the element at the given index.
+  - In SQL, array subscripts are 1-based, so `ARRAY[10, 20, 30][1]` returns `10`.
+  - In XTQL, `nth` is 0-based, so `(nth [10 20 30] 0)` returns `10`.
+  - Returns `NULL` / `nil` if `idx` is null, negative, out of bounds, or the input value is not a list.
+
+Examples:
+
+```sql
+SELECT ARRAY[10, 20, 30][1] AS first_val
+-- 10
+```
+
+```clojure
+(nth [10 20 30] 0)
+;; 10
+```
+
+```clojure
+(nth [10 20 30] 5)
+;; nil
+```

--- a/docs/src/content/docs/reference/main/stdlib/other.md
+++ b/docs/src/content/docs/reference/main/stdlib/other.md
@@ -2,9 +2,6 @@
 title: Other Functions
 ---
 
-`CARDINALITY(list)`
-: returns the number of elements in the list.
-
 `LENGTH(expr)`
 : returns the length of the value in `expr`, where `<expr>` is one of the following:
   - A **string**: returns the number of utf8 characters in the string (alias for `CHAR_LENGTH`)
@@ -12,9 +9,6 @@ title: Other Functions
   - A **list**: returns the number of elements in the list (alias for `CARDINALITY`)
   - A **set**: returns the number of elements in the set
   - A **struct**: returns the number of **non-absent** fields in the struct
-
-`TRIM_ARRAY(array, n)`
-: returns a copy of `array` with the last `n` elements removed.
 
 `obj->field`
 : PostgreSQL-compatible JSON field access operator. Extracts a field from a struct by key (preserving the original type).

--- a/docs/src/content/docs/reference/main/xtql/queries.md
+++ b/docs/src/content/docs/reference/main/xtql/queries.md
@@ -487,12 +487,23 @@ XTQL expressions are valid within predicates, projections, bindings and argument
 ### Subqueries
 
 - Subquery expressions must return a single row containing a single column - otherwise, a runtime exception will be thrown.
-- 'Exists' expressions will return false if the subquery returns no rows; true otherwise.
-- 'Pull' expressions must return a single row - otherwise, a runtime exception will be thrown.
+- `exists?` expressions return false if the subquery returns no rows, and true otherwise.
+- `pull` expressions must return a single row - otherwise, a runtime exception will be thrown.
   The columns in the returned row will be nested into a map in the outer expression.
-- 'Pull many' expressions may return any number of rows.
+- `pull*` expressions may return any number of rows.
   The rows will be nested into an array of maps in the outer expression.
 - The arguments to sub-queries are referred to as parameters in the inner query; no other variables from the outer scope are available in the inner query.
+
+`exists?`
+: tests whether a subquery returns at least one row.
+
+```clojure
+(-> (from :docs [{:xt/id e}])
+    (where (exists? (fn [e]
+                      (from :docs [{:parent e}])))))
+```
+
+This returns documents that have at least one child.
 
 <!-- -->
 
@@ -515,7 +526,7 @@ XTQL expressions are valid within predicates, projections, bindings and argument
     CallExpr :: (symbol Expr*)
 
     SubqueryExpr :: (q Subquery)
-    ExistsExpr :: (exists Subquery)
+    ExistsExpr :: (exists? Subquery)
     PullExpr :: (pull Subquery)
     PullManyExpr :: (pull* Subquery)
 

--- a/docs/src/content/docs/reference/main/xtql/stdlib.md
+++ b/docs/src/content/docs/reference/main/xtql/stdlib.md
@@ -26,6 +26,9 @@ The following notes and exceptions apply:
         - `p1 STRICTLY CONTAINS p2` → \`(strictly-contains? p1 p2)
     - `DATE_TRUNC('UNIT', date_time)` → `(date-trunc "UNIT" date-time)`
     - `EXTRACT('FIELD' FROM date_time)` → `(extract "FIELD" date-time)`
+- [Collection functions](/reference/main/stdlib/collections):
+    - SQL `array[1]` → XTQL `(nth array 0)`
+    - `nth` returns `nil` for null, out-of-bounds, negative indexes, and non-list inputs
 
 ## Control structures
 


### PR DESCRIPTION
Addresses part of #3055.

This PR:
- adds a new standard library reference page for collection functions
- documents collection indexing with SQL `array[idx]` and XTQL `nth`
- moves `CARDINALITY` and `TRIM_ARRAY` into the new collection docs section
- fixes the XTQL docs to document `exists?` with the spelling used on `main`
- fixes `exists?` / `pull` / `pull*` wording in the XTQL subquery docs
- adds a short `exists?` example

I did not document `first`/`last` in this PR.
I couldn't find evidence that they are currently supported as XTDB query functions on `main`, so I left them out rather than guessing at semantics.

This is a docs-only change.
I did not run the test suite.
