### PR TITLE
feat: Add trie/block GC metrics.

### DIFF
--- a/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
@@ -11,6 +11,7 @@ import xtdb.catalog.BlockCatalog
 import xtdb.catalog.BlockCatalog.Companion.allBlockFiles
 import xtdb.catalog.BlockCatalog.Companion.tableBlocks
 import xtdb.storage.BufferPool
+import xtdb.table.DatabaseName
 import xtdb.util.StringUtil.fromLexHex
 import xtdb.util.debug
 import xtdb.util.logger
@@ -45,6 +46,7 @@ class BlockGarbageCollector(
     tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
     deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    dbName: DatabaseName,
 ) : AutoCloseable {
 
     private val dbJob = Job()
@@ -63,12 +65,14 @@ class BlockGarbageCollector(
     private val blockDeleteTimer: Timer? = meterRegistry?.let {
         Timer.builder("xtdb.gc.block_files.delete.timer")
             .publishPercentiles(0.75, 0.95, 0.99)
+            .tag("db", dbName)
             .register(it)
     }
 
     private val tableBlockDeleteTimer: Timer? = meterRegistry?.let {
         Timer.builder("xtdb.gc.table_block_files.delete.timer")
             .publishPercentiles(0.75, 0.95, 0.99)
+            .tag("db", dbName)
             .register(it)
     }
 

--- a/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
@@ -1,5 +1,7 @@
 package xtdb.garbage_collector
 
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
@@ -39,6 +41,7 @@ class BlockGarbageCollector(
     private val blocksToKeep: Int,
     /** Gates the auto-signal from the leader's block-boundary path; direct `awaitNoGarbage()` is unaffected. */
     val enabled: Boolean,
+    private val meterRegistry: MeterRegistry? = null,
     tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
     deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -56,6 +59,18 @@ class BlockGarbageCollector(
 
     private val tableDispatcher = dispatcher.limitedParallelism(tableParallelism)
     private val deleteDispatcher = dispatcher.limitedParallelism(deleteParallelism)
+
+    private val blockDeleteTimer: Timer? = meterRegistry?.let {
+        Timer.builder("xtdb.gc.block_files.delete.timer")
+            .publishPercentiles(0.75, 0.95, 0.99)
+            .register(it)
+    }
+
+    private val tableBlockDeleteTimer: Timer? = meterRegistry?.let {
+        Timer.builder("xtdb.gc.table_block_files.delete.timer")
+            .publishPercentiles(0.75, 0.95, 0.99)
+            .register(it)
+    }
 
     init {
         require(blocksToKeep >= 1) { "blocksToKeep must be >= 1, got $blocksToKeep" }
@@ -117,24 +132,28 @@ class BlockGarbageCollector(
         fun Path.isGarbage(): Boolean =
             parseBlockIndex()?.let { it != latestBlockIndex && it <= latestBlockIndex - blocksToKeep } ?: false
 
-        suspend fun deleteGarbage(paths: Sequence<Path>) {
+        suspend fun deleteGarbage(paths: Sequence<Path>, gcTimer: Timer? = null) {
             coroutineScope {
                 paths.filter { it.isGarbage() }.forEach { path ->
-                    launch(deleteDispatcher) { bufferPool.deleteIfExists(path) }
+                    launch(deleteDispatcher) {
+                        val timer = meterRegistry?.let { Timer.start(it) }
+                        bufferPool.deleteIfExists(path)
+                        gcTimer?.let { timer?.stop(it) }
+                    }
                 }
             }
         }
 
         supervisorScope {
             launch(tableDispatcher) {
-                deleteGarbage(bufferPool.allBlockFiles.asSequence().map { it.key })
+                deleteGarbage(bufferPool.allBlockFiles.asSequence().map { it.key }, blockDeleteTimer)
             }
         }
 
         supervisorScope {
             for (table in blockCatalog.allTables) {
                 launch(tableDispatcher) {
-                    deleteGarbage(bufferPool.tableBlocks(table).asSequence().map { it.key })
+                    deleteGarbage(bufferPool.tableBlocks(table).asSequence().map { it.key }, tableBlockDeleteTimer)
                 }
             }
         }

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -1,6 +1,5 @@
 package xtdb.garbage_collector
 
-import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.*
@@ -11,6 +10,7 @@ import kotlinx.coroutines.selects.select
 import xtdb.catalog.BlockCatalog.Companion.blockFromLatest
 import xtdb.database.DatabaseState
 import xtdb.storage.BufferPool
+import xtdb.table.DatabaseName
 import xtdb.table.TableRef
 import xtdb.time.microsAsInstant
 import xtdb.trie.Trie.dataFilePath
@@ -68,6 +68,7 @@ class TrieGarbageCollector(
     tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
     deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    dbName: DatabaseName,
 ) : AutoCloseable {
 
     private val blockCatalog = dbState.blockCatalog
@@ -86,6 +87,7 @@ class TrieGarbageCollector(
     private val deleteTimer: Timer? = meterRegistry?.let {
         Timer.builder("xtdb.gc.tries.delete.timer")
             .publishPercentiles(0.75, 0.95, 0.99)
+            .tag("db", dbName)
             .register(it)
     }
     

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -1,5 +1,8 @@
 package xtdb.garbage_collector
 
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
@@ -61,6 +64,7 @@ class TrieGarbageCollector(
     private val garbageLifetime: Duration,
     /** Gates [signal]s from the leader's block-boundary path; direct [awaitNoGarbage] is unaffected. */
     val enabled: Boolean,
+    private val meterRegistry: MeterRegistry? = null,
     tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
     deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -79,6 +83,12 @@ class TrieGarbageCollector(
     private val tableDispatcher = dispatcher.limitedParallelism(tableParallelism)
     private val deleteDispatcher = dispatcher.limitedParallelism(deleteParallelism)
 
+    private val deleteTimer: Timer? = meterRegistry?.let {
+        Timer.builder("xtdb.gc.tries.delete.timer")
+            .publishPercentiles(0.75, 0.95, 0.99)
+            .register(it)
+    }
+    
     init {
         LOGGER.debug("Starting TrieGarbageCollector (enabled=$enabled, blocksToKeep=$blocksToKeep, garbageLifetime=$garbageLifetime)")
 
@@ -160,8 +170,10 @@ class TrieGarbageCollector(
             coroutineScope {
                 for (trieKey in chunk) {
                     launch(deleteDispatcher) {
+                        val timer = meterRegistry?.let { Timer.start(it) }
                         bufferPool.deleteIfExists(tableName.dataFilePath(trieKey))
                         bufferPool.deleteIfExists(tableName.metaFilePath(trieKey))
+                        deleteTimer?.let { timer?.stop(it) }
                     }
                 }
             }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -100,6 +100,7 @@ class LeaderLogProcessor(
             blocksToKeep = cfg.blocksToKeep,
             enabled = cfg.enabled,
             meterRegistry = nodeBase.meterRegistry,
+            dbName = dbName
         )
     }
 
@@ -151,6 +152,7 @@ class LeaderLogProcessor(
             garbageLifetime = cfg.garbageLifetime,
             enabled = cfg.enabled,
             meterRegistry = nodeBase.meterRegistry,
+            dbName = dbName
         )
     }
 

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -99,6 +99,7 @@ class LeaderLogProcessor(
             bufferPool, blockCatalog,
             blocksToKeep = cfg.blocksToKeep,
             enabled = cfg.enabled,
+            meterRegistry = nodeBase.meterRegistry,
         )
     }
 
@@ -149,6 +150,7 @@ class LeaderLogProcessor(
             blocksToKeep = cfg.blocksToKeep,
             garbageLifetime = cfg.garbageLifetime,
             enabled = cfg.enabled,
+            meterRegistry = nodeBase.meterRegistry,
         )
     }
 

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -128,6 +128,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 garbageLifetime = garbageLifetime,
                 enabled = false,
                 dispatcher = dispatcher,
+                dbName = "xtdb"
             )
             MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, garbageCollector)
         }

--- a/src/test/clojure/xtdb/metrics_test.clj
+++ b/src/test/clojure/xtdb/metrics_test.clj
@@ -204,9 +204,9 @@ $$"])
           (.gcAll primary)
 
           (t/testing "block GC meters"
-            (t/is (= 4 (.count ^Timer (.timer (.find registry "xtdb.gc.block_files.delete.timer")))))
+            (t/is (= 4 (.count ^Timer (.timer (.tag (.find registry "xtdb.gc.block_files.delete.timer") "db" "xtdb")))))
             ;; Deletes table blocks for foo and xt$txs (4 each)
-            (t/is (= 8 (.count ^Timer (.timer (.find registry "xtdb.gc.table_block_files.delete.timer"))))))
+            (t/is (= 8 (.count ^Timer (.timer (.tag (.find registry "xtdb.gc.table_block_files.delete.timer") "db" "xtdb"))))))
 
           (t/testing "trie GC meters"
-            (t/is (= 8 (.count ^Timer (.timer (.find registry "xtdb.gc.tries.delete.timer")))))))))))
+            (t/is (= 8 (.count ^Timer (.timer (.tag (.find registry "xtdb.gc.tries.delete.timer") "db" "xtdb")))))))))))

--- a/src/test/clojure/xtdb/metrics_test.clj
+++ b/src/test/clojure/xtdb/metrics_test.clj
@@ -2,11 +2,15 @@
   (:require [clojure.test :as t]
             [next.jdbc :as jdbc]
             [xtdb.api :as xt]
+            [xtdb.compactor :as c]
+            [xtdb.db-catalog :as db]
             [xtdb.node :as xtn]
             [xtdb.test-util :as tu]
+            [xtdb.trie-catalog :as cat]
             [xtdb.types]
             [xtdb.util :as util])
-  (:import (io.micrometer.core.instrument Counter Gauge Timer)))
+  (:import (io.micrometer.core.instrument Counter Gauge Timer)
+           (java.time Duration)))
 
 (t/use-fixtures :each tu/with-mock-clock)
 
@@ -174,3 +178,35 @@ $$"])
       (let [^Timer timer (.timer (.find registry "block.upload.timer"))]
         (t/is (= (.count timer) 1))
         (t/is (> (.totalTime timer java.util.concurrent.TimeUnit/NANOSECONDS) 0))))))
+
+(t/deftest test-gc-metrics
+  (binding [c/*ignore-signal-block?* true
+            ;; Drive L1 supersession: each new L1 trie marks earlier same-recency L1 tries as
+            ;; garbage when their data-file-size < `*file-size-target*`. A small target keeps
+            ;; the test scoped — without this trie GC has no eligible tries to delete.
+            cat/*file-size-target* 16]
+    (let [node-dir (util/->path "target/metrics-test/test-gc-metrics")
+          clock (tu/->mock-clock (tu/->instants :hour))
+          opts {:node-dir node-dir, :compactor-threads 1, :instant-src clock
+                :gc? false, :blocks-to-keep 2, :garbage-lifetime (Duration/ofHours 0)
+                :instant-source-for-non-tx-msgs? true}]
+      (util/delete-dir node-dir)
+
+      (with-open [node (tu/->local-node opts)]
+        (let [primary (db/primary-db node)
+              registry (.getMeterRegistry (util/node-base node))]
+
+          (doseq [i (range 6)]
+            (xt/execute-tx node [[:put-docs :foo {:xt/id i}]])
+            (tu/flush-block! node)
+            (c/compact-all! node #xt/duration "PT1S"))
+
+          (.gcAll primary)
+
+          (t/testing "block GC meters"
+            (t/is (= 4 (.count ^Timer (.timer (.find registry "xtdb.gc.block_files.delete.timer")))))
+            ;; Deletes table blocks for foo and xt$txs (4 each)
+            (t/is (= 8 (.count ^Timer (.timer (.find registry "xtdb.gc.table_block_files.delete.timer"))))))
+
+          (t/testing "trie GC meters"
+            (t/is (= 8 (.count ^Timer (.timer (.find registry "xtdb.gc.tries.delete.timer")))))))))))

--- a/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
@@ -69,6 +69,7 @@ class BlockGarbageCollectorTest {
                     bufferPool, blockCat,
                     blocksToKeep = 3,
                     enabled = false,
+                    dbName = "xtdb",
                 )
 
                 // Validate that the latest block is correct


### PR DESCRIPTION
Resolves #5518

Adds some additional timers for various parts of the GC - specifically:
- Timer for individual block deletes.
- Timer for individual table block deletes.
- Timer for trie deletes (encompasses deletion of both meta and data files).

These timers, by definition, also give us a count of how many of these have occurred since last restart,

These are also tagged by database - as we do GC per database.