### PR TITLE
tidy(test): fail-fast on cross-thread DeterministicDispatcher misuse

### DIFF
--- a/core/src/test/kotlin/xtdb/DeterministicDispatcher.kt
+++ b/core/src/test/kotlin/xtdb/DeterministicDispatcher.kt
@@ -13,8 +13,7 @@ class DeterministicDispatcher(private val rand: Random) : CoroutineDispatcher() 
 
     private val jobs = mutableListOf<DispatchJob>()
 
-    @Volatile
-    private var running = false
+    private var runningThread: Thread? = null
 
     /** Total number of jobs picked from the queue. */
     var totalPicks = 0
@@ -25,10 +24,14 @@ class DeterministicDispatcher(private val rand: Random) : CoroutineDispatcher() 
         private set
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {
+        check(runningThread == null || runningThread == Thread.currentThread()) {
+            "Cross-thread dispatch from ${Thread.currentThread().name} while running on ${runningThread?.name}"
+        }
+
         jobs.add(DispatchJob(context, block))
 
-        if (!running) {
-            running = true
+        if (runningThread == null) {
+            runningThread = Thread.currentThread()
             while (jobs.isNotEmpty()) {
                 totalPicks++
                 if (jobs.size > 1) interleavedPicks++
@@ -36,7 +39,7 @@ class DeterministicDispatcher(private val rand: Random) : CoroutineDispatcher() 
                 val job = jobs.removeAt(idx)
                 job.block.run()
             }
-            running = false
+            runningThread = null
         }
     }
 }

--- a/core/src/test/kotlin/xtdb/DeterministicDispatcherTest.kt
+++ b/core/src/test/kotlin/xtdb/DeterministicDispatcherTest.kt
@@ -1,0 +1,46 @@
+package xtdb
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.CountDownLatch
+import kotlin.coroutines.EmptyCoroutineContext
+
+class DeterministicDispatcherTest {
+
+    @Test
+    fun `cross-thread dispatch while running throws`() {
+        val dispatcher = DeterministicDispatcher(seed = 42)
+        val latch = CountDownLatch(1)
+        var crossThreadError: Throwable? = null
+
+        dispatcher.dispatch(EmptyCoroutineContext, Runnable {
+            // We're inside the drain loop on the main thread.
+            // Dispatch from a different thread — should fail.
+            val thread = Thread {
+                crossThreadError = assertThrows<IllegalStateException> {
+                    dispatcher.dispatch(EmptyCoroutineContext, Runnable {})
+                }
+                latch.countDown()
+            }
+            thread.start()
+            latch.await()
+        })
+
+        assert(crossThreadError != null) { "Expected cross-thread dispatch to throw" }
+        assert("Cross-thread dispatch" in crossThreadError!!.message!!)
+    }
+
+    @Test
+    fun `re-entrant dispatch from same thread succeeds`() {
+        val dispatcher = DeterministicDispatcher(seed = 42)
+        var innerRan = false
+
+        dispatcher.dispatch(EmptyCoroutineContext, Runnable {
+            dispatcher.dispatch(EmptyCoroutineContext, Runnable {
+                innerRan = true
+            })
+        })
+
+        assert(innerRan) { "Re-entrant dispatch should execute" }
+    }
+}


### PR DESCRIPTION
The dispatcher is single-threaded by design — determinism requires it. Previously, cross-thread dispatch would silently hang (the continuation sits in the queue with nobody draining it) or break determinism by introducing real-time scheduling into the interleaving order.

Replace the boolean `running` flag with `runningThread: Thread?`, which serves double duty: re-entrancy guard (was `running`) and cross-thread check (new).