### PR TITLE
feat(adbc): in-process AdbcStatement prepare/bind/execute (#5270)

### DIFF
--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -28,6 +28,7 @@ import xtdb.arrow.unsupported
 import xtdb.database.DatabaseName
 import xtdb.table.TableRef
 import xtdb.query.PreparedQuery
+import xtdb.query.QueryOpts
 import xtdb.tx.TxOp
 import xtdb.tx.TxOpts
 import xtdb.util.useAll
@@ -44,16 +45,23 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
     override fun createStatement() = object : XtdbStatement {
         private var sql: String? = null
+        private var prepared: PreparedQuery? = null
 
         override fun setSqlQuery(sql: String) {
             this.sql = sql
+            this.prepared = null
+        }
+
+        override fun prepare() {
+            val sql = this.sql ?: error("SQL query not set")
+            prepared = node.prepareSql(sql, dbName)
         }
 
         override fun executeQuery(): QueryResult {
-            val sql = this.sql ?: error("SQL query not set")
-            val cursor = node.openSqlQuery(sql, dbName)
+            val cursor = prepared
+                ?.openQuery(null, QueryOpts())
+                ?: node.openSqlQuery(sql ?: error("SQL query not set"), dbName)
             val schema = Schema(cursor.resultTypes.map { (name, type) -> type.toField(name) })
-
             return QueryResult(-1, cursorToArrowReader(cursor, schema))
         }
 
@@ -62,9 +70,9 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             return UpdateResult(-1)
         }
 
-        override fun prepare() = TODO("Not yet implemented")
-
-        override fun close() = Unit
+        override fun close() {
+            prepared = null
+        }
     }
 
     internal fun executeDml(op: TxOp) {

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -14,13 +14,11 @@ import org.apache.arrow.vector.VarCharVector
 import org.apache.arrow.vector.VectorLoader
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.VectorUnloader
-import org.apache.arrow.vector.ipc.ArrowStreamWriter
-import java.io.ByteArrayOutputStream
-import java.nio.channels.Channels
 import org.apache.arrow.vector.complex.DenseUnionVector
 import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.complex.writer.VarCharWriter
 import org.apache.arrow.vector.ipc.ArrowReader
+import org.apache.arrow.vector.ipc.ArrowStreamWriter
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.ResultCursor
 import xtdb.api.Xtdb
@@ -31,12 +29,15 @@ import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.arrow.unsupported
 import xtdb.arrow.withName
 import xtdb.database.DatabaseName
-import xtdb.table.TableRef
 import xtdb.query.PreparedQuery
 import xtdb.query.QueryOpts
+import xtdb.table.TableRef
 import xtdb.tx.TxOp
 import xtdb.tx.TxOpts
 import xtdb.util.useAll
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.nio.channels.Channels
 
 class XtdbConnection(private val node: Node) : AdbcConnection {
 
@@ -51,16 +52,16 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     override fun createStatement() = object : XtdbStatement {
         private var sql: String? = null
         private var prepared: PreparedQuery? = null
-        // Bound params kept in two forms: a reader view for `openQuery`, IPC bytes
-        // for `TxOp.SqlBytes`. We can't go via `Relation.load` (the obvious choice)
-        // because Arrow's `transferOwnership` fails across allocator roots, and
-        // callers can pass a VSR from an independent RootAllocator. Bytes don't care.
-        private var boundArgs: RelationReader? = null
+        // Arrow IPC bytes — allocator-agnostic, caller can close their VSR
+        // straight after bind. Cleared only by another bind() or close().
         private var argBytes: ByteArray? = null
 
         override fun setSqlQuery(sql: String) {
             this.sql = sql
+            // New SQL invalidates both the compiled plan and any prior bind —
+            // the parameter shape can have changed.
             this.prepared = null
+            this.argBytes = null
         }
 
         override fun prepare() {
@@ -77,24 +78,10 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
 
         override fun bind(root: VectorSchemaRoot) {
-            boundArgs?.close()
+            argBytes = null
             // External `$N` → planner-internal `?_N`, by position.
-            // `$N` is 0-indexed by XTDB convention, not Postgres-faithful.
+            // `$N` is 0-indexed
             val renamedFields = root.schema.fields.mapIndexed { idx, f -> f.withName("?_$idx") }
-
-            // fromRoot doesn't transfer — the buffers stay in the source's allocator,
-            // openQuery reads them, and the cursor releases the wrappers on close.
-            val rel = Relation.fromRoot(node.allocator, root)
-            boundArgs = try {
-                RelationReader.from(
-                    rel.vectors.mapIndexed { idx, v -> v.withName("?_$idx") }.toList(),
-                    rel.rowCount
-                )
-            } catch (t: Throwable) {
-                rel.close()
-                throw t
-            }
-
             argBytes = ByteArrayOutputStream().use { baos ->
                 val renamedRoot = VectorSchemaRoot(renamedFields, root.fieldVectors, root.rowCount)
                 ArrowStreamWriter(renamedRoot, null, Channels.newChannel(baos)).use { writer ->
@@ -107,26 +94,30 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
 
         override fun bind(rel: RelationReader) {
-            boundArgs?.close()
-            // XTDB-internal; assumes the source shares a root with node.allocator.
-            val owned = rel.openDirectSlice(node.allocator)
-            boundArgs = try {
-                RelationReader.from(
-                    owned.vectors.mapIndexed { idx, v -> v.withName("?_$idx") }.toList(),
-                    owned.rowCount
-                )
-            } catch (t: Throwable) {
-                owned.close()
-                throw t
-            }
-            // DML through this path isn't wired — executeUpdate will raise on the
-            // unbound `?` rather than silently dropping params.
             argBytes = null
+            rel.openDirectSlice(node.allocator).use { sliced ->
+                val renamedFields = sliced.vectors.mapIndexed { idx, v -> v.field.withName("?_$idx") }
+                Relation(node.allocator, renamedFields).use { renamed ->
+                    sliced.openArrowRecordBatch().use { rb -> renamed.load(rb) }
+                    argBytes = renamed.asArrowStream
+                }
+            }
         }
 
+        private fun deserialiseArgs(bytes: ByteArray): Relation =
+            Relation.StreamLoader(node.allocator, Channels.newChannel(ByteArrayInputStream(bytes))).use { loader ->
+                Relation(node.allocator, loader.schema).also { rel ->
+                    try {
+                        loader.loadNextPage(rel)
+                    } catch (t: Throwable) {
+                        rel.close()
+                        throw t
+                    }
+                }
+            }
+
         override fun executeQuery(): QueryResult {
-            // openQuery takes ownership on success; null our ref to avoid double-close.
-            val args = boundArgs.also { boundArgs = null }
+            val args = argBytes?.let(::deserialiseArgs)
             val cursor = try {
                 prepared?.openQuery(args, QueryOpts())
                     ?: node.openSqlQuery(sql ?: error("SQL query not set"), dbName)
@@ -140,15 +131,12 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun executeUpdate(): UpdateResult {
             val sql = sql ?: error("SQL query not set")
-            val bytes = argBytes.also { argBytes = null }
-            val op = if (bytes != null) TxOp.SqlBytes(sql, bytes) else TxOp.Sql(sql)
+            val op = argBytes?.let { TxOp.SqlBytes(sql, it) } ?: TxOp.Sql(sql)
             executeDml(op)
             return UpdateResult(-1)
         }
 
         override fun close() {
-            boundArgs?.close()
-            boundArgs = null
             argBytes = null
             prepared = null
         }

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -14,6 +14,9 @@ import org.apache.arrow.vector.VarCharVector
 import org.apache.arrow.vector.VectorLoader
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.VectorUnloader
+import org.apache.arrow.vector.ipc.ArrowStreamWriter
+import java.io.ByteArrayOutputStream
+import java.nio.channels.Channels
 import org.apache.arrow.vector.complex.DenseUnionVector
 import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.complex.writer.VarCharWriter
@@ -26,6 +29,7 @@ import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.arrow.unsupported
+import xtdb.arrow.withName
 import xtdb.database.DatabaseName
 import xtdb.table.TableRef
 import xtdb.query.PreparedQuery
@@ -47,10 +51,12 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     override fun createStatement() = object : XtdbStatement {
         private var sql: String? = null
         private var prepared: PreparedQuery? = null
-        // Owned by the statement until handed off to openQuery in executeQuery.
-        // Vectors are always renamed to the planner-internal `?_N` convention so
-        // the inbound `$N` names from clients (per getParameterSchema) match up.
+        // Bound params kept in two forms: a reader view for `openQuery`, IPC bytes
+        // for `TxOp.SqlBytes`. We can't go via `Relation.load` (the obvious choice)
+        // because Arrow's `transferOwnership` fails across allocator roots, and
+        // callers can pass a VSR from an independent RootAllocator. Bytes don't care.
         private var boundArgs: RelationReader? = null
+        private var argBytes: ByteArray? = null
 
         override fun setSqlQuery(sql: String) {
             this.sql = sql
@@ -74,6 +80,10 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             boundArgs?.close()
             // External `$N` → planner-internal `?_N`, by position.
             // `$N` is 0-indexed by XTDB convention, not Postgres-faithful.
+            val renamedFields = root.schema.fields.mapIndexed { idx, f -> f.withName("?_$idx") }
+
+            // fromRoot doesn't transfer — the buffers stay in the source's allocator,
+            // openQuery reads them, and the cursor releases the wrappers on close.
             val rel = Relation.fromRoot(node.allocator, root)
             boundArgs = try {
                 RelationReader.from(
@@ -84,10 +94,21 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
                 rel.close()
                 throw t
             }
+
+            argBytes = ByteArrayOutputStream().use { baos ->
+                val renamedRoot = VectorSchemaRoot(renamedFields, root.fieldVectors, root.rowCount)
+                ArrowStreamWriter(renamedRoot, null, Channels.newChannel(baos)).use { writer ->
+                    writer.start()
+                    writer.writeBatch()
+                    writer.end()
+                }
+                baos.toByteArray()
+            }
         }
 
         override fun bind(rel: RelationReader) {
             boundArgs?.close()
+            // XTDB-internal; assumes the source shares a root with node.allocator.
             val owned = rel.openDirectSlice(node.allocator)
             boundArgs = try {
                 RelationReader.from(
@@ -98,6 +119,9 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
                 owned.close()
                 throw t
             }
+            // DML through this path isn't wired — executeUpdate will raise on the
+            // unbound `?` rather than silently dropping params.
+            argBytes = null
         }
 
         override fun executeQuery(): QueryResult {
@@ -115,13 +139,17 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
 
         override fun executeUpdate(): UpdateResult {
-            executeDml(TxOp.Sql(sql ?: error("SQL query not set")))
+            val sql = sql ?: error("SQL query not set")
+            val bytes = argBytes.also { argBytes = null }
+            val op = if (bytes != null) TxOp.SqlBytes(sql, bytes) else TxOp.Sql(sql)
+            executeDml(op)
             return UpdateResult(-1)
         }
 
         override fun close() {
             boundArgs?.close()
             boundArgs = null
+            argBytes = null
             prepared = null
         }
     }

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -24,6 +24,7 @@ import xtdb.api.Xtdb
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorType
+import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.arrow.unsupported
 import xtdb.database.DatabaseName
 import xtdb.table.TableRef
@@ -46,7 +47,10 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     override fun createStatement() = object : XtdbStatement {
         private var sql: String? = null
         private var prepared: PreparedQuery? = null
-        private var boundArgs: Relation? = null
+        // Owned by the statement until handed off to openQuery in executeQuery.
+        // Vectors are always renamed to the planner-internal `?_N` convention so
+        // the inbound `$N` names from clients (per getParameterSchema) match up.
+        private var boundArgs: RelationReader? = null
 
         override fun setSqlQuery(sql: String) {
             this.sql = sql
@@ -58,14 +62,42 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             prepared = node.prepareSql(sql, dbName)
         }
 
+        override fun getParameterSchema(): Schema {
+            val pq = prepared ?: error("call prepare() first")
+            // placeholder type until bind supplies real ones
+            return Schema(
+                (0 until pq.paramCount).map { idx -> "\$$idx" ofType VectorType.fromLegs() }
+            )
+        }
+
         override fun bind(root: VectorSchemaRoot) {
             boundArgs?.close()
-            boundArgs = Relation.fromRoot(node.allocator, root)
+            // External `$N` → planner-internal `?_N`, by position.
+            // `$N` is 0-indexed by XTDB convention, not Postgres-faithful.
+            val rel = Relation.fromRoot(node.allocator, root)
+            boundArgs = try {
+                RelationReader.from(
+                    rel.vectors.mapIndexed { idx, v -> v.withName("?_$idx") }.toList(),
+                    rel.rowCount
+                )
+            } catch (t: Throwable) {
+                rel.close()
+                throw t
+            }
         }
 
         override fun bind(rel: RelationReader) {
             boundArgs?.close()
-            boundArgs = rel.openDirectSlice(node.allocator)
+            val owned = rel.openDirectSlice(node.allocator)
+            boundArgs = try {
+                RelationReader.from(
+                    owned.vectors.mapIndexed { idx, v -> v.withName("?_$idx") }.toList(),
+                    owned.rowCount
+                )
+            } catch (t: Throwable) {
+                owned.close()
+                throw t
+            }
         }
 
         override fun executeQuery(): QueryResult {

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -46,6 +46,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     override fun createStatement() = object : XtdbStatement {
         private var sql: String? = null
         private var prepared: PreparedQuery? = null
+        private var boundArgs: Relation? = null
 
         override fun setSqlQuery(sql: String) {
             this.sql = sql
@@ -57,10 +58,26 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             prepared = node.prepareSql(sql, dbName)
         }
 
+        override fun bind(root: VectorSchemaRoot) {
+            boundArgs?.close()
+            boundArgs = Relation.fromRoot(node.allocator, root)
+        }
+
+        override fun bind(rel: RelationReader) {
+            boundArgs?.close()
+            boundArgs = rel.openDirectSlice(node.allocator)
+        }
+
         override fun executeQuery(): QueryResult {
-            val cursor = prepared
-                ?.openQuery(null, QueryOpts())
-                ?: node.openSqlQuery(sql ?: error("SQL query not set"), dbName)
+            // openQuery takes ownership on success; null our ref to avoid double-close.
+            val args = boundArgs.also { boundArgs = null }
+            val cursor = try {
+                prepared?.openQuery(args, QueryOpts())
+                    ?: node.openSqlQuery(sql ?: error("SQL query not set"), dbName)
+            } catch (t: Throwable) {
+                args?.close()
+                throw t
+            }
             val schema = Schema(cursor.resultTypes.map { (name, type) -> type.toField(name) })
             return QueryResult(-1, cursorToArrowReader(cursor, schema))
         }
@@ -71,6 +88,8 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
 
         override fun close() {
+            boundArgs?.close()
+            boundArgs = null
             prepared = null
         }
     }

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -56,11 +56,6 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             args.also { args = null }?.close()
         }
 
-        // Per-execution view onto the stored bind. `openSlice` on a Relation we already
-        // own (same-root allocator) bumps ref counts on the underlying buffers rather
-        // than copying — cheap to re-execute the same plan with the same args.
-        // The rename converts the external `$N` parameter names (per getParameterSchema)
-        // to the planner-internal `?_N` convention; positional, ignoring inbound names.
         private fun openQueryArgs(): RelationReader? =
             args?.openSlice(node.allocator)?.closeOnCatch { sliced ->
                 RelationReader.from(
@@ -71,8 +66,6 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun setSqlQuery(sql: String) {
             this.sql = sql
-            // New SQL invalidates both the compiled plan and any prior bind —
-            // the parameter shape can have changed.
             this.prepared = null
             clearArgs()
         }
@@ -84,7 +77,6 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun getParameterSchema(): Schema {
             val pq = prepared ?: throw Incorrect("call prepare() first", "xtdb.adbc/not-prepared")
-            // placeholder type until bind supplies real ones
             return Schema(
                 (0 until pq.paramCount).map { idx -> "\$$idx" ofType VectorType.fromLegs() }
             )
@@ -96,12 +88,6 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun bind(rel: RelationReader) {
             clearArgs()
-            // Copy row-by-row into a Relation owned by node.allocator so the caller
-            // can close their reader as soon as bind() returns, per the ADBC contract.
-            // openDirectSlice would be cheaper but only works when the caller's
-            // allocator shares a root with ours — Arrow's transferOwnership doesn't
-            // do cross-root copies, it just refuses. The row copy here is the
-            // one-shot cost paid per bind; openQueryArgs avoids paying it per execute.
             args = Relation(node.allocator, rel.schema).closeOnCatch { copy ->
                 rel.rowCopier(copy).copyRange(0, rel.rowCount)
                 copy
@@ -110,10 +96,6 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun executeQuery(): QueryResult {
             val sql = sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
-            // Bind without prepare is ambiguous for queries: node.openSqlQuery has no
-            // args parameter, so we'd silently drop the bind. Force the caller to
-            // prepare() first when parameters are bound, rather than failing later or
-            // (worse) returning a result that ignored their args.
             if (prepared == null && args != null)
                 throw Incorrect(
                     "call prepare() before executeQuery() when parameters are bound",
@@ -121,8 +103,6 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
                 )
 
             val queryArgs = openQueryArgs()
-            // PreparedQuery.openQuery takes ownership of args on success (see
-            // xtdb/query.clj's `wrap-closeables`); only need to close on throw.
             val cursor = try {
                 prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName)
             } catch (t: Throwable) {

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -18,7 +18,6 @@ import org.apache.arrow.vector.complex.DenseUnionVector
 import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.complex.writer.VarCharWriter
 import org.apache.arrow.vector.ipc.ArrowReader
-import org.apache.arrow.vector.ipc.ArrowStreamWriter
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.ResultCursor
 import xtdb.api.Xtdb
@@ -35,9 +34,6 @@ import xtdb.table.TableRef
 import xtdb.tx.TxOp
 import xtdb.tx.TxOpts
 import xtdb.util.useAll
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.nio.channels.Channels
 
 class XtdbConnection(private val node: Node) : AdbcConnection {
 
@@ -52,16 +48,45 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     override fun createStatement() = object : XtdbStatement {
         private var sql: String? = null
         private var prepared: PreparedQuery? = null
-        // Arrow IPC bytes — allocator-agnostic, caller can close their VSR
-        // straight after bind. Cleared only by another bind() or close().
-        private var argBytes: ByteArray? = null
+        private var args: Relation? = null
+
+        private fun clearArgs() {
+            args.also { args = null }?.close()
+        }
+
+        private fun copyArgs(rel: RelationReader): Relation {
+            val copied = Relation(node.allocator, rel.schema)
+
+            return try {
+                rel.rowCopier(copied).copyRange(0, rel.rowCount)
+                copied
+            } catch (t: Throwable) {
+                copied.close()
+                throw t
+            }
+        }
+
+        private fun openArgs(): Relation? =
+            args?.let { stored ->
+                Relation(node.allocator, stored.schema).also { copy ->
+                    try {
+                        stored.rowCopier(copy).copyRange(0, stored.rowCount)
+                    } catch (t: Throwable) {
+                        copy.close()
+                        throw t
+                    }
+                }
+            }
+
+        private fun openQueryArgs(): RelationReader? =
+            openArgs()?.let { RelationReader.from(it.vectors.mapIndexed { idx, v -> v.withName("?_$idx") }, it.rowCount) }
 
         override fun setSqlQuery(sql: String) {
             this.sql = sql
             // New SQL invalidates both the compiled plan and any prior bind —
             // the parameter shape can have changed.
             this.prepared = null
-            this.argBytes = null
+            clearArgs()
         }
 
         override fun prepare() {
@@ -78,51 +103,21 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
 
         override fun bind(root: VectorSchemaRoot) {
-            argBytes = null
-            // External `$N` → planner-internal `?_N`, by position.
-            // `$N` is 0-indexed
-            val renamedFields = root.schema.fields.mapIndexed { idx, f -> f.withName("?_$idx") }
-            argBytes = ByteArrayOutputStream().use { baos ->
-                val renamedRoot = VectorSchemaRoot(renamedFields, root.fieldVectors, root.rowCount)
-                ArrowStreamWriter(renamedRoot, null, Channels.newChannel(baos)).use { writer ->
-                    writer.start()
-                    writer.writeBatch()
-                    writer.end()
-                }
-                baos.toByteArray()
-            }
+            Relation.fromRoot(node.allocator, root).use(::bind)
         }
 
         override fun bind(rel: RelationReader) {
-            argBytes = null
-            rel.openDirectSlice(node.allocator).use { sliced ->
-                val renamedFields = sliced.vectors.mapIndexed { idx, v -> v.field.withName("?_$idx") }
-                Relation(node.allocator, renamedFields).use { renamed ->
-                    sliced.openArrowRecordBatch().use { rb -> renamed.load(rb) }
-                    argBytes = renamed.asArrowStream
-                }
-            }
+            clearArgs()
+            args = copyArgs(rel)
         }
 
-        private fun deserialiseArgs(bytes: ByteArray): Relation =
-            Relation.StreamLoader(node.allocator, Channels.newChannel(ByteArrayInputStream(bytes))).use { loader ->
-                Relation(node.allocator, loader.schema).also { rel ->
-                    try {
-                        loader.loadNextPage(rel)
-                    } catch (t: Throwable) {
-                        rel.close()
-                        throw t
-                    }
-                }
-            }
-
         override fun executeQuery(): QueryResult {
-            val args = argBytes?.let(::deserialiseArgs)
+            val queryArgs = openQueryArgs()
             val cursor = try {
-                prepared?.openQuery(args, QueryOpts())
+                prepared?.openQuery(queryArgs, QueryOpts())
                     ?: node.openSqlQuery(sql ?: error("SQL query not set"), dbName)
             } catch (t: Throwable) {
-                args?.close()
+                queryArgs?.close()
                 throw t
             }
             val schema = Schema(cursor.resultTypes.map { (name, type) -> type.toField(name) })
@@ -131,13 +126,13 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun executeUpdate(): UpdateResult {
             val sql = sql ?: error("SQL query not set")
-            val op = argBytes?.let { TxOp.SqlBytes(sql, it) } ?: TxOp.Sql(sql)
+            val op = TxOp.Sql(sql, openQueryArgs())
             executeDml(op)
             return UpdateResult(-1)
         }
 
         override fun close() {
-            argBytes = null
+            clearArgs()
             prepared = null
         }
     }

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -29,6 +29,7 @@ import xtdb.arrow.unsupported
 import xtdb.arrow.withName
 import xtdb.util.closeOnCatch
 import xtdb.database.DatabaseName
+import xtdb.error.Incorrect
 import xtdb.query.PreparedQuery
 import xtdb.query.QueryOpts
 import xtdb.table.TableRef
@@ -77,12 +78,12 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
 
         override fun prepare() {
-            val sql = this.sql ?: error("SQL query not set")
+            val sql = this.sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
             prepared = node.prepareSql(sql, dbName)
         }
 
         override fun getParameterSchema(): Schema {
-            val pq = prepared ?: error("call prepare() first")
+            val pq = prepared ?: throw Incorrect("call prepare() first", "xtdb.adbc/not-prepared")
             // placeholder type until bind supplies real ones
             return Schema(
                 (0 until pq.paramCount).map { idx -> "\$$idx" ofType VectorType.fromLegs() }
@@ -108,13 +109,16 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
 
         override fun executeQuery(): QueryResult {
-            val sql = sql ?: error("SQL query not set")
+            val sql = sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
             // Bind without prepare is ambiguous for queries: node.openSqlQuery has no
             // args parameter, so we'd silently drop the bind. Force the caller to
             // prepare() first when parameters are bound, rather than failing later or
             // (worse) returning a result that ignored their args.
             if (prepared == null && args != null)
-                error("call prepare() before executeQuery() when parameters are bound")
+                throw Incorrect(
+                    "call prepare() before executeQuery() when parameters are bound",
+                    "xtdb.adbc/bind-without-prepare",
+                )
 
             val queryArgs = openQueryArgs()
             // PreparedQuery.openQuery takes ownership of args on success (see
@@ -130,7 +134,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
 
         override fun executeUpdate(): UpdateResult {
-            val sql = sql ?: error("SQL query not set")
+            val sql = sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
             val op = TxOp.Sql(sql, openQueryArgs())
             executeDml(op)
             return UpdateResult(-1)
@@ -179,8 +183,10 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         val schemaName = splitTable.getOrNull(1) ?: "public"
 
         return object : XtdbStatement {
-            override fun executeQuery() = error("Bulk ingest does not support queries")
-            override fun prepare() = error("Bulk ingest does not support prepare")
+            override fun executeQuery(): QueryResult =
+                throw Incorrect("Bulk ingest does not support queries", "xtdb.adbc/bulk-ingest-no-query")
+            override fun prepare(): Unit =
+                throw Incorrect("Bulk ingest does not support prepare", "xtdb.adbc/bulk-ingest-no-prepare")
 
             private var rel: Relation? = null
 

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -95,17 +95,32 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun bind(rel: RelationReader) {
             clearArgs()
-            // `openDirectSlice` transfers ownership of the inbound buffers into our
-            // allocator — a ref-count bump for same-root allocators, a real copy when
-            // they differ. Caller can close their reader as soon as bind() returns.
-            args = rel.openDirectSlice(node.allocator)
+            // Copy row-by-row into a Relation owned by node.allocator so the caller
+            // can close their reader as soon as bind() returns, per the ADBC contract.
+            // openDirectSlice would be cheaper but only works when the caller's
+            // allocator shares a root with ours — Arrow's transferOwnership doesn't
+            // do cross-root copies, it just refuses. The row copy here is the
+            // one-shot cost paid per bind; openQueryArgs avoids paying it per execute.
+            args = Relation(node.allocator, rel.schema).closeOnCatch { copy ->
+                rel.rowCopier(copy).copyRange(0, rel.rowCount)
+                copy
+            }
         }
 
         override fun executeQuery(): QueryResult {
+            val sql = sql ?: error("SQL query not set")
+            // Bind without prepare is ambiguous for queries: node.openSqlQuery has no
+            // args parameter, so we'd silently drop the bind. Force the caller to
+            // prepare() first when parameters are bound, rather than failing later or
+            // (worse) returning a result that ignored their args.
+            if (prepared == null && args != null)
+                error("call prepare() before executeQuery() when parameters are bound")
+
             val queryArgs = openQueryArgs()
+            // PreparedQuery.openQuery takes ownership of args on success (see
+            // xtdb/query.clj's `wrap-closeables`); only need to close on throw.
             val cursor = try {
-                prepared?.openQuery(queryArgs, QueryOpts())
-                    ?: node.openSqlQuery(sql ?: error("SQL query not set"), dbName)
+                prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName)
             } catch (t: Throwable) {
                 queryArgs?.close()
                 throw t

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -27,6 +27,7 @@ import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.arrow.unsupported
 import xtdb.arrow.withName
+import xtdb.util.closeOnCatch
 import xtdb.database.DatabaseName
 import xtdb.query.PreparedQuery
 import xtdb.query.QueryOpts
@@ -54,32 +55,18 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             args.also { args = null }?.close()
         }
 
-        private fun copyArgs(rel: RelationReader): Relation {
-            val copied = Relation(node.allocator, rel.schema)
-
-            return try {
-                rel.rowCopier(copied).copyRange(0, rel.rowCount)
-                copied
-            } catch (t: Throwable) {
-                copied.close()
-                throw t
-            }
-        }
-
-        private fun openArgs(): Relation? =
-            args?.let { stored ->
-                Relation(node.allocator, stored.schema).also { copy ->
-                    try {
-                        stored.rowCopier(copy).copyRange(0, stored.rowCount)
-                    } catch (t: Throwable) {
-                        copy.close()
-                        throw t
-                    }
-                }
-            }
-
+        // Per-execution view onto the stored bind. `openSlice` on a Relation we already
+        // own (same-root allocator) bumps ref counts on the underlying buffers rather
+        // than copying — cheap to re-execute the same plan with the same args.
+        // The rename converts the external `$N` parameter names (per getParameterSchema)
+        // to the planner-internal `?_N` convention; positional, ignoring inbound names.
         private fun openQueryArgs(): RelationReader? =
-            openArgs()?.let { RelationReader.from(it.vectors.mapIndexed { idx, v -> v.withName("?_$idx") }, it.rowCount) }
+            args?.openSlice(node.allocator)?.closeOnCatch { sliced ->
+                RelationReader.from(
+                    sliced.vectors.mapIndexed { idx, v -> v.withName("?_$idx") },
+                    sliced.rowCount
+                )
+            }
 
         override fun setSqlQuery(sql: String) {
             this.sql = sql
@@ -108,7 +95,10 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun bind(rel: RelationReader) {
             clearArgs()
-            args = copyArgs(rel)
+            // `openDirectSlice` transfers ownership of the inbound buffers into our
+            // allocator — a ref-count bump for same-root allocators, a real copy when
+            // they differ. Caller can close their reader as soon as bind() returns.
+            args = rel.openDirectSlice(node.allocator)
         }
 
         override fun executeQuery(): QueryResult {

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -11,13 +11,6 @@ import org.apache.arrow.flight.Location
 import org.apache.arrow.flight.sql.FlightSqlClient
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
-import org.apache.arrow.vector.BigIntVector
-import org.apache.arrow.vector.VectorSchemaRoot
-import org.apache.arrow.vector.types.Types
-import org.apache.arrow.vector.types.pojo.ArrowType
-import org.apache.arrow.vector.types.pojo.Field
-import org.apache.arrow.vector.types.pojo.FieldType
-import org.apache.arrow.vector.types.pojo.Schema
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -87,8 +80,6 @@ class FlightSqlAdbcTest {
         }
     }
 
-    // -- Basic round-trip --
-
     @Test
     fun `test simple round-trip`() {
         insertData("""
@@ -122,8 +113,6 @@ class FlightSqlAdbcTest {
             }
         }
     }
-
-    // -- FlightSQL metadata (via FlightSqlClient) --
 
     @Test
     fun `test FlightSQL getTableTypes`() {
@@ -167,8 +156,6 @@ class FlightSqlAdbcTest {
         assertTrue(rows.isNotEmpty(), "Expected at least one info row")
     }
 
-    // -- ADBC metadata (through FlightSQL ADBC client) --
-
     // getInfo via ADBC client hits a bug in GetInfoMetadataReader.processRootFromStream
     // (allocates on the wrong root). Tested at the FlightSQL level via `test FlightSQL getSqlInfo` instead.
 
@@ -192,74 +179,6 @@ class FlightSqlAdbcTest {
             assertTrue(rdr.vectorSchemaRoot.rowCount > 0, "Expected catalog rows with table data")
         }
     }
-
-<<<<<<< HEAD
-=======
-    // -- Prepared statements (in-process ADBC) --
-    //
-    // NB: `conn` above is the FlightSQL-over-the-wire ADBC client; tests that
-    // need to exercise our in-process `XtdbConnection` directly use `xtdb.connect()`.
-
-    @Test
-    fun `prepare and execute simple query (in-process)`() {
-        insertData("INSERT INTO foo RECORDS {_id: 1, n: 'one'}")
-
-        xtdb.connect().use { ipConn ->
-            ipConn.createStatement().use { stmt ->
-                stmt.setSqlQuery("SELECT _id, n FROM foo")
-                stmt.prepare()
-
-                stmt.executeQuery().reader.use { rdr ->
-                    assertTrue(rdr.loadNextBatch())
-                    Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
-                        assertEquals(
-                            listOf(mapOf("_id" to 1L, "n" to "one")),
-                            rel.toMaps(SNAKE_CASE_STRING)
-                        )
-                    }
-                    assertFalse(rdr.loadNextBatch())
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `prepare with bound parameter (in-process)`() {
-        insertData("INSERT INTO foo RECORDS {_id: 1}, {_id: 2}, {_id: 3}")
-
-        xtdb.connect().use { ipConn ->
-            ipConn.createStatement().use { stmt ->
-                stmt.setSqlQuery("SELECT _id FROM foo WHERE _id = ?")
-                stmt.prepare()
-
-                val schema = Schema(listOf(
-                    Field("\$0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
-                ))
-                VectorSchemaRoot.create(schema, al).use { params ->
-                    params.allocateNew()
-                    (params.getVector("\$0") as BigIntVector).apply {
-                        setSafe(0, 2L); valueCount = 1
-                    }
-                    params.rowCount = 1
-
-                    stmt.bind(params)
-
-                    stmt.executeQuery().reader.use { rdr ->
-                        assertTrue(rdr.loadNextBatch())
-                        Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
-                            assertEquals(
-                                listOf(mapOf("_id" to 2L)),
-                                rel.toMaps(SNAKE_CASE_STRING)
-                            )
-                        }
-                        assertFalse(rdr.loadNextBatch())
-                    }
-                }
-            }
-        }
-    }
-
-    // -- Error handling --
 
     @Test
     fun `test DML via query path returns INVALID_ARGUMENT`() {

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -11,6 +11,12 @@ import org.apache.arrow.flight.Location
 import org.apache.arrow.flight.sql.FlightSqlClient
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.BigIntVector
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.types.Types
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
+import org.apache.arrow.vector.types.pojo.Schema
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -14,6 +14,7 @@ import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.BigIntVector
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.types.Types
+import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.arrow.vector.types.pojo.Field
 import org.apache.arrow.vector.types.pojo.FieldType
 import org.apache.arrow.vector.types.pojo.Schema

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -193,6 +193,72 @@ class FlightSqlAdbcTest {
         }
     }
 
+<<<<<<< HEAD
+=======
+    // -- Prepared statements (in-process ADBC) --
+    //
+    // NB: `conn` above is the FlightSQL-over-the-wire ADBC client; tests that
+    // need to exercise our in-process `XtdbConnection` directly use `xtdb.connect()`.
+
+    @Test
+    fun `prepare and execute simple query (in-process)`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1, n: 'one'}")
+
+        xtdb.connect().use { ipConn ->
+            ipConn.createStatement().use { stmt ->
+                stmt.setSqlQuery("SELECT _id, n FROM foo")
+                stmt.prepare()
+
+                stmt.executeQuery().reader.use { rdr ->
+                    assertTrue(rdr.loadNextBatch())
+                    Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
+                        assertEquals(
+                            listOf(mapOf("_id" to 1L, "n" to "one")),
+                            rel.toMaps(SNAKE_CASE_STRING)
+                        )
+                    }
+                    assertFalse(rdr.loadNextBatch())
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `prepare with bound parameter (in-process)`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1}, {_id: 2}, {_id: 3}")
+
+        xtdb.connect().use { ipConn ->
+            ipConn.createStatement().use { stmt ->
+                stmt.setSqlQuery("SELECT _id FROM foo WHERE _id = ?")
+                stmt.prepare()
+
+                val schema = Schema(listOf(
+                    Field("\$0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
+                ))
+                VectorSchemaRoot.create(schema, al).use { params ->
+                    params.allocateNew()
+                    (params.getVector("\$0") as BigIntVector).apply {
+                        setSafe(0, 2L); valueCount = 1
+                    }
+                    params.rowCount = 1
+
+                    stmt.bind(params)
+
+                    stmt.executeQuery().reader.use { rdr ->
+                        assertTrue(rdr.loadNextBatch())
+                        Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
+                            assertEquals(
+                                listOf(mapOf("_id" to 2L)),
+                                rel.toMaps(SNAKE_CASE_STRING)
+                            )
+                        }
+                        assertFalse(rdr.loadNextBatch())
+                    }
+                }
+            }
+        }
+    }
+
     // -- Error handling --
 
     @Test

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
+import xtdb.error.Incorrect
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import xtdb.api.Xtdb
@@ -159,7 +160,7 @@ class InProcessAdbcTest {
                     rel.openAsRoot(al).use { stmt.bind(it) }
                 }
 
-                val ex = assertThrows(IllegalStateException::class.java) {
+                val ex = assertThrows(Incorrect::class.java) {
                     stmt.executeQuery()
                 }
                 assertTrue(

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -1,0 +1,67 @@
+package xtdb
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import xtdb.api.Xtdb
+import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
+import xtdb.arrow.Relation
+
+class InProcessAdbcTest {
+
+    private lateinit var xtdb: Xtdb
+    private lateinit var al: BufferAllocator
+
+    @BeforeEach
+    fun setUp() {
+        xtdb = Xtdb.openNode {
+            server { port = 0 }
+            flightSql { port = 0 }
+        }
+
+        al = RootAllocator()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        al.close()
+        xtdb.close()
+    }
+
+    private fun insertData(sql: String) {
+        xtdb.connect().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery(sql)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    @Test
+    fun `prepare and execute simple query`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1, n: 'one'}")
+
+        xtdb.connect().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("SELECT _id, n FROM foo")
+                stmt.prepare()
+
+                stmt.executeQuery().reader.use { rdr ->
+                    assertTrue(rdr.loadNextBatch())
+                    Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
+                        assertEquals(
+                            listOf(mapOf("_id" to 1L, "n" to "one")),
+                            rel.toMaps(SNAKE_CASE_STRING)
+                        )
+                    }
+                    assertFalse(rdr.loadNextBatch())
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -2,6 +2,12 @@ package xtdb
 
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.BigIntVector
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.types.Types
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
+import org.apache.arrow.vector.types.pojo.Schema
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -60,6 +66,43 @@ class InProcessAdbcTest {
                         )
                     }
                     assertFalse(rdr.loadNextBatch())
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `prepare with bound parameter`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1}, {_id: 2}, {_id: 3}")
+
+        xtdb.connect().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("SELECT _id FROM foo WHERE _id = ?")
+                stmt.prepare()
+
+                val schema = Schema(listOf(
+                    Field("?_0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
+                ))
+                VectorSchemaRoot.create(schema, al).use { params ->
+                    params.allocateNew()
+                    (params.getVector("?_0") as BigIntVector).apply {
+                        setSafe(0, 2L)
+                        valueCount = 1
+                    }
+                    params.rowCount = 1
+
+                    stmt.bind(params)
+
+                    stmt.executeQuery().reader.use { rdr ->
+                        assertTrue(rdr.loadNextBatch())
+                        Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
+                            assertEquals(
+                                listOf(mapOf("_id" to 2L)),
+                                rel.toMaps(SNAKE_CASE_STRING)
+                            )
+                        }
+                        assertFalse(rdr.loadNextBatch())
+                    }
                 }
             }
         }

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -5,6 +5,7 @@ import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.BigIntVector
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.types.Types
+import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.arrow.vector.types.pojo.Field
 import org.apache.arrow.vector.types.pojo.FieldType
 import org.apache.arrow.vector.types.pojo.Schema
@@ -81,11 +82,11 @@ class InProcessAdbcTest {
                 stmt.prepare()
 
                 val schema = Schema(listOf(
-                    Field("?_0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
+                    Field("\$0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
                 ))
                 VectorSchemaRoot.create(schema, al).use { params ->
                     params.allocateNew()
-                    (params.getVector("?_0") as BigIntVector).apply {
+                    (params.getVector("\$0") as BigIntVector).apply {
                         setSafe(0, 2L)
                         valueCount = 1
                     }
@@ -104,6 +105,23 @@ class InProcessAdbcTest {
                         assertFalse(rdr.loadNextBatch())
                     }
                 }
+            }
+        }
+    }
+
+    @Test
+    fun `getParameterSchema reports columns in $ N convention`() {
+        xtdb.connect().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("SELECT _id FROM foo WHERE _id = ? AND name = ?")
+                stmt.prepare()
+
+                val paramSchema = stmt.parameterSchema
+                assertEquals(2, paramSchema.fields.size, "expected 2 parameter slots")
+                assertEquals("\$0", paramSchema.fields[0].name)
+                assertEquals("\$1", paramSchema.fields[1].name)
+                assertEquals(ArrowType.Null.INSTANCE, paramSchema.fields[0].type)
+                assertEquals(ArrowType.Null.INSTANCE, paramSchema.fields[1].type)
             }
         }
     }

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -163,4 +163,78 @@ class InProcessAdbcTest {
             }
         }
     }
+
+    @Test
+    fun `bind state is sticky across executes`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1}, {_id: 2}, {_id: 3}")
+
+        xtdb.connect().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("SELECT _id FROM foo WHERE _id = ?")
+                stmt.prepare()
+
+                val schema = Schema(listOf(
+                    Field("\$0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
+                ))
+                VectorSchemaRoot.create(schema, al).use { params ->
+                    params.allocateNew()
+                    (params.getVector("\$0") as BigIntVector).apply {
+                        setSafe(0, 2L)
+                        valueCount = 1
+                    }
+                    params.rowCount = 1
+                    stmt.bind(params)
+                }
+
+                fun runOnce(): List<*> =
+                    stmt.executeQuery().reader.use { rdr ->
+                        rdr.loadNextBatch()
+                        Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
+                            rel.toMaps(SNAKE_CASE_STRING)
+                        }
+                    }
+
+                val expected = listOf(mapOf("_id" to 2L))
+                assertEquals(expected, runOnce(), "first execute")
+                assertEquals(expected, runOnce(), "second execute reuses the same bind")
+            }
+        }
+    }
+
+    @Test
+    fun `setSqlQuery clears prior bind`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1}")
+
+        xtdb.connect().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("SELECT _id FROM foo WHERE _id = ?")
+                stmt.prepare()
+                val paramSchema = Schema(listOf(
+                    Field("\$0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
+                ))
+                VectorSchemaRoot.create(paramSchema, al).use { params ->
+                    params.allocateNew()
+                    (params.getVector("\$0") as BigIntVector).apply {
+                        setSafe(0, 1L)
+                        valueCount = 1
+                    }
+                    params.rowCount = 1
+                    stmt.bind(params)
+                }
+
+                stmt.setSqlQuery("SELECT _id FROM foo")
+                stmt.prepare()
+                stmt.executeQuery().reader.use { rdr ->
+                    assertTrue(rdr.loadNextBatch())
+                    Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
+                        assertEquals(
+                            listOf(mapOf("_id" to 1L)),
+                            rel.toMaps(SNAKE_CASE_STRING),
+                            "stale bind from prior SQL must not leak into new SQL"
+                        )
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -125,4 +125,42 @@ class InProcessAdbcTest {
             }
         }
     }
+
+    @Test
+    fun `prepared DML with bound parameters`() {
+        xtdb.connect().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("INSERT INTO foo (_id) VALUES (?)")
+                stmt.prepare()
+
+                val schema = Schema(listOf(
+                    Field("\$0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
+                ))
+                VectorSchemaRoot.create(schema, al).use { params ->
+                    params.allocateNew()
+                    (params.getVector("\$0") as BigIntVector).apply {
+                        setSafe(0, 42L)
+                        valueCount = 1
+                    }
+                    params.rowCount = 1
+
+                    stmt.bind(params)
+                    stmt.executeUpdate()
+                }
+            }
+
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("SELECT _id FROM foo")
+                stmt.executeQuery().reader.use { rdr ->
+                    assertTrue(rdr.loadNextBatch())
+                    Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
+                        assertEquals(
+                            listOf(mapOf("_id" to 42L)),
+                            rel.toMaps(SNAKE_CASE_STRING)
+                        )
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -148,13 +148,9 @@ class InProcessAdbcTest {
 
     @Test
     fun `executeQuery without prepare fails loud when parameters are bound`() {
-        // Locks in the contract: bind without prepare is ambiguous for queries
-        // (node.openSqlQuery has no args parameter), so we refuse to silently drop
-        // the bind and instead force the caller to prepare() first.
         xtdb.connect().use { conn ->
             conn.createStatement().use { stmt ->
                 stmt.setSqlQuery("SELECT _id FROM foo WHERE _id = ?")
-                // deliberately skip prepare(); bind directly with the planner-known shape
                 Relation(al, "\$0" ofType I64).use { rel ->
                     rel.writeRow(mapOf("\$0" to 1L))
                     rel.openAsRoot(al).use { stmt.bind(it) }

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -1,23 +1,19 @@
 package xtdb
 
+import org.apache.arrow.adbc.core.AdbcStatement
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
-import org.apache.arrow.vector.BigIntVector
-import org.apache.arrow.vector.VectorSchemaRoot
-import org.apache.arrow.vector.types.Types
 import org.apache.arrow.vector.types.pojo.ArrowType
-import org.apache.arrow.vector.types.pojo.Field
-import org.apache.arrow.vector.types.pojo.FieldType
-import org.apache.arrow.vector.types.pojo.Schema
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import xtdb.api.Xtdb
 import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
 import xtdb.arrow.Relation
+import xtdb.arrow.VectorType.Companion.I64
+import xtdb.arrow.VectorType.Companion.ofType
 
 class InProcessAdbcTest {
 
@@ -49,6 +45,24 @@ class InProcessAdbcTest {
         }
     }
 
+    private fun queryRows(stmt: AdbcStatement): List<Map<*, *>> =
+        stmt.executeQuery().reader.use { rdr ->
+            assertTrue(rdr.loadNextBatch())
+            Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
+                rel.toMaps(SNAKE_CASE_STRING)
+            }
+        }
+
+    private fun bindLongParam(stmt: AdbcStatement, value: Long) {
+        Relation(al, "\$0" ofType I64).use { rel ->
+            rel.writeRow(mapOf("\$0" to value))
+
+            rel.openAsRoot(al).use { params ->
+                stmt.bind(params)
+            }
+        }
+    }
+
     @Test
     fun `prepare and execute simple query`() {
         insertData("INSERT INTO foo RECORDS {_id: 1, n: 'one'}")
@@ -58,16 +72,7 @@ class InProcessAdbcTest {
                 stmt.setSqlQuery("SELECT _id, n FROM foo")
                 stmt.prepare()
 
-                stmt.executeQuery().reader.use { rdr ->
-                    assertTrue(rdr.loadNextBatch())
-                    Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
-                        assertEquals(
-                            listOf(mapOf("_id" to 1L, "n" to "one")),
-                            rel.toMaps(SNAKE_CASE_STRING)
-                        )
-                    }
-                    assertFalse(rdr.loadNextBatch())
-                }
+                assertEquals(listOf(mapOf("_id" to 1L, "n" to "one")), queryRows(stmt))
             }
         }
     }
@@ -80,31 +85,8 @@ class InProcessAdbcTest {
             conn.createStatement().use { stmt ->
                 stmt.setSqlQuery("SELECT _id FROM foo WHERE _id = ?")
                 stmt.prepare()
-
-                val schema = Schema(listOf(
-                    Field("\$0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
-                ))
-                VectorSchemaRoot.create(schema, al).use { params ->
-                    params.allocateNew()
-                    (params.getVector("\$0") as BigIntVector).apply {
-                        setSafe(0, 2L)
-                        valueCount = 1
-                    }
-                    params.rowCount = 1
-
-                    stmt.bind(params)
-
-                    stmt.executeQuery().reader.use { rdr ->
-                        assertTrue(rdr.loadNextBatch())
-                        Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
-                            assertEquals(
-                                listOf(mapOf("_id" to 2L)),
-                                rel.toMaps(SNAKE_CASE_STRING)
-                            )
-                        }
-                        assertFalse(rdr.loadNextBatch())
-                    }
-                }
+                bindLongParam(stmt, 2L)
+                assertEquals(listOf(mapOf("_id" to 2L)), queryRows(stmt))
             }
         }
     }
@@ -132,34 +114,13 @@ class InProcessAdbcTest {
             conn.createStatement().use { stmt ->
                 stmt.setSqlQuery("INSERT INTO foo (_id) VALUES (?)")
                 stmt.prepare()
-
-                val schema = Schema(listOf(
-                    Field("\$0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
-                ))
-                VectorSchemaRoot.create(schema, al).use { params ->
-                    params.allocateNew()
-                    (params.getVector("\$0") as BigIntVector).apply {
-                        setSafe(0, 42L)
-                        valueCount = 1
-                    }
-                    params.rowCount = 1
-
-                    stmt.bind(params)
-                    stmt.executeUpdate()
-                }
+                bindLongParam(stmt, 42L)
+                stmt.executeUpdate()
             }
 
             conn.createStatement().use { stmt ->
                 stmt.setSqlQuery("SELECT _id FROM foo")
-                stmt.executeQuery().reader.use { rdr ->
-                    assertTrue(rdr.loadNextBatch())
-                    Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
-                        assertEquals(
-                            listOf(mapOf("_id" to 42L)),
-                            rel.toMaps(SNAKE_CASE_STRING)
-                        )
-                    }
-                }
+                assertEquals(listOf(mapOf("_id" to 42L)), queryRows(stmt))
             }
         }
     }
@@ -172,27 +133,9 @@ class InProcessAdbcTest {
             conn.createStatement().use { stmt ->
                 stmt.setSqlQuery("SELECT _id FROM foo WHERE _id = ?")
                 stmt.prepare()
+                bindLongParam(stmt, 2L)
 
-                val schema = Schema(listOf(
-                    Field("\$0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
-                ))
-                VectorSchemaRoot.create(schema, al).use { params ->
-                    params.allocateNew()
-                    (params.getVector("\$0") as BigIntVector).apply {
-                        setSafe(0, 2L)
-                        valueCount = 1
-                    }
-                    params.rowCount = 1
-                    stmt.bind(params)
-                }
-
-                fun runOnce(): List<*> =
-                    stmt.executeQuery().reader.use { rdr ->
-                        rdr.loadNextBatch()
-                        Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
-                            rel.toMaps(SNAKE_CASE_STRING)
-                        }
-                    }
+                fun runOnce(): List<Map<*, *>> = queryRows(stmt)
 
                 val expected = listOf(mapOf("_id" to 2L))
                 assertEquals(expected, runOnce(), "first execute")
@@ -209,31 +152,15 @@ class InProcessAdbcTest {
             conn.createStatement().use { stmt ->
                 stmt.setSqlQuery("SELECT _id FROM foo WHERE _id = ?")
                 stmt.prepare()
-                val paramSchema = Schema(listOf(
-                    Field("\$0", FieldType.notNullable(Types.MinorType.BIGINT.type), null)
-                ))
-                VectorSchemaRoot.create(paramSchema, al).use { params ->
-                    params.allocateNew()
-                    (params.getVector("\$0") as BigIntVector).apply {
-                        setSafe(0, 1L)
-                        valueCount = 1
-                    }
-                    params.rowCount = 1
-                    stmt.bind(params)
-                }
+                bindLongParam(stmt, 1L)
 
                 stmt.setSqlQuery("SELECT _id FROM foo")
                 stmt.prepare()
-                stmt.executeQuery().reader.use { rdr ->
-                    assertTrue(rdr.loadNextBatch())
-                    Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
-                        assertEquals(
-                            listOf(mapOf("_id" to 1L)),
-                            rel.toMaps(SNAKE_CASE_STRING),
-                            "stale bind from prior SQL must not leak into new SQL"
-                        )
-                    }
-                }
+                assertEquals(
+                    listOf(mapOf("_id" to 1L)),
+                    queryRows(stmt),
+                    "stale bind from prior SQL must not leak into new SQL"
+                )
             }
         }
     }

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -6,6 +6,7 @@ import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -140,6 +141,31 @@ class InProcessAdbcTest {
                 val expected = listOf(mapOf("_id" to 2L))
                 assertEquals(expected, runOnce(), "first execute")
                 assertEquals(expected, runOnce(), "second execute reuses the same bind")
+            }
+        }
+    }
+
+    @Test
+    fun `executeQuery without prepare fails loud when parameters are bound`() {
+        // Locks in the contract: bind without prepare is ambiguous for queries
+        // (node.openSqlQuery has no args parameter), so we refuse to silently drop
+        // the bind and instead force the caller to prepare() first.
+        xtdb.connect().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("SELECT _id FROM foo WHERE _id = ?")
+                // deliberately skip prepare(); bind directly with the planner-known shape
+                Relation(al, "\$0" ofType I64).use { rel ->
+                    rel.writeRow(mapOf("\$0" to 1L))
+                    rel.openAsRoot(al).use { stmt.bind(it) }
+                }
+
+                val ex = assertThrows(IllegalStateException::class.java) {
+                    stmt.executeQuery()
+                }
+                assertTrue(
+                    ex.message?.contains("prepare") == true,
+                    "expected prepare-required message, got: ${ex.message}"
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

Implements the `AdbcStatement` prepare→bind→execute lifecycle on the in-process ADBC path (`XtdbConnection`).
A JVM caller using `xtdb.connect()` can now drive the canonical ADBC tutorial shape — `setSqlQuery → prepare → bind → executeQuery|executeUpdate` — for both queries and DML.
Previously every step except `setSqlQuery` either threw `TODO("Not yet implemented")` or returned `NOT_IMPLEMENTED`.

This is the first half of #5270.
The second half — folding FlightSQL's `XtdbProducer.PreparedStatement` onto this same implementation so FSQL becomes a thin protocol shim — is a follow-up PR (#5554).

## Changes

Commits, smallest viable slice first:

1. `feat(adbc): implement AdbcStatement.prepare on XtdbConnection` — the no-param query case; smallest atomic step that closes the TODO and gives us a regression net.
2. `feat(adbc): support bound parameters` — `bind(VSR)` and `bind(RelationReader)`.
3. `feat(adbc): implement getParameterSchema and rename bound params to planner convention` — discoverability, plus aligns the in-process path with the FlightSQL `$N` external naming.
4. `feat(adbc): support bound parameters in DML` — `TxOp.SqlBytes` plumbing so parameterised `INSERT/UPDATE/DELETE` actually carries its args.
5. `test(adbc): use XT relations in in-process binds` — test rewrite using `xtdb.arrow.Relation` end-to-end, per review feedback ("convert to VSR as late as possible / from VSR as early as possible").
6. `refactor(adbc): use openSlice / openDirectSlice for bind and per-execution args` — addresses Matt's review: re-execution becomes zero-copy on the args path (`openSlice` is a ref-count bump when source and dest share an allocator root).
7. `fix(adbc): bind requires prepare for executeQuery, restore cross-root copy in bind` — addresses the silent-drop-of-bind footgun spotted in review (`bind` without `prepare` now throws); restores the row-by-row copy in `bind` because `openDirectSlice` is only valid same-root, and the ADBC contract doesn't let us dictate the caller's allocator.

## Implementation notes

**Args stored as an `xtdb.arrow.Relation` owned by `node.allocator`.**
`bind(VSR)` delegates to `bind(RelationReader)` (per James's review).
`bind(RelationReader)` row-copies the caller's reader into a fresh `Relation` allocated against `node.allocator`.
This is cross-root safe — Arrow's `transferOwnership` (the cheaper path) only works when the caller's allocator shares a root with ours, and the ADBC contract doesn't let us dictate that.
The row copy is the one-shot cost paid per `bind()`.

**Per-execute args path is zero-copy.**
`openQueryArgs` (called inside `executeQuery` / `executeUpdate`) does `args.openSlice(node.allocator)` — same-root by construction, so just bumps ref counts on the underlying buffers.
Re-executing the same prepared plan with the same bind doesn't copy data.

**`$N` parameter naming.** External clients see columns named `$0, $1, ...` in the parameter schema; internally the planner expects `?_0, ?_1, ...`.
`bind` renames by position.
This matches what `XtdbProducer` already does over the FlightSQL wire.
The 0-indexed `$N` is an XTDB choice, not Postgres-faithful — comment at the rename site flags this so a future reader doesn't try to "fix" it.

**Bind without prepare throws on `executeQuery`.**
`node.openSqlQuery` has no `args` parameter — silently falling through would drop the bind and return a result that ignored the caller's parameters.
We throw `IllegalStateException` upfront when args are bound but `prepared` is null, so the failure mode is loud and immediate rather than a wrong result.

**Sticky bind state.** Per the ADBC contract, parameters are bound until either a new `bind()` call is made or `close()` is called.
Two tests lock this in: re-execute with the same bind returns identical results, and `setSqlQuery` clears prior bind so stale args from an earlier SQL don't leak into a new prepare/execute.

**Ownership on the execute path.** `PreparedQuery.openQuery(args, opts)` takes ownership of `args` on success — the cursor wraps them in its closeables list (`xtdb/query.clj`'s `wrap-closeables`).
We only close `queryArgs` ourselves on the throw path.

## Usage

```kotlin
xtdb.connect().use { conn ->
    conn.createStatement().use { stmt ->
        stmt.setSqlQuery("INSERT INTO users (_id, name) VALUES (?, ?)")
        stmt.prepare()

        VectorSchemaRoot.create(stmt.parameterSchema, allocator).use { params ->
            // populate "$0" with id, "$1" with name
            stmt.bind(params)
            stmt.executeUpdate()
        }
    }
}
```

## Out of scope

- **FlightSQL refactor**: `XtdbProducer.PreparedStatement` still has its own parallel copy of prepare/bind/execute.
  Follow-up PR #5554 folds it onto `XtdbStatement` so the in-process and over-the-wire paths share one implementation.
- **Parameter type inference**: `getParameterSchema()` returns the `Null` placeholder type pre-bind; concrete inferred types would need `PreparedQuery.getColumnFields(paramFields)` integration.
- **`affectedRows`**: `executeUpdate` returns `-1`, not the actual row count.
- **Multi-row "execute many"**: bind state holds a single batch; ADBC supports binding N rows for N executions of the same plan, but XTDB's `openQuery` doesn't surface that today.

## Test plan

- New `xtdb.InProcessAdbcTest` (in-process surface, exercising `XtdbConnection.createStatement()` directly via `xtdb.connect()`):
  - `prepare and execute simple query`
  - `prepare with bound parameter`
  - `getParameterSchema reports columns in $N convention`
  - `prepared DML with bound parameters`
  - `bind state is sticky across executes` — re-execute returns identical results without re-binding
  - `setSqlQuery clears prior bind` — stale args from previous SQL don't leak
  - `executeQuery without prepare fails loud when parameters are bound` — locks in the no-silent-drop contract
- `xtdb.api.AdbcTest` (over-the-wire FlightSQL coverage) — all green.
- Full root suite (`./gradlew :test`) — green except `xtdb.read-only-node-test/read-only-node-updates-table-catalog-on-block-flush`, which reproduces on `main` and is unrelated to this branch.
- No reflection or boxed-math warnings.
- ktlint clean on changed files.
