### PR TITLE
fix(indexer): block (not suspend) during parallel table-block uploads

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -6,8 +6,9 @@ import java.nio.ByteBuffer
 import java.time.Instant
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import xtdb.api.log.Log
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.api.log.MessageId
@@ -87,13 +88,13 @@ class BlockUploader(
 
         val tableBlocks = tableCatalog.finishBlock(blockCatalog.currentBlockIndex, finishedBlocks, tablePartitions)
 
-        coroutineScope {
-            tableBlocks.forEach { (table, tableBlock) ->
-                launch(blockUploadDispatcher) {
+        runBlocking {
+            tableBlocks.map { (table, tableBlock) ->
+                async(blockUploadDispatcher) {
                     val path = BlockCatalog.tableBlockPath(table, blockIdx)
                     bufferPool.putObject(path, ByteBuffer.wrap(tableBlock.toByteArray()))
                 }
-            }
+            }.awaitAll()
         }
 
         val secondaryDatabasesForBlock = dbCatalog?.serialisedSecondaryDatabases


### PR DESCRIPTION
`coroutineScope { launch(blockUploadDispatcher) }` *suspends* the calling coroutine while IO children run, then the IO threads dispatch the continuation back to the caller's dispatcher. In the sim tests, that dispatcher is the single-threaded `DeterministicDispatcher`, which is not thread-safe — the cross-thread callback can be lost, hanging the test.

`runBlocking { async(blockUploadDispatcher) }` achieves the same IO parallelism but *blocks* the calling thread instead of suspending.
The `DeterministicDispatcher`'s drain loop simply pauses until all uploads finish — no cross-thread dispatch needed.
This matches the existing pattern in `LiveTable.finishBlock`.

Every call site is a sequential record-processing pipeline where the next record can't start until `finishBlock` returns, so the thread has nothing else to do during the wait — no practical cost from blocking vs suspending.