### PR TITLE
feat(cloud): Kafka replica-log + transactional-id prefix for v2.2

### DIFF
--- a/aws/helm/templates/statefulset.yaml
+++ b/aws/helm/templates/statefulset.yaml
@@ -63,8 +63,12 @@ spec:
                   fieldPath: metadata.name
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ required "xtdbConfig.kafkaBootstrapServers is required." .Values.xtdbConfig.kafkaBootstrapServers }}
-            - name: KAFKA_LOG_TOPIC
+            - name: XTDB_LOG_TOPIC
               value: {{ required "xtdbConfig.kafkaLogTopic is required." .Values.xtdbConfig.kafkaLogTopic }}
+            - name: XTDB_REPLICA_LOG_TOPIC
+              value: {{ required "xtdbConfig.kafkaReplicaLogTopic is required." .Values.xtdbConfig.kafkaReplicaLogTopic }}
+            - name: XTDB_TRANSACTIONAL_ID_PREFIX
+              value: {{ .Values.xtdbConfig.kafkaTransactionalIdPrefix | quote }}
             - name: AWS_S3_BUCKET
               value: {{ required "xtdbConfig.s3Bucket is required." .Values.xtdbConfig.s3Bucket }}
             {{- range $key, $value := .Values.xtdbConfig.env }}

--- a/aws/helm/values.yaml
+++ b/aws/helm/values.yaml
@@ -46,8 +46,12 @@ xtdbConfig:
 
   # Kafka bootstrap servers
   kafkaBootstrapServers: "kafka.xtdb-deployment.svc.cluster.local:9092"
-  # XTDB log topic on Kafka 
+  # XTDB source log topic on Kafka
   kafkaLogTopic: "xtdb-log"
+  # XTDB replica log topic on Kafka (v2.2+)
+  kafkaReplicaLogTopic: "xtdb-log-replica"
+  # Kafka transactional-ID prefix (v2.2+). Override per deployment when sharing a Kafka cluster.
+  kafkaTransactionalIdPrefix: "xtdb"
 
   # OPTIONAL
   # JDK options - ensure that heap + direct memory + metaspace <= memory limit, and that some overhead is left for the OS
@@ -69,10 +73,12 @@ xtdbConfig:
     logClusters:
       kafkaCluster: !Kafka
         bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
+        transactionalIdPrefix: !Env XTDB_TRANSACTIONAL_ID_PREFIX
 
     log: !Kafka
       cluster: kafkaCluster
       topic: !Env XTDB_LOG_TOPIC
+      replicaTopic: !Env XTDB_REPLICA_LOG_TOPIC
 
     storage: !Remote
       objectStore: !S3

--- a/azure/helm/templates/statefulset.yaml
+++ b/azure/helm/templates/statefulset.yaml
@@ -64,8 +64,12 @@ spec:
                   fieldPath: metadata.name
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ required "xtdbConfig.kafkaBootstrapServers is required." .Values.xtdbConfig.kafkaBootstrapServers }}
-            - name: KAFKA_LOG_TOPIC
+            - name: XTDB_LOG_TOPIC
               value: {{ required "xtdbConfig.kafkaLogTopic is required." .Values.xtdbConfig.kafkaLogTopic }}
+            - name: XTDB_REPLICA_LOG_TOPIC
+              value: {{ required "xtdbConfig.kafkaReplicaLogTopic is required." .Values.xtdbConfig.kafkaReplicaLogTopic }}
+            - name: XTDB_TRANSACTIONAL_ID_PREFIX
+              value: {{ .Values.xtdbConfig.kafkaTransactionalIdPrefix | quote }}
             - name: AZURE_STORAGE_ACCOUNT
               value: {{ required "xtdbConfig.storageAccountName is required." .Values.xtdbConfig.storageAccountName }}
             - name: AZURE_STORAGE_CONTAINER

--- a/azure/helm/values.yaml
+++ b/azure/helm/values.yaml
@@ -49,8 +49,12 @@ xtdbConfig:
   storageContainerName: ""
   # Kafka bootstrap servers
   kafkaBootstrapServers: "kafka.xtdb-deployment.svc.cluster.local:9092"
-  # XTDB log topic on Kafka 
+  # XTDB source log topic on Kafka
   kafkaLogTopic: "xtdb-log"
+  # XTDB replica log topic on Kafka (v2.2+)
+  kafkaReplicaLogTopic: "xtdb-log-replica"
+  # Kafka transactional-ID prefix (v2.2+). Override per deployment when sharing a Kafka cluster.
+  kafkaTransactionalIdPrefix: "xtdb"
 
   # OPTIONAL
   # JDK options - ensure that heap + direct memory + metaspace <= memory limit, and that some overhead is left for the OS
@@ -72,10 +76,12 @@ xtdbConfig:
     logClusters:
       kafkaCluster: !Kafka
         bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
+        transactionalIdPrefix: !Env XTDB_TRANSACTIONAL_ID_PREFIX
 
     log: !Kafka
       cluster: kafkaCluster
       topic: !Env XTDB_LOG_TOPIC
+      replicaTopic: !Env XTDB_REPLICA_LOG_TOPIC
 
     storage: !Remote
       objectStore: !Azure

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,6 +58,14 @@ ENV GIT_SHA=${GIT_SHA}
 ENV XTDB_VERSION=${XTDB_VERSION}
 ENV XTDB_LOG_JSON_TEMPLATE=${XTDB_LOG_JSON_TEMPLATE}
 
+# Default Kafka replica log topic (v2.2+). Override when customising XTDB_LOG_TOPIC
+# so the pair stays consistent (e.g. XTDB_LOG_TOPIC=foo XTDB_REPLICA_LOG_TOPIC=foo-replica).
+ENV XTDB_REPLICA_LOG_TOPIC=xtdb-log-replica
+
+# Default Kafka transactional-ID prefix (v2.2+). Override per deployment when sharing
+# a Kafka cluster across multiple XTDB clusters (e.g. "prod", "staging"). Set to empty to disable prefixing.
+ENV XTDB_TRANSACTIONAL_ID_PREFIX=xtdb
+
 COPY docker/${VARIANT}/*.yaml ./
 COPY docker/${VARIANT}/build/libs/xtdb-${VARIANT}.jar xtdb.jar
 

--- a/docker/aws/config.yaml
+++ b/docker/aws/config.yaml
@@ -9,10 +9,12 @@ flightSql:
 logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
+    transactionalIdPrefix: !Env XTDB_TRANSACTIONAL_ID_PREFIX
 
 log: !Kafka
   cluster: kafkaCluster
   topic: !Env XTDB_LOG_TOPIC
+  replicaTopic: !Env XTDB_REPLICA_LOG_TOPIC
 
 storage: !Remote
   objectStore: !S3

--- a/docker/azure/config.yaml
+++ b/docker/azure/config.yaml
@@ -9,10 +9,12 @@ flightSql:
 logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
+    transactionalIdPrefix: !Env XTDB_TRANSACTIONAL_ID_PREFIX
 
 log: !Kafka
   cluster: kafkaCluster
   topic: !Env XTDB_LOG_TOPIC
+  replicaTopic: !Env XTDB_REPLICA_LOG_TOPIC
 
 storage: !Remote
   objectStore: !Azure

--- a/docker/azure/private_auth.yaml
+++ b/docker/azure/private_auth.yaml
@@ -14,9 +14,12 @@ logClusters:
       security.protocol: !Env KAFKA_SECURITY_PROTOCOL
       sasl.jaas.config: !Env KAFKA_SASL_JAAS_CONFIG
 
+    transactionalIdPrefix: !Env XTDB_TRANSACTIONAL_ID_PREFIX
+
 log: !Kafka
   cluster: kafkaCluster
   topic: !Env XTDB_LOG_TOPIC
+  replicaTopic: !Env XTDB_REPLICA_LOG_TOPIC
 
 storage: !Remote
   objectStore: !Azure

--- a/docker/google-cloud/config.yaml
+++ b/docker/google-cloud/config.yaml
@@ -9,10 +9,12 @@ flightSql:
 logClusters:
   kafkaCluster: !Kafka
     bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
+    transactionalIdPrefix: !Env XTDB_TRANSACTIONAL_ID_PREFIX
 
 log: !Kafka
   cluster: kafkaCluster
   topic: !Env XTDB_LOG_TOPIC
+  replicaTopic: !Env XTDB_REPLICA_LOG_TOPIC
 
 storage: !Remote
   objectStore: !GoogleCloud

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,8 +109,32 @@ vX.Y-1: earlier headline
 </details>
 ````
 
-The main page body describes *current* behaviour only.
-The changelog carries the *transition* story.
+The main page body describes *current* behaviour only — write as if the feature has always been there.
+The changelog carries the *transition* story — what it was, why it changed, how to upgrade.
+
+Avoid narrative phrases in the main body like "now", "under v2.2+", "previously", "with this change", "the default handles this transparently" — these belong in the changelog.
+Inline `(vX.Y+)` markers on section headings are the right place to flag when a feature arrived, without narrating the change.
+
+Example — a Helm chart that gained an extra Kafka topic in v2.2:
+
+Wrong (main body, narrates the transition):
+
+```md
+Under single-writer indexing (v2.2+), each database uses two Kafka topics — a source log and a replica log.
+The default chart handles this transparently: the replica topic defaults to `${kafkaLogTopic}-replica` and auto-creates alongside the source topic.
+Most single-deployment setups don't need to do anything.
+```
+
+Right (main body, states the current fact):
+
+```md
+Kafka topics used by the chart (v2.2+):
+
+- `xtdbConfig.kafkaLogTopic` — source log topic.
+- `xtdbConfig.kafkaReplicaLogTopic` — replica log topic.
+```
+
+The "previously X, now Y, how to upgrade" content for that feature lives in the changelog block at the top.
 
 ### Changelog entry vs inline version marker
 

--- a/docs/src/content/docs/ops/aws.md
+++ b/docs/src/content/docs/ops/aws.md
@@ -2,6 +2,24 @@
 title: AWS
 ---
 
+<details>
+<summary>Changelog (last updated v2.2)</summary>
+
+v2.2: Kafka replica log topic
+
+: The `xtdb-aws` Docker image and Helm chart now expose the replica log topic alongside the source log topic, to support [single-writer indexing](/about/dbs-in-xtdb#database-architecture).
+
+  Previously, only `XTDB_LOG_TOPIC` / `xtdbConfig.kafkaLogTopic` existed; a database used a single Kafka topic.
+
+  Upgrading:
+
+  - **Docker image** — `XTDB_REPLICA_LOG_TOPIC` defaults to `xtdb-log-replica` via the Dockerfile. If you customise `XTDB_LOG_TOPIC`, override this env var too so the pair stays consistent.
+  - **Helm chart** — `xtdbConfig.kafkaReplicaLogTopic` defaults to `xtdb-log-replica` and auto-creates alongside the source topic. Existing deployments pick this up on next rollout without any values changes.
+  - **Shared Kafka clusters** — `XTDB_TRANSACTIONAL_ID_PREFIX` / `xtdbConfig.kafkaTransactionalIdPrefix` defaults to `xtdb`.
+    If multiple XTDB deployments share a Kafka cluster, set a distinct prefix per deployment so their leaders don't fence each other — see ['Leader election and fencing'](config/log/kafka#leader-election-and-fencing).
+
+</details>
+
 XTDB provides modular support for AWS environments, including a pre-built Docker image, integrations for **S3 storage** and **CloudWatch metrics**, and configuration options for deploying onto AWS infrastructure.
 
 :::note
@@ -160,6 +178,17 @@ helm show values oci://ghcr.io/xtdb/helm-xtdb-aws \
   --version 2.0.0-snapshot
 ```
 
+#### Kafka topics
+
+The chart uses one Kafka topic for each of the source and replica logs (v2.2+):
+
+- `xtdbConfig.kafkaLogTopic` — source log topic (defaults to `xtdb-log`).
+- `xtdbConfig.kafkaReplicaLogTopic` — replica log topic (defaults to `xtdb-log-replica`).
+
+Both topics auto-create on startup.
+
+If multiple XTDB deployments share a Kafka cluster, set `xtdbConfig.kafkaTransactionalIdPrefix` to a distinct value per deployment (defaults to `xtdb`) — see [Leader election and fencing](config/log/kafka#leader-election-and-fencing).
+
 ### Resources
 
 By default, the following resources are deployed by the Helm chart:
@@ -191,10 +220,11 @@ The following environment variables are used to configure the `xtdb-aws` image:
 | Variable | Description |
 | --- | --- |
 | `KAFKA_BOOTSTRAP_SERVERS` | Kafka bootstrap server containing the XTDB topics. |
-| `XTDB_LOG_TOPIC` | Kafka topic to be used as the XTDB log. |
+| `XTDB_LOG_TOPIC` | Kafka topic used as the source log. |
+| `XTDB_REPLICA_LOG_TOPIC` | (v2.2+) Kafka topic used as the replica log. Defaults to `xtdb-log-replica`. If you override `XTDB_LOG_TOPIC`, override this too to keep the pair consistent. |
+| `XTDB_TRANSACTIONAL_ID_PREFIX` | (v2.2+) Prefix applied to Kafka transactional producer IDs. Defaults to `xtdb`. Override per deployment when sharing a Kafka cluster across multiple XTDB clusters — see [Leader election and fencing](config/log/kafka#leader-election-and-fencing). |
 | `XTDB_S3_BUCKET` | Name of the S3 bucket used for remote storage. |
 | `XTDB_NODE_ID` | Persistent node id for labelling Prometheus metrics. |
-
 
 You can also [set the XTDB log level](/ops/troubleshooting#loglevel) using environment variables.
 

--- a/docs/src/content/docs/ops/azure.md
+++ b/docs/src/content/docs/ops/azure.md
@@ -2,6 +2,24 @@
 title: Azure
 ---
 
+<details>
+<summary>Changelog (last updated v2.2)</summary>
+
+v2.2: Kafka replica log topic
+
+: The `xtdb-azure` Docker image and Helm chart now expose the replica log topic alongside the source log topic, to support [single-writer indexing](/about/dbs-in-xtdb#database-architecture).
+
+  Previously, only `XTDB_LOG_TOPIC` / `xtdbConfig.kafkaLogTopic` existed; a database used a single Kafka topic.
+
+  Upgrading:
+
+  - **Docker image** — `XTDB_REPLICA_LOG_TOPIC` defaults to `xtdb-log-replica` via the Dockerfile. If you customise `XTDB_LOG_TOPIC`, override this env var too so the pair stays consistent.
+  - **Helm chart** — `xtdbConfig.kafkaReplicaLogTopic` defaults to `xtdb-log-replica` and auto-creates alongside the source topic. Existing deployments pick this up on next rollout without any values changes.
+  - **Shared Kafka clusters** — `XTDB_TRANSACTIONAL_ID_PREFIX` / `xtdbConfig.kafkaTransactionalIdPrefix` defaults to `xtdb`.
+    If multiple XTDB deployments share a Kafka cluster, set a distinct prefix per deployment so their leaders don't fence each other — see ['Leader election and fencing'](config/log/kafka#leader-election-and-fencing).
+
+</details>
+
 XTDB provides modular support for Azure environments, including a prebuilt Docker image, integrations with **Azure Blob Storage**, **Application Insights monitoring** and configuration options for deploying onto Azure infrastructure.
 
 :::note
@@ -118,6 +136,17 @@ helm show values oci://ghcr.io/xtdb/helm-xtdb-azure \
   --version 2.0.0-snapshot
 ```
 
+#### Kafka topics
+
+The chart uses one Kafka topic for each of the source and replica logs (v2.2+):
+
+- `xtdbConfig.kafkaLogTopic` — source log topic (defaults to `xtdb-log`).
+- `xtdbConfig.kafkaReplicaLogTopic` — replica log topic (defaults to `xtdb-log-replica`).
+
+Both topics auto-create on startup.
+
+If multiple XTDB deployments share a Kafka cluster, set `xtdbConfig.kafkaTransactionalIdPrefix` to a distinct value per deployment (defaults to `xtdb`) — see [Leader election and fencing](config/log/kafka#leader-election-and-fencing).
+
 ### Resources
 
 By default, the following resources are deployed by the Helm chart:
@@ -149,7 +178,9 @@ The following environment variables configure the `xtdb-azure` image:
 | Variable | Description |
 | --- | --- |
 | `KAFKA_BOOTSTRAP_SERVERS` | Kafka bootstrap server containing the XTDB topics. |
-| `XTDB_LOG_TOPIC` | Kafka topic to be used as the XTDB log. |
+| `XTDB_LOG_TOPIC` | Kafka topic used as the source log. |
+| `XTDB_REPLICA_LOG_TOPIC` | (v2.2+) Kafka topic used as the replica log. Defaults to `xtdb-log-replica`. If you override `XTDB_LOG_TOPIC`, override this too to keep the pair consistent. |
+| `XTDB_TRANSACTIONAL_ID_PREFIX` | (v2.2+) Prefix applied to Kafka transactional producer IDs. Defaults to `xtdb`. Override per deployment when sharing a Kafka cluster across multiple XTDB clusters — see [Leader election and fencing](config/log/kafka#leader-election-and-fencing). |
 | `XTDB_AZURE_STORAGE_ACCOUNT` | Name of the Azure Storage Account. |
 | `XTDB_AZURE_STORAGE_CONTAINER` | Name of the Azure Storage Container. |
 | `XTDB_AZURE_USER_MANAGED_IDENTITY_CLIENT_ID` | Azure Client ID for the User Assigned Managed Identity used for authentication. |
@@ -158,6 +189,7 @@ The following environment variables configure the `xtdb-azure` image:
 
 
 You can also [set the XTDB log level](/ops/troubleshooting#loglevel) using environment variables.
+
 
 ### Using the "private auth" Configuration File
 

--- a/docs/src/content/docs/ops/google-cloud.md
+++ b/docs/src/content/docs/ops/google-cloud.md
@@ -2,6 +2,24 @@
 title: Google Cloud
 ---
 
+<details>
+<summary>Changelog (last updated v2.2)</summary>
+
+v2.2: Kafka replica log topic
+
+: The `xtdb-google-cloud` Docker image and Helm chart now expose the replica log topic alongside the source log topic, to support [single-writer indexing](/about/dbs-in-xtdb#database-architecture).
+
+  Previously, only `XTDB_LOG_TOPIC` / `xtdbConfig.kafkaLogTopic` existed; a database used a single Kafka topic.
+
+  Upgrading:
+
+  - **Docker image** — `XTDB_REPLICA_LOG_TOPIC` defaults to `xtdb-log-replica` via the Dockerfile. If you customise `XTDB_LOG_TOPIC`, override this env var too so the pair stays consistent.
+  - **Helm chart** — `xtdbConfig.kafkaReplicaLogTopic` defaults to `xtdb-log-replica` and auto-creates alongside the source topic. Existing deployments pick this up on next rollout without any values changes.
+  - **Shared Kafka clusters** — `XTDB_TRANSACTIONAL_ID_PREFIX` / `xtdbConfig.kafkaTransactionalIdPrefix` defaults to `xtdb`.
+    If multiple XTDB deployments share a Kafka cluster, set a distinct prefix per deployment so their leaders don't fence each other — see ['Leader election and fencing'](config/log/kafka#leader-election-and-fencing).
+
+</details>
+
 XTDB provides modular support for Google Cloud environments, including a prebuilt Docker image, integrations with **Google Cloud Storage**, and configuration options for deploying onto Google Cloud infrastructure.
 
 :::note
@@ -132,6 +150,17 @@ helm show values oci://ghcr.io/xtdb/helm-xtdb-google-cloud
   --version 2.0.0-snapshot
 ```
 
+#### Kafka topics
+
+The chart uses one Kafka topic for each of the source and replica logs (v2.2+):
+
+- `xtdbConfig.kafkaLogTopic` — source log topic (defaults to `xtdb-log`).
+- `xtdbConfig.kafkaReplicaLogTopic` — replica log topic (defaults to `xtdb-log-replica`).
+
+Both topics auto-create on startup.
+
+If multiple XTDB deployments share a Kafka cluster, set `xtdbConfig.kafkaTransactionalIdPrefix` to a distinct value per deployment (defaults to `xtdb`) — see [Leader election and fencing](config/log/kafka#leader-election-and-fencing).
+
 ### Resources
 
 By default, the following resources are deployed by the Helm chart:
@@ -163,7 +192,9 @@ The following environment variables are used to configure the `xtdb-google-cloud
 | Variable | Description |
 | --- | --- |
 | `KAFKA_BOOTSTRAP_SERVERS` | Kafka bootstrap server containing the XTDB topics. |
-| `XTDB_LOG_TOPIC` | Kafka topic to be used as the XTDB log. |
+| `XTDB_LOG_TOPIC` | Kafka topic used as the source log. |
+| `XTDB_REPLICA_LOG_TOPIC` | (v2.2+) Kafka topic used as the replica log. Defaults to `xtdb-log-replica`. If you override `XTDB_LOG_TOPIC`, override this too to keep the pair consistent. |
+| `XTDB_TRANSACTIONAL_ID_PREFIX` | (v2.2+) Prefix applied to Kafka transactional producer IDs. Defaults to `xtdb`. Override per deployment when sharing a Kafka cluster across multiple XTDB clusters — see [Leader election and fencing](config/log/kafka#leader-election-and-fencing). |
 | `XTDB_GCP_PROJECT_ID` | GCP project ID containing the bucket. |
 | `XTDB_GCP_BUCKET` | Name of the Google Cloud Storage bucket used for remote storage. |
 | `XTDB_GCP_LOCAL_DISK_CACHE_PATH` | Path to the local disk cache. |
@@ -171,6 +202,7 @@ The following environment variables are used to configure the `xtdb-google-cloud
 
 
 You can also [set the XTDB log level](/ops/troubleshooting#loglevel) using environment variables.
+
 
 ### Using a Custom Node Configuration
 

--- a/google-cloud/helm/templates/statefulset.yaml
+++ b/google-cloud/helm/templates/statefulset.yaml
@@ -63,8 +63,12 @@ spec:
                   fieldPath: metadata.name
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ required "xtdbConfig.kafkaBootstrapServers is required." .Values.xtdbConfig.kafkaBootstrapServers }}
-            - name: KAFKA_LOG_TOPIC
+            - name: XTDB_LOG_TOPIC
               value: {{ required "xtdbConfig.kafkaLogTopic is required." .Values.xtdbConfig.kafkaLogTopic }}
+            - name: XTDB_REPLICA_LOG_TOPIC
+              value: {{ required "xtdbConfig.kafkaReplicaLogTopic is required." .Values.xtdbConfig.kafkaReplicaLogTopic }}
+            - name: XTDB_TRANSACTIONAL_ID_PREFIX
+              value: {{ .Values.xtdbConfig.kafkaTransactionalIdPrefix | quote }}
             - name: GCP_PROJECT_ID
               value: {{ required "xtdbConfig.gcpProjectId is required." .Values.xtdbConfig.gcpProjectId }}
             - name: GCP_BUCKET

--- a/google-cloud/helm/values.yaml
+++ b/google-cloud/helm/values.yaml
@@ -49,8 +49,12 @@ xtdbConfig:
   gcpBucket: "" 
   # Kafka bootstrap servers
   kafkaBootstrapServers: "kafka.xtdb-deployment.svc.cluster.local:9092"
-  # XTDB log topic on Kafka 
+  # XTDB source log topic on Kafka
   kafkaLogTopic: "xtdb-log"
+  # XTDB replica log topic on Kafka (v2.2+)
+  kafkaReplicaLogTopic: "xtdb-log-replica"
+  # Kafka transactional-ID prefix (v2.2+). Override per deployment when sharing a Kafka cluster.
+  kafkaTransactionalIdPrefix: "xtdb"
 
   # OPTIONAL
   # JDK options - ensure that heap + direct memory + metaspace <= memory limit, and that some overhead is left for the OS
@@ -72,10 +76,12 @@ xtdbConfig:
     logClusters:
       kafkaCluster: !Kafka
         bootstrapServers: !Env KAFKA_BOOTSTRAP_SERVERS
+        transactionalIdPrefix: !Env XTDB_TRANSACTIONAL_ID_PREFIX
 
     log: !Kafka
       cluster: kafkaCluster
       topic: !Env XTDB_LOG_TOPIC
+      replicaTopic: !Env XTDB_REPLICA_LOG_TOPIC
 
     storage: !Remote
       objectStore: !GoogleCloud

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -347,7 +347,13 @@ class KafkaCluster(
                 .plus(propertiesFile?.asPropertiesMap.orEmpty())
 
         override fun open(): KafkaCluster =
-            KafkaCluster(configMap, pollDuration, schemaRegistryUrl, transactionalIdPrefix, groupId, coroutineContext)
+            KafkaCluster(
+                configMap, pollDuration, schemaRegistryUrl,
+                // normalise empty/blank prefix to null so `ENV XTDB_TRANSACTIONAL_ID_PREFIX=""`
+                // from the Docker image produces `xtdb-leader` rather than `-xtdb-leader`.
+                transactionalIdPrefix?.ifBlank { null },
+                groupId, coroutineContext
+            )
     }
 
     interface AtomicProducer<M> : Log.AtomicProducer<M> {


### PR DESCRIPTION
Surfaces v2.2's second Kafka topic and the `transactionalIdPrefix` knob through the `xtdb-{aws,azure,google-cloud}` Docker images, Helm charts, and corresponding docs.

## Context

v2.2 introduced single-writer indexing, which gave each database a second Kafka topic (the replica log) and added `transactionalIdPrefix` for deployments sharing a Kafka cluster.
Neither was exposed through the cloud Docker images or Helm charts — operators would only hit them by mounting a custom config, which defeats the point of shipping default configs.

## Shape

**Dockerfile** defaults `XTDB_REPLICA_LOG_TOPIC=xtdb-log-replica` and `XTDB_TRANSACTIONAL_ID_PREFIX=xtdb`; each variant's `config.yaml` references them via `!Env`.
Operators override per-deployment.

**Helm charts** expose `xtdbConfig.kafkaReplicaLogTopic` / `kafkaTransactionalIdPrefix` values with the same defaults, wired through the statefulset.

**`KafkaCluster.ClusterFactory.open()`** normalises empty/blank `transactionalIdPrefix` to null, so operators can set `XTDB_TRANSACTIONAL_ID_PREFIX=""` to opt out of prefixing and get a clean `xtdb-leader` transactional ID rather than `-xtdb-leader`.

## Decisions

- **Default prefix `"xtdb"`** — gives transactional IDs a sensible namespace (`xtdb-my-db-leader`), useful when a Kafka cluster hosts more than just XTDB.
  The primary DB's transactional ID becomes `xtdb-xtdb-leader` (slightly repetitive but not broken); overridable.
- **Default replica topic `xtdb-log-replica`** — a static default.
  If operators customise `XTDB_LOG_TOPIC` they need to override `XTDB_REPLICA_LOG_TOPIC` too; called out in the docs table and the Dockerfile comment.

## Also, in passing

- **Pre-existing Helm chart bug** fixed: the three statefulset templates set `KAFKA_LOG_TOPIC` as the pod env var, but the nodeConfig referenced `!Env XTDB_LOG_TOPIC`.
  The mismatch meant the charts as shipped couldn't resolve the source log topic unless operators supplied `XTDB_LOG_TOPIC` manually via `xtdbConfig.env`.
- **`docs/README.md`** — sharpened the main-body-vs-changelog rule with a worked example after this pass tripped on it twice; the rule now has a right/wrong example drawn from this exact scenario.

## Test plan

- [ ] `helm template` the three charts to confirm the new values render correctly.
- [ ] End-to-end smoke test: one Helm deployment (or Docker image with `-e ...` override) against a live Kafka — verify `!Env` references resolve and both topics auto-create.
- [ ] Unit test on `ClusterFactory.open()` for the `ifBlank` normalisation (empty string → null, `"xtdb"` stays `"xtdb"`).