### PR TITLE
feat(external-source): add "remotes" section to config to hold Postgres credentials

### DIFF
--- a/core/src/main/kotlin/xtdb/NodeBase.kt
+++ b/core/src/main/kotlin/xtdb/NodeBase.kt
@@ -7,6 +7,8 @@ import org.apache.arrow.memory.RootAllocator
 import xtdb.Metrics.registerRootAllocatorMeters
 import xtdb.Metrics.rootAllocatorListener
 import xtdb.Tracer.openTracer
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.api.Xtdb
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
@@ -25,6 +27,7 @@ class NodeBase(
     val memoryCache: MemoryCache, val diskCache: DiskCache?,
     val meterRegistry: MeterRegistry?, val tracer: OtelTracer?,
     val logClusters: Map<LogClusterAlias, Log.Cluster>,
+    val remotes: Map<RemoteAlias, Remote>,
     val compactor: Compactor,
     val infoSchema: AutoCloseable,
     val querySource: IQuerySource,
@@ -35,6 +38,7 @@ class NodeBase(
         compactor.close()
         querySource.close()
         infoSchema.close()
+        remotes.values.closeAll()
         logClusters.values.closeAll()
         memoryCache.close()
         if (closeAllocator) allocator.close()
@@ -78,6 +82,7 @@ class NodeBase(
                     }
 
                 val logClusters = config.logClusters.mapValues { (_, factory) -> open { factory.open() } }
+                val remotes = config.remotes.mapValues { (_, factory) -> open { factory.open() } }
 
                 val compactor = open { compactorFactory.create(meterReg, config.compactor.threads) }
 
@@ -94,6 +99,7 @@ class NodeBase(
                     meterRegistry = meterReg,
                     tracer = config.tracer.openTracer(),
                     logClusters = logClusters,
+                    remotes = remotes,
                     compactor = compactor,
                     infoSchema = infoSchema,
                     querySource = querySource,

--- a/core/src/main/kotlin/xtdb/api/Remote.kt
+++ b/core/src/main/kotlin/xtdb/api/Remote.kt
@@ -1,0 +1,40 @@
+package xtdb.api
+
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import java.util.ServiceLoader
+
+typealias RemoteAlias = String
+
+/**
+ * A named, node-local handle for an external system XT authenticates against
+ * — a Postgres instance, a cloud identity (AWS/Azure/GCP), etc.
+ *
+ * Credentials and connection details live on the node config, never on the
+ * source log. ATTACH payloads carry only the [RemoteAlias]; each node
+ * resolves the alias against its own remotes map.
+ */
+interface Remote : AutoCloseable {
+
+    interface Factory<R : Remote> {
+        fun open(): R
+
+        companion object {
+            private val registrations = ServiceLoader.load(Registration::class.java).toList()
+
+            val serializersModule = SerializersModule {
+                for (reg in registrations) include(reg.serializersModule)
+
+                polymorphic(Factory::class) {
+                    for (reg in registrations) reg.registerSerde(this)
+                }
+            }
+        }
+    }
+
+    interface Registration {
+        fun registerSerde(builder: PolymorphicModuleBuilder<Factory<*>>)
+        val serializersModule: SerializersModule get() = SerializersModule {}
+    }
+}

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -70,6 +70,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         var server: ServerConfig? = ServerConfig(),
         var flightSql: FlightSqlConfig? = FlightSqlConfig(),
         var logClusters: Map<LogClusterAlias, Log.Cluster.Factory<*>> = emptyMap(),
+        var remotes: Map<RemoteAlias, Remote.Factory<*>> = emptyMap(),
         var log: Log.Factory = Log.inMemoryLog,
         var storage: Storage.Factory = Storage.inMemory(),
         val memoryCache: MemoryCache.Factory = MemoryCache.Factory(),
@@ -93,6 +94,11 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
         fun logCluster(alias: LogClusterAlias, cluster: Log.Cluster.Factory<*>) =
             apply { logClusters += alias to cluster }
+
+        fun remotes(remotes: Map<RemoteAlias, Remote.Factory<*>>) = apply { this.remotes += remotes }
+
+        fun remote(alias: RemoteAlias, remote: Remote.Factory<*>) =
+            apply { this.remotes += alias to remote }
 
         fun log(log: Log.Factory) = apply { this.log = log }
         fun storage(storage: Storage.Factory) = apply { this.storage = storage }

--- a/core/src/main/kotlin/xtdb/api/YamlSerde.kt
+++ b/core/src/main/kotlin/xtdb/api/YamlSerde.kt
@@ -78,6 +78,7 @@ val YAML_SERDE = Yaml(
     serializersModule = SerializersModule {
         include(Log.Factory.serializersModule)
         include(Log.Cluster.Factory.serializersModule)
+        include(Remote.Factory.serializersModule)
         include(ObjectStore.Factory.serializersModule)
         include(XtdbModule.Factory.serializersModule)
         include(ExternalSource.Factory.serializersModule)

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -213,7 +213,7 @@ class Database(
                                     allocator, storage, replicaProducer, state,
                                     watchers, blockUploader,
                                     partition = 0, afterSourceMsgId, afterReplicaMsgId,
-                                    extSource = extFactory.open(dbName, base.logClusters),
+                                    extSource = extFactory.open(dbName, base.logClusters, base.remotes),
                                     // watchers has the latest token from replica log replay,
                                     // which may be ahead of blockCatalog if no block boundary was flushed.
                                     afterToken = watchers.externalSourceToken,

--- a/core/src/main/kotlin/xtdb/database/ExternalSource.kt
+++ b/core/src/main/kotlin/xtdb/database/ExternalSource.kt
@@ -3,6 +3,8 @@ package xtdb.database
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
 import xtdb.database.proto.DatabaseConfig
@@ -43,7 +45,11 @@ interface ExternalSource : AutoCloseable {
 
     interface Factory {
         fun writeTo(dbConfig: DatabaseConfig.Builder)
-        fun open(dbName: String, clusters: Map<LogClusterAlias, Log.Cluster>): ExternalSource
+        fun open(
+            dbName: String,
+            clusters: Map<LogClusterAlias, Log.Cluster>,
+            remotes: Map<RemoteAlias, Remote>,
+        ): ExternalSource
 
         companion object {
             private val registrations = ServiceLoader.load(Registration::class.java).toList()

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumKafkaSource.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumKafkaSource.kt
@@ -16,6 +16,8 @@ import org.apache.kafka.common.errors.InterruptException
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.Deserializer
 import org.slf4j.LoggerFactory
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.api.log.KafkaCluster
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
@@ -76,7 +78,11 @@ class DebeziumKafkaSource @JvmOverloads constructor(
         val messageFormat: MessageFormat,
     ) : ExternalSource.Factory {
 
-        override fun open(dbName: String, clusters: Map<LogClusterAlias, Log.Cluster>): ExternalSource {
+        override fun open(
+            dbName: String,
+            clusters: Map<LogClusterAlias, Log.Cluster>,
+            remotes: Map<RemoteAlias, Remote>,
+        ): ExternalSource {
             val cluster =
                 requireNotNull(clusters[logCluster] as? KafkaCluster) { "missing Kafka cluster: '${logCluster}'" }
 

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresRemote.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresRemote.kt
@@ -1,0 +1,36 @@
+package xtdb.postgres
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.subclass
+import xtdb.api.Remote
+
+class PostgresRemote(
+    val hostname: String,
+    val port: Int,
+    val database: String,
+    val username: String,
+    val password: String,
+) : Remote {
+
+    override fun close() = Unit
+
+    @Serializable
+    @SerialName("!Postgres")
+    data class Factory(
+        val hostname: String,
+        val port: Int = 5432,
+        val database: String,
+        val username: String,
+        val password: String,
+    ) : Remote.Factory<PostgresRemote> {
+        override fun open() = PostgresRemote(hostname, port, database, username, password)
+    }
+
+    class Registration : Remote.Registration {
+        override fun registerSerde(builder: PolymorphicModuleBuilder<Remote.Factory<*>>) {
+            builder.subclass(Factory::class)
+        }
+    }
+}

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -14,6 +14,8 @@ import org.postgresql.PGProperty
 import org.postgresql.replication.LogSequenceNumber
 import org.postgresql.replication.PGReplicationStream
 import org.slf4j.LoggerFactory
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.database.ExternalSource
 import xtdb.database.ExternalSource.TxResult
 import xtdb.database.ExternalSourceToken
@@ -65,29 +67,42 @@ class PostgresSource(
     @Serializable
     @SerialName("!Postgres")
     data class Factory(
-        val hostname: String,
-        val port: Int = 5432,
-        val database: String,
-        val username: String,
-        val password: String,
+        val remote: RemoteAlias,
         val slotName: String,
         val publicationName: String,
         val schemaIncludeList: List<String> = listOf("public"),
     ) : ExternalSource.Factory {
 
-        override fun open(dbName: String, clusters: Map<LogClusterAlias, Log.Cluster>): ExternalSource =
-            PostgresSource(
-                dbName, hostname, port, database, username, password,
+        override fun open(
+            dbName: String,
+            clusters: Map<LogClusterAlias, Log.Cluster>,
+            remotes: Map<RemoteAlias, Remote>,
+        ): ExternalSource {
+            val raw = remotes[remote]
+                ?: throw Incorrect(
+                    "no remote configured with alias '$remote' — add a '!Postgres' entry under 'remotes:' in node config",
+                    errorCode = "xtdb.postgres/missing-remote",
+                    data = mapOf("alias" to remote),
+                )
+
+            val actualType = raw::class.simpleName ?: raw::class.qualifiedName ?: "unknown"
+
+            val pg = raw as? PostgresRemote
+                ?: throw Incorrect(
+                    "remote '$remote' is a $actualType, expected a !Postgres remote",
+                    errorCode = "xtdb.postgres/wrong-remote-type",
+                    data = mapOf("alias" to remote, "actualType" to actualType),
+                )
+
+            return PostgresSource(
+                dbName, pg.hostname, pg.port, pg.database, pg.username, pg.password,
                 slotName, publicationName, schemaIncludeList,
             )
+        }
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.externalSource = ProtoAny.pack(postgresSourceConfig {
-                hostname = this@Factory.hostname
-                port = this@Factory.port
-                database = this@Factory.database
-                username = this@Factory.username
-                password = this@Factory.password
+                remote = this@Factory.remote
                 slotName = this@Factory.slotName
                 publicationName = this@Factory.publicationName
                 schemaIncludeList += this@Factory.schemaIncludeList
@@ -100,11 +115,7 @@ class PostgresSource(
             override fun fromProto(msg: ProtoAny): ExternalSource.Factory {
                 val config = msg.unpack(PostgresSourceConfig::class.java)
                 return Factory(
-                    hostname = config.hostname,
-                    port = config.port,
-                    database = config.database,
-                    username = config.username,
-                    password = config.password,
+                    remote = config.remote,
                     slotName = config.slotName,
                     publicationName = config.publicationName,
                     schemaIncludeList = config.schemaIncludeListList,

--- a/modules/postgres-source/src/main/proto/postgres_source.proto
+++ b/modules/postgres-source/src/main/proto/postgres_source.proto
@@ -5,14 +5,10 @@ package xtdb.postgres.proto;
 option java_multiple_files = true;
 
 message PostgresSourceConfig {
-    string hostname = 1;
-    int32 port = 2;
-    string database = 3;
-    string username = 4;
-    string password = 5;
-    string slot_name = 6;
-    string publication_name = 7;
-    repeated string schema_include_list = 8;
+    string remote = 1;
+    string slot_name = 2;
+    string publication_name = 3;
+    repeated string schema_include_list = 4;
 }
 
 message PostgresSourceToken {

--- a/modules/postgres-source/src/main/resources/META-INF/services/xtdb.api.Remote$Registration
+++ b/modules/postgres-source/src/main/resources/META-INF/services/xtdb.api.Remote$Registration
@@ -1,0 +1,1 @@
+xtdb.postgres.PostgresRemote$Registration

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
@@ -1,0 +1,116 @@
+package xtdb.postgres
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import xtdb.api.nodeConfig
+import xtdb.database.Database
+
+class PostgresSourceFactoryTest {
+
+    private fun protoRoundTrip(factory: PostgresSource.Factory): PostgresSource.Factory {
+        val dbConfig = Database.Config().externalSource(factory)
+        val restored = Database.Config.fromProto(dbConfig.serializedConfig)
+        return restored.externalSource as PostgresSource.Factory
+    }
+
+    @Test
+    fun `proto round-trips factory`() {
+        val original = PostgresSource.Factory(
+            remote = "pg",
+            slotName = "my_slot",
+            publicationName = "my_pub",
+            schemaIncludeList = listOf("public", "analytics"),
+        )
+
+        val restored = protoRoundTrip(original)
+
+        assertEquals("pg", restored.remote)
+        assertEquals("my_slot", restored.slotName)
+        assertEquals("my_pub", restored.publicationName)
+        assertEquals(listOf("public", "analytics"), restored.schemaIncludeList)
+    }
+
+    @Test
+    fun `YAML round-trips factory as external source`() {
+        val yaml = """
+            externalSource: !Postgres
+              remote: pg
+              slotName: my_slot
+              publicationName: my_pub
+              schemaIncludeList: [public]
+        """.trimIndent()
+
+        val config = Database.Config.fromYaml(yaml)
+        val factory = config.externalSource as PostgresSource.Factory
+
+        assertEquals("pg", factory.remote)
+        assertEquals("my_slot", factory.slotName)
+        assertEquals("my_pub", factory.publicationName)
+        assertEquals(listOf("public"), factory.schemaIncludeList)
+    }
+
+    @Test
+    fun `node config decodes Postgres remote under remotes`() {
+        val yaml = """
+            remotes:
+              pg: !Postgres
+                hostname: pg.prod.internal
+                port: 5433
+                database: app
+                username: xtdb
+                password: secret
+        """.trimIndent()
+
+        val config = nodeConfig(yaml)
+        val remote = config.remotes["pg"] as PostgresRemote.Factory
+
+        assertEquals("pg.prod.internal", remote.hostname)
+        assertEquals(5433, remote.port)
+        assertEquals("app", remote.database)
+        assertEquals("xtdb", remote.username)
+        assertEquals("secret", remote.password)
+    }
+
+    @Test
+    fun `port defaults to 5432 when omitted`() {
+        val yaml = """
+            remotes:
+              pg: !Postgres
+                hostname: localhost
+                database: test
+                username: u
+                password: p
+        """.trimIndent()
+
+        val remote = nodeConfig(yaml).remotes["pg"] as PostgresRemote.Factory
+
+        assertEquals(5432, remote.port)
+    }
+
+    @Test
+    fun `dual !Postgres tag is disambiguated by YAML position`() {
+        // Both PostgresSource.Factory (ExternalSource) and PostgresRemote.Factory (Remote)
+        // carry @SerialName("!Postgres"). Kaml must dispatch by polymorphic root, not by tag.
+        val nodeYaml = """
+            remotes:
+              pg: !Postgres
+                hostname: localhost
+                database: db
+                username: u
+                password: p
+        """.trimIndent()
+
+        val dbYaml = """
+            externalSource: !Postgres
+              remote: pg
+              slotName: s
+              publicationName: p
+        """.trimIndent()
+
+        val nodeRemote = nodeConfig(nodeYaml).remotes["pg"]
+        val extSource = Database.Config.fromYaml(dbYaml).externalSource
+
+        assertTrue(nodeRemote is PostgresRemote.Factory, "node remote should resolve to PostgresRemote.Factory")
+        assertTrue(extSource is PostgresSource.Factory, "external source should resolve to PostgresSource.Factory")
+    }
+}

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -64,6 +64,13 @@ class PostgresSourceIntegrationTest {
     private fun openNode(sourceTopic: String): Xtdb = Xtdb.openNode {
         server { port = 0 }; flightSql = null
         logCluster("kafka", KafkaCluster.ClusterFactory(kafka.bootstrapServers))
+        remote("pg", PostgresRemote.Factory(
+            hostname = postgres.host,
+            port = postgres.getMappedPort(5432),
+            database = "testdb",
+            username = "testuser",
+            password = "testpass",
+        ))
         log(KafkaCluster.LogFactory("kafka", sourceTopic))
     }
 
@@ -82,11 +89,7 @@ class PostgresSourceIntegrationTest {
                           cluster: kafka
                           topic: test-replica-${UUID.randomUUID()}
                         externalSource: !Postgres
-                          hostname: ${postgres.host}
-                          port: ${postgres.getMappedPort(5432)}
-                          database: testdb
-                          username: testuser
-                          password: testpass
+                          remote: pg
                           slotName: $slotName
                           publicationName: $publicationName
                           schemaIncludeList: [public]


### PR DESCRIPTION
Part of #5466 — closes the Postgres external-source path of the credential-leak bug.
Storage creds (S3, Azure) and log-cluster migration are deferred follow-ups; the issue stays open until those land.

Unblocks a client deployment where PG passwords landing on the Kafka source log (and transitively in the object store) was a blocker.

## Mental model — `Remote`

A `Remote` is a named thing XT authenticates *to*.
It lives only in node-local config; it never goes into any proto or log message.
The ATTACH payload carries a `remote: <alias>` string, and each node resolves the alias against its own `remotes:` map.

Deliberately distinct from user authentication *to* XT (pgwire), and from the per-database ATTACH config.
One Remote can back many attached databases; a future single `!AWS` entry will span S3/SQS/DynamoDB, while Postgres is per-instance because the natural auth boundary for databases is the instance itself.

Registration mirrors `Log.Cluster` — polymorphic YAML factory via `ServiceLoader`.
No proto round-trip pattern (à la `ExternalSource.Registration`) because remotes are node-local and never touch the log.
The per-registration `serializersModule` hook is kept for forward-compat with richer remote shapes.

## Shape

```yaml
remotes:
  pg: !Postgres
    hostname: pg.prod.internal
    port: 5432
    database: app
    username: xtdb
    password: !Env PG_PW
```

```sql
ATTACH DATABASE cdc WITH $$
  log: !Kafka { cluster: kafka, topic: cdc-replica }
  externalSource: !Postgres
    remote: pg
    slotName: ...
    publicationName: ...
    schemaIncludeList: [public]
$$
```

Credentials never leave the node config.
Rotation = update node config + restart, same story as log-clusters today.

## Why the log-cluster alias pattern

Operators already know `logClusters:` from v2.1 — `remotes:` is the same idea, extended to non-log external systems.
One mental model; `remotes:` can eventually subsume `logClusters:` as a tidy-first follow-up, and the two patterns coexist cleanly in the meantime.

## Non-breaking

External sources (direct Postgres, Debezium) landed entirely post-v2.1.0 — not reachable from any release tag.
Reshaping the `!Postgres` YAML and its `PostgresSourceConfig` protobuf (dropping `hostname/port/database/username/password`, adding `string remote = 1;`) doesn't affect any shipped user.

## Post-rebase note: dual `!Postgres` tag

Rebased on top of upstream's `postgres-cdc` → `postgres-source` rename (commit 326f48dde, which also renamed the YAML tag to `!Postgres`).
Both `PostgresSource.Factory` (ExternalSource hierarchy) and `PostgresRemote.Factory` (Remote hierarchy) now carry `@SerialName("!Postgres")`.
Kaml dispatches by polymorphic root, so serde is clean — verified by tests.
YAML position (`externalSource:` vs an entry under `remotes:`) disambiguates for the reader.
Happy to rename one if the reading grates; trivial follow-up.

## Scope

In scope:
- New `xtdb.api.Remote` abstraction — interface, Factory, Registration, ServiceLoader polymorphic YAML.
- `!Postgres` remote type (`PostgresRemote` in the postgres-source module).
- `Xtdb.Config.remotes` + `NodeBase` lifecycle (opens alongside log-clusters, closes on shutdown).
- `ExternalSource.Factory.open(..., remotes)` — single call site in `Database.kt`.
- `PostgresSource.Factory` + `PostgresSourceConfig` proto rewritten to reference a remote alias.
- Error split for alias resolution: separate diagnostics for "no entry under alias" vs "entry is the wrong remote type", using `xtdb.error.Incorrect` per project convention.
- Integration test (`PostgresSourceIntegrationTest`) updated to register the remote and use `remote: pg` in the ATTACH; restart path verifies the ATTACH replayed from the source log resolves the alias on a fresh node.

Deferred:
- Storage creds (S3 `access_key`/`secret_key`, Azure `storage_account_key`/`connection_string`) — on the released surface, breaking reshape.
- Log-cluster migration into the `remotes:` section — tidy-first pass.
- Clojure-side `::remotes` apply-config method — add when there's a caller.

## Testing

- `./gradlew test` clean on the worktree; zero new reflection or boxed-math warnings.
- `PostgresSourceIntegrationTest` updated, including the `resume from token after restart` case which specifically exercises the alias-replay flow.
- Integration tests require Docker + `XTDB_SINGLE_WRITER=true`; CI covers them.

Refs #5466
