### PR TITLE
feat: Add block.upload.timer metric.

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -183,7 +183,7 @@ class Database(
             })
 
             if (indexerConfig.enabled) {
-                val blockUploader = BlockUploader(storage, state, compactorForDb, dbCatalog)
+                val blockUploader = BlockUploader(storage, state, compactorForDb, dbCatalog, base.meterRegistry)
 
                 val procFactory = object : LogProcessor.ProcessorFactory {
                     override fun openFollower(

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -1,5 +1,9 @@
 package xtdb.indexer
 
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import java.nio.ByteBuffer
+import java.time.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import xtdb.api.log.Log
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
@@ -18,15 +22,15 @@ import xtdb.log.proto.TrieDetails
 import xtdb.util.StringUtil.asLexHex
 import xtdb.util.debug
 import xtdb.util.logger
-import java.nio.ByteBuffer
-import java.time.Instant
 
 private val LOG = BlockUploader::class.logger
 
 class BlockUploader(
-    dbStorage: DatabaseStorage, dbState: DatabaseState,
+    dbStorage: DatabaseStorage,
+    dbState: DatabaseState,
     private val compactor: Compactor.ForDatabase,
     private val dbCatalog: Database.Catalog?,
+    private val meterRegistry: MeterRegistry?,
 ) {
     private val sourceLog = dbStorage.sourceLog
     private val bufferPool = dbStorage.bufferPool
@@ -34,6 +38,11 @@ class BlockUploader(
     private val blockCatalog = dbState.blockCatalog
     private val trieCatalog = dbState.trieCatalog
     private val tableCatalog = dbState.tableCatalog
+    private val blockUploadTimer: Timer? = meterRegistry?.let {
+        Timer.builder("block.upload.timer")
+            .publishPercentiles(0.75, 0.85, 0.95, 0.98, 0.99, 0.999)
+            .register(it)
+    }
 
     suspend fun uploadBlock(
         replicaProducer: Log.AtomicProducer<ReplicaMessage>, boundaryReplicaMsgId: MessageId, boundary: BlockBoundary,
@@ -41,6 +50,7 @@ class BlockUploader(
         val latestProcessedMsgId = boundary.latestProcessedMsgId
         val blockIdx = boundary.blockIndex
         LOG.debug("finishing block: 'b${blockIdx.asLexHex}'...")
+        val timer = meterRegistry?.let { Timer.start(it) }
 
         val finishedBlocks = liveIndex.finishBlock(bufferPool, blockIdx)
 
@@ -99,6 +109,7 @@ class BlockUploader(
 
         LOG.debug("block uploaded b${blockIdx.asLexHex}: source=$latestProcessedMsgId, replica=$uploadedMsgId")
 
+        blockUploadTimer?.let { timer?.stop(it) }
         liveIndex.nextBlock()
         compactor.signalBlock()
         LOG.debug("finished block: 'b${blockIdx.asLexHex}'.")

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -95,7 +95,7 @@ class ExternalSourceTest {
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader")
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
-        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
+        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null)
 
         return ExternalSourceProcessor(
             allocator, nodeBase, dbStorage, dbState, blockUploader, watchers, extSource, replicaProducer,

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -65,7 +65,7 @@ class LeaderLogProcessorTest {
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader")
-        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
+        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null)
 
         return LeaderLogProcessor(
             allocator, nodeBase, dbStorage, replicaProducer, dbState,
@@ -118,7 +118,7 @@ class LeaderLogProcessorTest {
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader")
-        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
+        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null)
 
         val lp = LeaderLogProcessor(
             allocator, nodeBase, dbStorage, replicaProducer,
@@ -182,7 +182,7 @@ class LeaderLogProcessorTest {
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader")
-        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
+        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null)
 
         val lp = LeaderLogProcessor(
             allocator, nodeBase, dbStorage, replicaProducer,

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -149,7 +149,7 @@ class LogProcessorSimTest : SimulationTestBase() {
 
         val watchers = Watchers(-1)
         val dbStorage = DatabaseStorage(srcLog, replicaLog, bp, null)
-        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
+        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null)
         val crashLogger = CrashLogger(allocator, bp, "sim-node")
         val indexer = simIndexerWrapper(dbName, dbStorage)
 

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -67,7 +67,7 @@ class LogProcessorTest {
                 afterReplicaMsgId: MessageId,
             ): LogProcessor.LeaderSystem {
                 val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
-                val blockUploader = BlockUploader(dbStorage, dbState, compactor, null)
+                val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null)
                 val leaderProc = LeaderLogProcessor(
                     allocator, nodeBase, dbStorage, replicaProducer,
                     dbState, mockk(relaxed = true), mockk(relaxed = true), watchers,
@@ -86,7 +86,7 @@ class LogProcessorTest {
             ): LogProcessor.TransitionProcessor =
                 TransitionLogProcessor(
                     allocator, bufferPool, dbState, dbState.liveIndex,
-                    BlockUploader(dbStorage, dbState, mockk(relaxed = true), null),
+                    BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null),
                     replicaProducer, watchers, dbCatalog = null,
                     afterSourceMsgId = afterSourceMsgId,
                     afterReplicaMsgId = afterReplicaMsgId,
@@ -111,7 +111,7 @@ class LogProcessorTest {
         val bufferPool = mockBufferPool()
         val dbState = dbState()
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
-        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
+        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null)
         val watchers = Watchers(-1)
 
         val scope = CoroutineScope(SupervisorJob())
@@ -135,7 +135,7 @@ class LogProcessorTest {
         val bufferPool = mockBufferPool(epoch = 1)
         val dbState = dbState()
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
-        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
+        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null)
         val watchers = Watchers(-1)
 
         val scope = CoroutineScope(SupervisorJob())
@@ -162,7 +162,7 @@ class LogProcessorTest {
         }
         val dbState = dbState(liveIndex = liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
-        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
+        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null)
         val watchers = Watchers(-1)
 
         // Pre-populate the replica log with a transaction
@@ -199,7 +199,7 @@ class LogProcessorTest {
         }
         val dbState = dbState(liveIndex = liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
-        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null)
+        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null)
         val watchers = Watchers(-1)
 
         // Pre-populate the replica log

--- a/src/test/clojure/xtdb/metrics_test.clj
+++ b/src/test/clojure/xtdb/metrics_test.clj
@@ -164,3 +164,13 @@ $$"])
         (t/is (thrown? Exception (jdbc/execute! conn ["INSERT INTO foo (a) VALUES (42)"])))
         (let [^Timer timer (.timer (.find registry "pgwire.tx.latency"))]
           (t/is (= (.count timer) 3)))))))
+
+(t/deftest test-block-uploaded-timer
+  (let [node (xtn/start-node tu/*node-opts*)
+        registry (.getMeterRegistry (util/node-base node))]
+    (t/testing "blocks uploaded to storage are recorded in block.upload.timer"
+      (xt/submit-tx node [[:put-docs :foo {:xt/id 1}]])
+      (tu/flush-block! node)
+      (let [^Timer timer (.timer (.find registry "block.upload.timer"))]
+        (t/is (= (.count timer) 1))
+        (t/is (> (.totalTime timer java.util.concurrent.TimeUnit/NANOSECONDS) 0))))))


### PR DESCRIPTION
Github actions runs: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Afeat%2Fblock-uploader-metrics

Adds a timer for the contents of uploadBlock.