### PR TITLE
fix(test): deterministic sim tests with parallel block uploads

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import java.nio.ByteBuffer
 import java.time.Instant
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
@@ -32,7 +33,7 @@ private val LOG = BlockUploader::class.logger
 // `TableBlock.toByteArray()` buffers. S3's default HTTP client caps concurrency at 50, so
 // parallelism beyond this would queue inside the SDK with the `byte[]`s still pinned on heap.
 private const val MAX_CONCURRENT_BLOCK_UPLOADS = 16
-private val blockUploadDispatcher = IO.limitedParallelism(MAX_CONCURRENT_BLOCK_UPLOADS, "block-upload")
+private val defaultBlockUploadDispatcher = IO.limitedParallelism(MAX_CONCURRENT_BLOCK_UPLOADS, "block-upload")
 
 class BlockUploader(
     dbStorage: DatabaseStorage,
@@ -40,6 +41,7 @@ class BlockUploader(
     private val compactor: Compactor.ForDatabase,
     private val dbCatalog: Database.Catalog?,
     private val meterRegistry: MeterRegistry?,
+    private val uploadDispatcher: CoroutineDispatcher = defaultBlockUploadDispatcher,
 ) {
     private val sourceLog = dbStorage.sourceLog
     private val bufferPool = dbStorage.bufferPool
@@ -89,7 +91,7 @@ class BlockUploader(
 
         coroutineScope {
             tableBlocks.forEach { (table, tableBlock) ->
-                launch(blockUploadDispatcher) {
+                launch(uploadDispatcher) {
                     val path = BlockCatalog.tableBlockPath(table, blockIdx)
                     bufferPool.putObject(path, ByteBuffer.wrap(tableBlock.toByteArray()))
                 }

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -149,7 +149,7 @@ class LogProcessorSimTest : SimulationTestBase() {
 
         val watchers = Watchers(-1)
         val dbStorage = DatabaseStorage(srcLog, replicaLog, bp, null)
-        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null)
+        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, uploadDispatcher = dispatcher)
         val crashLogger = CrashLogger(allocator, bp, "sim-node")
         val indexer = simIndexerWrapper(dbName, dbStorage)
 

--- a/core/src/test/kotlin/xtdb/indexer/SimLog.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLog.kt
@@ -2,6 +2,7 @@ package xtdb.indexer
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.selects.select
 import xtdb.api.log.Log
 import xtdb.api.log.LogOffset
 import xtdb.api.log.MessageId
@@ -50,33 +51,42 @@ internal class SimLog<M>(private val name: String, ctx: CoroutineContext, privat
     private val scope = CoroutineScope(ctx + job)
 
     /**
-     * Delivers records to the current group leader.
+     * Unified group loop: delivers records and handles rebalances in a single coroutine.
+     * Rebalances and record delivery are serialized via `select` — a rebalance can only
+     * fire between `processRecords` calls, matching real Kafka consumer-thread semantics
+     * where rebalance callbacks fire inside `poll()`, never during record processing.
      */
-    suspend fun processMessagesLoop() {
+    suspend fun groupLoop() {
         while (true) {
-            wakeLeader.receive()
+            // Rebalance branch first: Kafka processes pending rebalances before fetching records.
+            select<Unit> {
+                rebalanceTrigger.onReceive { doRebalance() }
+                wakeLeader.onReceive { deliverGroupRecords() }
+            }
             yield()
+        }
+    }
 
-            this.leader?.let { leader ->
-                val tailSpec = leader.tailSpec
-                    ?: run {
-                        LOG.debug("$name/processMessages: leader has no tail spec, skipping")
-                        return@let
-                    }
-
-                val nextOffset = leader.nextOffset
-                val lag = topic.size - nextOffset
-
-                if (lag > 0) {
-                    val messageCount = rand.nextInt(1, lag + 1)
-                    LOG.debug("$name/processMessages: delivering $messageCount group record(s) [$nextOffset..${nextOffset + messageCount - 1}] (lag=$lag)")
-                    tailSpec.processor.processRecords(topic.subList(nextOffset, nextOffset + messageCount).toList())
-                    leader.nextOffset += messageCount
+    private suspend fun deliverGroupRecords() {
+        this.leader?.let { leader ->
+            val tailSpec = leader.tailSpec
+                ?: run {
+                    LOG.debug("$name/processMessages: leader has no tail spec, skipping")
+                    return@let
                 }
 
-                if (leader.nextOffset < topic.size)
-                    wakeLeader.send(Unit)
+            val nextOffset = leader.nextOffset
+            val lag = topic.size - nextOffset
+
+            if (lag > 0) {
+                val messageCount = rand.nextInt(1, lag + 1)
+                LOG.debug("$name/processMessages: delivering $messageCount group record(s) [$nextOffset..${nextOffset + messageCount - 1}] (lag=$lag)")
+                tailSpec.processor.processRecords(topic.subList(nextOffset, nextOffset + messageCount).toList())
+                leader.nextOffset += messageCount
             }
+
+            if (leader.nextOffset < topic.size)
+                wakeLeader.send(Unit)
         }
     }
 
@@ -105,45 +115,36 @@ internal class SimLog<M>(private val name: String, ctx: CoroutineContext, privat
         }
     }
 
-    /**
-     * Handles leader election — reacts to consumer join/leave events.
-     */
-    suspend fun chooseLeaderLoop() {
-        while (true) {
-            rebalanceTrigger.receive()
-            yield()
+    private suspend fun doRebalance() {
+        LOG.debug("$name/chooseLeader: rebalance triggered (${groupConsumers.size} consumers)")
 
-            LOG.debug("$name/chooseLeader: rebalance triggered (${groupConsumers.size} consumers)")
+        leader?.let { old ->
+            LOG.debug("$name/chooseLeader: revoking old leader")
+            old.listener.onPartitionsRevoked(listOf(0))
+            old.tailSpec = null
+            leader = null
+        }
 
-            leader?.let { old ->
-                LOG.debug("$name/chooseLeader: revoking old leader")
-                old.listener.onPartitionsRevoked(listOf(0))
-                old.tailSpec = null
-                leader = null
+        if (groupConsumers.isNotEmpty()) {
+            val newLeader = groupConsumers.random(rand)
+            LOG.debug("$name/chooseLeader: assigning new leader")
+            val tailSpec = newLeader.listener.onPartitionsAssigned(listOf(0))
+            newLeader.tailSpec = tailSpec
+            if (tailSpec != null) {
+                val startOffset = (MsgIdUtil.afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1).toInt()
+                newLeader.nextOffset = startOffset
             }
-
-            if (groupConsumers.isNotEmpty()) {
-                val newLeader = groupConsumers.random(rand)
-                LOG.debug("$name/chooseLeader: assigning new leader")
-                val tailSpec = newLeader.listener.onPartitionsAssigned(listOf(0))
-                newLeader.tailSpec = tailSpec
-                if (tailSpec != null) {
-                    val startOffset = (MsgIdUtil.afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1).toInt()
-                    newLeader.nextOffset = startOffset
-                }
-                leader = newLeader
-                wakeLeader.send(Unit)
-            } else {
-                LOG.debug("$name/chooseLeader: no consumers, no leader elected")
-            }
+            leader = newLeader
+            wakeLeader.send(Unit)
+        } else {
+            LOG.debug("$name/chooseLeader: no consumers, no leader elected")
         }
     }
 
     init {
         LOG.debug("$name: starting loops")
-        scope.launch(CoroutineName("SimLog/processMessages")) { processMessagesLoop() }
+        scope.launch(CoroutineName("SimLog/group")) { groupLoop() }
         scope.launch(CoroutineName("SimLog/plainConsumers")) { plainConsumerLoop() }
-        scope.launch(CoroutineName("SimLog/chooseLeader")) { chooseLeaderLoop() }
     }
 
     private fun appendSync(message: M): Log.MessageMetadata {


### PR DESCRIPTION
## Context

`88b7ca489` parallelised per-table block-metadata uploads in `BlockUploader` using `coroutineScope { launch(Dispatchers.IO) }`.
This introduced two independent bugs in the `LogProcessorSimTest` property tests — both latent until the right seed triggers them.

## Bug 1: cross-thread callback race (`DeterministicDispatcher`)

`coroutineScope` suspends the calling coroutine while IO children run on real threads.
When the children complete, they dispatch the continuation back to the caller's `DeterministicDispatcher`.
The dispatcher was never designed for cross-thread access: its `jobs` list is a plain `ArrayList` and the `running` flag check-then-set is non-atomic.

The specific race: the drain loop checks `jobs.isEmpty()` → true, is about to set `running = false`.
The IO thread calls `dispatch`, adds the continuation, checks `running` → still `true`, returns without starting a drain loop.
The drain loop sets `running = false`.
The continuation sits in the queue with nobody draining it — hang.

Even without the race, any cross-thread dispatch breaks the determinism guarantee: the IO callback arrives at a non-deterministic real-time moment, changing which jobs are in the queue when `rand.nextInt(jobs.size)` picks the next one.

**Fix**: parameterise `BlockUploader`'s upload dispatcher.
The sim test passes its `DeterministicDispatcher`; production uses the default IO-backed pool.
Everything stays on one thread in tests — no cross-thread callback, determinism preserved.

## Bug 2: rebalance during `processRecords` (SimLog)

The `DeterministicDispatcher` randomly picks from all queued coroutines.
When `processRecords` suspends (at the `coroutineScope` in `uploadBlock`), the upload children enter the queue — but so does `chooseLeaderLoop` if a rebalance trigger is pending.
The dispatcher can pick the rebalance, firing `onPartitionsRevoked` mid-processing.
This causes "Cannot finish block 0 when current block is 0" — the transition re-uploads a block that the interrupted `uploadBlock` later tries to finish.

In real Kafka, `ConsumerRebalanceListener` callbacks fire inside `poll()`, strictly between `processRecords` calls — never during.
The SimLog's separate `processMessagesLoop` and `chooseLeaderLoop` coroutines didn't model this.

**Fix**: merge the two loops into a single coroutine using `select`.
Once a branch's handler starts (record delivery or rebalance), it runs to completion before the next `select` iteration.
A rebalance cannot interleave with record processing.

## Dead ends

- **Making `DeterministicDispatcher` thread-safe** (`synchronized`): fixes the crash but breaks determinism — the IO callback timing is still non-deterministic.
- **`runBlocking { async(IO) }` instead of `coroutineScope { launch(IO) }`**: blocks the calling thread, containing the IO non-determinism. Works, but the parameterised-dispatcher approach is cleaner — it keeps `coroutineScope`/`launch` (no thread blocking in production) and makes the test fully deterministic.
- **SimLog mutex instead of `select`**: would work but holds a coroutine `Mutex` across suspension points (`awaitReplicaMsgId` during transitions), which is harder to reason about.