### PR TITLE
feat(external-source): expose openQuery on writer OpenTx

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -48,7 +48,7 @@
            xtdb.arrow.RelationReader
            xtdb.database.Database$Config
            (xtdb.error Incorrect Interrupted)
-           xtdb.IResultCursor
+           xtdb.ResultCursor
            (xtdb.pgwire PgType PgTypes)
            xtdb.JsonSerde
            xtdb.JsonLdSerde
@@ -1113,12 +1113,12 @@
 
         xt-args (xtify-args conn args stmt)]
 
-    (letfn [(->cursor ^xtdb.IResultCursor [xt-args]
+    (letfn [(->cursor ^xtdb.ResultCursor [xt-args]
               (with-auth-check conn
                 (util/with-close-on-catch [args-rel (vw/open-args allocator xt-args)]
                   (.openQuery prepared-query args-rel query-opts))))
 
-            (->pg-cols [prepared-pg-cols ^IResultCursor cursor]
+            (->pg-cols [prepared-pg-cols ^ResultCursor cursor]
               (let [resolved-pg-cols (mapv (fn [[col-name vec-type]] (type->pg-col col-name vec-type)) (.getResultTypes cursor))]
                 (when-not (and (= (count prepared-pg-cols) (count resolved-pg-cols))
                                (->> (map vector prepared-pg-cols resolved-pg-cols)
@@ -1169,7 +1169,7 @@
                                       :pg-cols (-> (:pg-cols stmt)
                                                    (with-result-formats result-format))))))
 
-        :execute (util/with-open [^IResultCursor args-cursor (->cursor xt-args)]
+        :execute (util/with-open [^ResultCursor args-cursor (->cursor xt-args)]
                    ;; in the case of execute, we've just bound the args query rather than the inner query.
                    ;; so now we bind the inner query and pretend this was the one we were running all along
                    (let [{^PreparedQuery inner-pq :prepared-query, :as inner} (get-in @conn-state [:prepared-statements (:statement-name stmt)])
@@ -1362,7 +1362,7 @@
       Future$State/FAILED (throw (.exceptionNow task)))))
 
 (defn cmd-exec-query [{:keys [conn-state !closing? query-error-counter] :as conn}
-                      {:keys [limit statement-type query ^IResultCursor cursor pg-cols portal-name pending-rows total-rows-sent]
+                      {:keys [limit statement-type query ^ResultCursor cursor pg-cols portal-name pending-rows total-rows-sent]
                        :as _portal}]
   ;; Create an implicit transaction if one hasn't already been started
   (let [transaction (get-in @conn-state [:transaction])]

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -44,7 +44,7 @@
            [java.util.stream Stream StreamSupport]
            (org.apache.arrow.memory BufferAllocator RootAllocator)
            org.apache.arrow.vector.types.pojo.Field
-           (xtdb ICursor IResultCursor IResultCursor$ErrorTrackingCursor PagesCursor)
+           (xtdb ICursor ResultCursor ResultCursor$ErrorTrackingCursor PagesCursor)
            (xtdb.antlr Sql$DirectlyExecutableStatementContext)
            (xtdb.api.query IKeyFn)
            (xtdb.arrow RelationReader VectorReader VectorType)
@@ -55,7 +55,7 @@
            xtdb.util.RefCounter))
 
 (defn- wrap-result-types [^ICursor cursor, result-types]
-  (reify IResultCursor
+  (reify ResultCursor
     (getResultTypes [_] result-types)
     (tryAdvance [_ c] (.tryAdvance cursor c))
 
@@ -71,10 +71,10 @@
     (trySplit [_] (.trySplit cursor))
     (close [_] (.close cursor))))
 
-(defn- wrap-dynvars ^xtdb.IResultCursor [^IResultCursor cursor
+(defn- wrap-dynvars ^xtdb.ResultCursor [^ResultCursor cursor
                                          current-time, snapshot-token, default-tz
                                          ^RefCounter ref-ctr]
-  (reify IResultCursor
+  (reify ResultCursor
     (getResultTypes [_] (.getResultTypes cursor))
     (tryAdvance [_ c]
       (when (.isClosing ref-ctr)
@@ -97,9 +97,9 @@
     (trySplit [_] (.trySplit cursor))
     (close [_] (.close cursor))))
 
-(defn- wrap-closeables ^xtdb.IResultCursor [^IResultCursor cursor, ^RefCounter ref-ctr, closeables]
+(defn- wrap-closeables ^xtdb.ResultCursor [^ResultCursor cursor, ^RefCounter ref-ctr, closeables]
   (let [!closed? (AtomicBoolean. false)]
-    (reify IResultCursor
+    (reify ResultCursor
       (getResultTypes [_] (.getResultTypes cursor))
       (tryAdvance [_ c] (.tryAdvance cursor c))
 
@@ -258,7 +258,7 @@
                (map (fn [[k v]] [k (truncate-pushdown-val k v)]))
                col-pushdowns))))
 
-(defn- explain-analyze-results [^IResultCursor cursor]
+(defn- explain-analyze-results [^ResultCursor cursor]
   (letfn [(->results [^ICursor cursor, depth]
             (lazy-seq
              (if-let [ea (.getExplainAnalyze cursor)]
@@ -484,12 +484,12 @@
                               (.denormalize key-fn k))))))))
 
 (defn cursor->stream
-  (^java.util.stream.Stream [^IResultCursor cursor query-opts]
+  (^java.util.stream.Stream [^ResultCursor cursor query-opts]
    (cursor->stream cursor query-opts {}))
-  (^java.util.stream.Stream [^IResultCursor cursor {:keys [key-fn]} {:keys [query-error-counter]}]
+  (^java.util.stream.Stream [^ResultCursor cursor {:keys [key-fn]} {:keys [query-error-counter]}]
    (let [key-fn (cache-key-fn key-fn)]
      (-> (StreamSupport/stream (cond-> cursor
-                                 query-error-counter (IResultCursor$ErrorTrackingCursor. query-error-counter))
+                                 query-error-counter (ResultCursor$ErrorTrackingCursor. query-error-counter))
                                false)
          ^Stream (.onClose (fn []
                              (util/close cursor)))

--- a/core/src/main/kotlin/xtdb/ResultCursor.kt
+++ b/core/src/main/kotlin/xtdb/ResultCursor.kt
@@ -6,13 +6,13 @@ import xtdb.arrow.VectorType
 import java.util.function.Consumer
 import java.util.SequencedMap
 
-interface IResultCursor : ICursor {
+interface ResultCursor : ICursor {
     val resultTypes: SequencedMap<String, VectorType>
 
     class ErrorTrackingCursor(
-        private val inner: IResultCursor,
+        private val inner: ResultCursor,
         private val counter: Counter
-    ) : IResultCursor by inner {
+    ) : ResultCursor by inner {
         override fun tryAdvance(c: Consumer<in RelationReader>): Boolean =
             try {
                 inner.tryAdvance(c)

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -19,7 +19,7 @@ import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.complex.writer.VarCharWriter
 import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.Schema
-import xtdb.IResultCursor
+import xtdb.ResultCursor
 import xtdb.api.Xtdb
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
@@ -137,9 +137,9 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     }
 
     fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName)
-    fun openSqlQuery(sql: String): IResultCursor = node.openSqlQuery(sql, dbName)
+    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName)
 
-    private fun cursorToArrowReader(cursor: IResultCursor, schema: Schema): ArrowReader =
+    private fun cursorToArrowReader(cursor: ResultCursor, schema: Schema): ArrowReader =
         object : ArrowReader(node.allocator) {
             override fun readSchema() = schema
 
@@ -397,7 +397,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         val databaseNames: Collection<DatabaseName>
         fun submitTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.SubmittedTx
         fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx
-        fun openSqlQuery(sql: String, dbName: DatabaseName): IResultCursor
+        fun openSqlQuery(sql: String, dbName: DatabaseName): ResultCursor
         fun prepareSql(sql: String, dbName: DatabaseName): PreparedQuery
         fun getColumnTypes(table: TableRef): Map<String, VectorType>?
     }

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -211,7 +211,7 @@ class Database(
                             return if (extFactory != null) {
                                 val leaderProc = ExternalSourceProcessor(
                                     allocator, storage, replicaProducer, state,
-                                    watchers, blockUploader,
+                                    watchers, blockUploader, base.querySource,
                                     partition = 0, afterSourceMsgId, afterReplicaMsgId,
                                     extSource = extFactory.open(dbName, base.logClusters, base.remotes),
                                     // watchers has the latest token from replica log replay,

--- a/core/src/main/kotlin/xtdb/database/ExternalSource.kt
+++ b/core/src/main/kotlin/xtdb/database/ExternalSource.kt
@@ -3,13 +3,17 @@ package xtdb.database
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
+import xtdb.ResultCursor
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
+import xtdb.arrow.RelationReader
 import xtdb.database.proto.DatabaseConfig
-import xtdb.indexer.OpenTx
+import xtdb.indexer.OpenTx.Table
+import xtdb.table.TableRef
 import java.time.Instant
+import java.time.ZoneId
 import java.util.*
 import com.google.protobuf.Any as ProtoAny
 
@@ -42,6 +46,45 @@ interface ExternalSource : AutoCloseable {
             writer: suspend (OpenTx) -> TxResult,
         ): TxResult
     }
+
+    /**
+     * The per-tx handle passed to the writer lambda in [TxIndexer.indexTx].
+     * Writes go via [table]; reads via [openQuery], with visibility into writes made earlier
+     * in the same writer call.
+     *
+     * Scoped to the writer's database — and, once XTDB supports multi-partition external sources,
+     * to the current partition. Other databases and partitions are not visible.
+     */
+    interface OpenTx {
+        val systemFrom: Long
+
+        fun table(ref: TableRef): Table
+        fun table(schemaName: String, tableName: String): Table
+
+        /**
+         * Run SQL against the database's live index, with visibility into writes made earlier
+         * in this transaction.
+         *
+         * Positional `?` parameters are supplied through [args] as a single-row [RelationReader].
+         * [xtdb.arrow.Relation.openFromRows] wraps a `List<Map<*, *>>` — keys can be column names
+         * or positional placeholders (`_0`, `_1`, …):
+         *
+         *     Relation.openFromRows(al, listOf(mapOf("_0" to pk))).use { rel ->
+         *         openTx.openQuery("SELECT * FROM t WHERE _id = ?", rel.relReader).use { cursor ->
+         *             …
+         *         }
+         *     }
+         *
+         * Defaults for [opts] are derived from the tx's system-time and the database's default
+         * timezone; most callers can omit it.
+         */
+        fun openQuery(sql: String, args: RelationReader? = null, opts: QueryOpts = QueryOpts()): ResultCursor
+    }
+
+    data class QueryOpts(
+        val currentTime: Instant? = null,
+        val defaultTz: ZoneId? = null,
+    )
 
     interface Factory {
         fun writeTo(dbConfig: DatabaseConfig.Builder)

--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -31,7 +31,7 @@ import xtdb.arrow.RelationReader
 import xtdb.arrow.Vector
 import xtdb.arrow.VectorType
 import xtdb.asBytes
-import xtdb.IResultCursor
+import xtdb.ResultCursor
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.arrow.withName
 import xtdb.kw
@@ -126,7 +126,7 @@ private class PreparedStatement(
     val txHandle: TxHandle?,
     val dbName: DatabaseName,
     val prepdQuery: PreparedQuery?,
-    var cursor: IResultCursor? = null
+    var cursor: ResultCursor? = null
 ) : AutoCloseable {
     override fun close() {
         cursor?.close()
@@ -169,7 +169,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
     private val txConnections = ConcurrentHashMap<TxHandle, XtdbConnection>()
     private val defaultConnections = ConcurrentHashMap<DatabaseName, XtdbConnection>()
     private val stmts = ConcurrentHashMap<PreparedStatementHandle, PreparedStatement>()
-    private val tickets = ConcurrentHashMap<TicketHandle, IResultCursor>()
+    private val tickets = ConcurrentHashMap<TicketHandle, ResultCursor>()
 
     private fun defaultConnectionFor(dbName: DatabaseName): XtdbConnection =
         defaultConnections.computeIfAbsent(dbName) {
@@ -201,7 +201,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         }
     }
 
-    private fun handleGetStream(cursor: IResultCursor, listener: ServerStreamListener) {
+    private fun handleGetStream(cursor: ResultCursor, listener: ServerStreamListener) {
         try {
             VectorSchemaRoot.create(resultTypesToSchema(cursor.resultTypes), allocator).use { vsr ->
                 val rootLoader = VectorLoader(vsr)

--- a/core/src/main/kotlin/xtdb/indexer/ExternalSourceProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ExternalSourceProcessor.kt
@@ -1,5 +1,6 @@
 package xtdb.indexer
 
+import clojure.lang.Keyword
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -7,6 +8,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.apache.arrow.memory.BufferAllocator
+import xtdb.ResultCursor
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
 import xtdb.api.log.*
@@ -14,6 +16,7 @@ import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.api.log.ReplicaMessage.BlockBoundary
 import xtdb.api.log.ReplicaMessage.TriesAdded
 import xtdb.api.storage.Storage
+import xtdb.arrow.RelationReader
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
 import xtdb.database.ExternalSource
@@ -21,6 +24,8 @@ import xtdb.database.ExternalSource.TxResult
 import xtdb.database.ExternalSourceToken
 import xtdb.error.Interrupted
 import xtdb.indexer.Indexer.Companion.addTxRow
+import xtdb.query.IQuerySource
+import xtdb.query.QueryOpts
 import xtdb.table.TableRef
 import xtdb.time.InstantUtil.asMicros
 import xtdb.time.InstantUtil.fromMicros
@@ -38,11 +43,12 @@ private val LOG = ExternalSourceProcessor::class.logger
 
 class ExternalSourceProcessor(
     private val allocator: BufferAllocator,
-    dbStorage: DatabaseStorage,
+    private val dbStorage: DatabaseStorage,
     private val replicaProducer: Log.AtomicProducer<ReplicaMessage>,
     private val dbState: DatabaseState,
     private val watchers: Watchers,
     private val blockUploader: BlockUploader,
+    private val querySource: IQuerySource,
     partition: Int,
     afterSourceMsgId: MessageId,
     afterReplicaMsgId: MessageId,
@@ -90,11 +96,46 @@ class ExternalSourceProcessor(
         return if (systemTime.isBefore(floor)) floor else systemTime
     }
 
+    // Wraps the inner [OpenTx] and exposes the narrow surface source authors see:
+    // writes via [table], reads via [openQuery]. The wrapper forwards query execution
+    // to the node's [IQuerySource], scoped to this database with a snapshot that includes
+    // the tx's in-flight writes.
+    private inner class WriterOpenTx(val inner: OpenTx) : ExternalSource.OpenTx {
+        override val systemFrom get() = inner.systemFrom
+
+        override fun table(ref: TableRef) = inner.table(ref)
+        override fun table(schemaName: String, tableName: String) =
+            inner.table(TableRef(dbName, schemaName, tableName))
+
+        override fun openQuery(
+            sql: String,
+            args: RelationReader?,
+            opts: ExternalSource.QueryOpts,
+        ): ResultCursor {
+            val currentTime = opts.currentTime ?: inner.txKey.systemTime
+
+            val snapSource = object : Snapshot.Source {
+                override fun openSnapshot() = liveIndex.openSnapshot(inner)
+            }
+            val queryCat = Indexer.queryCatalog(dbStorage, dbState, snapSource)
+
+            val prepareOpts = mapOf(
+                Keyword.intern("current-time") to currentTime,
+                Keyword.intern("default-tz") to opts.defaultTz,
+                Keyword.intern("default-db") to dbName,
+                Keyword.intern("query-text") to sql,
+            )
+
+            val pq = querySource.prepareQuery(sql, queryCat, prepareOpts)
+            return pq.openQuery(args, QueryOpts(currentTime = currentTime, defaultTz = opts.defaultTz))
+        }
+    }
+
     private val txIndexer = object : ExternalSource.TxIndexer {
         override suspend fun indexTx(
             externalSourceToken: ExternalSourceToken?,
             systemTime: Instant?,
-            writer: suspend (OpenTx) -> TxResult,
+            writer: suspend (ExternalSource.OpenTx) -> TxResult,
         ): TxResult {
             val txId = (liveIndex.latestCompletedTx?.txId ?: -1) + 1
             val txKey = TransactionKey(txId, smoothSystemTime(systemTime ?: instantSource.instant()))
@@ -102,7 +143,7 @@ class ExternalSourceProcessor(
             try {
                 val openTx = OpenTx(allocator, txKey)
                 val result = try {
-                    writer(openTx)
+                    writer(WriterOpenTx(openTx))
                 } catch (e: Throwable) {
                     openTx.close()
                     throw e

--- a/core/src/main/kotlin/xtdb/query/PreparedQuery.kt
+++ b/core/src/main/kotlin/xtdb/query/PreparedQuery.kt
@@ -1,7 +1,7 @@
 package xtdb.query
 
 import org.apache.arrow.vector.types.pojo.Field
-import xtdb.IResultCursor
+import xtdb.ResultCursor
 import xtdb.trie.ColumnName
 import xtdb.arrow.RelationReader
 
@@ -12,5 +12,5 @@ interface PreparedQuery {
 
     val warnings: List<String>
 
-    fun openQuery(args: RelationReader?, opts: QueryOpts): IResultCursor
+    fun openQuery(args: RelationReader?, opts: QueryOpts): ResultCursor
 }

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -3,6 +3,7 @@ package xtdb.database
 import com.google.protobuf.StringValue
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import xtdb.ResultCursor
 import xtdb.api.log.InMemoryLog
 import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
@@ -22,6 +24,8 @@ import xtdb.compactor.Compactor
 import xtdb.database.ExternalSource.TxResult
 import xtdb.error.Incorrect
 import xtdb.indexer.*
+import xtdb.query.IQuerySource
+import xtdb.query.PreparedQuery
 import xtdb.storage.MemoryStorage
 import xtdb.tx.TxOpts
 import java.time.Instant
@@ -75,6 +79,7 @@ class ExternalSourceTest {
         watchers: Watchers = Watchers(-1),
         extSource: ExternalSource = InMemoryExternalSource(),
         afterToken: ExternalSourceToken? = null,
+        querySource: IQuerySource = mockk(relaxed = true),
         ctx: CoroutineContext,
     ): ExternalSourceProcessor {
         val blockCatalog = BlockCatalog("test", null)
@@ -87,7 +92,7 @@ class ExternalSourceTest {
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
 
         return ExternalSourceProcessor(
-            allocator, dbStorage, replicaProducer, dbState, watchers, blockUploader,
+            allocator, dbStorage, replicaProducer, dbState, watchers, blockUploader, querySource,
             partition = 0, afterSourceMsgId = -1, afterReplicaMsgId = -1,
             extSource = extSource, afterToken = afterToken, ctx = ctx,
         )
@@ -227,6 +232,61 @@ class ExternalSourceTest {
             extSource.channel.send(null)
             delay(500)
             assertNotNull(watchers.exception, "watchers should be in failed state")
+        } finally {
+            lp.close()
+        }
+    }
+
+    @Test
+    fun `openQuery on writer OpenTx delegates to querySource with tx-scoped snapshot`() = runTest {
+        val cursor = mockk<ResultCursor>(relaxed = true)
+        val pq = mockk<PreparedQuery> {
+            every { openQuery(any(), any()) } returns cursor
+        }
+
+        val sqlSlot = slot<Any>()
+        val catSlot = slot<IQuerySource.QueryCatalog>()
+        val querySource = mockk<IQuerySource> {
+            every { prepareQuery(capture(sqlSlot), capture(catSlot), any()) } returns pq
+        }
+
+        val receivedCursor = CompletableDeferred<ResultCursor>()
+        val receivedTable = CompletableDeferred<Unit>()
+
+        val extSource = object : ExternalSource {
+            override suspend fun onPartitionAssigned(
+                partition: Int, afterToken: ExternalSourceToken?, txIndexer: ExternalSource.TxIndexer,
+            ) {
+                txIndexer.indexTx(null) { openTx ->
+                    openTx.table("public", "customers")
+                    receivedTable.complete(Unit)
+
+                    val cur = openTx.openQuery("SELECT _id FROM public.customers")
+                    receivedCursor.complete(cur)
+                    TxResult.Committed()
+                }
+            }
+
+            override fun close() {}
+        }
+
+        val liveIndex = mockk<LiveIndex>(relaxed = true) {
+            every { latestCompletedTx } returns null
+        }
+
+        val lp = leaderProc(
+            liveIndex = liveIndex, extSource = extSource,
+            querySource = querySource, ctx = coroutineContext,
+        )
+
+        try {
+            receivedTable.await()
+            val cur = receivedCursor.await()
+
+            assertSame(cursor, cur, "openQuery should return the querySource's cursor")
+            assertEquals("SELECT _id FROM public.customers", sqlSlot.captured)
+            assertEquals(setOf("test"), catSlot.captured.databaseNames.toSet())
+            verify { pq.openQuery(isNull(), any()) }
         } finally {
             lp.close()
         }

--- a/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumKafkaSource.kt
+++ b/modules/debezium/src/main/kotlin/xtdb/debezium/DebeziumKafkaSource.kt
@@ -29,7 +29,7 @@ import xtdb.database.proto.DatabaseConfig
 import xtdb.debezium.proto.*
 import xtdb.debezium.proto.DebeziumKafkaSourceConfig.MessageFormatCase
 import xtdb.error.Incorrect
-import xtdb.indexer.OpenTx
+import xtdb.database.ExternalSource.OpenTx
 import xtdb.table.TableRef
 import xtdb.time.InstantUtil.asMicros
 import xtdb.util.asIid

--- a/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumKafkaSourceTest.kt
+++ b/modules/debezium/src/test/kotlin/xtdb/debezium/DebeziumKafkaSourceTest.kt
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.testcontainers.kafka.ConfluentKafkaContainer
 import org.apache.arrow.memory.RootAllocator
 import xtdb.api.TransactionKey
+import xtdb.ResultCursor
+import xtdb.arrow.RelationReader
 import xtdb.database.ExternalSource
 import xtdb.database.ExternalSource.TxResult
 import xtdb.database.ExternalSourceToken
@@ -21,6 +23,7 @@ import xtdb.debezium.proto.DebeziumOffsetToken
 import xtdb.debezium.proto.debeziumOffsetToken
 import xtdb.debezium.proto.partitionOffsets
 import xtdb.indexer.OpenTx
+import xtdb.table.TableRef
 import com.google.protobuf.Any as ProtoAny
 import java.time.Instant
 import java.util.Collections
@@ -100,15 +103,26 @@ class DebeziumKafkaSourceTest {
             override suspend fun indexTx(
                 externalSourceToken: ExternalSourceToken?,
                 systemTime: Instant?,
-                writer: suspend (OpenTx) -> ExternalSource.TxResult,
+                writer: suspend (ExternalSource.OpenTx) -> ExternalSource.TxResult,
             ): ExternalSource.TxResult {
                 val txKey = TransactionKey(nextTxId++, systemTime ?: Instant.now())
 
-                return OpenTx(al, txKey).use { openTx ->
-                    val result = writer(openTx)
+                return OpenTx(al, txKey).use { inner ->
+                    val captured = object : ExternalSource.OpenTx {
+                        override val systemFrom get() = inner.systemFrom
+                        override fun table(ref: TableRef) = inner.table(ref)
+                        override fun table(schemaName: String, tableName: String) =
+                            inner.table(TableRef("testdb", schemaName, tableName))
+
+                        override fun openQuery(
+                            sql: String, args: RelationReader?, opts: ExternalSource.QueryOpts,
+                        ): ResultCursor = error("openQuery not supported in CapturingTxIndexer — wire a real ESP if you need this")
+                    }
+
+                    val result = writer(captured)
 
                     received.add(CapturedTx(
-                        cdcRows = openTx.tables
+                        cdcRows = inner.tables
                             .filter { (ref, _) -> ref.schemaName != "xt" }
                             .sumOf { (_, table) -> table.txRelation.rowCount },
                         resumeToken = externalSourceToken,

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -25,7 +25,7 @@ import xtdb.database.proto.DatabaseConfig
 import xtdb.api.log.Log
 import xtdb.api.log.LogClusterAlias
 import xtdb.error.Incorrect
-import xtdb.indexer.OpenTx
+import xtdb.database.ExternalSource.OpenTx
 import xtdb.postgres.proto.PostgresSourceConfig
 import xtdb.postgres.proto.PostgresSourceToken
 import xtdb.postgres.proto.postgresSourceConfig


### PR DESCRIPTION
Part of #5130.

### Context

External source authors (Debezium, Postgres logical replication, future sources) previously only had `table(...)` for writes inside the `indexTx` lambda.
There was no way to read back existing state — let alone see in-flight writes from the same tx — so idempotent replay and deterministic conflict resolution pushed resolution into either XT's temporal semantics or upstream SQL.

### Approach

Introduce a narrow `ExternalSource.OpenTx` interface — `systemFrom`, `table(...)`, `openQuery(...)` — and wrap the internal `xtdb.indexer.OpenTx` so source authors can only reach what's safe to reach.
The wrapper (`WriterOpenTx`) is an inner class of `ExternalSourceProcessor`, giving it access to the node's `IQuerySource` and `DatabaseState` without plumbing them through every source.

`openQuery` routes through `IQuerySource` with a snapshot taken from the writer's in-flight `OpenTx`, so reads see earlier writes in the same tx.
The query is scoped to the writer's database — cross-database reads from a CDC writer aren't a use case we want to support, so the `QueryCatalog` has a single entry and `databaseOrNull` returns null for anything else.
Structural constraint, not a runtime check.

`QueryOpts` derives `currentTime` from the tx's `systemTime` and `defaultTz` from the query source.
Most callers pass `openQuery(sql)` with no opts.

### Why a new interface vs. widening `xtdb.indexer.OpenTx`

The internal `OpenTx` exposes tx-plumbing the source has no business touching.
A narrow interface makes the writer-facing contract explicit, and the diff shape keeps Debezium/Postgres unaware of anything they don't use.

### Worked example — idempotent CDC replay

```kotlin
txIndexer.indexTx(batch.resumeToken, batch.timestamp) { openTx ->
    val customers = openTx.table("public", "customers")
    for (record in batch.records) {
        val id = record.after["_id"] as Int
        val newVersion = record.after["_version"] as Long

        Relation.openFromRows(al, listOf(mapOf("_0" to id))).use { rel ->
            openTx.openQuery(
                "SELECT _version FROM public.customers WHERE _id = ?",
                rel.relReader,
            ).use { cur ->
                val current = cur.firstRow()?.get("_version") as Long?
                if (current == null || current < newVersion) {
                    customers.logPut(id.asIid.toByteBuffer(), openTx.systemFrom, Long.MAX_VALUE) {
                        customers.docWriter.writeObject(record.after)
                    }
                }
            }
        }
    }
    TxResult.Committed(userMetadata = mapOf("lsn" to batch.maxOffset))
}
```

### Scope

- Existing sources (Debezium Kafka, Postgres logical replication) haven't been ported to use `openQuery` yet.
  This PR is the capability; actual adoption lands with the features that need it.
- The test-side `CapturingTxIndexer` in the Debezium test suite throws from `openQuery` so any future test that accidentally relies on query execution against the in-memory stub fails loudly rather than silently no-opping.

### Depends on

The `IResultCursor → ResultCursor` rename landing on `main` (separate PR) — `ext-src-query` carries that commit until it does, at which point the diff collapses to the single `feat` commit.

### Test plan

- [x] New: `ExternalSourceTest."openQuery on writer OpenTx delegates to querySource with tx-scoped snapshot"`
- [x] Existing `ExternalSourceTest` / `DebeziumKafkaSourceTest` still pass against the updated `ExternalSource.OpenTx`
- [x] `modules:xtdb-debezium` / `modules:xtdb-postgres-source` recompile clean