### PR TITLE
fix(external-source): force-close PG connection on cancellation

### DIFF
--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -174,78 +174,97 @@ class PostgresSource(
     }
 
     /**
+     * Runs [block] with a child coroutine that force-closes [closeable] on cancellation.
+     *
+     * pgjdbc's socket reads don't respond to Thread.interrupt(), so coroutine
+     * cancellation alone can't unblock them. The child coroutine watches for
+     * cancellation and closes the resource, causing the blocked read to throw.
+     */
+    private suspend fun <T : AutoCloseable, R> closeOnCancel(closeable: T, block: suspend () -> R): R =
+        coroutineScope {
+            val watcher = launch {
+                try { awaitCancellation() }
+                finally { runCatching { closeable.close() } }
+            }
+            try { block() }
+            finally { watcher.cancel() }
+        }
+
+    /**
      * Returns the slot LSN for streaming to resume from.
      */
     private suspend fun initialSnapshot(txIndexer: TxIndexer): Long {
         LOG.debug { "[$dbName] Opening replication connection to $hostname:$port/$database" }
 
         openJdbcConnection().use { replConn ->
-            val pgReplConn = replConn.unwrap(PGConnection::class.java)
+            return closeOnCancel(replConn) {
+                val pgReplConn = replConn.unwrap(PGConnection::class.java)
 
-            LOG.debug { "[$dbName] Creating replication slot '$slotName' with pgoutput" }
+                LOG.debug { "[$dbName] Creating replication slot '$slotName' with pgoutput" }
 
-            // Create replication slot and get exported snapshot
-            val slotInfo = pgReplConn.replicationAPI
-                .createReplicationSlot()
-                .logical()
-                .withSlotName(slotName)
-                .withOutputPlugin("pgoutput")
-                .make()
+                // Create replication slot and get exported snapshot
+                val slotInfo = pgReplConn.replicationAPI
+                    .createReplicationSlot()
+                    .logical()
+                    .withSlotName(slotName)
+                    .withOutputPlugin("pgoutput")
+                    .make()
 
-            val snapshotName = slotInfo.snapshotName
-            val slotLsn = slotInfo.consistentPoint.asLong()
+                val snapshotName = slotInfo.snapshotName
+                val slotLsn = slotInfo.consistentPoint.asLong()
 
-            LOG.info("[$dbName] Created slot '$slotName' at LSN ${LogSequenceNumber.valueOf(slotLsn)}, snapshot=$snapshotName")
+                LOG.info("[$dbName] Created slot '$slotName' at LSN ${LogSequenceNumber.valueOf(slotLsn)}, snapshot=$snapshotName")
 
-            // Read tables using the exported snapshot for consistency
-            jdbi.open().use { handle ->
-                handle.begin()
-                try {
-                    handle.transactionIsolationLevel = REPEATABLE_READ
+                // Read tables using the exported snapshot for consistency
+                jdbi.open().use { handle ->
+                    handle.begin()
+                    try {
+                        handle.transactionIsolationLevel = REPEATABLE_READ
 
-                    LOG.debug { "[$dbName] SET TRANSACTION SNAPSHOT '$snapshotName'" }
-                    handle.execute("SET TRANSACTION SNAPSHOT '$snapshotName'")
+                        LOG.debug { "[$dbName] SET TRANSACTION SNAPSHOT '$snapshotName'" }
+                        handle.execute("SET TRANSACTION SNAPSHOT '$snapshotName'")
 
-                    val tables = handle.discoverTables()
-                    LOG.info("[$dbName] Discovered ${tables.size} tables in publication '$publicationName': ${tables.joinToString { "${it.first}.${it.second}" }}")
+                        val tables = handle.discoverTables()
+                        LOG.info("[$dbName] Discovered ${tables.size} tables in publication '$publicationName': ${tables.joinToString { "${it.first}.${it.second}" }}")
 
-                    for ((schema, table) in tables) {
-                        val columns = handle.discoverColumns(schema, table)
-                        val fullTableName = "$schema.$table"
+                        for ((schema, table) in tables) {
+                            val columns = handle.discoverColumns(schema, table)
+                            val fullTableName = "$schema.$table"
 
-                        LOG.info("[$dbName] Snapshotting $fullTableName (${columns.size} columns: ${columns.joinToString { it.name }})")
+                            LOG.info("[$dbName] Snapshotting $fullTableName (${columns.size} columns: ${columns.joinToString { it.name }})")
 
-                        var rowCount = 0
-                        handle.createQuery("SELECT * FROM \"$schema\".\"$table\"")
-                            .setFetchSize(SNAPSHOT_BATCH_SIZE)
-                            .map { rs, _ -> columns.associate { col -> col.name to rs.getObject(col.name) } }
-                            .iterator().use {
-                                it.asSequence()
-                                    .chunked(SNAPSHOT_BATCH_SIZE)
-                                    .forEach { batch ->
-                                        rowCount += batch.size
-                                        LOG.debug { "[$dbName] Flushing $fullTableName batch: ${batch.size} rows (total: $rowCount)" }
-                                        flushSnapshotBatch(txIndexer, slotLsn, schema, table, batch)
-                                    }
-                            }
+                            var rowCount = 0
+                            handle.createQuery("SELECT * FROM \"$schema\".\"$table\"")
+                                .setFetchSize(SNAPSHOT_BATCH_SIZE)
+                                .map { rs, _ -> columns.associate { col -> col.name to rs.getObject(col.name) } }
+                                .iterator().use {
+                                    it.asSequence()
+                                        .chunked(SNAPSHOT_BATCH_SIZE)
+                                        .forEach { batch ->
+                                            rowCount += batch.size
+                                            LOG.debug { "[$dbName] Flushing $fullTableName batch: ${batch.size} rows (total: $rowCount)" }
+                                            flushSnapshotBatch(txIndexer, slotLsn, schema, table, batch)
+                                        }
+                                }
 
-                        LOG.info("[$dbName] Finished snapshotting $fullTableName ($rowCount rows)")
+                            LOG.info("[$dbName] Finished snapshotting $fullTableName ($rowCount rows)")
+                        }
+
+                        // Mark snapshot complete
+                        val completeToken = ProtoAny.pack(postgresSourceToken {
+                            latestCommittedLsn = slotLsn
+                            snapshotCompleted = true
+                        }, PROTO_TAG)
+
+                        LOG.debug { "[$dbName] Writing snapshot-complete marker" }
+                        txIndexer.indexTx(completeToken) {
+                            TxResult.Committed()
+                        }
+
+                        slotLsn
+                    } finally {
+                        handle.rollback()
                     }
-
-                    // Mark snapshot complete
-                    val completeToken = ProtoAny.pack(postgresSourceToken {
-                        latestCommittedLsn = slotLsn
-                        snapshotCompleted = true
-                    }, PROTO_TAG)
-
-                    LOG.debug { "[$dbName] Writing snapshot-complete marker" }
-                    txIndexer.indexTx(completeToken) {
-                        TxResult.Committed()
-                    }
-
-                    return slotLsn
-                } finally {
-                    handle.rollback()
                 }
             }
         }
@@ -316,89 +335,91 @@ class PostgresSource(
         LOG.debug { "[$dbName] Opening replication connection for streaming" }
 
         openJdbcConnection().use { replConn ->
-            val pgReplConn = replConn.unwrap(PGConnection::class.java)
+            closeOnCancel(replConn) {
+                val pgReplConn = replConn.unwrap(PGConnection::class.java)
 
-            LOG.info("[$dbName] Starting replication stream from LSN ${LogSequenceNumber.valueOf(startLsn)} on slot '$slotName'")
+                LOG.info("[$dbName] Starting replication stream from LSN ${LogSequenceNumber.valueOf(startLsn)} on slot '$slotName'")
 
-            val stream: PGReplicationStream = startReplicationStream(pgReplConn, startLsn)
+                val stream: PGReplicationStream = startReplicationStream(pgReplConn, startLsn)
 
-            val relations = mutableMapOf<Int, PgOutputMessage.Relation>()
+                val relations = mutableMapOf<Int, PgOutputMessage.Relation>()
 
-            // Accumulated operations within a single PG transaction
-            var currentTxOps = mutableListOf<Pair<PgOutputMessage.Relation, PgOutputMessage>>()
+                // Accumulated operations within a single PG transaction
+                var currentTxOps = mutableListOf<Pair<PgOutputMessage.Relation, PgOutputMessage>>()
 
-            while (currentCoroutineContext().isActive) {
-                // read() blocks until a message is available; runInterruptible
-                // lets coroutine cancellation interrupt the blocking call.
-                val msg = runInterruptible(Dispatchers.IO) {
-                    stream.read()!!
-                }
-
-                val parsed = PgOutputMessage.parse(msg)
-                LOG.trace { "[$dbName] Received ${parsed::class.simpleName}" }
-
-                when (parsed) {
-                    is PgOutputMessage.Relation -> {
-                        relations[parsed.relationId] = parsed
-                        LOG.debug { "[$dbName] Relation: ${parsed.schema}.${parsed.table} (id=${parsed.relationId}, ${parsed.columns.size} columns)" }
+                while (currentCoroutineContext().isActive) {
+                    // read() blocks until a message is available; runInterruptible
+                    // lets coroutine cancellation interrupt the blocking call.
+                    val msg = runInterruptible(Dispatchers.IO) {
+                        stream.read()!!
                     }
 
-                    is PgOutputMessage.Begin -> {
-                        LOG.trace { "[$dbName] Begin tx (finalLsn=${LogSequenceNumber.valueOf(parsed.finalLsn)})" }
-                        currentTxOps = mutableListOf()
-                    }
+                    val parsed = PgOutputMessage.parse(msg)
+                    LOG.trace { "[$dbName] Received ${parsed::class.simpleName}" }
 
-                    is PgOutputMessage.Insert, is PgOutputMessage.Update, is PgOutputMessage.Delete -> {
-                        val relationId = when (parsed) {
-                            is PgOutputMessage.Insert -> parsed.relationId
-                            is PgOutputMessage.Update -> parsed.relationId
-                            is PgOutputMessage.Delete -> parsed.relationId
+                    when (parsed) {
+                        is PgOutputMessage.Relation -> {
+                            relations[parsed.relationId] = parsed
+                            LOG.debug { "[$dbName] Relation: ${parsed.schema}.${parsed.table} (id=${parsed.relationId}, ${parsed.columns.size} columns)" }
                         }
-                        val relation = relations[relationId]
-                            ?: error("Relation $relationId not found — missing Relation message before data message")
 
-                        LOG.trace { "[$dbName] ${parsed::class.simpleName} on ${relation.schema}.${relation.table}" }
-                        currentTxOps.add(relation to parsed)
-                    }
+                        is PgOutputMessage.Begin -> {
+                            LOG.trace { "[$dbName] Begin tx (finalLsn=${LogSequenceNumber.valueOf(parsed.finalLsn)})" }
+                            currentTxOps = mutableListOf()
+                        }
 
-                    is PgOutputMessage.Commit -> {
-                        val commitLsn = LogSequenceNumber.valueOf(parsed.endLsn)
-
-                        if (currentTxOps.isNotEmpty()) {
-                            val commitTime = pgTimestampToInstant(parsed.commitTimestamp)
-                            LOG.debug { "[$dbName] Commit at $commitLsn: ${currentTxOps.size} ops, commitTime=$commitTime" }
-
-                            val token = ProtoAny.pack(postgresSourceToken {
-                                latestCommittedLsn = parsed.endLsn
-                                snapshotCompleted = true
-                            }, PROTO_TAG)
-
-                            val ops = currentTxOps.toList()
-
-                            txIndexer.indexTx(token, commitTime) { openTx ->
-                                for ((relation, op) in ops) {
-                                    applyStreamingOp(openTx, dbName, relation, op)
-                                }
-                                TxResult.Committed()
+                        is PgOutputMessage.Insert, is PgOutputMessage.Update, is PgOutputMessage.Delete -> {
+                            val relationId = when (parsed) {
+                                is PgOutputMessage.Insert -> parsed.relationId
+                                is PgOutputMessage.Update -> parsed.relationId
+                                is PgOutputMessage.Delete -> parsed.relationId
                             }
-                        } else {
-                            LOG.trace { "[$dbName] Empty commit at $commitLsn (keepalive)" }
+                            val relation = relations[relationId]
+                                ?: error("Relation $relationId not found — missing Relation message before data message")
+
+                            LOG.trace { "[$dbName] ${parsed::class.simpleName} on ${relation.schema}.${relation.table}" }
+                            currentTxOps.add(relation to parsed)
                         }
 
-                        // Acknowledge up to the commit LSN
-                        LOG.trace { "[$dbName] Acknowledging LSN $commitLsn" }
-                        runInterruptible(Dispatchers.IO) {
-                            stream.setFlushedLSN(commitLsn)
-                            stream.setAppliedLSN(commitLsn)
-                            stream.forceUpdateStatus()
-                        }
+                        is PgOutputMessage.Commit -> {
+                            val commitLsn = LogSequenceNumber.valueOf(parsed.endLsn)
 
-                        currentTxOps = mutableListOf()
+                            if (currentTxOps.isNotEmpty()) {
+                                val commitTime = pgTimestampToInstant(parsed.commitTimestamp)
+                                LOG.debug { "[$dbName] Commit at $commitLsn: ${currentTxOps.size} ops, commitTime=$commitTime" }
+
+                                val token = ProtoAny.pack(postgresSourceToken {
+                                    latestCommittedLsn = parsed.endLsn
+                                    snapshotCompleted = true
+                                }, PROTO_TAG)
+
+                                val ops = currentTxOps.toList()
+
+                                txIndexer.indexTx(token, commitTime) { openTx ->
+                                    for ((relation, op) in ops) {
+                                        applyStreamingOp(openTx, dbName, relation, op)
+                                    }
+                                    TxResult.Committed()
+                                }
+                            } else {
+                                LOG.trace { "[$dbName] Empty commit at $commitLsn (keepalive)" }
+                            }
+
+                            // Acknowledge up to the commit LSN
+                            LOG.trace { "[$dbName] Acknowledging LSN $commitLsn" }
+                            runInterruptible(Dispatchers.IO) {
+                                stream.setFlushedLSN(commitLsn)
+                                stream.setAppliedLSN(commitLsn)
+                                stream.forceUpdateStatus()
+                            }
+
+                            currentTxOps = mutableListOf()
+                        }
                     }
                 }
-            }
 
-            LOG.info("[$dbName] Streaming loop exiting (coroutine no longer active)")
+                LOG.info("[$dbName] Streaming loop exiting (coroutine no longer active)")
+            }
         }
     }
 

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -358,4 +358,53 @@ class PostgresSourceIntegrationTest {
             }
         }
     }
+
+    @Test
+    fun `cancellation releases replication slot`() = runTest(timeout = 120.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+        val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS pg_cancel (_id INT PRIMARY KEY, name TEXT)",
+            "INSERT INTO pg_cancel (_id, name) VALUES (1, 'Alice')",
+            "CREATE PUBLICATION $pubName FOR TABLE pg_cancel",
+        )
+
+        // Start a node, let it snapshot and begin streaming (holds the slot)
+        openNode(sourceTopic).use { node ->
+            attachPostgresSource(node, slotName = slotName, publicationName = pubName)
+
+            awaitTxs(node, 2, db = "cdc")
+
+            // Stream an insert so we know streaming is running and holding the slot
+            pgExecute("INSERT INTO pg_cancel (_id, name) VALUES (2, 'Bob')")
+            awaitCondition("Bob appears", timeout = 30.seconds) {
+                xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_cancel WHERE _id = 2").isNotEmpty()
+            }
+
+            // Streaming connection is now holding the slot
+            assertEquals(true, pgSlotState(slotName), "Slot should be active while streaming")
+        }
+        // node.close() triggers ExternalSourceProcessor.close() → extJob.cancel()
+        // The closeOnCancel child coroutine should force-close the PG connection,
+        // releasing the replication slot.
+
+        awaitCondition("slot released after node close", timeout = 10.seconds) {
+            pgSlotState(slotName) == false
+        }
+    }
+
+    /**
+     * Returns true if the slot is active, false if it exists but is inactive, null if the slot doesn't exist.
+     */
+    private fun pgSlotState(slotName: String): Boolean? {
+        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeQuery("SELECT active FROM pg_replication_slots WHERE slot_name = '$slotName'").use { rs ->
+                    return if (rs.next()) rs.getBoolean("active") else null
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `closeOnCancel` — a child coroutine that force-closes the JDBC connection when the parent is cancelled
- Fixes the "replication slot is active" error during leadership handover
- Adds integration test verifying the slot is released on node close

## Context

pgjdbc's `PGReplicationStream.read()` blocks on `java.net.SocketInputStream.socketRead0()`, which doesn't respond to `Thread.interrupt()`.
When `ExternalSourceProcessor.close()` cancels the streaming coroutine via `extJob.cancel()`, the `runInterruptible` interrupt goes unnoticed — the connection stays open, holding the replication slot.

During rolling restarts, when leadership moves to a new node, the new leader's `startReplicationStream` fails with "replication slot is active for PID X" because the old connection hasn't been torn down.

`closeOnCancel` launches a child coroutine that watches for cancellation and force-closes the JDBC connection from outside, unblocking the stuck `read()`.
Same approach as Debezium's `PostgresReplicationConnection.close()`.

## Test plan

- [x] New test: `cancellation releases replication slot` — verifies the PG slot becomes inactive (not dropped) after node close
- [x] All existing integration tests pass (5 tests)
- [ ] Deploy to staging and verify rebalance doesn't trigger "slot is active" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)