### PR TITLE
fix(docker): use BasicContextSelector for single Log4j2 LoggerContext

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,7 @@ ENTRYPOINT ["java", \
     "--add-opens=java.base/java.nio=ALL-UNNAMED", \
     "--enable-native-access=ALL-UNNAMED", \
     "-Dio.netty.tryReflectionSetAccessible=true", \
+    "-Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector", \
     "-cp","xtdb.jar", \
     "clojure.main", "-m", "xtdb.main"]
 


### PR DESCRIPTION
## Summary

- Adds `-Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector` to the Docker entrypoint
- Fixes `XTDB_LOGGING_LEVEL_*` env vars not working for Kotlin code (e.g. PostgresSource)

## Context

Log4j2's default `ClassLoaderContextSelector` creates two separate `LoggerContext` instances in the fat jar — one used by Clojure code (via `clojure.tools.logging`) and another used by Kotlin code (via the JPL bridge for `java.lang.System.Logger`). The `XTDB_LOGGING_LEVEL_*` env vars only set levels on the Clojure context via `Configurator/setLevel`, leaving Kotlin loggers stuck at INFO.

`BasicContextSelector` forces a single context for the whole JVM. The multi-context behaviour is designed for servlet containers with per-webapp isolation — not relevant for XTDB's single fat-jar deployment.

## Test plan

- [x] Verified `XTDB_LOGGING_LEVEL_POSTGRES=TRACE` produces DEBUG/TRACE output from `PostgresSource` with `BasicContextSelector`
- [x] Verified no side effects — `BasicContextSelector` is the [recommended selector](https://logging.apache.org/log4j/2.x/manual/logsep.html) for standalone applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)