### PR TITLE
feat(pgwire): add pgwire.tx.latency timer metric

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -557,7 +557,7 @@
   (swap! conn-state dissoc :transaction)
   (close-all-portals conn))
 
-(defn cmd-commit [{:keys [^Xtdb node conn-state default-db ^BufferAllocator allocator, tx-error-counter] :as conn}]
+(defn cmd-commit [{:keys [^Xtdb node conn-state default-db ^BufferAllocator allocator, tx-error-counter, tx-latency-timer] :as conn}]
   (let [{:keys [transaction session]} @conn-state
         {:keys [failed dml-buf system-time access-mode default-tz async? user-metadata]} transaction
         {:keys [parameters]} session]
@@ -566,37 +566,38 @@
 
       (try
         (when (= :read-write access-mode)
-          (let [tx-opts (TxOpts. default-tz
-                                 (some-> system-time (time/->instant {:default-tz default-tz}))
-                                 (get parameters "user")
-                                 user-metadata)]
-            (util/with-open [tx-ops (->> dml-buf
-                                         (mapcat (fn [op]
-                                                   (or (when (instance? Sql op)
-                                                         (let [^Sql op op]
-                                                           (seq (sql/sql->static-ops (.getSql op) (.getArgRows op)))))
-                                                       [op])))
-                                         (util/safe-mapv #(xt-log/open-tx-op % allocator {:default-tz default-tz})))]
-              (if async?
-                (let [tx-id (with-auth-check conn (.submitTx node default-db tx-ops tx-opts))
-                      msg-id (.getTxId tx-id)]
-                  (swap! conn-state (fn [cs]
-                                      (-> cs
-                                          (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {default-db [msg-id]}))
-                                          (assoc :latest-submitted-tx {:tx-id msg-id})))))
+          (metrics/record-callable! tx-latency-timer
+                                    (let [tx-opts (TxOpts. default-tz
+                                                           (some-> system-time (time/->instant {:default-tz default-tz}))
+                                                           (get parameters "user")
+                                                           user-metadata)]
+                                      (util/with-open [tx-ops (->> dml-buf
+                                                                   (mapcat (fn [op]
+                                                                             (or (when (instance? Sql op)
+                                                                                   (let [^Sql op op]
+                                                                                     (seq (sql/sql->static-ops (.getSql op) (.getArgRows op)))))
+                                                                                 [op])))
+                                                                   (util/safe-mapv #(xt-log/open-tx-op % allocator {:default-tz default-tz})))]
+                                        (if async?
+                                          (let [tx-id (with-auth-check conn (.submitTx node default-db tx-ops tx-opts))
+                                                msg-id (.getTxId tx-id)]
+                                            (swap! conn-state (fn [cs]
+                                                                (-> cs
+                                                                    (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {default-db [msg-id]}))
+                                                                    (assoc :latest-submitted-tx {:tx-id msg-id})))))
 
-                (let [tx (with-auth-check conn (.executeTx node default-db tx-ops tx-opts))
-                      msg-id (.getTxId tx)]
-                  (swap! conn-state (fn [cs]
-                                      (-> cs
-                                          (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {default-db [msg-id]}))
-                                          (assoc :latest-submitted-tx {:tx-id msg-id
-                                                                       :system-time (.getSystemTime tx)
-                                                                       :committed? (.getCommitted tx)
-                                                                       :error (.getError tx)}))))
+                                          (let [tx (with-auth-check conn (.executeTx node default-db tx-ops tx-opts))
+                                                msg-id (.getTxId tx)]
+                                            (swap! conn-state (fn [cs]
+                                                                (-> cs
+                                                                    (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {default-db [msg-id]}))
+                                                                    (assoc :latest-submitted-tx {:tx-id msg-id
+                                                                                                 :system-time (.getSystemTime tx)
+                                                                                                 :committed? (.getCommitted tx)
+                                                                                                 :error (.getError tx)}))))
 
-                  (when-let [error (.getError tx)]
-                    (throw error)))))))
+                                            (when-let [error (.getError tx)]
+                                              (throw error))))))))
         (catch Throwable t
           (metrics/inc-counter! tx-error-counter)
           (throw t))
@@ -1793,7 +1794,7 @@
   freed at the end of this function. So the connections lifecycle should be totally enclosed over the lifetime of a connect call.
 
   See comment 'Connection lifecycle'."
-  [{:keys [node, ^Authenticator authn, server-state, port, allocator, query-error-counter, tx-error-counter, ^Counter total-connections-counter, ^Counter cancelled-connections-counter, query-timer, query-tracer] :as server} ^Socket conn-socket]
+  [{:keys [node, ^Authenticator authn, server-state, port, allocator, query-error-counter, tx-error-counter, tx-latency-timer, ^Counter total-connections-counter, ^Counter cancelled-connections-counter, query-timer, query-tracer] :as server} ^Socket conn-socket]
   (let [close-promise (promise)
         {:keys [cid !closing?] :as conn} (util/with-close-on-catch [_ conn-socket]
                                            (let [cid (:next-cid (swap! server-state update :next-cid (fnil inc 0)))
@@ -1819,6 +1820,7 @@
                     :query-timer query-timer
                     :query-tracer query-tracer
                     :tx-error-counter tx-error-counter
+                    :tx-latency-timer tx-latency-timer
                     :cancelled-connections-counter cancelled-connections-counter)]
 
     (try
@@ -1913,6 +1915,7 @@
            query-error-counter (when metrics-registry (metrics/add-counter metrics-registry "query.error"))
            query-timer (when metrics-registry (metrics/add-timer metrics-registry "query.timer" {}))
            tx-error-counter (when metrics-registry (metrics/add-counter metrics-registry "tx.error"))
+           tx-latency-timer (when metrics-registry (metrics/add-timer metrics-registry "pgwire.tx.latency" {}))
            total-connections-counter (when metrics-registry (metrics/add-counter metrics-registry "pgwire.total_connections"))
            cancelled-connections-counter (when metrics-registry (metrics/add-counter metrics-registry "pgwire.cancelled_connections")) 
            server (map->Server {:allocator allocator
@@ -1947,6 +1950,7 @@
                          :query-timer query-timer
                          :query-tracer (when query-tracing? tracer)
                          :tx-error-counter tx-error-counter
+                         :tx-latency-timer tx-latency-timer
                          :total-connections-counter total-connections-counter
                          :cancelled-connections-counter cancelled-connections-counter)
            accept-thread (-> (Thread/ofVirtual)

--- a/src/test/clojure/xtdb/metrics_test.clj
+++ b/src/test/clojure/xtdb/metrics_test.clj
@@ -131,13 +131,36 @@ $$"])
         (let [^Timer timer (.timer (.find registry "query.timer"))]
           (t/is (= (.count timer) 2))
           (t/is (> (.totalTime timer java.util.concurrent.TimeUnit/NANOSECONDS) 0))))
-      
+
       (t/testing "runtime pgwire error queries should be added to timer"
         (t/is (thrown? Exception (jdbc/execute! conn ["SELECT 1/0"])))
         (let [^Timer timer (.timer (.find registry "query.timer"))]
           (t/is (= (.count timer) 3)))))
 
-    (t/testing "queries via the node should be added to timer" 
+    (t/testing "queries via the node should be added to timer"
       (xt/q node "SELECT 1")
       (let [^Timer timer (.timer (.find registry "query.timer"))]
         (t/is (= (.count timer) 4))))))
+
+(t/deftest test-pgwire-tx-latency-timer
+  (let [node (xtn/start-node tu/*node-opts*)
+        registry (.getMeterRegistry (util/node-base node))]
+
+    (with-open [conn (jdbc/get-connection node)]
+      (t/testing "synchronous transactions via pgwire are recorded in pgwire.tx.latency timer"
+        (jdbc/execute! conn ["INSERT INTO foo (_id, a) VALUES (1, 42)"])
+        (let [^Timer timer (.timer (.find registry "pgwire.tx.latency"))]
+          (t/is (= (.count timer) 1))
+          (t/is (> (.totalTime timer java.util.concurrent.TimeUnit/NANOSECONDS) 0))))
+
+      (t/testing "explicit transactions are recorded on commit"
+        (jdbc/execute! conn ["START TRANSACTION"])
+        (jdbc/execute! conn ["INSERT INTO foo (_id, a) VALUES (2, 43)"])
+        (jdbc/execute! conn ["COMMIT"])
+        (let [^Timer timer (.timer (.find registry "pgwire.tx.latency"))]
+          (t/is (= (.count timer) 2))))
+
+      (t/testing "failed transactions are also recorded"
+        (t/is (thrown? Exception (jdbc/execute! conn ["INSERT INTO foo (a) VALUES (42)"])))
+        (let [^Timer timer (.timer (.find registry "pgwire.tx.latency"))]
+          (t/is (= (.count timer) 3)))))))


### PR DESCRIPTION
Resolves #5503 
Github actions: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Apgwire-tx-latency-metric

Add a new `pgwire.tx.latency` timer to the PGWire server that measures the end-to-end latency of a transaction from when commit is called until the result (committed, aborted, or error) is returned to the client.

This captures:
- Time to build tx ops from the DML buffer
- Time to submit to the transaction log
- For synchronous transactions: time waiting for indexing to complete
- Time to process the result

The timer is registered in the metrics registry alongside the existing `tx.error` counter and `query.timer`, and is passed down to each connection. It wraps the transaction execution in `cmd-commit` via the existing `metrics/record-callable!` macro.