### PR TITLE
fix(cache): fix two buffer leak paths on cancellation in MemoryCache

### DIFF
--- a/core/src/main/kotlin/xtdb/cache/MemoryCache.kt
+++ b/core/src/main/kotlin/xtdb/cache/MemoryCache.kt
@@ -108,7 +108,7 @@ class MemoryCache @JvmOverloads internal constructor(
 
             if (openSlice != null) {
                 LOGGER.trace("FetchReq: Fast path cache hit for $pathSlice")
-                res.complete(openSlice)
+                if (!res.complete(openSlice)) openSlice.referenceManager.release()
             } else {
                 yieldIfSimulation() // interleave between openSlice check and compute
                 val path = pathSlice.path
@@ -222,9 +222,9 @@ class MemoryCache @JvmOverloads internal constructor(
         yieldIfSimulation() // interleave between cache check and fetch request
 
         val res = CompletableDeferred<ArrowBuf>()
-        fetchCh.send(FetchReq(pathSlice, fetch, res))
 
         return try {
+            fetchCh.send(FetchReq(pathSlice, fetch, res))
             res.await()
         } catch (e: Throwable) {
             res.cancel()

--- a/core/src/test/kotlin/xtdb/cache/CacheSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/cache/CacheSimulationTest.kt
@@ -209,6 +209,29 @@ class CacheSimulationTest : SimulationTestBase() {
 
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    fun `cancelled fetch on cache hit does not leak`(iteration: Int) = runTest {
+        val loader = TestPathLoader()
+        MemoryCache(allocator, 250, loader, dispatcher).use { cache ->
+            val path = Path.of("test/100")
+            val slice = Slice(0, 100)
+
+            async(dispatcher) {
+                val jobs = (0..1).map {
+                    launch {
+                        cache.get(path, slice) { it to null }.use { yield() }
+                    }
+                }
+                yield()
+                jobs.forEach { it.cancel() }
+                jobs.forEach { it.join() }
+            }.await()
+
+            assertEquals(MemoryCache.Stats(0L, 250L), cache.stats0)
+        }
+    }
+
+    @RepeatableSimulationTest
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
     fun `deterministic concurrent fetches with some OOMs`() = runTest {
         val loader = TestPathLoader()
         MemoryCache(allocator, 100L, loader, dispatcher).use { cache ->


### PR DESCRIPTION
Two races between coroutine cancellation and buffer handoff in `get()`, both caused by `res.complete(buf)` returning `true` on an effectively orphaned `CompletableDeferred` — the caller is gone but nobody releases the buffer.

### FetchReq fast-path (cancel before complete)

Cancellation lands during `res.await()`, the catch block cancels the deferred, but the fetch loop then processes the `FetchReq`, hits the cache fast-path, retains the buffer, and `res.complete()` returns false.
`FetchDone.handle()` already had the `if (!complete) release` guard; the `FetchReq` fast-path was missing it.

### Cancellation during send (cancel before await)

Cancellation lands during `fetchCh.send()` — after the rendezvous delivers the `FetchReq` but before the caller reaches `res.await()`.
The `CancellationException` propagates from `send()`, completely bypassing the `try { res.await() }` catch block that calls `res.cancel()`.
The deferred is never cancelled, so `FetchDone.handle()` completes it successfully (`complete()` returns true, no release) and the buffer is orphaned.
Moving `send()` inside the try block ensures the catch covers both paths.

### Ownership protocol

`res.complete()` is the linearisation point for buffer ownership: the producer (fetch loop) and consumer (`get()` caller) each handle cleanup for the side of the race they lose.
The two fixes close the remaining gaps in that protocol.

### Test

DST simulation test that launches two concurrent fetches for the same cold path, cancels both, and asserts zero leaked bytes.
Not every seed exercises the race (~6% hit rate for the fast-path variant, higher for the send variant), but across 100 iterations it reliably catches both leaks.

Fixes #4262