### PR TITLE
fix(test): fix flaky test-metrics assertion on optional percentile keys

### DIFF
--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -447,9 +447,7 @@
 
 (t/deftest test-metrics
   (let [res (xt/q tu/*node* "SELECT * FROM xt.metrics_timers")]
-    (t/is (= #{:name :tags :count
-               :mean-time :p75-time :p95-time :p99-time :p999-time :max-time}
-             (set (keys (first res)))))
+    (t/is (every? #(set/subset? #{:name :tags :count} (set (keys %))) res))
 
     (t/is (empty? (set/difference #{"tx.op.timer", "query.timer", "compactor.job.timer"}
                                   (into #{} (map :name) res)))


### PR DESCRIPTION
Not all timers in the registry are configured with the same percentiles. TrieGarbageCollector and BlockGarbageCollector publish [0.75, 0.95, 0.99] while most other timers (via metrics/add-timer) publish [0.75, 0.85, 0.95, 0.98, 0.99, 0.999].

The test used `(first res)` and asserted an exact key set including `:p999-time`, but meter ordering from the registry is non-deterministic — when a GC timer happened to come first, the assertion failed.

The schema already declares the percentile columns as optional (`[:? :duration :nano]`), so the fix checks that every timer row has the required non-optional keys rather than asserting an exact set on an arbitrary row.