### PR TITLE
perf(indexer): parallelise per-table block-metadata uploads

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -4,7 +4,10 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import java.nio.ByteBuffer
 import java.time.Instant
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import xtdb.api.log.Log
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.api.log.MessageId
@@ -78,10 +81,15 @@ class BlockUploader(
 
         val tableBlocks = tableCatalog.finishBlock(blockCatalog.currentBlockIndex, finishedBlocks, tablePartitions)
 
-        for ((table, tableBlock) in tableBlocks) {
-            val path = BlockCatalog.tableBlockPath(table, blockIdx)
-            bufferPool.putObject(path, ByteBuffer.wrap(tableBlock.toByteArray()))
+        coroutineScope {
+            tableBlocks.forEach { (table, tableBlock) ->
+                launch(Dispatchers.IO) {
+                    val path = BlockCatalog.tableBlockPath(table, blockIdx)
+                    bufferPool.putObject(path, ByteBuffer.wrap(tableBlock.toByteArray()))
+                }
+            }
         }
+
         val secondaryDatabasesForBlock = dbCatalog?.serialisedSecondaryDatabases
 
         val externalSourceToken = boundary.externalSourceToken


### PR DESCRIPTION
## Context

Block finalisation in `BlockUploader.uploadBlock` ends with two bursts of object-store writes: per-table block-metadata files, then the overall block file.
The trie / data / metadata files that make up each table's L0 trie were already being written in parallel per-table inside `LiveTable.finishBlock` (`async(Dispatchers.IO) + awaitAll`).
The per-table block-metadata loop, though, was still a serial `for` over `bufferPool.putObject` — the last remaining serial I/O in the finalisation path.
On a schema with many tables that turns into `N × single-put-latency` for something a well-provisioned object store is happy to do concurrently.

## Approach

The loop moves into `coroutineScope { tableBlocks.forEach { launch(Dispatchers.IO) { putObject(...) } } }`.
`uploadBlock` is already `suspend`, so `coroutineScope` costs nothing — no new thread pools, no lifecycle changes — and structured concurrency preserves the old failure semantics: one failed put cancels its siblings and rethrows, same as the serial loop would.

The overall block file (`BlockCatalog.blockFilePath(blockIdx)`) still writes sequentially, after `coroutineScope` returns.
That's load-bearing: followers treat its arrival as the "block is available" signal, so it must not land before the per-table blocks it references.
Keeping the overall-block write outside the scope block is the simplest way to encode that ordering.

Mirrors the existing pattern at `LiveTable.kt:112-124`, so there's nothing new to learn in this corner of the code.

## Out of scope

Within `LiveTable.finishBlock`, each table's data-file and meta-file uploads are still serial.
The meta file's page indices are assigned during the data-file trie walk, so the two writers are tightly interleaved — splitting their *uploads* into parallel work after the walk would need `DataFileWriter` / `MetadataFileWriter` restructured to separate "finalise local temp" from "upload to object store".
Real payoff, but non-trivial and its own test surface.
Left as a follow-up.

Also noticed but not addressed: `LiveTable.kt:114` uses `runBlocking { … }`, but its only caller (`uploadBlock`) is now `suspend`.
Blocking a coroutine dispatcher thread inside a `suspend` caller is an anti-pattern worth tidying — drop `runBlocking`, make the Map-extension `suspend`, swap for `coroutineScope`.
Equivalence change, separate commit.

## Test plan

- [x] `./gradlew :core:test --tests '*indexer*' --tests '*block*' --tests '*log-processor*' --tests '*log_processor*'` — 78 tests, all pass locally
- [x] Narrow sweep: `LogProcessorTest`, `LogProcessorSimTest`, `LeaderLogProcessorTest`, `TransitionLogProcessorTest`, `ExternalSourceTest` — pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)