### PR TITLE
perf(indexer): drop redundant table_name from in-block tries

### DIFF
--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -34,6 +34,22 @@
                           :trie-metadata trie-metadata
                           :state state})))
 
+(defn ->table-block-trie-details ^TrieDetails
+  ;; In-block companion to ->trie-details. Builds a TrieDetails without table_name,
+  ;; since inside a block the table is already fixed by the file path. Saves the
+  ;; per-trie name bytes on garbage-heavy tables — see #5512.
+  [{:keys [trie-key, ^long data-file-size, ^TrieMetadata trie-metadata state garbage-as-of]}]
+  (-> (TrieDetails/newBuilder)
+      (.setTrieKey trie-key)
+      (.setDataFileSize data-file-size)
+      (cond-> trie-metadata (.setTrieMetadata trie-metadata))
+      (cond-> state (.setTrieState (case state
+                                     :live TrieState/LIVE
+                                     :nascent TrieState/NASCENT
+                                     :garbage TrieState/GARBAGE)))
+      (cond-> garbage-as-of (.setGarbageAsOf (time/instant->micros garbage-as-of)))
+      (.build)))
+
 (declare parse-trie-key)
 
 (defn <-trie-details [^TrieDetails trie-details]

--- a/core/src/main/clojure/xtdb/trie_catalog.clj
+++ b/core/src/main/clojure/xtdb/trie_catalog.clj
@@ -491,7 +491,7 @@
          (mapv (fn [partition]
                  (table-cat/->partition
                    (update partition :tries
-                           (partial mapv #(trie/->trie-details table %))))))))
+                           (partial mapv trie/->table-block-trie-details)))))))
 
   PTrieCatalog
   (trie-state [_ table] (.get ^Map (:table-cats @!state) table))

--- a/core/src/main/proto/xtdb/meta/block/proto/block.proto
+++ b/core/src/main/proto/xtdb/meta/block/proto/block.proto
@@ -14,6 +14,8 @@ message Partition {
   int32 level = 1;
   int64 recency = 2;
   bytes part = 3;
+  // The `table_name` field on each TrieDetails is left unset inside a block —
+  // the table is fixed by the enclosing TableBlock's path. See #5512.
   repeated xtdb.log.proto.TrieDetails tries = 4;
   int64 max_block_index = 5;
 }

--- a/src/test/clojure/xtdb/table_catalog_test.clj
+++ b/src/test/clojure/xtdb/table_catalog_test.clj
@@ -3,7 +3,6 @@
             [xtdb.api :as xt]
             [xtdb.db-catalog :as db]
             [xtdb.object-store :as os]
-            [xtdb.table :as table]
             [xtdb.table-catalog :as table-cat]
             [xtdb.test-util :as tu]
             [xtdb.trie :as trie]
@@ -23,8 +22,9 @@
            (xtdb.util HyperLogLog)))
 
 (defn trie-details->edn [^TrieDetails trie]
-  (cond-> {:table (table/->ref "xtdb" (.getTableName trie)) ; TODO multi-db, db is likely going to be part of the TrieDetails msg
-           :trie-key (.getTrieKey trie)
+  ;; In-block tries don't carry table_name (#5512); the table comes from the
+  ;; surrounding TableBlock's path, not the trie itself.
+  (cond-> {:trie-key (.getTrieKey trie)
            :data-file-size (.getDataFileSize trie)}
     (.hasTrieMetadata trie) (assoc :trie-metadata (trie-cat/<-trie-metadata (.getTrieMetadata trie)))))
 
@@ -47,8 +47,8 @@
         (xt/execute-tx node [[:put-docs :foo {:xt/id 2}]])
         (tu/flush-block! node)
 
-        (t/is (= [(os/->StoredObject "tables/public$foo/blocks/b00.binpb" 4427)
-                  (os/->StoredObject "tables/public$foo/blocks/b01.binpb" 4581)]
+        (t/is (= [(os/->StoredObject "tables/public$foo/blocks/b00.binpb" 4415)
+                  (os/->StoredObject "tables/public$foo/blocks/b01.binpb" 4557)]
                  (.listAllObjects bp (table-cat/->table-block-dir #xt/table foo))))
 
         (let [{hlls1 :hlls :as _table-block1} (->> (.getByteArray bp (util/->path "tables/public$foo/blocks/b00.binpb"))
@@ -70,12 +70,8 @@
 
           (t/is (= 1 (-> partitions first :max-block-idx)))
 
-          (t/is (= [{:table #xt/table foo,
-                     :trie-key "l00-rc-b00",
-                     :data-file-size 1918}
-                    {:table #xt/table foo,
-                     :trie-key "l00-rc-b01",
-                     :data-file-size 1918}]
+          (t/is (= [{:trie-key "l00-rc-b00", :data-file-size 1918}
+                    {:trie-key "l00-rc-b01", :data-file-size 1918}]
                    (map #(dissoc % :trie-metadata) current-tries)))
 
           (t/is (= [{:min-valid-from #xt/instant "2020-01-01T00:00:00Z",


### PR DESCRIPTION
Resolves #5512.

## Summary

`TrieDetails` inside `TableBlock.partitions[].tries[]` carried a `table_name` string that was always identical to the table the block belongs to.
On garbage-heavy tables that adds up — one block file inspected for the issue had ~190K trie entries paying ~2.5 MB (~18% of the file) for the redundancy.

## Approach

`TrieDetails` is shared with the source/replica log, where `table_name` is genuinely needed: a single `TriesAdded` or `BlockUploaded` message can span multiple tables, and the receiver groups by `tableName` to dispatch the batch back out per-table.
Inside a block, the table is fixed by the file path — the field was never read on that path, so it was just bytes on disk.

The change is a new in-block companion builder, `xtdb.trie/->table-block-trie-details`, that produces a `TrieDetails` without setting `table_name`.
`xtdb.trie-catalog/getPartitions` routes through it instead of `xtdb.trie/->trie-details`.
Proto type and wire format are unchanged.

## Reasons for this shape over a separate proto type

The issue called out two options.
The original lean was option 1 — a separate `TableBlockTrieDetails` proto message — and most of that change had landed before pivoting.

Two things drove the pivot.

The first was naming.
A separate type in `xtdb.block.proto` would clash with `xtdb.log.proto.TrieDetails` at the Clojure namespace level — `:import` can't alias Java classes — so one of them ends up fully qualified at every use site, or the new type takes a `TableBlock-` prefix that's only there to dodge the clash.
That tail wags the dog.

The second was reading the issue's "complecting" objection more carefully.
The field is just optional metadata that the log path sets and the block path doesn't, because in the block path the table is fixed by the file path.
That's a normal optional-field shape, not two meanings on one slot.
And the harm direction is the opposite of what type-system enforcement would protect against: setting `table_name` accidentally on a block-bound trie does no damage (the reader doesn't consume it anyway); failing to set it on a log-bound trie *would* break dispatch.
Both options keep the log path identical, so neither addresses the latter risk.

So the change reduces to ~20 lines: a new builder, one call-site swap, and a clarifying comment on the proto.
No type duplication, no API ripple.

## Verification

Confirmed nothing in the in-block read path consumes the field today:

- `xtdb.table-catalog/<-partition` and `xtdb.trie-catalog/load-tries` go through `<-trie-details`, which sets `:table-name` in the parsed map, but no downstream code reads that key.
- `xtdb.block-tables` (`xt.table_block_file_tries`) takes the table from the query predicate, not from the trie.
- `xtdb.information-schema/trie-stats` gets the table from the outer `(.getTables trie-catalog)` iteration.

Block file size verified to drop by 12 bytes per trie in `current-tries-on-finish-block` (4427→4415 with one trie, 4581→4557 with two).
Scales linearly with trie count, matching the predicted ~2.5 MB / ~18% reduction on the garbage-heavy block from the issue.

Old block files (with `table_name` populated) deserialise unchanged — the field was never structurally required by the in-block parser.

## Out of scope

`table_name` only exists on `TrieDetails` at all because a single `TriesAdded` / `BlockUploaded` log message can span multiple tables.
That structural reason could be removed by reshaping the log message to lift the table from per-element to per-batch — e.g. `repeated TablePartition tries` with `TablePartition { string table_name = 1; repeated TrieDetails tries = 2; }`, or one `TriesAdded` per table for the block-flush path (the compactor already only emits one table per message).
That's a wire change to the log and the issue puts it explicitly out of scope.
Worth a follow-up.

## Test plan

- [x] `:test` — 1447 passing
- [x] `:core:test` — 1445 passing
- [ ] CI green