### PR TITLE
feat(indexer): add OpenTx.executeDml, use it from indexer.clj

### DIFF
--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -26,10 +26,10 @@
            (xtdb.arrow Relation Relation$ILoader RelationAsStructReader RelationReader RowCopier SingletonListReader VectorReader)
            (xtdb.error Anomaly$Caller Interrupted)
            (xtdb.database DatabaseState)
-           (xtdb.indexer CrashLogger Indexer Indexer$Factory Indexer$ForDatabase LiveIndex OpenTx OpenTx$Table OpIndexer RelationIndexer Snapshot Snapshot$Source TxIndexer)
+           (xtdb.indexer CrashLogger Indexer Indexer$Factory Indexer$ForDatabase LiveIndex OpenTx OpenTx$Table OpIndexer Snapshot Snapshot$Source TxIndexer TxIndexer$QueryOpts)
            (xtdb.table TableRef)
            xtdb.NodeBase
-           (xtdb.query IQuerySource IQuerySource$QueryCatalog PreparedDmlQuery PreparedDmlQuery$Assert PreparedDmlQuery$Delete PreparedDmlQuery$Erase PreparedDmlQuery$Patch PreparedDmlQuery$Put PreparedQuery QueryOpts)))
+           (xtdb.query IQuerySource IQuerySource$QueryCatalog QueryOpts)))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -165,101 +165,8 @@
 
         nil))))
 
-(defn- ->upsert-rel-indexer ^xtdb.indexer.RelationIndexer [^LiveIndex live-idx, ^OpenTx open-tx, ^VectorReader tx-ops-rdr,
-                                                           {:keys [^Instant current-time, ^CrashLogger crash-logger tx-key]}]
-  (let [current-time-µs (time/instant->micros current-time)]
-    (reify RelationIndexer
-      (indexOp [_ in-rel {:keys [table]}]
-        (when (xt-log/forbidden-table? table)
-          (throw (xt-log/forbidden-table-ex table)))
-
-        (when-not (.vectorForOrNull in-rel "_id")
-          (throw (err/incorrect :xtdb.indexer/missing-xt-id-column
-                                "Missing ID column"
-                                {:column-names (vec (for [^VectorReader col in-rel] (.getName col)))})))
-
-        (let [row-count (.getRowCount in-rel)
-              content-rel (vr/rel-reader (->> in-rel
-                                              (remove (comp types/temporal-col-name? #(.getName ^VectorReader %))))
-                                         row-count)
-              put-rel (vr/rel-reader (concat [(-> (.vectorFor in-rel "_id") (.withName "_id"))
-                                              (-> (RelationAsStructReader. "doc" content-rel) (.withName "doc"))]
-                                             (some-> (.vectorForOrNull in-rel "_valid_from") vector)
-                                             (some-> (.vectorForOrNull in-rel "_valid_to") vector))
-                                     row-count)
-              live-table (.table open-tx table)]
-          (with-crash-log crash-logger "error upserting rows"
-            {:table table, :tx-key tx-key}
-            {:live-idx live-idx, :open-tx-table live-table, :query-rel in-rel, :tx-ops-rdr tx-ops-rdr}
-            (.logPuts live-table current-time-µs Long/MAX_VALUE put-rel)))))))
-
-(defn- ->delete-rel-indexer ^xtdb.indexer.RelationIndexer [^LiveIndex live-idx, ^OpenTx open-tx, ^VectorReader tx-ops-rdr, {:keys [^CrashLogger crash-logger tx-key]}]
-  (reify RelationIndexer
-    (indexOp [_ in-rel {:keys [table]}]
-      (when (xt-log/forbidden-table? table)
-        (throw (xt-log/forbidden-table-ex table)))
-
-      (let [live-table (.table open-tx table)]
-        (with-crash-log crash-logger "error deleting rows"
-          {:table table, :tx-key tx-key}
-          {:live-idx live-idx, :open-tx-table live-table, :query-rel in-rel, :tx-ops-rdr tx-ops-rdr}
-          (.logDeletes live-table 0 Long/MAX_VALUE in-rel))))))
-
-(defn- ->erase-rel-indexer ^xtdb.indexer.RelationIndexer [^LiveIndex live-idx, ^OpenTx open-tx, ^VectorReader tx-ops-rdr, {:keys [^CrashLogger crash-logger tx-key]}]
-  (reify RelationIndexer
-    (indexOp [_ in-rel {:keys [table]}]
-      (when (xt-log/forbidden-table? table)
-        (throw (xt-log/forbidden-table-ex table)))
-
-      (let [live-table (.table open-tx table)]
-        (with-crash-log crash-logger "error erasing rows"
-          {:table table, :tx-key tx-key}
-          {:live-idx live-idx, :open-tx-table live-table, :query-rel in-rel, :tx-ops-rdr tx-ops-rdr}
-          (.logErases live-table (.vectorFor in-rel "_iid")))))))
-
-(defn- wrap-sql-args [f ^long param-count]
-  (fn [^RelationReader args]
-    (if (not args)
-      (if (zero? param-count)
-        (f nil)
-        (throw (err/incorrect :xtdb.indexer/missing-sql-args
-                              "Arguments list was expected but not provided"
-                              {:param-count param-count})))
-
-      (let [arg-count (count args)]
-        (if (not= arg-count param-count)
-          (throw (err/incorrect :xtdb.indexer/incorrect-sql-arg-count
-                                (format "Parameter error: %d provided, %d expected" arg-count param-count)
-                                {:param-count param-count, :arg-count arg-count}))
-
-          (f args))))))
-
 (defn- ->query-opts ^xtdb.query.QueryOpts [{:keys [current-time default-tz snapshot-token snapshot-time tracer]}]
   (QueryOpts. current-time default-tz snapshot-token snapshot-time tracer))
-
-(defn- ->assert-idxer [^PreparedQuery pq, message, tx-opts]
-  (-> (fn eval-query [^RelationReader args]
-        (with-open [res (.openQuery pq args (->query-opts tx-opts))]
-
-          (letfn [(throw-assert-failed []
-                    (throw (err/conflict :xtdb/assert-failed (or message "Assert failed"))))]
-            (or (.tryAdvance res
-                             (fn [^RelationReader in-rel]
-                               (when-not (pos? (.getRowCount in-rel))
-                                 (throw-assert-failed))))
-
-                (throw-assert-failed)))))
-
-      (wrap-sql-args (.getParamCount pq))))
-
-(defn- query-indexer [^PreparedQuery pq, ^RelationIndexer rel-idxer, ^TableRef table, tx-opts]
-  (-> (fn eval-query [^RelationReader args]
-        (with-open [res (-> (.openQuery pq args (->query-opts tx-opts)))]
-          (.forEachRemaining res
-                             (fn [^RelationReader in-rel]
-                               (.indexOp rel-idxer in-rel {:table table})))))
-
-      (wrap-sql-args (.getParamCount pq))))
 
 (defn- open-args-rdr ^xtdb.arrow.Relation$Loader [^BufferAllocator allocator, ^VectorReader args-rdr, ^long tx-op-idx]
   (when-not (.isNull args-rdr tx-op-idx)
@@ -337,51 +244,22 @@
 
           nil)))))
 
-(defn- ->sql-indexer ^xtdb.indexer.OpIndexer [^BufferAllocator allocator, ^LiveIndex live-idx, ^OpenTx open-tx
-                                              ^VectorReader tx-ops-rdr, ^IQuerySource q-src, db-cat,
-                                              {:keys [default-db ^CrashLogger crash-logger tx-key ^Tracer tracer] :as tx-opts}]
+(defn- ->sql-indexer ^xtdb.indexer.OpIndexer [^BufferAllocator allocator, ^OpenTx open-tx,
+                                              ^VectorReader tx-ops-rdr,
+                                              {:keys [current-time default-tz tx-key ^Tracer tracer]}]
   (let [sql-leg (.vectorFor tx-ops-rdr "sql")
         query-rdr (.vectorFor sql-leg "query")
         args-rdr (.vectorFor sql-leg "args")
-        upsert-idxer (->upsert-rel-indexer live-idx open-tx tx-ops-rdr tx-opts)
-        patch-idxer (reify RelationIndexer
-                      (indexOp [_ rel {:keys [table]}]
-                        (when (xt-log/forbidden-table? table)
-                          (throw (xt-log/forbidden-table-ex table)))
-                        (let [live-table (.table open-tx table)]
-                          (with-crash-log crash-logger "error patching rows"
-                            {:table table, :tx-key tx-key}
-                            {:live-idx live-idx, :open-tx-table live-table, :query-rel rel, :tx-ops-rdr tx-ops-rdr}
-                            (.logPuts live-table 0 Long/MAX_VALUE rel)))))
-        delete-idxer (->delete-rel-indexer live-idx open-tx tx-ops-rdr tx-opts)
-        erase-idxer (->erase-rel-indexer live-idx open-tx tx-ops-rdr tx-opts)]
+        q-opts (TxIndexer$QueryOpts. current-time default-tz)]
     (reify OpIndexer
       (indexOp [_ tx-op-idx]
         (let [query-str (.getObject query-rdr tx-op-idx)]
           (err/wrap-anomaly {:sql query-str, :tx-op-idx tx-op-idx, :tx-key tx-key}
                             (util/with-open [^Relation$ILoader args-loader (open-args-rdr allocator args-rdr tx-op-idx)]
                               (metrics/with-span tracer "xtdb.transaction.sql" {:attributes {:query.text query-str}}
-                                (let [tx-opts (assoc tx-opts
-                                                     :arg-fields (some-> args-loader (.getSchema) (.getFields))
-                                                     :query-text query-str)
-                                      ^PreparedDmlQuery pq (.prepareDmlQuery q-src query-str db-cat tx-opts)
-                                      kind (.getKind pq)]
-                                  (foreach-arg-row allocator args-loader
-                                                   (condp instance? kind
-                                                     PreparedDmlQuery$Put
-                                                     (query-indexer pq upsert-idxer (.getTable ^PreparedDmlQuery$Put kind) tx-opts)
-
-                                                     PreparedDmlQuery$Patch
-                                                     (query-indexer pq patch-idxer (.getTable ^PreparedDmlQuery$Patch kind) tx-opts)
-
-                                                     PreparedDmlQuery$Delete
-                                                     (query-indexer pq delete-idxer (.getTable ^PreparedDmlQuery$Delete kind) tx-opts)
-
-                                                     PreparedDmlQuery$Erase
-                                                     (query-indexer pq erase-idxer (.getTable ^PreparedDmlQuery$Erase kind) tx-opts)
-
-                                                     PreparedDmlQuery$Assert
-                                                     (->assert-idxer pq (.getMessage ^PreparedDmlQuery$Assert kind) tx-opts))))))))
+                                (foreach-arg-row allocator args-loader
+                                                 (fn [^RelationReader args]
+                                                   (.executeDml open-tx query-str args q-opts)))))))
 
         nil))))
 
@@ -464,7 +342,7 @@
                       !patch-docs-idxer (delay (->patch-docs-indexer allocator live-index open-tx tx-ops-rdr q-src db-cat system-time tx-opts))
                       !delete-docs-idxer (delay (->delete-docs-indexer live-index open-tx tx-ops-rdr system-time tx-opts))
                       !erase-docs-idxer (delay (->erase-docs-indexer live-index open-tx tx-ops-rdr tx-opts))
-                      !sql-idxer (delay (->sql-indexer allocator live-index open-tx tx-ops-rdr q-src db-cat tx-opts))]
+                      !sql-idxer (delay (->sql-indexer allocator open-tx tx-ops-rdr tx-opts))]
 
                   (if-let [e (try
                                (err/wrap-anomaly {}

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -13,10 +13,14 @@ import xtdb.arrow.VectorWriter
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
+import clojure.lang.PersistentArrayMap
+import xtdb.arrow.RelationAsStructReader
 import xtdb.database.ExternalSourceToken
+import xtdb.error.Conflict
 import xtdb.error.Incorrect
 import xtdb.kw
 import xtdb.query.IQuerySource
+import xtdb.query.PreparedDmlQuery
 import xtdb.table.TableRef
 import xtdb.time.InstantUtil.asMicros
 import xtdb.time.InstantUtil.fromMicros
@@ -99,7 +103,130 @@ class OpenTx(
             .openQuery(args, xtdb.query.QueryOpts(currentTime, opts.defaultTz, tracer = tracer))
     }
 
+    /**
+     * Execute a SQL DML statement (INSERT / UPDATE / PATCH / DELETE / ERASE / ASSERT)
+     * against this tx, with visibility into writes made earlier in the same writer call.
+     * Positional `?` parameters come from [args], like [openQuery].
+     *
+     * Writes to forbidden schemas (`xt`, `information_schema`, `pg_catalog`) throw.
+     */
+    fun executeDml(
+        sql: String,
+        args: RelationReader? = null,
+        opts: TxIndexer.QueryOpts = TxIndexer.QueryOpts(),
+    ) {
+        val currentTime = opts.currentTime ?: txKey.systemTime
+        val currentTimeµs = currentTime.asMicros
+        val qOpts = xtdb.query.QueryOpts(currentTime, opts.defaultTz, tracer = tracer)
+
+        val prepareOpts = PersistentArrayMap.create(mapOf(
+            "current-time".kw to currentTime,
+            "default-tz".kw to opts.defaultTz,
+            "default-db".kw to dbState.name,
+            "query-text".kw to sql,
+            "arg-fields".kw to args?.schema?.fields,
+        ))
+
+        val prepared = nodeBase.querySource.prepareDmlQuery(sql, queryCatalog(), prepareOpts)
+
+        checkArgCount(args, prepared.paramCount)
+
+        when (val kind = prepared.kind) {
+            is PreparedDmlQuery.Assert -> {
+                val msg = kind.message ?: "Assert failed"
+                fun fail(): Nothing = throw Conflict(msg, "xtdb/assert-failed", emptyMap<String, Any?>())
+                prepared.openQuery(args, qOpts).use { cursor ->
+                    if (!cursor.tryAdvance { rel -> if (rel.rowCount == 0) fail() }) fail()
+                }
+            }
+
+            is PreparedDmlQuery.Put -> {
+                checkNotForbidden(kind.table)
+                val table = table(kind.table)
+                prepared.openQuery(args, qOpts).use { cursor ->
+                    cursor.forEachRemaining { rel ->
+                        // INSERT/UPDATE plans emit `_id` + flat content cols + optional temporal,
+                        // not the canonical `_iid` + `doc` shape `logPuts` expects.
+                        // Package content cols into a `doc` struct here.
+                        val tempColNames = setOf("_iid", "_system_from", "_system_to", "_valid_from", "_valid_to")
+                        val contentRel = RelationReader.from(
+                            rel.vectors.filter { it.name !in tempColNames },
+                            rel.rowCount,
+                        )
+                        val putCols = listOfNotNull(
+                            rel.vectorFor("_id"),
+                            RelationAsStructReader("doc", contentRel),
+                            rel.vectorForOrNull("_valid_from"),
+                            rel.vectorForOrNull("_valid_to"),
+                        )
+                        table.logPuts(currentTimeµs, Long.MAX_VALUE, RelationReader.from(putCols, rel.rowCount))
+                    }
+                }
+            }
+
+            is PreparedDmlQuery.Patch -> {
+                checkNotForbidden(kind.table)
+                val table = table(kind.table)
+                prepared.openQuery(args, qOpts).use { cursor ->
+                    cursor.forEachRemaining { rel -> table.logPuts(0, Long.MAX_VALUE, rel) }
+                }
+            }
+
+            is PreparedDmlQuery.Delete -> {
+                checkNotForbidden(kind.table)
+                val table = table(kind.table)
+                prepared.openQuery(args, qOpts).use { cursor ->
+                    cursor.forEachRemaining { rel -> table.logDeletes(0, Long.MAX_VALUE, rel) }
+                }
+            }
+
+            is PreparedDmlQuery.Erase -> {
+                checkNotForbidden(kind.table)
+                val table = table(kind.table)
+                prepared.openQuery(args, qOpts).use { cursor ->
+                    cursor.forEachRemaining { rel -> table.logErases(rel.vectorFor("_iid")) }
+                }
+            }
+        }
+    }
+
     override fun close() = tableTxs.values.closeAll()
+
+    companion object {
+        // Must stay in sync with xtdb.log/forbidden-schemas and xtdb.tx.TxWriter's FORBIDDEN_SCHEMAS.
+        private val FORBIDDEN_SCHEMAS = setOf("xt", "information_schema", "pg_catalog")
+
+        private fun checkNotForbidden(tableRef: TableRef) {
+            if (tableRef.schemaName in FORBIDDEN_SCHEMAS) {
+                throw Incorrect(
+                    "Cannot write to table: ${tableRef.schemaAndTable}",
+                    "xtdb/forbidden-table",
+                    mapOf("table" to tableRef),
+                )
+            }
+        }
+
+        private fun checkArgCount(args: RelationReader?, paramCount: Int) {
+            if (args == null) {
+                if (paramCount != 0) {
+                    throw Incorrect(
+                        "Arguments list was expected but not provided",
+                        "xtdb.indexer/missing-sql-args",
+                        mapOf("param-count" to paramCount),
+                    )
+                }
+            } else {
+                val argCount = args.vectors.size
+                if (argCount != paramCount) {
+                    throw Incorrect(
+                        "Parameter error: $argCount provided, $paramCount expected",
+                        "xtdb.indexer/incorrect-sql-arg-count",
+                        mapOf("param-count" to paramCount, "arg-count" to argCount),
+                    )
+                }
+            }
+        }
+    }
 
     class Table(
         allocator: BufferAllocator,

--- a/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
@@ -66,6 +66,7 @@ class TxIndexer internal constructor(
 
     fun startTx(txKey: TransactionKey): OpenTx = openTx(txKey, null)
 
+
     suspend fun indexTx(
         externalSourceToken: ExternalSourceToken?,
         txId: Long = (liveIndex.latestCompletedTx?.txId ?: -1) + 1,


### PR DESCRIPTION
Part of #5445.

**External source writers can now issue SQL DML against their tx.**
Previously the only write surface was `OpenTx.Table.logPuts` / `logDeletes` / `logErases` — so a source had to parse its own feed, map columns, assemble an Arrow rel in the canonical `_iid` + `doc` shape, and hand-roll conflict / assertion logic.
`executeDml` lets the source offload all of that to the SQL planner:

```kotlin
override suspend fun onPartitionAssigned(
    partition: Int, afterToken: ExternalSourceToken?, txIndexer: TxIndexer,
) {
    txIndexer.indexTx(someToken) { openTx ->
        openTx.executeDml(
            "INSERT INTO users (_id, name, age) VALUES (?, ?, ?)",
            args,
        )
        openTx.executeDml(
            "UPDATE users SET age = ? WHERE _id = ?",
            moreArgs,
        )
        TxResult.Committed()
    }
}
```

As a corollary, the internal indexer uses the same seam: indexer.clj's `->sql-indexer` collapses onto `.executeDml` and its hand-rolled per-kind rel-indexers + arg-count wrapper drop out — which is also what gives us confidence the external-source path works end-to-end, since the internal SQL tests now exercise it.

Three non-obvious decisions along the way:

- **INSERT/UPDATE plans emit flat content, not `doc` struct.**
  The Put branch repackages `_id` + flat content cols + optional temporal into the canonical `_iid` + `doc` shape `logPuts` expects — same dance Clojure's former `->upsert-rel-indexer` did.

- **`prepareOpts` must be a Clojure `Associative`.**
  A Kotlin `mapOf` is a `LinkedHashMap`; `query.clj` calls `(update opts :default-tz …)` and blows up with `ClassCastException`. Wrapped with `PersistentArrayMap.create(...)`.

- **Put's `validFrom` default is `currentTimeµs`, not `0`.**
  Rows with null `_valid_from` would otherwise land at the epoch instead of the tx's system-time.

**Scope boundaries.**
`executePatchDocs` is on a sibling branch and excluded here — its single live caller trips a pre-existing `RefCnt has gone negative` buffer-lifecycle assertion; shipping only `executeDml` means no un-exercised code lands.
The broader internal-indexer migration to `TxIndexer.indexTx` is separately ongoing.

## Test plan

- [x] `compileTestKotlin` + `compileTestClojure` green
- [x] `tracer-test`'s multi-SQL-op span nesting — `xtdb.query` and cursor spans land under `xtdb.transaction.sql`
- [ ] Full `./gradlew :test` on CI
