### PR TITLE
feat(indexer): add OpenTx.patchDocs, use it from indexer.clj

### DIFF
--- a/core/src/main/clojure/xtdb/indexer.clj
+++ b/core/src/main/clojure/xtdb/indexer.clj
@@ -23,13 +23,12 @@
            (org.apache.arrow.memory BufferAllocator)
            xtdb.api.TransactionKey
            (xtdb.api.log ReplicaMessage$ResolvedTx)
-           (xtdb.arrow Relation Relation$ILoader RelationAsStructReader RelationReader RowCopier SingletonListReader VectorReader)
+           (xtdb.arrow Relation Relation$ILoader RelationAsStructReader RelationReader RowCopier VectorReader)
            (xtdb.error Anomaly$Caller Interrupted)
            (xtdb.database DatabaseState)
-           (xtdb.indexer CrashLogger Indexer Indexer$Factory Indexer$ForDatabase LiveIndex OpenTx OpenTx$Table OpIndexer Snapshot Snapshot$Source TxIndexer TxIndexer$QueryOpts)
+           (xtdb.indexer CrashLogger Indexer Indexer$Factory Indexer$ForDatabase LiveIndex OpenTx OpenTx$Table OpIndexer TxIndexer TxIndexer$QueryOpts)
            (xtdb.table TableRef)
-           xtdb.NodeBase
-           (xtdb.query IQuerySource IQuerySource$QueryCatalog QueryOpts)))
+           xtdb.NodeBase))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -165,9 +164,6 @@
 
         nil))))
 
-(defn- ->query-opts ^xtdb.query.QueryOpts [{:keys [current-time default-tz snapshot-token snapshot-time tracer]}]
-  (QueryOpts. current-time default-tz snapshot-token snapshot-time tracer))
-
 (defn- open-args-rdr ^xtdb.arrow.Relation$Loader [^BufferAllocator allocator, ^VectorReader args-rdr, ^long tx-op-idx]
   (when-not (.isNull args-rdr tx-op-idx)
     (Relation/streamLoader allocator ^bytes (.getObject args-rdr tx-op-idx))))
@@ -184,9 +180,8 @@
                               (aset selection 0 idx)
                               (eval-query (-> param-rel (.select selection) (.openSlice al))))))))))
 
-(defn- ->patch-docs-indexer [^BufferAllocator allocator, ^LiveIndex live-idx, ^OpenTx open-tx, ^VectorReader tx-ops-rdr,
-                             ^IQuerySource q-src, ^IQuerySource$QueryCatalog db-cat, ^Instant system-time
-                             {:keys [^String default-db, ^CrashLogger crash-logger, tx-key, ^Tracer tracer] :as tx-opts}]
+(defn- ->patch-docs-indexer [^OpenTx open-tx, ^VectorReader tx-ops-rdr, ^Instant system-time
+                             {:keys [^String default-db, tx-key, ^Tracer tracer]}]
   (let [patch-leg (.vectorFor tx-ops-rdr "patch-docs")
         iids-rdr (.vectorFor patch-leg "iids")
         iid-rdr (.getListElements iids-rdr)
@@ -197,51 +192,36 @@
     (reify OpIndexer
       (indexOp [_ tx-op-idx]
         (let [^String leg-name (.getLeg docs-rdr tx-op-idx)
-              ^TableRef table (table/->ref default-db leg-name)]
-          (when (xt-log/forbidden-table? table)
-            (throw (xt-log/forbidden-table-ex table)))
+              ^TableRef table-ref (table/->ref default-db leg-name)
+              table-docs-rdr (.vectorFor docs-rdr leg-name)
+              doc-rdr (.getListElements table-docs-rdr)
+              ks (.getKeyNames doc-rdr)]
+          (when-let [forbidden-cols (not-empty (->> ks
+                                                    (into #{} (filter (every-pred #(str/starts-with? % "_")
+                                                                                  (complement #{"_id" "_fn"}))))))]
+            (throw (err/incorrect :xtdb/forbidden-columns
+                                  (str "Cannot patch documents with columns: " (pr-str forbidden-cols))
+                                  {:table table-ref, :forbidden-cols forbidden-cols})))
 
-          (let [table-docs-rdr (.vectorFor docs-rdr leg-name)
-                doc-rdr (.getListElements table-docs-rdr)
-                ks (.getKeyNames doc-rdr)]
-            (when-let [forbidden-cols (not-empty (->> ks
-                                                      (into #{} (filter (every-pred #(str/starts-with? % "_")
-                                                                                    (complement #{"_id" "_fn"}))))))]
-              (throw (err/incorrect :xtdb/forbidden-columns
-                                    (str "Cannot patch documents with columns: " (pr-str forbidden-cols))
-                                    {:table table, :forbidden-cols forbidden-cols})))
-
-            (err/wrap-anomaly {:tx-op-idx tx-op-idx, :tx-key tx-key}
-              (let [valid-from-µs (if (.isNull valid-from-rdr tx-op-idx)
-                                    system-time-µs
-                                    (.getLong valid-from-rdr tx-op-idx))
-                    valid-to-µs (if (.isNull valid-to-rdr tx-op-idx)
-                                  Long/MAX_VALUE
-                                  (.getLong valid-to-rdr tx-op-idx))
-                    valid-from (time/micros->instant valid-from-µs)
-                    valid-to (when-not (.isNull valid-to-rdr tx-op-idx)
-                               (time/micros->instant valid-to-µs))
-                    live-table (.table open-tx table)]
-                (metrics/with-span tracer "xtdb.transaction.patch-docs" {:attributes {:db (.getDbName table)
-                                                                                      :schema (.getSchemaName table)
-                                                                                      :table (.getTableName table)}}
-                  (let [pq (.preparePatchDocsQuery q-src table valid-from valid-to db-cat tx-opts)
-                        args (vr/rel-reader [(SingletonListReader.
-                                               "?patch_docs"
-                                               (RelationAsStructReader.
-                                                 "patch_doc"
-                                                 (vr/rel-reader [(-> (.select iid-rdr (.getListStartIndex iids-rdr tx-op-idx) (.getListCount iids-rdr tx-op-idx))
-                                                                     (.withName "_iid"))
-                                                                 (-> (.select doc-rdr (.getListStartIndex table-docs-rdr tx-op-idx) (.getListCount table-docs-rdr tx-op-idx))
-                                                                     (.withName "doc"))])))])]
-                    (util/with-open [res (.openQuery pq (.openSlice args allocator) (->query-opts tx-opts))]
-                      (.forEachRemaining res
-                                         (fn [^RelationReader rel]
-                                           (with-crash-log crash-logger "error patching documents"
-                                             {:table table, :tx-key tx-key, :tx-op-idx tx-op-idx}
-                                             {:live-idx live-idx, :open-tx-table live-table, :query-rel rel, :tx-ops-rdr tx-ops-rdr}
-                                             (.logPuts live-table valid-from-µs valid-to-µs rel))))))))))
-
+          (err/wrap-anomaly {:tx-op-idx tx-op-idx, :tx-key tx-key}
+            ;; Arrow-null `_valid_from` on a patch-docs tx-op means "from now" (matches put-docs /
+            ;; delete-docs). SQL `PATCH ... FROM NULL` doesn't go through this path as Arrow-null —
+            ;; the SQL planner writes the start-of-time µs sentinel explicitly (see sql.clj
+            ;; #visitPatchStatementValidTimePortion).
+            (let [valid-from-µs (if (.isNull valid-from-rdr tx-op-idx)
+                                  system-time-µs
+                                  (.getLong valid-from-rdr tx-op-idx))
+                  valid-to-µs (if (.isNull valid-to-rdr tx-op-idx)
+                                Long/MAX_VALUE
+                                (.getLong valid-to-rdr tx-op-idx))
+                  docs (vr/rel-reader [(-> (.select iid-rdr (.getListStartIndex iids-rdr tx-op-idx) (.getListCount iids-rdr tx-op-idx))
+                                           (.withName "_iid"))
+                                       (-> (.select doc-rdr (.getListStartIndex table-docs-rdr tx-op-idx) (.getListCount table-docs-rdr tx-op-idx))
+                                           (.withName "doc"))])]
+              (metrics/with-span tracer "xtdb.transaction.patch-docs" {:attributes {:db (.getDbName table-ref)
+                                                                                    :schema (.getSchemaName table-ref)
+                                                                                    :table (.getTableName table-ref)}}
+                (.patchDocs open-tx (.table open-tx table-ref) valid-from-µs valid-to-µs docs))))
           nil)))))
 
 (defn- ->sql-indexer ^xtdb.indexer.OpIndexer [^BufferAllocator allocator, ^OpenTx open-tx,
@@ -278,9 +258,8 @@
                                 table-data
                                 nil nil)))
 
-(defrecord IndexerForDatabase [^BufferAllocator allocator, node-id, ^IQuerySource q-src
-                               db-name, db-storage, db-state
-                               ^LiveIndex live-index, table-catalog
+(defrecord IndexerForDatabase [^BufferAllocator allocator, node-id
+                               db-name, ^LiveIndex live-index
                                ^CrashLogger crash-logger
                                ^TxIndexer tx-indexer
                                ^Timer tx-timer
@@ -324,12 +303,7 @@
                     (add-tx-row! db-name open-tx tx-key skipped-exn user-metadata)
                     (commit live-index open-tx false skipped-exn)))
 
-                (let [db-cat (Indexer/queryCatalog db-storage db-state
-                                                   (reify Snapshot$Source
-                                                     (openSnapshot [_]
-                                                       (Snapshot/open allocator table-catalog live-index open-tx))))
-
-                      tx-opts {:snapshot-token (basis/->time-basis-str {db-name [system-time]})
+                (let [tx-opts {:snapshot-token (basis/->time-basis-str {db-name [system-time]})
                                :current-time system-time
                                :default-tz default-tz
                                :tx-key tx-key
@@ -339,7 +313,7 @@
                                :tracer tracer}
 
                       !put-docs-idxer (delay (->put-docs-indexer live-index open-tx tx-ops-rdr system-time tx-opts))
-                      !patch-docs-idxer (delay (->patch-docs-indexer allocator live-index open-tx tx-ops-rdr q-src db-cat system-time tx-opts))
+                      !patch-docs-idxer (delay (->patch-docs-indexer open-tx tx-ops-rdr system-time tx-opts))
                       !delete-docs-idxer (delay (->delete-docs-indexer live-index open-tx tx-ops-rdr system-time tx-opts))
                       !erase-docs-idxer (delay (->erase-docs-indexer live-index open-tx tx-ops-rdr tx-opts))
                       !sql-idxer (delay (->sql-indexer allocator open-tx tx-ops-rdr tx-opts))]
@@ -390,18 +364,16 @@
      create [_ ^NodeBase base]
       (let [config (.getConfig base)
             metrics-registry (.getMeterRegistry base)
-            q-src (.getQuerySource base)
             ^Tracer tracer (when (.getTransactionTracing (.getTracer config)) (.getTracer base))
             tx-timer (metrics/add-timer metrics-registry "tx.op.timer"
                                         {:description "indicates the timing and number of transactions"})
             tx-error-counter (metrics/add-counter metrics-registry "tx.error")]
         (reify Indexer
-          (openForDatabase [_ allocator db-storage db-state live-index crash-logger tx-indexer]
+          (openForDatabase [_ allocator db-state live-index crash-logger tx-indexer]
             (let [db-name (.getName db-state)]
               (util/with-close-on-catch [allocator (util/->child-allocator allocator (str "indexer/" db-name))]
-                (->IndexerForDatabase allocator (.getNodeId config) q-src
-                                      db-name db-storage db-state
-                                      live-index (.getTableCatalog db-state)
+                (->IndexerForDatabase allocator (.getNodeId config)
+                                      db-name live-index
                                       crash-logger tx-indexer
                                       tx-timer tx-error-counter tracer))))
 

--- a/core/src/main/kotlin/xtdb/indexer/Indexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Indexer.kt
@@ -8,8 +8,6 @@ import xtdb.arrow.VectorReader
 import xtdb.arrow.VectorType
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
-import xtdb.query.IQuerySource
 import xtdb.table.TableRef
 import xtdb.time.InstantUtil.asMicros
 import xtdb.types.ClojureForm
@@ -77,23 +75,6 @@ interface Indexer : AutoCloseable {
                 docWriter.endStruct()
             }
         }
-
-        @JvmStatic
-        fun queryCatalog(
-            storage: DatabaseStorage,
-            state: DatabaseState,
-            snapSource: Snapshot.Source
-        ): IQuerySource.QueryCatalog {
-            val queryDb = object : IQuerySource.QueryDatabase {
-                override val storage get() = storage
-                override val queryState get() = state
-                override fun openSnapshot() = snapSource.openSnapshot()
-            }
-            return object : IQuerySource.QueryCatalog {
-                override val databaseNames: Collection<DatabaseName> get() = setOf(state.name)
-                override fun databaseOrNull(dbName: DatabaseName) = queryDb.takeIf { dbName == state.name }
-            }
-        }
     }
 
     fun interface Factory {
@@ -102,7 +83,6 @@ interface Indexer : AutoCloseable {
 
     fun openForDatabase(
         allocator: BufferAllocator,
-        storage: DatabaseStorage,
         state: DatabaseState,
         liveIndex: LiveIndex,
         crashLogger: CrashLogger,

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -67,7 +67,7 @@ class LeaderLogProcessor(
     private val txIndexer = TxIndexer(this.allocator, nodeBase, dbStorage, dbState, watchers, committer = this, tracer = tracer)
 
     private val indexer: Indexer.ForDatabase =
-        indexer.openForDatabase(this.allocator, dbStorage, dbState, liveIndex, crashLogger, txIndexer)
+        indexer.openForDatabase(this.allocator, dbState, liveIndex, crashLogger, txIndexer)
 
     override suspend fun commit(openTx: OpenTx, result: TxResult) {
         throw UnsupportedOperationException("LeaderLogProcessor.commit — internal-indexer migration not yet complete")

--- a/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
@@ -16,7 +16,7 @@ import xtdb.util.RowCounter
 
 class LiveTable @JvmOverloads constructor(
     private val al: BufferAllocator,
-    private val table: TableRef,
+    val table: TableRef,
     private val rowCounter: RowCounter,
     liveTrieFactory: LiveTrieFactory = LiveTrieFactory { MemoryHashTrie.emptyTrie(it) }
 ) : AutoCloseable {

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -15,20 +15,25 @@ import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
 import clojure.lang.PersistentArrayMap
 import xtdb.arrow.RelationAsStructReader
+import xtdb.arrow.SingletonListReader
 import xtdb.database.ExternalSourceToken
 import xtdb.error.Conflict
 import xtdb.error.Incorrect
 import xtdb.kw
 import xtdb.query.IQuerySource
 import xtdb.query.PreparedDmlQuery
+import xtdb.table.SchemaName
+import xtdb.table.TableName
 import xtdb.table.TableRef
 import xtdb.time.InstantUtil.asMicros
 import xtdb.time.InstantUtil.fromMicros
+import xtdb.time.microsAsInstant
 import xtdb.trie.MemoryHashTrie
 import xtdb.trie.Trie
 import xtdb.util.asIid
 import xtdb.util.closeAll
 import java.nio.ByteBuffer
+import java.time.Instant
 import kotlin.Long.Companion.MAX_VALUE as MAX_LONG
 import kotlin.Long.Companion.MIN_VALUE as MIN_LONG
 
@@ -47,9 +52,9 @@ class OpenTx(
     private val tableTxs = HashMap<TableRef, Table>()
 
     fun table(table: TableRef): Table =
-        tableTxs.getOrPut(table) { Table(allocator, systemFrom) }
+        tableTxs.getOrPut(table) { Table(table, allocator, systemFrom) }
 
-    fun table(schemaName: String, tableName: String) =
+    fun table(schemaName: SchemaName, tableName: TableName) =
         table(TableRef(dbState.name, schemaName, tableName))
 
     val tables: Iterable<Map.Entry<TableRef, Table>> get() = tableTxs.entries
@@ -190,6 +195,68 @@ class OpenTx(
         }
     }
 
+    /**
+     * Bulk-patch docs into [table], keyed by `_iid`, preserving existing columns where
+     * the patched doc doesn't supply a new value.
+     *
+     * [docs] carries one row per doc, columns `_iid` (fixed-size binary) and `doc` (struct).
+     * [validFromµs] / [validToµs] default to [Long.MIN_VALUE] / [Long.MAX_VALUE] — the start/end of
+     * valid time — on the Instant overload, a null on either side means the same thing.
+     */
+    fun patchDocs(
+        table: Table,
+        validFromµs: Long,
+        validToµs: Long,
+        docs: RelationReader,
+    ) {
+        checkNotForbidden(table.ref)
+
+        val prepareOpts = PersistentArrayMap.create(mapOf(
+            "current-time".kw to txKey.systemTime,
+            "default-db".kw to dbState.name,
+            "arg-fields".kw to docs.schema.fields,
+        ))
+
+        // The planner (plan-patch in sql.clj) requires concrete Instant bounds — no nil support.
+        // The MIN/MAX µs bounds become start-of-time / end-of-time Instants; the planner treats
+        // them as literals and doesn't round-trip them through `asMicros`, so the lossiness of
+        // those sentinel Instants doesn't bite here.
+        val pq = nodeBase.querySource.preparePatchDocsQuery(
+            table.ref, validFromµs.microsAsInstant, validToµs.microsAsInstant,
+            queryCatalog(), prepareOpts,
+        )
+
+        val patchArgs = RelationReader.from(listOf(
+            SingletonListReader("?patch_docs", RelationAsStructReader("patch_doc", docs))
+        ))
+
+        val qOpts = xtdb.query.QueryOpts(txKey.systemTime, tracer = tracer)
+
+        // openQuery takes ownership of the sliced args and closes them when the cursor closes —
+        // no separate `.use` on the slice here or it'd double-free.
+        pq.openQuery(patchArgs.openSlice(allocator), qOpts).use { cursor ->
+            cursor.forEachRemaining { rel -> table.logPuts(validFromµs, validToµs, rel) }
+        }
+    }
+
+    /**
+     * Instant-based overload of [patchDocs] for end-user callers working with `java.time.Instant`
+     * (external-source writers typically do). Null on either bound means the same as passing
+     * [Long.MIN_VALUE] / [Long.MAX_VALUE] to the µs overload.
+     */
+    @JvmOverloads
+    fun patchDocs(
+        table: Table,
+        validFrom: Instant? = null,
+        validTo: Instant? = null,
+        docs: RelationReader,
+    ) = patchDocs(
+        table,
+        validFrom?.asMicros ?: Long.MIN_VALUE,
+        validTo?.asMicros ?: Long.MAX_VALUE,
+        docs,
+    )
+
     override fun close() = tableTxs.values.closeAll()
 
     companion object {
@@ -229,6 +296,7 @@ class OpenTx(
     }
 
     class Table(
+        val ref: TableRef,
         allocator: BufferAllocator,
         private val systemFrom: Long,
     ) : AutoCloseable {

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -127,11 +127,11 @@ class LogProcessorSimTest : SimulationTestBase() {
             override fun close() {}
         }
 
-    private fun simIndexerWrapper(dbName: String) = object : Indexer {
+    private fun simIndexerWrapper(dbName: String, dbStorage: DatabaseStorage) = object : Indexer {
         override fun openForDatabase(
-            allocator: BufferAllocator, storage: DatabaseStorage, state: DatabaseState,
+            allocator: BufferAllocator, state: DatabaseState,
             liveIndex: LiveIndex, crashLogger: CrashLogger, txIndexer: TxIndexer,
-        ) = simIndexer(allocator, dbName, storage, state)
+        ) = simIndexer(allocator, dbName, dbStorage, state)
 
         override fun close() {}
     }
@@ -151,7 +151,7 @@ class LogProcessorSimTest : SimulationTestBase() {
         val dbStorage = DatabaseStorage(srcLog, replicaLog, bp, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
         val crashLogger = CrashLogger(allocator, bp, "sim-node")
-        val indexer = simIndexerWrapper(dbName)
+        val indexer = simIndexerWrapper(dbName, dbStorage)
 
         override fun openLeaderSystem(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,

--- a/src/test/clojure/xtdb/indexer/live_table_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_table_test.clj
@@ -40,7 +40,7 @@
                          allocator (RootAllocator.)
                          live-table (LiveTable. allocator #xt/table foo (RowCounter.) (partial trie/->live-trie 2 4))]
 
-          (with-open [open-tx-table (OpenTx$Table. allocator 0)]
+          (with-open [open-tx-table (OpenTx$Table. #xt/table foo allocator 0)]
             (let [doc-wtr (.getDocWriter open-tx-table)]
               (dotimes [_n n]
                 (.logPut open-tx-table (ByteBuffer/wrap (util/uuid->bytes uuid))
@@ -72,7 +72,7 @@
                          bp (.getBufferPool (db/primary-db node))
                          allocator (RootAllocator.)
                          live-table (LiveTable. allocator #xt/table foo (RowCounter.))]
-          (with-open [open-tx-table (OpenTx$Table. allocator 0)]
+          (with-open [open-tx-table (OpenTx$Table. #xt/table foo allocator 0)]
             (let [doc-wtr (.getDocWriter open-tx-table)]
 
               (dotimes [_n n]
@@ -117,7 +117,7 @@
                      bp (.getBufferPool (db/primary-db node))
                      allocator (RootAllocator.)
                      live-table (LiveTable. allocator #xt/table foo rc)]
-      (let [open-tx-table (OpenTx$Table. allocator 0)
+      (let [open-tx-table (OpenTx$Table. #xt/table foo allocator 0)
             doc-wtr (.getDocWriter open-tx-table)]
 
         (doseq [uuid uuids]

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -354,7 +354,7 @@
 
 (defn index-tx! [^LiveTable live-table, ^TransactionKey tx-key, docs]
   (let [system-time (.getSystemTime tx-key)]
-    (with-open [open-tx-table (OpenTx$Table. *allocator* (time/instant->micros system-time))]
+    (with-open [open-tx-table (OpenTx$Table. (.getTable live-table) *allocator* (time/instant->micros system-time))]
       (let [doc-wtr (.getDocWriter open-tx-table)]
         (doseq [{eid :xt/id, :as doc} docs
                 :let [{:keys [:xt/valid-from :xt/valid-to],


### PR DESCRIPTION
Part of #5445

## What this unlocks

External source writers can now **bulk-patch docs on their tx** — no more hand-rolling the `?patch_docs` singleton-list-of-struct argument wrapping, or the `preparePatchDocsQuery` → `openQuery` → `forEachRemaining` → `logPuts` chain.

A typical external-source writer (e.g. the pgwire replication source's `onPartitionAssigned` callback) can now write:

```kotlin
override suspend fun onPartitionAssigned(...) {
    // ...pull a batch of _iid+doc rows off the source stream...

    txIndexer.indexTx(msgId, msgTimestamp) { openTx ->
        openTx.patchDocs(
            openTx.table(schemaName, tableName),
            validFrom = sourceRow.validFrom,   // java.time.Instant, or null for "from now"
            validTo = null,                    // null for open-ended
            docs = docsRel,                    // RelationReader with _iid + doc columns
        )
    }
}
```

Sources already working in µs (like `indexer.clj`, which reads the tx-op straight out of Arrow) skip the `Instant` round-trip entirely via the Long overload:

```kotlin
openTx.patchDocs(openTx.table(tableRef), validFromµs, validToµs, docs)
```

## Non-obvious decisions

**Two overloads, one underlying implementation.**
The primary `patchDocs(table, validFromµs: Long, validToµs: Long, docs)` takes µs — matching the shape `logPuts` already expects, and the shape `indexer.clj` is already in.
The `Instant?` overload delegates (`null` → `Long.MIN_VALUE` / `Long.MAX_VALUE` for `logPuts`, `start-of-time` / `end-of-time` for the planner).
External-source writers typically have Instants (that's what their source DB rows carry); internal callers have µs.
Having both lets each call site use its natural shape without round-tripping.

**Don't round-trip sentinel Instants through `asMicros`.**
`Long.MIN_VALUE.microsAsInstant.asMicros` throws: Java's `Instant.plus(MIN_VALUE, MICROS)` normalises to one second further past than `MIN_VALUE` µs can represent, so `epochSecond * 1_000_000` overflows.
The Long-first design avoids the round-trip entirely — the `Instant` overload computes `vfµs` / `vtµs` directly from `null` (→ `MIN` / `MAX`), and the sentinel Instants are only handed to the planner, which treats them as literals.

**`openQuery` takes ownership of the sliced args.**
No separate `.use` on `patchArgs.openSlice(allocator)` — the cursor closes it.
A double-`.use` surfaces as `RefCnt has gone negative` on the parent tx-ops rel (the shared buffer chain underflows, not the slice).
Matches the `foreach-arg-row` pattern `executeDml`'s caller already uses.

**Arrow-null `_valid_from` on a patch-docs tx-op still means "from current tx time".**
Pre-existing convention, shared with put-docs / delete-docs.
Collapsing it to `Long.MIN_VALUE` would change the no-`FROM`/`TO` semantic from "patch from now" to "patch across all valid time" — `patch-gaps-filling-test-4649` exercises the distinction.
The SQL `FROM NULL` case is separate: the SQL planner writes an explicit `start-of-time` µs sentinel, not an Arrow null.

## Corollary: `indexer.clj` gets thinner

`->query-opts`, the `db-cat` binding, and the `q-src` / `db-storage` / `db-state` / `table-catalog` fields on `IndexerForDatabase` existed only to feed `preparePatchDocsQuery`.
`OpenTx.patchDocs` owns that now, so they go — along with `Indexer.queryCatalog` and the `DatabaseStorage` arg on `Indexer.openForDatabase`.

This is the second step in the "converge LLP and external sources onto the same `TxIndexer` lifecycle" path that #5445 is tracking — after #5500 did the same for `executeDml`, `indexer.clj` now writes through the same `OpenTx` surface external sources do.