### PR TITLE
build(docker): pre-build jlink stage as a published builder image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,4 +1,29 @@
+// Run from the repo root, naming the target explicitly so `docker buildx bake` (no args)
+// doesn't accidentally rebuild/push everything as more targets get added here:
+//   docker buildx bake <target>              # build only
+//   docker buildx bake <target> --push       # build and push to ghcr.io
+//
+// Multi-arch push needs a buildx builder with both linux/amd64 and linux/arm64 — set one up
+// once with `docker buildx create --use --bootstrap` (and QEMU, if not already installed).
+
 target "bench" {
   context = "modules/bench"
   tags = ["ghcr.io/xtdb/xtdb-bench:latest"]
+}
+
+// xtdb-builder — a pre-built multi-arch image containing a custom JRE, used as the
+// `jlink` stage of docker/Dockerfile so CD doesn't re-run `./gradlew buildCustomJre`
+// (5+ minutes under arm64 emulation) on every build. Bump BUILDER_TAG (and the
+// BUILDER_IMAGE default in docker/Dockerfile) when build-logic/jlink/ or the JDK base
+// image changes.
+
+variable "BUILDER_TAG" {
+  default = "20260429-1"
+}
+
+target "builder" {
+  context = "."
+  dockerfile = "docker/builder.Dockerfile"
+  platforms = ["linux/amd64", "linux/arm64"]
+  tags = ["ghcr.io/xtdb/xtdb-builder:${BUILDER_TAG}"]
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,7 @@
-# Build JRE
-FROM eclipse-temurin:21-jdk-alpine AS jlink
-WORKDIR /build
-COPY gradlew gradlew
-COPY gradle/wrapper gradle/wrapper
-COPY build-logic/jlink/settings.gradle.kts settings.gradle.kts
-COPY build-logic/jlink/build.gradle.kts build.gradle.kts
-RUN chmod +x gradlew && ./gradlew buildCustomJre --no-daemon
+# Pre-built custom JRE — see docker/builder.Dockerfile and the repo-root docker-bake.hcl.
+# Bump the default (and the matching TAG in the bake file) when build-logic/jlink/ or the JDK base image changes.
+ARG BUILDER_IMAGE=ghcr.io/xtdb/xtdb-builder:20260429-1
+FROM ${BUILDER_IMAGE} AS jlink
 
 # Runtime
 FROM alpine:3.23.3
@@ -27,7 +23,7 @@ LABEL usage="For custom logging: \
 # For healthcheck
 RUN apk add --no-cache wget gcompat
 
-COPY --from=jlink /build/build/custom-jre /opt/java
+COPY --from=jlink /opt/java /opt/java
 ENV PATH="/opt/java/bin:$PATH"
 ENV JAVA_HOME="/opt/java"
 

--- a/docker/README.adoc
+++ b/docker/README.adoc
@@ -13,6 +13,47 @@
 If you wish to build the local image with a different default configuration included, you can change the content of the `standalone/local_config.edn` file prior to building, or create a new file and replace references to `local_config.edn` with the new config file.
 The created uberjar should have all XTDB modules included, so the node can be configured however you wish.
 
+== Builder image (custom JRE)
+
+The `jlink` stage of `docker/Dockerfile` is pre-built and published as `ghcr.io/xtdb/xtdb-builder:<tag>` so CD doesn't re-run `./gradlew buildCustomJre` on every build (it takes ~5 min on `linux/arm64` under emulation).
+
+The builder content depends only on:
+
+* the JDK base image (`eclipse-temurin:21-jdk-alpine` in `docker/builder.Dockerfile`)
+* `build-logic/jlink/` (the jlink module list and gradle wrapper inputs)
+
+When either changes, bump the tag and rebuild (from the repo root):
+
+. Pick a new tag, e.g. `YYYYMMDD-N`.
+. Update `BUILDER_TAG` in `docker-bake.hcl` (repo root) *and* the `BUILDER_IMAGE` default in `docker/Dockerfile` to match.
+. Authenticate to ghcr.io (see below).
+. `docker buildx bake builder --push`
+. Commit the bumped tag.
+
+Drop `--push` to build locally without publishing.
+Multi-arch push needs a buildx builder with both `linux/amd64` and `linux/arm64` — `docker buildx create --use --bootstrap` (with QEMU installed) is enough.
+
+=== One-time setup: ghcr.io auth via `gh`
+
+The simplest way to authenticate is to reuse the OAuth token from the GitHub CLI rather than minting a separate PAT.
+Pair it with a Docker https://docs.docker.com/engine/reference/commandline/login/#credential-stores[credential store] (e.g. `pass` or `secretservice` on Linux, `osxkeychain` on macOS) so the token isn't sat in `~/.docker/config.json` in plaintext.
+
+. Grant the `gh` token the package scopes (one-off):
++
+[source,bash]
+----
+gh auth refresh -h github.com -s write:packages,read:packages
+----
+
+. Set up a credential store per the Docker docs above, then log in (the token goes straight into the store):
++
+[source,bash]
+----
+gh auth token | docker login ghcr.io -u "$(gh api user --jq .login)" --password-stdin
+----
+
+The `gh` OAuth token is long-lived, so this only needs redoing if you `gh auth logout` or rotate scopes — in which case `docker logout ghcr.io` and repeat the login.
+
 == Docker compose setup
 
 There is a docker compose setup under link:docker-compose[docker-compose]. It uses https://min.io/[minio] for object storage and confluence kafka (with KRaft, so no Zookeper needed). It uses the `xtdb-aws` image but hooks in a tweaked config especially for `minio`. It should then be as simple as running `docker-compose up` in the `docker-compose` folder. When shutting down or restarting from scratch it is likely useful to run `docker-compose down --volumes --rmi all --remove-orphans` to remove any dangling dependencies.

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -1,0 +1,18 @@
+# Builds a custom JRE via jlink and packages just the JRE into a scratch image.
+# The resulting image is consumed by docker/Dockerfile as a `FROM ... AS jlink` source.
+#
+# Bump the tag in docker-bake.hcl AND the BUILDER_IMAGE default in docker/Dockerfile
+# whenever build-logic/jlink/ or the JDK base image changes, then rebuild via
+#   docker buildx bake builder --push
+# from the repo root. See docker/README.adoc for full instructions.
+
+FROM eclipse-temurin:21-jdk-alpine AS jlink
+WORKDIR /build
+COPY gradlew gradlew
+COPY gradle/wrapper gradle/wrapper
+COPY build-logic/jlink/settings.gradle.kts settings.gradle.kts
+COPY build-logic/jlink/build.gradle.kts build.gradle.kts
+RUN chmod +x gradlew && ./gradlew buildCustomJre --no-daemon
+
+FROM scratch
+COPY --from=jlink /build/build/custom-jre /opt/java


### PR DESCRIPTION
## Summary

Cuts ~5 min off every CD docker build by replacing the inline `jlink` stage with a pre-published multi-arch builder image at `ghcr.io/xtdb/xtdb-builder:<tag>`.

## Context

Reading the timing on a recent edge build:

- `[linux/amd64 jlink 7/7] RUN ./gradlew buildCustomJre`: ~52s.
- `[linux/arm64 jlink 7/7] RUN ./gradlew buildCustomJre`: ~349s.

That step's inputs (`gradlew`, `gradle/wrapper`, `build-logic/jlink/`) only change when we touch the jlink module list or the JDK base image — every other build is redoing identical work, with QEMU emulation dominating the arm64 leg.

## Approach

Pull the jlink stage out into `docker/builder.Dockerfile` and publish it as a multi-arch image at `ghcr.io/xtdb/xtdb-builder:<tag>`.
The main `docker/Dockerfile` becomes:

```dockerfile
ARG BUILDER_IMAGE=ghcr.io/xtdb/xtdb-builder:20260429-1
FROM ${BUILDER_IMAGE} AS jlink
...
COPY --from=jlink /opt/java /opt/java
```

CD pulls layers instead of rebuilding the JRE.

## Implementation notes

- `docker/builder.Dockerfile`'s final stage is `FROM scratch` containing only `/opt/java`, so `COPY --from=jlink` is cheap and the published image isn't carrying unused JDK runtime.
- The bake target is added to the existing repo-root `docker-bake.hcl` (alongside `bench`). Repo-root location matters: the Dockerfile context spans `gradlew`, `gradle/wrapper`, and `build-logic/jlink/` from the root, so `context = "."` works with `docker buildx bake builder` from the repo root, without buildx's `fs.read` entitlement flag.
- The README documents `docker buildx bake builder ...` with the target named explicitly so `bake` (no args) doesn't drag the `bench` target along as more targets accrue here.
- The `BUILDER_IMAGE` ARG in the Dockerfile and the `BUILDER_TAG` variable in the bake file have to be bumped together — the README spells the workflow out.

## Action required — one-time setup for the team

Anyone who needs to rebuild and push the builder image (when `build-logic/jlink/` or the JDK base image bumps) needs to follow the one-time setup in `docker/README.adoc` once: `gh auth refresh -s write:packages,read:packages` to scope the existing `gh` token, plus a Docker credential store of choice (`pass`, `secretservice`, `osxkeychain`, …) so the OAuth token isn't sat in `~/.docker/config.json` in plaintext.

## Test plan

- [x] `ghcr.io/xtdb/xtdb-builder:20260429-1` published (multi-arch — amd64 + arm64).
- [ ] CI on this PR builds the four image variants successfully against the new builder.