### PR TITLE
perf(trie-catalog): drop L0 entries on supersession

### DIFF
--- a/core/src/main/clojure/xtdb/compactor/reset.clj
+++ b/core/src/main/clojure/xtdb/compactor/reset.clj
@@ -8,10 +8,50 @@
             [xtdb.log :as xt-log]
             [xtdb.node :as xtn]
             xtdb.node.impl
+            [xtdb.trie :as trie]
             [xtdb.trie-catalog :as trie-cat])
-  (:import (xtdb.database Database)
+  (:import (java.nio.file Path)
+           (xtdb.api.storage ObjectStore$StoredObject)
+           (xtdb.database Database)
+           (xtdb.storage BufferPool)
            xtdb.table.TableRef
            (xtdb.trie Trie)))
+
+(defn- meta-file->trie-key
+  "\"…/meta/l00-rc-b00.arrow\" → \"l00-rc-b00\"."
+  [^Path path]
+  (let [file-name (str (.getFileName path))
+        dot (str/last-index-of file-name ".")]
+    (cond-> file-name dot (subs 0 dot))))
+
+(defn- list-data-file-sizes
+  "Build a `trie-key → data-file-size` lookup from the table's data dir."
+  [^BufferPool bp ^TableRef table]
+  (into {} (map (fn [^ObjectStore$StoredObject obj]
+                  [(meta-file->trie-key (.getKey obj)) (.getSize obj)]))
+        (.listAllObjects bp (Trie/dataFileDir table))))
+
+(defn- list-l0-entries
+  "Enumerate the L0 trie files for a table directly from the object store.
+   The catalog is no longer the authoritative source for L0 — see `trie-cat/reset->l0!`.
+   Meta is the completion marker (deleted last by GC), so we list it first; data-file-size
+   comes from the paired data file. Skips meta files whose data file is missing — those are
+   half-written tries that the GC's data-then-meta deletion order leaves transiently visible.
+   `:trie-metadata` is left absent — the post-reset `CatalogEntry.getTemporalMetadata` fallback
+   handles that until the next compaction re-derives it."
+  [^BufferPool bp ^TableRef table]
+  (let [data-sizes (list-data-file-sizes bp table)]
+    (->> (.listAllObjects bp (Trie/metaFileDir table))
+         (keep (fn [^ObjectStore$StoredObject obj]
+                 (let [trie-key (meta-file->trie-key (.getKey obj))]
+                   (when-some [parsed (trie/parse-trie-key trie-key)]
+                     (when-some [data-size (and (zero? ^long (:level parsed))
+                                                (data-sizes trie-key))]
+                       (assoc parsed :data-file-size data-size)))))))))
+
+(defn- enumerate-l0s [^BufferPool bp tables]
+  (into {} (for [^TableRef table tables]
+             [table (vec (list-l0-entries bp table))])))
 
 (defn reset-compactor! [node-opts ^String db-name {:keys [dry-run?]}]
   (let [config (doto (xtn/->config node-opts)
@@ -32,13 +72,18 @@
         (let [bp (.getBufferPool db)
               trie-cat (.getTrieCatalog db)
               live-idx (.getLiveIndex db)
-              compacted-file-keys (vec (for [^TableRef table (.getTables trie-cat)
+              tables (.getTables trie-cat)
+              compacted-file-keys (vec (for [^TableRef table tables
                                              ^String trie-key (trie-cat/compacted-trie-keys (trie-cat/trie-state trie-cat table))
 
                                              ;; meta file first, as it's the marker
                                              file-key [(Trie/metaFilePath table trie-key)
                                                        (Trie/dataFilePath table trie-key)]]
-                                         file-key))]
+                                         file-key))
+              ;; Source of truth for L0 is the object store, not the catalog: catalog L0s
+              ;; are dropped on supersession, so by the time we get here the catalog will be
+              ;; missing every L0 that's already been consumed by an L1C we're about to wipe.
+              table->l0-entries (enumerate-l0s bp tables)]
           (cond
             dry-run?
             (do
@@ -55,7 +100,7 @@
                                          (into {}))])
                              (into {})))]
                 (let [state-before (freeze-state)]
-                  (trie-cat/reset->l0! trie-cat)
+                  (trie-cat/reset->l0! trie-cat table->l0-entries)
                   (let [state-after (freeze-state)]
                     (log/info "Trie catalog state diff:")
                     (pp/pprint (->> (for [tbl (set/union (set (keys state-before))
@@ -85,7 +130,7 @@
             (do
               (log/info "Resetting compaction...")
 
-              (trie-cat/reset->l0! trie-cat)
+              (trie-cat/reset->l0! trie-cat table->l0-entries)
               (xt-log/send-flush-block-msg! db)
               (xt-log/sync-db db #xt/duration "PT5M")
               (log/info "Reset complete. Deleting compacted files...")

--- a/core/src/main/clojure/xtdb/trie_catalog.clj
+++ b/core/src/main/clojure/xtdb/trie_catalog.clj
@@ -102,9 +102,14 @@
 (defprotocol PTrieCatalog
   (trie-state [trie-cat table])
 
-  (reset->l0! [trie-cat]
-    "DANGER: resets the trie-catalog back to L0,
-     use if compaction has gone awry, and you want to completely recompact."))
+  (reset->l0! [trie-cat table->l0-entries]
+    "DANGER: resets the trie-catalog back to L0, use if compaction has gone awry and you
+     want to completely recompact.
+
+     `table->l0-entries` is a `Map<TableRef, Seq<L0Entry>>`; entries are typically enumerated
+     from the object store by the caller (the catalog is no longer the authoritative source
+     for L0 files). Each L0Entry should at minimum have `:level 0`, `:block-idx`, `:trie-key`,
+     `:recency nil`, `:part []`."))
 
 (def ^:const branch-factor 4)
 
@@ -176,6 +181,16 @@
         (assoc :live (reduce disj live new-garbage))
         (assoc :garbage (into garbage new-garbage)))))
 
+(defn- drop-superseded-l0 [tries, ^long block-idx]
+  ;; L0 files become irrelevant to the catalog the moment they're superseded by an L1C —
+  ;; we keep them on the object store as a recovery substrate (see `reset-compactor!`),
+  ;; but tracking them in the catalog (live or garbage) serves no purpose, so drop outright.
+  (let [{:keys [live] :as tries} (or tries (empty-shared block-idx))
+        to-drop (filter (fn [{^long other-block-idx :block-idx}]
+                          (<= other-block-idx block-idx))
+                        live)]
+    (assoc tries :live (reduce disj live to-drop))))
+
 (defn- sibling-tries [table-tries, {:keys [^long level, recency, part]}]
   (let [pop-part (pop part)]
     (for [p (range branch-factor)]
@@ -234,8 +249,9 @@
                           ;; L1C files are levelled, so this supersedes any previous partial files
                           (update [1 nil []] insert-levelled-trie trie opts)
 
-                          ;; and supersede L0 files
-                          (update [0 nil []] supersede-by-block-idx block-idx opts))))
+                          ;; and drop the L0 entries it covers — the L0 files stay on the object
+                          ;; store as recovery substrate, but the catalog stops tracking them
+                          (update [0 nil []] drop-superseded-l0 block-idx))))
 
             (update :l1h-recencies dissoc block-idx)))
 
@@ -379,16 +395,17 @@
         {:keys [trie-key]} tries]
     trie-key))
 
-(defn reset->l0 [{:keys [tries]}]
-  ;; combine live & garbage (there should be no nascent)
-  (let [{:keys [live garbage]} (get tries [0 nil []])
-        l0-tries (concat live garbage)
-        live-tries (->> l0-tries
+(defn reset->l0 [l0-entries]
+  ;; Build a fresh table-cat state with the supplied L0 entries marked :live.
+  ;; All higher levels are wiped — they'll be rebuilt by compaction after the reset.
+  ;; The entries themselves come from the caller — at reset time, the catalog is no longer
+  ;; the authoritative list of L0 files; the object store is.
+  (let [live-tries (->> l0-entries
                         (map #(assoc % :state :live))
                         (into empty-trie-state-list))]
-
-    {:tries {[0 nil []] {:max-block-idx (:block-idx (first live-tries))
-                         :live live-tries}}
+    {:tries {[0 nil []] {:max-block-idx (or (:block-idx (first live-tries)) -1)
+                         :live live-tries
+                         :garbage empty-trie-state-list}}
      :l1h-recencies {}}))
 
 (defn new-trie-details? [^TrieDetails trie-details]
@@ -414,7 +431,7 @@
   (some? (:max-block-idx partition)))
 
 (defn- repair-l0-l1c-consistency
-  "If a live L1C exists, ensure all L0s with block-idx <= the L1C's max live block-idx are marked garbage.
+  "If a live L1C exists, drop any L0s with block-idx <= the L1C's max live block-idx.
    Repairs an inconsistency where L0 and L1C are both live at the same block-idx,
    caused by concurrent MW/SW operation — see #5395."
   [tries]
@@ -422,12 +439,14 @@
         l1c-max-live-block-idx (some-> (first l1c-live) :block-idx)]
     (cond-> tries
       l1c-max-live-block-idx
-      (update [0 nil []] supersede-by-block-idx l1c-max-live-block-idx {:as-of (Instant/now)}))))
+      (update [0 nil []] drop-superseded-l0 l1c-max-live-block-idx))))
 
-(defn partition->entry [{:keys [level recency part tries max-block-idx] :as _partition}]
+(defn partition->entry [{:keys [^long level recency part tries max-block-idx] :as _partition}]
   (MapEntry/create [level recency part]
                    (let [{:keys [live nascent garbage]} (group-by :state tries)]
-                     (-> {:garbage (into empty-trie-state-list garbage)
+                     (-> {;; L0 garbage entries are no longer tracked — drop any persisted
+                          ;; from older block files. The L0 files themselves stay on disk.
+                          :garbage (if (zero? level) empty-trie-state-list (into empty-trie-state-list garbage))
                           :live (into empty-trie-state-list live)
                           :nascent (into empty-trie-state-list nascent)}
                          (assoc :max-block-idx max-block-idx)))))
@@ -491,11 +510,14 @@
   PTrieCatalog
   (trie-state [_ table] (.get !table-cats table))
 
-  (reset->l0! [this]
-    (doseq [table (.getTables this)]
+  (reset->l0! [_ table->l0-entries]
+    ;; Caller supplies the full set of L0 entries per table — typically enumerated from the
+    ;; object store (see `xtdb.compactor.reset/reset-compactor!`). Each table named in the map
+    ;; has its catalog state reset to those L0s; higher levels are wiped.
+    (doseq [[table l0-entries] table->l0-entries]
       (.compute !table-cats table
-                (fn [_table table-cat]
-                  (reset->l0 table-cat))))))
+                (fn [_table _table-cat]
+                  (reset->l0 l0-entries))))))
 
 
 (defn load-tries ^java.util.Map [table->table-block file-size-target]

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -13,6 +13,7 @@ import xtdb.storage.BufferPool
 import xtdb.table.DatabaseName
 import xtdb.table.TableRef
 import xtdb.time.microsAsInstant
+import xtdb.trie.Trie
 import xtdb.trie.Trie.dataFilePath
 import xtdb.trie.Trie.metaFilePath
 import xtdb.trie.TrieKey
@@ -171,6 +172,13 @@ class TrieGarbageCollector(
             // deleting it last keeps the pair from ever transiently looking complete-but-empty.
             coroutineScope {
                 for (trieKey in chunk) {
+                    // Defence in depth: trieCatalog.garbageTries already filters L0 out — L0
+                    // files are the recovery substrate for `reset-compactor!` and must never
+                    // be deleted by GC. If anything ever flips that filter, we want to fail
+                    // loud here rather than silently nuke the recovery path.
+                    check(Trie.parseKey(trieKey).level != 0L) {
+                        "L0 trie keys must never reach GC deletion: $trieKey"
+                    }
                     launch(deleteDispatcher) {
                         val timer = meterRegistry?.let { Timer.start(it) }
                         bufferPool.deleteIfExists(tableName.dataFilePath(trieKey))

--- a/core/src/main/kotlin/xtdb/trie/Trie.kt
+++ b/core/src/main/kotlin/xtdb/trie/Trie.kt
@@ -99,8 +99,11 @@ object Trie {
             tablesDir.resolve("$schemaName$$tableName".replace(Regex("[./]"), "\\$"))
 
     @JvmStatic
+    fun TableRef.dataFileDir(): Path = tablePath.resolve("data")
+
+    @JvmStatic
     fun TableRef.dataFilePath(trieKey: TrieKey): Path =
-        tablePath.resolve("data").resolve("$trieKey.arrow")
+        dataFileDir().resolve("$trieKey.arrow")
 
     @JvmStatic
     fun TableRef.metaFileDir(): Path = tablePath.resolve("meta")

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -564,14 +564,17 @@ class NodeSimulationTest : SimulationTestBase() {
         val l1Count = triesInCatalog.prefix("l01-rc-").size
         val l2Count = triesInCatalog.prefix("l02-rc-").size
         val l3Count = triesInCatalog.prefix("l03-rc-").size
-        assertEquals(16, l0Count, "L0 tries should still be present in catalog")
+        assertEquals(0, l0Count, "L0 entries leave the catalog when superseded by L1Cs (their files stay on disk)")
         assertEquals(0, l1Count, "L1 tries should be fully compacted and garbage collected")
         assertEquals(0, l2Count, "L2 tries should be fully compacted and garbage collected")
         assertEquals(16, l3Count, "Should have at least 16 L3 tries after cascading compaction")
 
-        val triesInBufferPool = sharedBufferPool.listTrieNames(table)
-        assertEquals(triesInCatalog.toSet(), triesInBufferPool.toSet(), "Buffer pool should match catalog after compaction and GC")
-
+        // Buffer pool keeps L0 files as the recovery substrate for `reset-compactor!`,
+        // even though the catalog has stopped tracking them. So the buffer pool has
+        // 16 L0s + 16 L3s, the catalog has just the L3s.
+        val triesInBufferPool = sharedBufferPool.listTrieNames(table).toSet()
+        assertEquals(l0Tries.toSet() + triesInCatalog.toSet(), triesInBufferPool,
+                     "Buffer pool retains L0 files plus whatever's in the catalog")
     }
 
     @RepeatableSimulationTest
@@ -627,7 +630,7 @@ class NodeSimulationTest : SimulationTestBase() {
             val l0Count = triesInCatalog.prefix("l00-rc-").size
             val l3Count = triesInCatalog.prefix("l03-rc-").size
 
-            assertEquals(16, l0Count, "L0 tries should still be present in catalog")
+            assertEquals(0, l0Count, "L0 entries leave the catalog when superseded by L1Cs (their files stay on disk)")
             assertEquals(16, l3Count, "Should have at least 16 L3 tries after cascading compaction")
         }
 
@@ -648,15 +651,17 @@ class NodeSimulationTest : SimulationTestBase() {
         val l2Count = finalTries.count { it.startsWith("l02-rc-") }
         val l3Count = finalTries.count { it.startsWith("l03-rc-") }
 
-        assertEquals(16, l0Count, "L0 tries are never marked as garbage")
+        assertEquals(0, l0Count, "L0 entries leave the catalog when superseded by L1Cs (their files stay on disk)")
         assertEquals(0, l1Count, "L1 tries should be fully GCed after final pass")
         assertEquals(0, l2Count, "L2 tries should be fully GCed after final pass")
         assertEquals(16, l3Count, "Should have at 16 L3 tries after final GC")
 
-        // Verify buffer pool matches catalog
+        // Buffer pool keeps L0 files as the recovery substrate for `reset-compactor!`,
+        // even though the catalog has stopped tracking them. So the buffer pool has
+        // 16 L0s + 16 L3s, the catalog has just the L3s.
         val bufferPoolTries = sharedBufferPool.listTrieNames(table).toSet()
-        assertEquals(finalTries.size, bufferPoolTries.size, "Buffer pool trie count should match catalog")
-        assertEquals(finalTries, bufferPoolTries, "Buffer pool should match catalog")
+        assertEquals(l0Tries.toSet() + finalTries, bufferPoolTries,
+                     "Buffer pool retains L0 files plus whatever's in the catalog")
     }
 
     @RepeatableSimulationTest

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -342,8 +342,10 @@ class CompactorSimulationTest : SimulationTestBase() {
             listOf("l01-rc-b00"),
             db.trieCatalog.listLiveAndNascentTrieKeys(docsTable),
         )
+        // L0 entries are dropped from the catalog when the L1C lands — they leave no
+        // :garbage trace behind, although the L0 files remain on the object store.
         assertEquals(
-            setOf("l00-rc-b00"),
+            emptySet<String>(),
             db.trieCatalog.listAllGarbageTrieKeys(docsTable),
         )
     }
@@ -378,9 +380,9 @@ class CompactorSimulationTest : SimulationTestBase() {
                 listOf("l01-rc-b02"),
                 db.trieCatalog.listLiveAndNascentTrieKeys(table)
             )
-            // 3 L0s garbage + 2 superseded L1Cs (b00, b01)
+            // L0s leave the catalog on supersession; only the 2 superseded L1Cs remain in :garbage
             assertEquals(
-                setOf("l00-rc-b00", "l00-rc-b01", "l00-rc-b02", "l01-rc-b00", "l01-rc-b01"),
+                setOf("l01-rc-b00", "l01-rc-b01"),
                 db.trieCatalog.listAllGarbageTrieKeys(table)
             )
 
@@ -401,12 +403,9 @@ class CompactorSimulationTest : SimulationTestBase() {
                 listOf("l01-rc-b05"),
                 db.trieCatalog.listLiveAndNascentTrieKeys(table)
             )
-            // 6 L0s garbage + 5 superseded L1Cs (b00-b04)
+            // L0s leave the catalog on supersession; only the 5 superseded L1Cs (b00-b04) remain in :garbage
             assertEquals(
-                setOf(
-                    "l00-rc-b00", "l00-rc-b01", "l00-rc-b02", "l00-rc-b03", "l00-rc-b04", "l00-rc-b05",
-                    "l01-rc-b00", "l01-rc-b01", "l01-rc-b02", "l01-rc-b03", "l01-rc-b04",
-                ),
+                setOf("l01-rc-b00", "l01-rc-b01", "l01-rc-b02", "l01-rc-b03", "l01-rc-b04"),
                 db.trieCatalog.listAllGarbageTrieKeys(table)
             )
         }
@@ -431,7 +430,7 @@ class CompactorSimulationTest : SimulationTestBase() {
             val liveTries = db.trieCatalog.listLiveAndNascentTrieKeys(docsTable)
             val garbageTries = db.trieCatalog.listAllGarbageTrieKeys(docsTable)
             assertEquals(0, liveTries.prefix("l00-rc-").size)
-            assertTrue(garbageTries.any { it.startsWith("l00-rc-") }, "L0s should be in garbage")
+            assertTrue(garbageTries.none { it.startsWith("l00-rc-") }, "L0s leave the catalog on supersession; they never become :garbage")
             assertTrue(liveTries.prefix("l01-rc-").isNotEmpty(), "Some L1Cs should be live")
             assertTrue(liveTries.prefix("l02-rc-").isNotEmpty(), "Some L2Cs should be live")
         }
@@ -583,8 +582,8 @@ class CompactorSimulationTest : SimulationTestBase() {
             assertEquals(0, docsKeys.prefix("l01-rc-").size)
             assertEquals(0, docsKeys.prefix("l02-rc-").size)
             assertEquals(16, docsKeys.prefix("l03-rc-").size)
-            // 16 L0 + 16 L1C + 16 L2C all superseded
-            assertEquals(48, db.trieCatalog.listAllGarbageTrieKeys(docsTable).size)
+            // 16 L1C + 16 L2C superseded; L0s leave the catalog on supersession (no :garbage trace)
+            assertEquals(32, db.trieCatalog.listAllGarbageTrieKeys(docsTable).size)
             assertEquals(docsKeys.toSet(), usersKeys.toSet(), "Docs and Users tables should have identical trie keys")
             assertEquals(docsKeys.toSet(), ordersKeys.toSet(), "Docs and Orders tables should have identical trie keys")
         }
@@ -634,7 +633,8 @@ class CompactorSimulationTest : SimulationTestBase() {
             trieKeys.first(),
         )
         dbs.forEach { db ->
-            assertEquals(setOf("l00-rc-b00"), db.trieCatalog.listAllGarbageTrieKeys(docsTable))
+            // L0 entries leave the catalog when the L1C lands; no :garbage trace remains.
+            assertEquals(emptySet<String>(), db.trieCatalog.listAllGarbageTrieKeys(docsTable))
         }
     }
 

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -400,7 +400,9 @@
                          :partitions
                          (mapcat :tries)
                          (into #{} (map table-test/trie-details->edn)))]
-          (t/is (= #{"l00-rc-b00" "l01-r20110103-b00" "l01-rc-b00" "l00-rc-b01" "l01-r20160104-b01" "l01-rc-b01"}
+          ;; L0 entries left the catalog when their L1Cs landed, so they don't appear in the
+          ;; persisted block file either — although the L0 .arrow files themselves remain on disk.
+          (t/is (= #{"l01-r20110103-b00" "l01-rc-b00" "l01-r20160104-b01" "l01-rc-b01"}
                    (into #{} (map :trie-key) tries)))
 
           (t/is (= {"l01-rc-b00" nil,

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -398,10 +398,9 @@
   (tu/flush-block! tu/*node*)
   (c/compact-all! tu/*node* #xt/duration "PT1S")
 
-  (t/is (= [{:schema-name "public", :table-name "foo", :trie-key "l00-rc-b00",
-             :level 0, :trie-state "garbage", :data-file-size 1966}
-
-            {:schema-name "public", :table-name "foo", :trie-key "l01-r20200106-b00",
+  ;; L0 entries leave the catalog when their L1C lands, so they don't appear in xt.trie_stats.
+  ;; The L0 *files* on the object store are kept as the recovery substrate for `reset-compactor!`.
+  (t/is (= [{:schema-name "public", :table-name "foo", :trie-key "l01-r20200106-b00",
              :level 1, :trie-state "live", :row-count 2, :data-file-size 1966, :recency #xt/date "2020-01-06",
              :temporal-metadata {:min-valid-from (time/->zdt #inst "2020-01-01")
                                  :max-valid-from (time/->zdt #inst "2020-01-04")
@@ -412,9 +411,6 @@
 
             {:schema-name "public", :table-name "foo", :trie-key "l01-rc-b00",
              :level 1, :trie-state "live", :data-file-size 1382}
-
-            {:schema-name "xt", :table-name "txs", :trie-key "l00-rc-b00",
-             :level 0, :trie-state "garbage", :data-file-size 2894}
 
             {:schema-name "xt", :table-name "txs", :trie-key "l01-rc-b00",
              :level 1, :trie-state "live", :row-count 1, :data-file-size 2894,

--- a/src/test/clojure/xtdb/table_catalog_test.clj
+++ b/src/test/clojure/xtdb/table_catalog_test.clj
@@ -93,7 +93,9 @@
 
           (tu/flush-block! node)
 
-          (t/is (= #{"l00-rc-b00" "l00-rc-b01" "l00-rc-b02" "l00-rc-b03"
+          ;; L0 entries are dropped from the catalog when their L1C lands. L0-b03 has no
+          ;; covering L1C yet, so it stays. The L0 *files* on the object store are kept.
+          (t/is (= #{"l00-rc-b03"
                      "l01-rc-b00" "l01-rc-b01" "l01-rc-b02"
                      "l02-rc-p0-b01" "l02-rc-p1-b01" "l02-rc-p2-b01" "l02-rc-p3-b01"}
                    (->> (.getByteArray bp (util/->path "tables/public$foo/blocks/b02.binpb"))
@@ -126,10 +128,9 @@
 
     (with-open [node (tu/->local-node {:node-dir node-dir, :compactor-threads 0})]
       (let [bp (.getBufferPool (db/primary-db node))]
-        (t/is (= #{"l00-rc-b00"
-                   "l00-rc-b01"
-                   "l00-rc-b02"
-                   "l00-rc-b03"
+        ;; L0 entries are dropped from the catalog when their L1C lands. L0-b03 has no
+        ;; covering L1C yet, so it stays. The L0 *files* on the object store are kept.
+        (t/is (= #{"l00-rc-b03"
                    "l01-r20200101-b00"
                    "l01-rc-b00"
                    "l01-r20200102-b01"

--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -15,6 +15,7 @@
            (java.util.concurrent ConcurrentHashMap)
            (xtdb.api.storage ObjectStore$StoredObject)
            (xtdb.log.proto TemporalMetadata TrieMetadata)
+           (xtdb.trie Trie)
            (xtdb.trie_catalog TrieCatalog)
            (xtdb.table TableRef)))
 
@@ -372,6 +373,28 @@
   (TrieCatalog. (cat/load-tries table->table-block cat/*file-size-target*)
                 cat/*file-size-target*))
 
+(t/deftest test-startup-drops-persisted-l0-garbage
+  ;; Block files written before the "drop L0 on supersession" change may persist L0 entries
+  ;; in the :garbage state. partition->entry filters those out at load time, even when no
+  ;; L1C is present (so repair-l0-l1c-consistency doesn't run).
+  (let [->trie-details (partial trie/->trie-details #xt/table foo)
+        table-blocks {:partitions
+                      [{:level 0 :recency nil :part []
+                        :max-block-idx 1
+                        :tries [(->trie-details {:trie-key "l00-rc-b00" :data-file-size 10
+                                                 :state :garbage
+                                                 :garbage-as-of #xt/instant "2000-01-01T00:00:00Z"})
+                                (->trie-details {:trie-key "l00-rc-b01" :data-file-size 10 :state :live})]}]}
+        cat (trie-catalog-init {#xt/table foo table-blocks})
+        l0-state (get-in (cat/trie-state cat #xt/table foo) [:tries [0 nil []]])]
+
+    (t/is (= #{"l00-rc-b01"}
+             (into #{} (map :trie-key) (:live l0-state)))
+          "L0 b01 (live) is loaded")
+
+    (t/is (empty? (:garbage l0-state))
+          "L0 b00 (persisted as :garbage) is dropped at load time — no L1C needed to trigger repair")))
+
 (t/deftest test-trie-catalog-init-old-and-new-block-files-mixed-4664
   (let [->trie-details (partial trie/->trie-details #xt/table foo)
         old-table-blocks {:partitions
@@ -549,21 +572,18 @@
       (add-tries [["l00-rc-b01" 1] ["l01-rc-b01" 1]]
                  #xt/instant "2001-01-01T00:00:00Z")
 
-      (t/is (= [["l00-rc-b00" :garbage #xt/instant "2000-01-01T00:00:00Z"]
-                ["l00-rc-b01" :garbage #xt/instant "2001-01-01T00:00:00Z"]
-                ["l01-rc-b00" :garbage #xt/instant "2001-01-01T00:00:00Z"]
+      (t/is (= [["l01-rc-b00" :garbage #xt/instant "2001-01-01T00:00:00Z"]
                 ["l01-rc-b01" :live nil]]
-               (all-tries)))
+               (all-tries))
+            "L0s superseded by L1C are dropped from the catalog outright; the L0 files
+             stay on the object store as the recovery substrate for `reset-compactor!`")
 
       (add-tries [["l00-rc-b02" 1] ["l00-rc-b03" 1]
                   ["l01-rc-b02" 2]
                   ["l02-rc-p0-b01" 4] ["l02-rc-p1-b01" 4] ["l02-rc-p2-b01" 4] ["l02-rc-p3-b01" 4]]
                  #xt/instant "2002-01-01T00:00:00Z")
 
-      (t/is (= [["l00-rc-b00" :garbage #xt/instant "2000-01-01T00:00:00Z"]
-                ["l00-rc-b01" :garbage #xt/instant "2001-01-01T00:00:00Z"]
-                ["l00-rc-b02" :garbage #xt/instant "2002-01-01T00:00:00Z"]
-                ["l00-rc-b03" :live nil]
+      (t/is (= [["l00-rc-b03" :live nil]
                 ["l01-rc-b00" :garbage #xt/instant "2001-01-01T00:00:00Z"]
                 ["l01-rc-b01" :garbage #xt/instant "2002-01-01T00:00:00Z"]
                 ["l01-rc-b02" :live nil]
@@ -579,10 +599,7 @@
 
       (delete-tries #{"l01-rc-b00" "l01-rc-b01"})
 
-      (t/is (= [["l00-rc-b00" :garbage #xt/instant "2000-01-01T00:00:00Z"]
-                ["l00-rc-b01" :garbage #xt/instant "2001-01-01T00:00:00Z"]
-                ["l00-rc-b02" :garbage #xt/instant "2002-01-01T00:00:00Z"]
-                ["l00-rc-b03" :live nil]
+      (t/is (= [["l00-rc-b03" :live nil]
                 ["l01-rc-b02" :live nil]
                 ["l02-rc-p0-b01" :live nil]
                 ["l02-rc-p1-b01" :live nil]
@@ -610,13 +627,10 @@
 
           (.gcAll db)
 
-          ;; we keep block 01 and 02
-          ;; the 01 latest-complete-tx is cutoff (no garbage lifetime), i.e. the level 1 block 01 remains as it is compacted later
-          (t/is (= ["l00-rc-b00"
-                    "l00-rc-b01"
-                    "l00-rc-b02"
-                    "l00-rc-b03"
-                    "l01-rc-b01"
+          ;; All L0s have been compacted into L1Cs. L0 supersession drops outright (no :garbage),
+          ;; so the catalog only sees the L1Cs — but the L0 files themselves stay on the object
+          ;; store as the recovery substrate for `reset-compactor!` (asserted below).
+          (t/is (= ["l01-rc-b01"
                     "l01-rc-b02"
                     "l01-rc-b03"]
                    (->> (cat/all-tries (cat/trie-state cat #xt/table foo))
@@ -624,7 +638,7 @@
 
           ;; `.gcAll` runs both block GC and trie GC. With `:blocks-to-keep 2`, block GC keeps
           ;; only the latest two per-table block files (b02, b03); trie GC leaves data/meta files
-          ;; alone here because all current tries are still live in the catalog.
+          ;; alone here — no non-L0 garbage in the catalog, and L0 files are explicitly preserved.
           (t/is (= ["tables/public$foo/blocks/b02.binpb"
                     "tables/public$foo/blocks/b03.binpb"
                     "tables/public$foo/data/l00-rc-b00.arrow"
@@ -656,10 +670,14 @@
     (t/is (= #{"l01-rc-b00" "l01-rc-b01" "l01-rc-b02" "l01-rc-b03"}
              (set (cat/compacted-trie-keys table-trie-cat))))
 
-    (t/is (= #{"l00-rc-b00" "l00-rc-b01" "l00-rc-b02" "l00-rc-b03" "l00-rc-b04"}
-             (->> (cat/reset->l0 table-trie-cat)
-                  (cat/current-tries)
-                  (into #{} (map :trie-key)))))))
+    ;; reset->l0 is now a passive sink — the caller (xtdb.compactor.reset/reset-compactor!)
+    ;; enumerates L0 files from the object store and supplies them, since the catalog drops
+    ;; L0 entries on supersession and is no longer the authoritative list.
+    (let [l0-entries (map trie/parse-trie-key ["l00-rc-b00" "l00-rc-b01" "l00-rc-b02" "l00-rc-b03" "l00-rc-b04"])]
+      (t/is (= #{"l00-rc-b00" "l00-rc-b01" "l00-rc-b02" "l00-rc-b03" "l00-rc-b04"}
+               (->> (cat/reset->l0 l0-entries)
+                    (cat/current-tries)
+                    (into #{} (map :trie-key))))))))
 
 (t/deftest max-block-index-always-set-test-5139
   (let [{:keys [tries] :as _table-trie-cat} (apply-msgs ["l02-r20200203-b00" 10])]
@@ -755,9 +773,9 @@
         (t/is (= #{"l01-rc-b00" "l01-rc-b01" "l02-rc-p0-b01"} garbage))
         (.deleteTries cat table garbage))
 
-      ;; Verify remaining tries
-      (t/is (= #{"l00-rc-b00" "l00-rc-b01"
-                 "l02-rc-p1-b01" "l02-rc-p2-b01" "l02-rc-p3-b01"
+      ;; Verify remaining tries — L0s left the catalog when L1Cs landed (no :garbage trace),
+      ;; so they don't reappear here even though their files still exist on the object store.
+      (t/is (= #{"l02-rc-p1-b01" "l02-rc-p2-b01" "l02-rc-p3-b01"
                  "l03-rc-p00-b01" "l03-rc-p01-b01" "l03-rc-p02-b01" "l03-rc-p03-b01"}
                (trie-keys (cat/all-tries (cat/trie-state cat table))))
             "garbage tries are removed"))))
@@ -788,7 +806,10 @@
           (t/is (= [0 1] (map :block-idx blocks)))
           (t/is (= [[:table_a :table_b :txs] [:table_c :txs]] tables)))))))
 
-(t/deftest test-l0-blocks-includes-garbage
+(t/deftest test-reset-rebuilds-l0-from-object-store
+  ;; After compaction, the catalog has no L0 entries — they're dropped on supersession.
+  ;; reset->l0! is a passive sink: callers (xtdb.compactor.reset) enumerate L0s from the
+  ;; object store and pass them in. This exercises that flow at the unit level.
   (tu/with-tmp-dirs #{node-dir}
     (with-open [node (tu/->local-node {:node-dir node-dir :compactor-threads 1})]
       (doseq [i (range 4)]
@@ -796,16 +817,57 @@
         (tu/flush-block! node))
       (c/compact-all! node #xt/duration "PT1S")
 
-      (let [trie-cat (.getTrieCatalog (db/primary-db node))
-            blocks (cat/l0-blocks trie-cat)]
+      (let [db (db/primary-db node)
+            bp (.getBufferPool db)
+            trie-cat (.getTrieCatalog db)
+            foo-state #(cat/trie-state trie-cat #xt/table foo)]
+
+        (t/is (empty? (->> (foo-state) :tries (get-in [[0 nil []] :live])))
+              "All L0s for foo have been compacted into an L1C — none remain in the catalog")
+        (t/is (empty? (->> (foo-state) :tries (get-in [[0 nil []] :garbage])))
+              "L0 supersession drops outright; no :garbage entries linger")
+
+        ;; Simulate what reset.clj does: list L0 meta files from the object store, parse keys,
+        ;; build minimal entries, hand them to reset->l0!.
+        (let [meta-dir (Trie/metaFileDir #xt/table foo)
+              l0-entries (->> (.listAllObjects bp meta-dir)
+                              (keep (fn [^ObjectStore$StoredObject obj]
+                                      (let [name (str (.getFileName ^Path (.getKey obj)))
+                                            trie-key (subs name 0 (.lastIndexOf name "."))]
+                                        (when-some [parsed (trie/parse-trie-key trie-key)]
+                                          (when (zero? ^long (:level parsed))
+                                            parsed))))))]
+          (t/is (= 4 (count l0-entries)) "All four L0 files still on disk")
+
+          (cat/reset->l0! trie-cat {#xt/table foo l0-entries})
+
+          (t/is (= #{"l00-rc-b00" "l00-rc-b01" "l00-rc-b02" "l00-rc-b03"}
+                   (->> (cat/current-tries (foo-state))
+                        (into #{} (map :trie-key))))
+                "Catalog is now repopulated with the L0s enumerated from the object store"))))))
+
+(t/deftest test-l0-blocks-dropped-on-compaction
+  ;; L0 entries leave the catalog the moment they're superseded by an L1C — so `l0-blocks`
+  ;; reflects only un-compacted L0s. The L0 *files* remain on the object store as the
+  ;; recovery substrate for `reset-compactor!`, but the catalog stops tracking them.
+  (tu/with-tmp-dirs #{node-dir}
+    (with-open [node (tu/->local-node {:node-dir node-dir :compactor-threads 1})]
+      (doseq [i (range 4)]
+        (xt/execute-tx node [[:put-docs :foo {:xt/id i}]])
+        (tu/flush-block! node))
+      (c/compact-all! node #xt/duration "PT1S")
+
+      (let [trie-cat (.getTrieCatalog (db/primary-db node))]
         (t/is (seq (cat/compacted-trie-keys (cat/trie-state trie-cat #xt/table foo)))
               "Compaction should have created non-L0 files")
-        (t/is (= 4 (count blocks))
-              "All L0 blocks should be visible even after compaction")))))
+        (t/is (empty? (->> (cat/l0-blocks trie-cat)
+                           (filter (fn [{:keys [tables]}]
+                                     (some #(= #xt/table foo (:table %)) tables)))))
+              "All L0s for foo have been compacted into an L1C — no L0 blocks remain in the catalog")))))
 
 (t/deftest test-repair-l0-l1c-consistency-5395
   (let [->trie-details (partial trie/->trie-details #xt/table foo)]
-    (t/testing "L0 and L1C both live at same block-idx — L0 should be repaired to garbage"
+    (t/testing "L0 and L1C both live at same block-idx — covered L0 should be dropped"
       (let [table-blocks {:partitions
                           [{:level 0 :recency nil :part []
                             :max-block-idx 2
@@ -821,7 +883,13 @@
         (t/is (= #{"l00-rc-b03" "l01-rc-b02"}
                  (->> (cat/current-tries (cat/trie-state cat #xt/table foo))
                       (into (sorted-set) (map :trie-key))))
-              "L0 b02 should be garbage (superseded by L1C b02), L0 b03 should remain live")))
+              "L0 b02 dropped (superseded by L1C b02); L0 b03 remains live")
+
+        (t/is (= #{}
+                 (->> (cat/l0-tries (cat/trie-state cat #xt/table foo))
+                      (filter (comp #{:garbage} :state))
+                      (into #{} (map :trie-key))))
+              "no L0 garbage entries — L0 supersession drops outright, not via :garbage")))
 
     (t/testing "no L1C — L0s should be unaffected"
       (let [table-blocks {:partitions

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/public$foo/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/public$foo/blocks/b01.binpb.edn
@@ -14,10 +14,7 @@
       :max-valid-to #xt/instant "2016-01-01T00:00:00Z",
       :min-system-from #xt/instant "2020-01-02T00:00:00Z",
       :max-system-from #xt/instant "2020-01-02T00:00:00Z",
-      :row-count 1}}
-    {:trie-key "l00-rc-b00",
-     :data-file-size 1918,
-     :trie-metadata nil}],
+      :row-count 1}}],
    :max-block-idx 1}
   {:level 1,
    :part [],

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/public$foo/blocks/b02.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/public$foo/blocks/b02.binpb.edn
@@ -2,14 +2,7 @@
  :fields {"_id" #xt/field {"_id" :i64}},
  :hlls {"_id" [-179776705 2.001955671862574]},
  :partitions
- [{:level 0,
-   :part [],
-   :tries
-   [{:trie-key "l00-rc-b01", :data-file-size 1918, :trie-metadata nil}
-    {:trie-key "l00-rc-b00",
-     :data-file-size 1918,
-     :trie-metadata nil}],
-   :max-block-idx 1}
+ [{:level 0, :part [], :tries [], :max-block-idx 1}
   {:level 1,
    :part [],
    :tries

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b01.binpb.edn
@@ -24,10 +24,7 @@
       :max-valid-to #xt/instant "+294247-01-10T04:00:54.775807Z",
       :min-system-from #xt/instant "2020-01-02T00:00:00Z",
       :max-system-from #xt/instant "2020-01-02T00:00:00Z",
-      :row-count 1}}
-    {:trie-key "l00-rc-b00",
-     :data-file-size 2894,
-     :trie-metadata nil}],
+      :row-count 1}}],
    :max-block-idx 1}
   {:level 1,
    :part [],

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b02.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/tables/xt$txs/blocks/b02.binpb.edn
@@ -12,14 +12,7 @@
   "user_metadata" [1743287434 1.0004885993744506],
   "error" [1743287434 1.0004885993744506]},
  :partitions
- [{:level 0,
-   :part [],
-   :tries
-   [{:trie-key "l00-rc-b01", :data-file-size 2894, :trie-metadata nil}
-    {:trie-key "l00-rc-b00",
-     :data-file-size 2894,
-     :trie-metadata nil}],
-   :max-block-idx 1}
+ [{:level 0, :part [], :tries [], :max-block-idx 1}
   {:level 1,
    :part [],
    :tries


### PR DESCRIPTION
## Problem

The trie-catalog tracked every trie file as `:live`, `:nascent`, or `:garbage`.
When an L1C landed, the L0 files that fed into it moved to `:garbage` and sat there forever — the GC sweep filter explicitly excluded level 0.
Net effect: L0 garbage entries accumulated in the in-memory catalog and in every persisted table block file, growing linearly with the lifetime of the database.

The asymmetry was load-bearing.
We *do* want to keep the L0 *files* on the object store indefinitely — they're the recovery substrate for `reset-compactor!` if a higher-level compaction goes wrong.
But we don't need to keep tracking them in the catalog once they've been compacted away.

## Approach

Split "L0 file exists on disk" from "L0 entry is tracked in the catalog":

- The catalog drops L0 entries the moment they're superseded — no `:garbage` state, no grace period.
- L0 files on the object store are never deleted by GC or by reset.
- The compactor reset path enumerates L0 trie keys directly from the object store, since the catalog is no longer the authoritative list.

`reset->l0!` is now a passive sink: callers (today, just `xtdb.compactor.reset/reset-compactor!`) supply a per-table map of L0 entries enumerated from the buffer pool.
The catalog never reaches into storage itself, keeping the normal-operation surface clean.

## Decisions

**Why drop on supersession instead of changing the GC sweep?**
Changing the sweep alone would still pile up L0 garbage entries in memory and in persisted block files until a sweep ran.
Dropping at supersession time gives the smallest in-memory state and the smallest persisted state.

**Why enumerate L0 from the object store on reset rather than keeping a parallel "L0 graveyard" data structure?**
The object store is already the authoritative store of L0 files; a parallel structure would be a second source of truth that can drift.
Listing during reset is rare (manual operator action) and the cost is bounded.

**Defence in depth in the GC path.**
`garbageTries` already filters L0 out via `garbage-fn`, so L0 keys can't reach the deletion path today.
Added a `check` in `TrieGarbageCollector` that fails loud if a future regression ever lets one through — the recovery path is critical enough that the cost is trivial.

**Block-file forward compatibility.**
Older block files written before this change carry L0 entries in `:garbage`; `partition->entry` filters those out at load time, so the next natural flush rewrites the cleaned state.
No migration step.

## Test plan

- [x] `xtdb.trie-catalog-test` — drop-on-supersede, startup-load filter, `repair-l0-l1c-consistency`, reset rebuilds catalog from object-store enumeration
- [x] `xtdb.compactor.reset-test` — fixture-based reset; this is what caught the missing `:data-file-size` hydration in an earlier draft of `list-l0-entries`
- [x] `xtdb.compactor-test` (incl. fixture updates for `compactor-trie-metadata`)
- [x] `xtdb.compactor.CompactorSimulationTest` — assertions updated wherever they expected L0 keys in `listAllGarbageTrieKeys`
- [x] `xtdb.api-test`, `xtdb.indexer-test`
- [x] No reflection or boxed-math warnings