### PR TITLE
fix(test): fix flaky test-cast-to-ts in DST gap scenarios

### DIFF
--- a/src/test/clojure/xtdb/expression/temporal_test.clj
+++ b/src/test/clojure/xtdb/expression/temporal_test.clj
@@ -746,9 +746,11 @@
   (tcp/for-all [t1 (tcg/one-of [ldt-gen ld-gen lt-gen zdt-gen])
                 default-tz zone-id-gen
                 now instant-gen]
-    (= (if (instance? LocalDate t1) ; see fix for #371
-         (.atStartOfDay ^LocalDate t1)
-         (LocalDateTime/ofInstant (->inst t1 now default-tz) default-tz))
+    (= (condp instance? t1
+         LocalDate (.atStartOfDay ^LocalDate t1)
+         LocalDateTime t1
+         LocalTime (LocalDateTime/of (LocalDate/ofInstant now default-tz) ^LocalTime t1)
+         (LocalDateTime/ofInstant (.toInstant ^ZonedDateTime t1) default-tz))
        (->> (tu/query-ra [:project {:projections [{'res (list 'cast '?t1 (types/->type [:timestamp-local :micro]))}]}
                           [:table {:rows [{}]}]]
                          {:args {:t1 t1}


### PR DESCRIPTION
The test fixture computed the expected value for timestamp-local casts by round-tripping through ->inst, which calls .atZone on LocalDateTimes. In DST gaps (e.g. 2034-03-26T01:00 in "Eire"), .atZone silently shifts the time forward — but the production cast code correctly treats LDT → timestamp-local as identity, so the two sides disagreed.

Compute the expected value directly per input type, matching the production semantics: LDT is identity, LocalTime combines with the current date, ZDT extracts via .toInstant.

Verified with the original failing seed (1777068766587).

Fixes #2422