### PR TITLE
test(indexer): increase DST action volume and weight toward txs

### DIFF
--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -206,15 +206,15 @@ class LogProcessorSimTest : SimulationTestBase() {
                 val groupJob = launch(dispatcher) { srcLog.openGroupSubscription(logProc) }
 
                 launch(dispatcher) {
-                    val totalActions = rand.nextInt(5, 20)
+                    val totalActions = rand.nextInt(50, 100)
                     LOG.debug("test: will perform $totalActions actions (rowsPerBlock=$rowsPerBlock)")
                     repeat(totalActions) { _ ->
                         yield()
 
-                        when (rand.nextInt(3)) {
-                            0 -> srcLog.appendMessage(emptyTx())
-                            1 -> srcLog.appendMessage(SourceMessage.FlushBlock(null))
-                            2 -> srcLog.rebalanceTrigger.send(Unit)
+                        when (rand.nextInt(100)) {
+                            in 0..<80 -> srcLog.appendMessage(emptyTx())
+                            in 80..<95 -> srcLog.rebalanceTrigger.send(Unit)
+                            else -> srcLog.appendMessage(SourceMessage.FlushBlock(null))
                         }
                     }
                     val lastSrcMsgId = srcLog.latestSubmittedMsgId
@@ -281,14 +281,14 @@ class LogProcessorSimTest : SimulationTestBase() {
                     val groupJobB = launch(dispatcher) { srcLog.openGroupSubscription(logProcB) }
 
                     launch(dispatcher) {
-                        val totalActions = rand.nextInt(5, 20)
+                        val totalActions = rand.nextInt(50, 100)
                         LOG.debug("test: multi-node will perform $totalActions actions (rowsPerBlock=$rowsPerBlock)")
                         repeat(totalActions) { _ ->
                             yield()
-                            when (rand.nextInt(3)) {
-                                0 -> srcLog.appendMessage(emptyTx())
-                                1 -> srcLog.appendMessage(SourceMessage.FlushBlock(null))
-                                2 -> srcLog.rebalanceTrigger.send(Unit)
+                            when (rand.nextInt(100)) {
+                                in 0..<80 -> srcLog.appendMessage(emptyTx())
+                                in 80..<95 -> srcLog.rebalanceTrigger.send(Unit)
+                                else -> srcLog.appendMessage(SourceMessage.FlushBlock(null))
                             }
                         }
 


### PR DESCRIPTION
The equal 1/3 split across tx/flush/rebalance with 5-20 actions meant most iterations produced too few txs to fill a block — ~50% of iterations finished zero blocks, so the file existence and block catalog assertions were vacuously true.

80/15/5 tx/rebalance/flush at 50-100 actions gives ~40-80 txs per iteration, producing 6-18 blocks at rowsPerBlock 3-10. Rebalances at 15% give roughly 1 leadership change per block — good odds of hitting mid-block transitions.