### PR TITLE
refactor(authn)!: remove CREATE USER / ALTER USER and !UserTable

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
     api(libs.hppc)
 
     api(libs.caffeine)
-    api(libs.buddy.hashers)
 
     // healthz server
     api(libs.ring.core)

--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -52,8 +52,6 @@ directlyExecutableStatement
     | SHOW AWAIT_TOKEN # ShowAwaitTokenStatement
     | SHOW SNAPSHOT_TOKEN # ShowSnapshotTokenStatement
     | SHOW CLOCK_TIME # ShowClockTimeStatement
-    | CREATE USER userName=identifier WITH PASSWORD password=characterString # CreateUserStatement
-    | ALTER USER userName=identifier WITH PASSWORD password=characterString # AlterUserStatement
     | ATTACH DATABASE dbName=identifier (WITH configYaml=characterString)? # AttachDatabaseStatement
     | DETACH DATABASE dbName=identifier # DetachDatabaseStatement
     ;

--- a/core/src/main/clojure/xtdb/authn.clj
+++ b/core/src/main/clojure/xtdb/authn.clj
@@ -1,39 +1,16 @@
 (ns xtdb.authn
-  (:require [buddy.hashers :as hashers]
-            [integrant.core :as ig]
+  (:require [integrant.core :as ig]
             [hato.client :as http]
-            [xtdb.api :as xt]
             [xtdb.node :as xtn]
-            [xtdb.query :as q]
-            [xtdb.error :as err]
-            [xtdb.util :as util]
-            [xtdb.vector.writer :as vw])
+            [xtdb.error :as err])
   (:import [java.io Writer]
-           [org.apache.arrow.memory BufferAllocator]
-           (xtdb.query QueryOpts)
            (xtdb.api Authenticator Authenticator$DeviceAuthResponse Authenticator$Factory Authenticator$Factory$OpenIdConnect
-                     Authenticator$Factory$SingleRootUser Authenticator$Factory$UserTable
+                     Authenticator$Factory$SingleRootUser
                      Authenticator$Method Authenticator$MethodRule Xtdb$Config
-                     SimpleResult OAuthPasswordResult OAuthClientCredentialsResult OAuthResult)
-           (xtdb.query IQuerySource)
+                     OAuthPasswordResult OAuthClientCredentialsResult OAuthResult)
            xtdb.NodeBase
            [java.net URI]
            [java.time Duration Instant InstantSource]))
-
-(defn verify-pw
-  [^BufferAllocator allocator ^IQuerySource q-src db-cat user password]
-  (when-not password
-    (throw (err/incorrect :xtdb/authn-failed (format "password authentication failed for user: %s" user))))
-
-  (with-open [res (util/with-close-on-catch [args (vw/open-args allocator [user])]
-                    (-> (.prepareQuery q-src
-                                       "SELECT passwd AS encrypted FROM pg_user WHERE username = ?"
-                                       db-cat {:default-db "xtdb"})
-                        (.openQuery args (QueryOpts.))))]
-    (let [{:keys [encrypted]} (first (.toList (q/cursor->stream res {:key-fn #xt/key-fn :kebab-case-keyword})))]
-      (if (and encrypted (:valid (hashers/verify password encrypted)))
-        user
-        (throw (err/incorrect :xtdb/authn-failed (format "password authentication failed for user: %s" user)))))))
 
 (defn- method-for [rules {:keys [remote-addr user]}]
   (some (fn [{rule-user :user, rule-address :address, :keys [method]}]
@@ -72,27 +49,10 @@
 (defmethod xtn/apply-config! :xtdb/authn [^Xtdb$Config config, _, [tag opts]]
   (xtn/apply-config! config
                      (case tag
-                       :user-table ::user-table-authn
                        :single-root-user ::single-root-user-authn
                        :openid-connect ::openid-connect-authn
                        tag)
                      opts))
-
-(defmethod xtn/apply-config! ::user-table-authn [^Xtdb$Config config, _, {:keys [rules]}]
-  (.authn config (Authenticator$Factory$UserTable. (->rules-cfg rules))))
-
-(defrecord UserTableAuthn [rules ^BufferAllocator allocator q-src db-cat]
-  Authenticator
-  (methodFor [_ user remote-addr]
-    (method-for rules {:user user, :remote-addr remote-addr}))
-
-  (verifyPassword [_ user password]
-    (let [user-id (verify-pw allocator q-src db-cat user password)]
-      (SimpleResult. user-id))))
-
-#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn ->user-table-authn [^Authenticator$Factory$UserTable cfg, ^BufferAllocator allocator, q-src, db-cat]
-  (->UserTableAuthn (<-rules-cfg (.getRules cfg)) allocator q-src db-cat))
 
 (defmethod xtn/apply-config! ::single-root-user-authn [^Xtdb$Config config, _, {:keys [password]}]
   (.authn config (Authenticator$Factory$SingleRootUser. password)))

--- a/core/src/main/clojure/xtdb/authn/crypt.clj
+++ b/core/src/main/clojure/xtdb/authn/crypt.clj
@@ -1,5 +1,0 @@
-(ns xtdb.authn.crypt
-  (:require [buddy.hashers :as hashers]))
-
-(defn encrypt-pw [pw]
-  (hashers/derive pw {:alg :argon2id}))

--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -2,7 +2,6 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [xtdb.api :as xt]
-            [xtdb.authn.crypt :as authn.crypt]
             [xtdb.basis :as basis]
             [xtdb.error :as err]
             [xtdb.indexer.crash-logger :refer [with-crash-log]]
@@ -456,30 +455,6 @@
             (.indexOp ^OpIndexer (get tables (.getLeg docs-rdr tx-op-idx))
                       tx-op-idx)))))))
 
-(def ^:private ^:const user-table #xt/table pg_catalog/pg_user)
-
-(defn- update-pg-user! [^OpenTx open-tx, ^TransactionKey tx-key, user, password]
-  (let [system-time-µs (time/instant->micros (.getSystemTime tx-key))
-
-        live-table (.table open-tx user-table)
-        doc-writer (.getDocWriter live-table)]
-
-    (.logPut live-table (ByteBuffer/wrap (util/->iid user)) system-time-µs Long/MAX_VALUE
-             (fn write-doc! []
-               (doto (.vectorFor doc-writer "_id" #xt.arrow/type :utf8 false)
-                 (.writeObject user))
-
-               (doto (.vectorFor doc-writer "username" #xt.arrow/type :utf8 false)
-                 (.writeObject user))
-
-               (doto (.vectorFor doc-writer "usesuper" #xt.arrow/type :bool false)
-                 (.writeObject false))
-
-               (doto (.vectorFor doc-writer "passwd" #xt.arrow/type :utf8 true)
-                 (.writeObject (authn.crypt/encrypt-pw password)))
-
-               (.endStruct doc-writer)))))
-
 (defn- ->sql-indexer ^xtdb.indexer.OpIndexer [^BufferAllocator allocator, ^LiveIndex live-idx, ^OpenTx open-tx
                                               ^VectorReader tx-ops-rdr, ^IQuerySource q-src, db-cat,
                                               {:keys [default-db tx-key ^Tracer tracer] :as tx-opts}]
@@ -515,12 +490,6 @@
                                                             (query-indexer allocator q-src db-cat erase-idxer tx-opts q-args))
                                     :assert (foreach-arg-row allocator args-loader
                                                              (->assert-idxer q-src db-cat tx-opts q-args))
-
-                                    :create-user (let [{:keys [username password]} q-args]
-                                                   (update-pg-user! open-tx tx-key username password))
-
-                                    :alter-user (let [{:keys [username password]} q-args]
-                                                  (update-pg-user! open-tx tx-key username password))
 
                                     (throw (err/incorrect ::invalid-sql-tx-op "Invalid SQL query sent as transaction operation"
                                                           {:query query-str}))))))))

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -1,11 +1,9 @@
 (ns xtdb.information-schema
   (:require [clojure.string :as str]
-            [xtdb.authn.crypt :as authn.crypt]
             [xtdb.block-tables :as block-tables]
             [xtdb.log-tables :as log-tables]
             [xtdb.serde.types :as st]
             [xtdb.table :as table]
-            [xtdb.trie :as trie]
             [xtdb.trie-catalog :as trie-cat]
             [xtdb.types :as types]
             [xtdb.util :as util]
@@ -13,19 +11,18 @@
   (:import (com.github.benmanes.caffeine.cache Cache Caffeine)
            (io.micrometer.core.instrument Counter Gauge MeterRegistry Tag Timer)
            (io.micrometer.core.instrument.distribution ValueAtPercentile)
-           [java.lang AutoCloseable]
            [java.time Duration]
            [java.util Map]
            (org.apache.arrow.memory BufferAllocator)
            (xtdb ICursor)
            xtdb.api.query.IKeyFn
-           (xtdb.arrow Relation RelationReader VectorType VectorReader VectorWriter)
+           (xtdb.arrow Relation RelationReader VectorType VectorReader)
            xtdb.pgwire.PgType
            (xtdb.indexer Snapshot)
            xtdb.operator.SelectionSpec
            (xtdb.query IQuerySource$QueryCatalog IQuerySource$QueryDatabase)
            xtdb.table.TableRef
-           (xtdb.trie MemoryHashTrie Trie TrieCatalog)))
+           xtdb.trie.TrieCatalog))
 
 (defn name->oid [s]
   (Math/abs ^Integer (hash s)))
@@ -94,11 +91,9 @@
 
           pg_catalog/pg_range {rngtypid :i32, rngsubtype :i32, rngmultitypid :i32
                                rngcollation :i32, rngsubopc :i32, rngcanonical :utf8, rngsubdiff :utf8}
-          pg_catalog/pg_am {oid :i32, amname :utf8, amhandler :utf8, amtype :utf8}}
-        (update-vals map->vec-types)))
+          pg_catalog/pg_am {oid :i32, amname :utf8, amhandler :utf8, amtype :utf8}
 
-  (def ^:private pg-catalog-template-tables
-    (-> '{pg_catalog/pg_user {username :utf8 usesuper :bool passwd [:? :utf8]}}
+          pg_catalog/pg_user {username :utf8, usesuper :bool, passwd [:? :utf8]}}
         (update-vals map->vec-types)))
 
   (def ^:private xt-derived-tables
@@ -128,12 +123,6 @@
   (defn derived-table [table-ref]
     (get derived-tables (table/ref->schema+table table-ref)))
 
-  (def template-tables
-    pg-catalog-template-tables)
-
-  (defn template-table [table-ref]
-    (get template-tables (table/ref->schema+table table-ref)))
-
   (def ^:private ^Cache table-info-cache
     (-> (Caffeine/newBuilder)
         (.maximumSize 1024)
@@ -143,7 +132,7 @@
     (.get table-info-cache (into (sorted-set) db-names)
           (fn [db-names]
             (->> (for [db-name db-names
-                       [table fields] (merge derived-tables template-tables)]
+                       [table fields] derived-tables]
                    [(table/->ref db-name table) (set (keys fields))])
                  (into {})))))
 
@@ -156,7 +145,7 @@
     (.get table-chains-cache [(into (sorted-set) db-names) default-db]
           (fn [[db-names default-db]]
             (->> (for [db-name db-names
-                       [table fields] (merge derived-tables template-tables)
+                       [table fields] derived-tables
                        :let [^TableRef table-ref (table/->ref db-name table)
                              db-sym (symbol db-name)
                              schema-name (symbol (.getSchemaName table-ref))
@@ -167,11 +156,10 @@
                      (and default? (= 'pg_catalog schema-name)) (conj [[table-name] table-ref])))
                  (into [] cat)))))
   (def meta-table-schemas
-    (merge info-tables pg-catalog-tables pg-catalog-template-tables))
+    (merge info-tables pg-catalog-tables))
 
   (def ^:private views
-    (-> (set (keys meta-table-schemas))
-        (disj 'pg_catalog/pg_user))))
+    (set (keys meta-table-schemas))))
 
 (do
   (def internal-schemas
@@ -344,35 +332,11 @@
     {:name setting-name
      :setting setting}))
 
-(def ^:private pg-user-field
-  (types/->field "put" [:struct {"_id" :utf8
-                                 "username" :utf8
-                                 "usesuper" :bool
-                                 "passwd" [:? :utf8]}]))
-
-(def ^:private initial-user-data
-  [{:_id "xtdb", :username "xtdb", :usesuper true, :passwd (authn.crypt/encrypt-pw "xtdb")}])
-
-(defn pg-user-template-page+trie [allocator]
-  (util/with-close-on-catch [out-rel (Trie/openLogDataWriter allocator (Trie/dataRelSchema pg-user-field))]
-    (let [{^VectorWriter iid-vec "_iid",
-           ^VectorWriter sf-vec "_system_from"
-           ^VectorWriter vf-vec "_valid_from",
-           ^VectorWriter vt-vec "_valid_to"} out-rel
-
-          ^VectorWriter put-vec (get-in out-rel ["op" "put"])]
-
-      (doseq [user initial-user-data]
-        (.writeObject iid-vec (util/->iid (:_id user)))
-        (.writeLong sf-vec 0)
-        (.writeLong vf-vec 0)
-        (.writeLong vt-vec Long/MAX_VALUE)
-        (.writeObject put-vec user)
-        (.endRow out-rel))
-      (let [dummy-trie (reduce #(.plus ^MemoryHashTrie %1 %2)
-                               (trie/->live-trie 32 1024 iid-vec)
-                               (range (count initial-user-data)))]
-        [out-rel dummy-trie]))))
+(defn pg-user []
+  ;; Read-only view; always shows the single `xtdb` root user.
+  ;; `passwd` is NULL — Postgres redacts stored credentials from pg_user too, and
+  ;; the !SingleRootUser authenticator holds its password in config, not here.
+  [{:username "xtdb", :usesuper true, :passwd nil}])
 
 (defn trie-stats [^TrieCatalog trie-catalog]
   (for [^TableRef table (.getTables trie-catalog)
@@ -463,78 +427,68 @@
 (defprotocol InfoSchema
   (->cursor [info-schema allocator db db-cat snapshot derived-table-schema
              table col-names col-preds
-             schema params])
+             schema params]))
 
-  (table-template [info-schema table-ref]))
+(defn ->info-schema [_allocator metrics-registry]
+  (reify InfoSchema
+    (->cursor [_ allocator db db-cat snap derived-table-schema
+               table col-names col-preds
+               schema params]
+      ;; TODO should use the schema passed to it, but also regular merge is insufficient here for colFields
+      ;; should be types/merge-types as per scan-vec-types
+      (let [^IQuerySource$QueryDatabase db db
+            ^IQuerySource$QueryCatalog db-cat db-cat
+            db-state (.getQueryState db)
+            db-name (.getName db-state)
+            table-catalog (.getTableCatalog db-state)
+            trie-catalog (.getTrieCatalog db-state)
+            schema-info (-> (merge-with merge
+                                        (update-vals (into {} (.getTypes table-catalog)) #(into {} %))
+                                        (.getAllColumnTypes ^Snapshot snap))
+                            (merge meta-table-schemas)
+                            (update-keys (fn [k]
+                                           (cond
+                                             (instance? TableRef k) k
+                                             (symbol? k) (table/->ref db-name k)))))]
 
-(defn ->info-schema [allocator metrics-registry]
-  (let [pg-user (pg-user-template-page+trie allocator)]
-    (reify InfoSchema
-      (table-template [_ table-ref]
-        (when (= 'pg_catalog/pg_user (table/ref->schema+table table-ref))
-          pg-user))
+        (util/with-close-on-catch [out-rel (Relation. ^BufferAllocator allocator
+                                                      ^Map (update-keys derived-table-schema str))]
 
-      (->cursor [_ allocator db db-cat snap derived-table-schema
-                 table col-names col-preds
-                 schema params]
-        ;; TODO should use the schema passed to it, but also regular merge is insufficient here for colFields
-        ;; should be types/merge-types as per scan-vec-types
-        (let [^IQuerySource$QueryDatabase db db
-              ^IQuerySource$QueryCatalog db-cat db-cat
-              db-state (.getQueryState db)
-              db-name (.getName db-state)
-              table-catalog (.getTableCatalog db-state)
-              trie-catalog (.getTrieCatalog db-state)
-              schema-info (-> (merge-with merge
-                                          (update-vals (into {} (.getTypes table-catalog)) #(into {} %))
-                                          (.getAllColumnTypes ^Snapshot snap))
-                              (merge meta-table-schemas)
-                              (update-keys (fn [k]
-                                             (cond
-                                               (instance? TableRef k) k
-                                               (symbol? k) (table/->ref db-name k)))))]
+          (.writeRows out-rel (->> (case (table/ref->schema+table table)
+                                     information_schema/tables (tables schema-info)
+                                     information_schema/columns (columns (schema-info->col-rows schema-info))
+                                     information_schema/schemata (schemas db-name)
+                                     pg_catalog/pg_tables (pg-tables schema-info)
+                                     pg_catalog/pg_type (pg-type)
+                                     pg_catalog/pg_class (pg-class schema-info)
+                                     pg_catalog/pg_description nil
+                                     pg_catalog/pg_views nil
+                                     pg_catalog/pg_matviews nil
+                                     pg_catalog/pg_attribute (pg-attribute (schema-info->col-rows schema-info))
+                                     pg_catalog/pg_namespace (pg-namespace)
+                                     pg_catalog/pg_proc (pg-proc)
+                                     pg_catalog/pg_database (pg-database (.getDatabaseNames db-cat))
+                                     pg_catalog/pg_stat_user_tables (pg-stat-user-tables schema-info)
+                                     pg_catalog/pg_settings (pg-settings)
+                                     pg_catalog/pg_range (pg-range)
+                                     pg_catalog/pg_am (pg-am)
+                                     pg_catalog/pg_user (pg-user)
+                                     xt/trie_stats (trie-stats trie-catalog)
+                                     xt/live_tables (live-tables snap)
+                                     xt/live_columns (live-columns snap)
+                                     xt/metrics_timers (metrics-timers metrics-registry)
+                                     xt/metrics_gauges (metrics-gauges metrics-registry)
+                                     xt/metrics_counters (metrics-counters metrics-registry)
+                                     (throw (UnsupportedOperationException. (str "Information Schema table does not exist: " table))))
+                                   (into-array java.util.Map)))
 
-          (util/with-close-on-catch [out-rel (Relation. ^BufferAllocator allocator
-                                                        ^Map (update-keys derived-table-schema str))]
-
-            (.writeRows out-rel (->> (case (table/ref->schema+table table)
-                                       information_schema/tables (tables schema-info)
-                                       information_schema/columns (columns (schema-info->col-rows schema-info))
-                                       information_schema/schemata (schemas db-name)
-                                       pg_catalog/pg_tables (pg-tables schema-info)
-                                       pg_catalog/pg_type (pg-type)
-                                       pg_catalog/pg_class (pg-class schema-info)
-                                       pg_catalog/pg_description nil
-                                       pg_catalog/pg_views nil
-                                       pg_catalog/pg_matviews nil
-                                       pg_catalog/pg_attribute (pg-attribute (schema-info->col-rows schema-info))
-                                       pg_catalog/pg_namespace (pg-namespace)
-                                       pg_catalog/pg_proc (pg-proc)
-                                       pg_catalog/pg_database (pg-database (.getDatabaseNames db-cat))
-                                       pg_catalog/pg_stat_user_tables (pg-stat-user-tables schema-info)
-                                       pg_catalog/pg_settings (pg-settings)
-                                       pg_catalog/pg_range (pg-range)
-                                       pg_catalog/pg_am (pg-am)
-                                       xt/trie_stats (trie-stats trie-catalog)
-                                       xt/live_tables (live-tables snap)
-                                       xt/live_columns (live-columns snap)
-                                       xt/metrics_timers (metrics-timers metrics-registry)
-                                       xt/metrics_gauges (metrics-gauges metrics-registry)
-                                       xt/metrics_counters (metrics-counters metrics-registry)
-                                       (throw (UnsupportedOperationException. (str "Information Schema table does not exist: " table))))
-                                     (into-array java.util.Map)))
-
-            ;;TODO reuse relation selector code from trie cursor
-            (InformationSchemaCursor. (reduce (fn [^RelationReader rel ^SelectionSpec col-pred]
-                                                (.select rel (.select col-pred allocator rel schema params)))
-                                              (-> out-rel
-                                                  (->> (filter (comp (set col-names) #(.getName ^VectorReader %))))
-                                                  (vr/rel-reader (.getRowCount out-rel))
-                                                  (vr/with-absent-cols allocator col-names))
-                                              (vals col-preds))
-                                      out-rel))))
-
-      AutoCloseable
-      (close [_]
-        (util/close (first pg-user))))))
+          ;;TODO reuse relation selector code from trie cursor
+          (InformationSchemaCursor. (reduce (fn [^RelationReader rel ^SelectionSpec col-pred]
+                                              (.select rel (.select col-pred allocator rel schema params)))
+                                            (-> out-rel
+                                                (->> (filter (comp (set col-names) #(.getName ^VectorReader %))))
+                                                (vr/rel-reader (.getRowCount out-rel))
+                                                (vr/with-absent-cols allocator col-names))
+                                            (vals col-preds))
+                                    out-rel))))))
 

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -29,7 +29,7 @@
            (xtdb.metadata MetadataPredicate PageMetadata)
            (xtdb.operator.scan MultiIidSelector ScanCursor SingleIidSelector)
            xtdb.query.IQuerySource$QueryCatalog
-           (xtdb.segment BufferPoolSegment MemorySegment MergePlanner)
+           (xtdb.segment BufferPoolSegment MergePlanner)
            xtdb.table.TableRef
            (xtdb.trie Bucketer)
            (xtdb.util TemporalBounds TemporalDimension)))
@@ -202,8 +202,6 @@
               (or (types/temporal-vec-types col-name)
                   (-> (info-schema/derived-table table)
                       (get (symbol col-name)))
-                  (-> (info-schema/template-table table)
-                      (get (symbol col-name)))
                   (let [db-name (.getDbName table)
                         state (.getQueryState (.databaseOrNull db-catalog db-name))
                         table-catalog (.getTableCatalog state)
@@ -270,8 +268,7 @@
          :stats {:row-count row-count}
          :->cursor (fn [{:keys [allocator, snaps, snapshot-token, schema, args pushdown-blooms pushdown-iids explain-analyze? tracer query-span] :as opts}]
                      (let [^Snapshot snapshot (get snaps db-name)
-                           derived-table-schema (info-schema/derived-table table)
-                           template-table? (boolean (info-schema/template-table table))]
+                           derived-table-schema (info-schema/derived-table table)]
                        (cond
                          (log-tables/log-table table)
                          (log-tables/->cursor db allocator table col-names col-preds selects schema args)
@@ -279,7 +276,7 @@
                          (block-tables/block-table table)
                          (block-tables/->cursor db allocator table col-names col-preds selects schema args)
 
-                         (and derived-table-schema (not template-table?))
+                         derived-table-schema
                          (info-schema/->cursor info-schema allocator db db-cat snapshot derived-table-schema table col-names col-preds schema args)
 
                          :else
@@ -326,11 +323,6 @@
                                ;; Add tx segment for read-own-writes (when snapshot opened from within transaction)
                                (when-let [tx-seg (.getTxSegment live-table-snap)]
                                  (.add !segments tx-seg)))
-
-                             (when template-table?
-                               (.add !segments
-                                     (let [[memory-rel trie] (info-schema/table-template info-schema table)]
-                                       (MemorySegment. trie memory-rel))))
 
                              (let [merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) #(trie/filter-pages % {:query-bounds temporal-bounds}))]
                                (cond-> (ScanCursor. allocator (vec col-names) col-preds

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -877,12 +877,6 @@
                                         (visitCopyFormatOption [_ ctx]
                                           [:format (sql/plan-expr (.format ctx) env)])
 
-                                        ;; could do pre-submit validation here
-                                        (visitCreateUserStatement [_ ctx]
-                                          {:statement-type :dml, :dml-type :create-role, :query (subsql ctx)})
-                                        (visitAlterUserStatement [_ ctx]
-                                          {:statement-type :dml, :dml-type :create-role, :query (subsql ctx)})
-
                                         (visitPrepareStatement [this ctx]
                                           (let [inner-ctx (.directlyExecutableStatement ctx)]
                                             {:statement-type :prepare

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -3501,9 +3501,7 @@
 
   (visitAssertStatement [_ _])
   (visitQueryExpr [_ _])
-  (visitShowVariableStatement [_ _])
-  (visitCreateUserStatement [_ _])
-  (visitAlterUserStatement [_ _]))
+  (visitShowVariableStatement [_ _]))
 
 (defn sql->static-ops
   ([sql arg-rows] (sql->static-ops sql arg-rows {}))

--- a/core/src/main/clojure/xtdb/sql/parse.clj
+++ b/core/src/main/clojure/xtdb/sql/parse.clj
@@ -42,16 +42,6 @@
   (visitShowTimeZone [_ _]
     [:show-time-zone])
 
-  (visitCreateUserStatement [_ stmt]
-    [:create-user {:username (-> (.userName stmt) (.getText))
-                   :password (-> (.password stmt)
-                                 (.accept sql/string-literal-visitor))}])
-
-  (visitAlterUserStatement [_ stmt]
-    [:alter-user {:username (-> (.userName stmt) (.getText))
-                  :password (-> (.password stmt)
-                                (.accept sql/string-literal-visitor))}])
-
   (visitExecuteStatement [_ stmt]
     [:execute {:stmt stmt}]))
 

--- a/core/src/main/kotlin/xtdb/NodeBase.kt
+++ b/core/src/main/kotlin/xtdb/NodeBase.kt
@@ -29,7 +29,6 @@ class NodeBase(
     val logClusters: Map<LogClusterAlias, Log.Cluster>,
     val remotes: Map<RemoteAlias, Remote>,
     val compactor: Compactor,
-    val infoSchema: AutoCloseable,
     val querySource: IQuerySource,
     val indexerFactory: Indexer.Factory,
 ) : AutoCloseable {
@@ -37,7 +36,6 @@ class NodeBase(
     override fun close() {
         compactor.close()
         querySource.close()
-        infoSchema.close()
         remotes.values.closeAll()
         logClusters.values.closeAll()
         memoryCache.close()
@@ -86,7 +84,7 @@ class NodeBase(
 
                 val compactor = open { compactorFactory.create(meterReg, config.compactor.threads) }
 
-                val infoSchema = open { infoSchemaFactory.invoke(al, meterReg) as AutoCloseable }
+                val infoSchema = infoSchemaFactory.invoke(al, meterReg)
                 val scanEmitter = scanEmitterFactory.invoke(infoSchema)
                 val querySource = open { querySourceFactory.create(al, meterReg, scanEmitter) }
 
@@ -101,7 +99,6 @@ class NodeBase(
                     logClusters = logClusters,
                     remotes = remotes,
                     compactor = compactor,
-                    infoSchema = infoSchema,
                     querySource = querySource,
                     indexerFactory = idxFactory,
                 )

--- a/core/src/main/kotlin/xtdb/api/Authenticator.kt
+++ b/core/src/main/kotlin/xtdb/api/Authenticator.kt
@@ -99,16 +99,6 @@ interface Authenticator : AutoCloseable {
     sealed interface Factory {
         fun open(allocator: BufferAllocator, querySource: IQuerySource, dbCatalog: Database.Catalog): Authenticator
 
-        @Serializable
-        @SerialName("!UserTable")
-        data class UserTable(var rules: List<MethodRule> = DEFAULT_RULES) : Factory {
-            fun rules(rules: List<MethodRule>) = apply { this.rules = rules }
-
-            override fun open(allocator: BufferAllocator, querySource: IQuerySource, dbCatalog: Database.Catalog): Authenticator =
-                requiringResolve("xtdb.authn/->user-table-authn")
-                    .invoke(this, allocator, querySource, dbCatalog) as Authenticator
-        }
-
         // One root user (`xtdb`) whose password is resolved at config-construction time:
         // the explicit YAML/Kotlin value first, then `XTDB_PASSWORD` env var.
         // With no password, connections run TRUST; with a password, PASSWORD is required.

--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -88,7 +88,7 @@ private fun isDml(sql: String, dbName: DatabaseName): Boolean {
         .invoke(sql, defaultDbOpts)
 
     val opKeyword = (parsed as? IPersistentVector)?.nth(0) as? clojure.lang.Keyword
-    return opKeyword?.name in setOf("insert", "update", "delete", "erase", "create-user", "alter-user")
+    return opKeyword?.name in setOf("insert", "update", "delete", "erase")
 }
 
 private fun FlightStream.toRows(allocator: BufferAllocator): List<List<Any?>> {

--- a/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import xtdb.api.Authenticator.Factory.OpenIdConnect
 import xtdb.api.Authenticator.Factory.SingleRootUser
-import xtdb.api.Authenticator.Factory.UserTable
 import xtdb.api.Authenticator.Method.*
 import xtdb.api.Authenticator.MethodRule
 import xtdb.api.log.KafkaCluster
@@ -349,29 +348,6 @@ class YamlSerdeTest {
         assertEquals(8081, nodeConfig(input).healthz?.port)
 
         unmockkObject(EnvironmentVariableProvider)
-    }
-
-    @Test
-    fun testAuthnConfigDecoding() {
-        val input = """
-        authn: !UserTable
-          rules:
-              - user: admin
-                remoteAddress: 127.0.0.42
-                method: TRUST  
-              - remoteAddress: 127.0.0.1
-                method: PASSWORD  
-        """.trimIndent()
-
-        assertEquals(
-            UserTable(
-                listOf(
-                    MethodRule(TRUST, user = "admin", remoteAddress = "127.0.0.42"),
-                    MethodRule(PASSWORD, remoteAddress = "127.0.0.1")
-                )
-            ),
-            nodeConfig(input).authn
-        )
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,6 @@ transit-java = { group = "com.cognitect", name = "transit-java", version.ref = "
 next-jdbc = { group = "com.github.seancorfield", name = "next.jdbc", version = "1.3.1093" }
 honeysql = { group = "com.github.seancorfield", name = "honeysql", version = "2.7.1368" }
 integrant = { group = "integrant", name = "integrant", version = "1.0.1" }
-buddy-hashers = { group = "buddy", name = "buddy-hashers", version = "2.0.167" }
 
 junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
 junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit" }

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -3,15 +3,11 @@
             [clojure.test :as t :refer [deftest]]
             [next.jdbc :as jdbc]
             [xtdb.api :as xt]
-            [xtdb.authn :as authn]
             [xtdb.compactor :as c]
             [xtdb.information-schema :as i-s]
-            [xtdb.node :as xtn]
             [xtdb.pgwire-test :as pgw-test]
             [xtdb.test-util :as tu]
-            [xtdb.time :as time]
-            [xtdb.util :as util])
-  (:import [xtdb.api SimpleResult]))
+            [xtdb.time :as time]))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-allocator tu/with-node)
 
@@ -337,29 +333,13 @@
                   WHERE column_name = 'set_column'"))))
 
 (deftest test-pg-user
-  ;; This test exercises `!UserTable` behaviour (CREATE/ALTER USER, the seeded
-  ;; xtdb/xtdb row, password verification via the pg_user table). The default
-  ;; authn is now `!SingleRootUser`, so start a dedicated node with `!UserTable`.
-  ;; `:trust` rules keep the pgwire-backed `xt/q` / `xt/execute-tx` callers
-  ;; working; we exercise password flow by calling `.verifyPassword` directly.
-  (util/with-open [node (xtn/start-node {:authn [:user-table {:rules [{:method :trust}]}]
-                                         :log [:in-memory {:instant-src (tu/->mock-clock)}]})]
-    (t/is (= [{:username "xtdb", :usesuper true, :xt/valid-from (time/->zdt #inst "1970")}]
-             (xt/q node "SELECT username, usesuper, _valid_from, _valid_to FROM pg_user")))
+  (t/testing "pg_user is a read-only view with the single xtdb root user"
+    (t/is (= [{:username "xtdb", :usesuper true}]
+             (xt/q tu/*node* "SELECT username, usesuper FROM pg_user")))
 
-    (t/is (= (SimpleResult. "xtdb") (.verifyPassword (authn/<-node node) "xtdb" "xtdb")))
-
-    (xt/execute-tx node ["CREATE USER ada WITH PASSWORD 'lovelace'"])
-
-    (t/is (= [{:username "ada", :usesuper false}]
-             (xt/q node "SELECT username, usesuper FROM pg_user WHERE username = 'ada'")))
-    (t/is (= (SimpleResult. "ada") (.verifyPassword (authn/<-node node) "ada" "lovelace")))
-
-    (xt/execute-tx node ["ALTER USER anonymous WITH PASSWORD 'anonymous'"])
-
-    (t/is (= [{:username "anonymous", :usesuper false}]
-             (xt/q node "SELECT username, usesuper FROM pg_user WHERE username = 'anonymous'")))
-    (t/is (= (SimpleResult. "anonymous") (.verifyPassword (authn/<-node node) "anonymous" "anonymous")))))
+    (t/is (= [{:username "xtdb", :usesuper true, :passwd-null true}]
+             (xt/q tu/*node* "SELECT username, usesuper, passwd IS NULL AS passwd_null FROM pg_user"))
+          "passwd is always NULL — credentials live in the authn config, not the table")))
 
 ;; required for Postgrex
 (deftest test-pg-range-3737
@@ -402,7 +382,7 @@
             {:table-catalog "xtdb",
              :table-schema "pg_catalog",
              :table-name "pg_user",
-             :table-type "BASE TABLE"}]
+             :table-type "VIEW"}]
            (xt/q tu/*node*
                  "SELECT table_catalog, table_schema, table_name, table_type
                   FROM information_schema.tables

--- a/src/test/clojure/xtdb/pgwire_protocol_test.clj
+++ b/src/test/clojure/xtdb/pgwire_protocol_test.clj
@@ -1,9 +1,7 @@
 (ns xtdb.pgwire-protocol-test
   (:require [clojure.test :as t :refer [deftest]]
             [jsonista.core :as json]
-            [xtdb.authn :as authn]
             [xtdb.authn-test :as authn-test]
-            [xtdb.db-catalog :as db]
             [xtdb.pgwire :as pgwire]
             [xtdb.pgwire.io :as pgio]
             [xtdb.test-util :as tu]
@@ -11,6 +9,7 @@
   (:import [java.lang AutoCloseable]
            [java.nio.charset StandardCharsets]
            [java.time Clock InstantSource]
+           xtdb.api.SingleRootUserAuthenticator
            xtdb.JsonLdSerde
            [xtdb.pgwire PgType]))
 
@@ -62,14 +61,10 @@
   ([out-msg] (->RecordingFrontend (atom []) (atom out-msg))))
 
 (defn ->conn
-  (^java.lang.AutoCloseable [frontend] (->conn frontend {}))
-  (^java.lang.AutoCloseable [frontend startup-opts]
-   (->conn frontend startup-opts [{:user nil, :method #xt.authn/method :trust, :address nil}]))
-  (^java.lang.AutoCloseable [frontend startup-opts authn-rules]
-   (let [authn (authn/->UserTableAuthn authn-rules
-                                       (.getAllocator (util/node-base tu/*node*))
-                                       (.getQuerySource (util/node-base tu/*node*))
-                                       (db/<-node tu/*node*))
+  (^java.lang.AutoCloseable [frontend] (->conn frontend {} nil))
+  (^java.lang.AutoCloseable [frontend startup-opts] (->conn frontend startup-opts nil))
+  (^java.lang.AutoCloseable [frontend startup-opts root-password]
+   (let [authn (SingleRootUserAuthenticator. root-password)
          conn (pgwire/map->Connection {:server {:server-state (atom {:parameters {"server_encoding" "UTF8"
                                                                                   "client_encoding" "UTF8"
                                                                                   "DateStyle" "ISO"
@@ -94,7 +89,7 @@
 
 (deftest test-startup
   (let [{:keys [!in-msgs] :as frontend} (->recording-frontend [{:msg-name :msg-password :password "xtdb"}])]
-    (with-open [_ (->conn frontend {"user" "xtdb", "database" "xtdb"} [{:user "xtdb", :method #xt.authn/method :password, :address "127.0.0.1"}])]
+    (with-open [_ (->conn frontend {"user" "xtdb", "database" "xtdb"} "xtdb")]
       (t/is (= [[:msg-auth {:result 3}]
                 [:msg-auth {:result 0}]
                 [:msg-parameter-status {:parameter "server_encoding", :value "UTF8"}]
@@ -111,7 +106,7 @@
 
 (deftest test-auth-failure
   (let [{:keys [!in-msgs] :as frontend} (->recording-frontend [{:msg-name :msg-simple-query, :query "SELECT 1"}])]
-    (with-open [_ (->conn frontend {"user" "xtdb", "database" "xtdb"} [{:user "xtdb", :method #xt.authn/method :password, :address "127.0.0.1"}])]
+    (with-open [_ (->conn frontend {"user" "xtdb", "database" "xtdb"} "xtdb")]
 
       (t/is (= [[:msg-auth {:result 3}]
                 [:msg-error-response

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2234,39 +2234,24 @@ ORDER BY t.oid DESC LIMIT 1"
         (t/is (= [{"_id" 8, "arr" [1 2 3]} {"_id" 9, "arr" [4 5 6]}] (rs->maps rs)))))))
 
 (deftest pg-authentication
-  (with-open [node (xtn/start-node {:authn [:user-table {:rules [{:user "xtdb", :method :password, :address "127.0.0.1"}]}]})]
-    (binding [*port* (.getServerPort node)]
-      (t/is (thrown-with-msg? PSQLException #"ERROR: no authentication record found for user: fin"
-                              (with-open [_ (jdbc-conn {"user" "fin", "password" "foobar"})]))
-            "users without record are blocked")
-
-      ;; user xtdb should be fine
-      (with-open [_ (jdbc-conn {"user" "xtdb", "password" "xtdb"})])
-      (t/is (thrown-with-msg? PSQLException #"ERROR: password authentication failed for user: xtdb"
-                              (with-open [_ (jdbc-conn {"user" "xtdb", "password" "foobar"})]))
-            "user with a wrong password gets blocked")))
-
-  (t/testing "users with a trusted record are allowed"
-    (with-open [node (xtn/start-node {:authn [:user-table {:rules [{:user "fin", :method :trust, :address "127.0.0.1"}]}]})]
+  (t/testing "default !SingleRootUser with no password configured runs TRUST — any user allowed"
+    (with-open [node (xtn/start-node {})]
       (binding [*port* (.getServerPort node)]
-        (with-open [_ (jdbc-conn {"user" "fin"})]))))
+        (with-open [_ (jdbc-conn {"user" "xtdb"})])
+        (with-open [_ (jdbc-conn {"user" "anyone"})]))))
 
-  (with-open [node (xtn/start-node {:authn [:user-table {:rules [{:user "xtdb", :method :password, :address "127.0.0.1"}
-                                                                 {:user "fin", :method :password, :address "127.0.0.1"}]}]})]
+  (t/testing "!SingleRootUser with password configured accepts the xtdb user"
+    (with-open [node (xtn/start-node {:authn [:single-root-user {:password "hunter2"}]})]
+      (binding [*port* (.getServerPort node)]
+        (with-open [_ (jdbc-conn {"user" "xtdb", "password" "hunter2"})])
 
-    (binding [*port* (.getServerPort node)]
-      (t/is (thrown-with-msg? PSQLException #"ERROR: password authentication failed for user: fin"
-                              (with-open [_ (jdbc-conn {"user" "fin", "password" "foobar"})]))
-            "users with a authentication record but not in the database")
+        (t/is (thrown-with-msg? PSQLException #"ERROR: password authentication failed for user: xtdb"
+                                (with-open [_ (jdbc-conn {"user" "xtdb", "password" "wrong"})]))
+              "wrong password is rejected")
 
-      (with-open [conn (jdbc-conn {"user" "xtdb" "password" "xtdb"})]
-        (jdbc/execute! conn ["CREATE USER fin WITH PASSWORD 'foobar'"])
-        (with-open [stmt (.createStatement conn)
-                    rs (.executeQuery stmt "SELECT username FROM pg_user")]
-          (is (= (set [{"username" "xtdb"} {"username" "fin"}])
-                 (set (rs->maps rs))))))
-
-      (with-open [_ (jdbc-conn {"user" "fin" "password" "foobar"})]))))
+        (t/is (thrown-with-msg? PSQLException #"ERROR: password authentication failed for user: fin"
+                                (with-open [_ (jdbc-conn {"user" "fin", "password" "hunter2"})]))
+              "non-root users are rejected even with the right password")))))
 
 (t/deftest test-keywordize-nested-values-3910
   (with-open [conn (jdbc-conn)]


### PR DESCRIPTION
Part of #4365 — second half of a two-commit story. Commit 1 (`acc3399b9`) landed the `!SingleRootUser` authenticator and made it the default; this PR removes the now-redundant password management path.

## Context

With `!SingleRootUser` now the default, and `XTDB_PASSWORD` covering the Postgres-container shape that #4365 was raised to unblock, the `!UserTable` factory and its `CREATE USER` / `ALTER USER` mutation path have no remaining job.
Leaving them in place would mean two overlapping ways to configure authn, a mutable credential table an operator can't turn off, and the `xtdb`/`xtdb` seeded row that #4365 was specifically raised to eliminate.
For the multi-user case, OIDC (shipped in 2.1) is the designated path — `!SingleRootUser` is only intended to cover dev and single-user containers.

## What goes

- `CREATE USER` / `ALTER USER` grammar productions and every downstream visitor (`xtdb.sql`, `xtdb.sql.parse`, `xtdb.pgwire`), plus the `:create-user` / `:alter-user` branches in `xtdb.indexer` (including `update-pg-user!`, which materialised the hashed password into the live trie).
- The `!UserTable` factory (Kotlin) and the `UserTableAuthn` record (Clojure), along with `verify-pw` — no other caller queried hashed passwords.
- `xtdb.authn.crypt` (the `buddy-hashers` wrapper) and the `buddy-hashers` dependency itself.
- The `template-table` machinery that existed solely to splice the seeded `xtdb`/`xtdb` row into `pg_user` scans at query time — `info-schema/template-table`, `pg-user-template-page+trie`, the `table-template` protocol method, and the corresponding branch in `xtdb.operator.scan`.
- `"create-user"` / `"alter-user"` from the FlightSQL DML op-name set.

## What stays

- `pg_user` as a read-only view on `pg-catalog-tables` — returns a single static row `{username: "xtdb", usesuper: true, passwd: NULL}`. Postgres tooling (dbeaver, Metabase, anything doing `SELECT * FROM pg_user` on startup) expects the table to exist; a single-row view keeps that contract with no moving parts. `passwd` is NULL deliberately — the authenticator config holds the only copy, mirroring Postgres's own redaction.
- `USER` and `PASSWORD` in the identifier-keyword list — they're still `CURRENT_USER`-shape SQL identifiers, unrelated to the removed statements.

## Breaking change

`!` applies:

- SQL `CREATE USER` / `ALTER USER` no longer parse.
- `!UserTable` is no longer a valid `authn` factory in YAML config. Use `!SingleRootUser` (the new default) or `!OpenIdConnect` instead.

One knock-on in the test suite: `schema-for-meta-tables-3550` flips `pg_user` from `BASE TABLE` to `VIEW`, because the row no longer comes from a materialised trie — which reflects reality and matches how the other `pg_catalog` entries are classified.

## Dead end worth recording

First spin of this branch failed CI with 213 downstream test failures. Root cause: `NodeBase.kt` was casting the info-schema factory's return to `AutoCloseable` (the reify used to close a template-page trie). After the template-table removal there's nothing for the info-schema to close, so the cast dangled. Both the cast and the corresponding `NodeBase.infoSchema` field are gone — no external readers, so the field was dead weight.

## Test plan

- [x] `./gradlew :test --tests 'xtdb.information-schema-test'` passes (including the rewritten `test-pg-user`)
- [x] `./gradlew :xtdb-core:test --tests 'xtdb.api.YamlSerdeTest'` passes
- [ ] Full CI green (in flight)