### PR TITLE
feat!(sql): make GENERATE_SERIES end-inclusive (#5382)

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -399,7 +399,7 @@ columnReference : identifierChain ;
 
 /// generate_series function
 
-generateSeries : (identifier '.')? ('GENERATE_SERIES' | 'RANGE') '(' seriesStart=expr ',' seriesEnd=expr (',' seriesStep=expr)? ')' ;
+generateSeries : (identifier '.')? fn=(GENERATE_SERIES | RANGE) '(' seriesStart=expr ',' seriesEnd=expr (',' seriesStep=expr)? ')' ;
 
 /// §6.10 <window function>
 

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -2336,21 +2336,30 @@
                                               false
                                               (recur (inc ~n-sym)))))))))))}))
 
-(defn series [^long start, ^long end, ^long step]
-  (let [box (ValueBox.)]
+(defn series [^long start, ^long end, ^long step, inclusive?]
+  (let [box (ValueBox.)
+        end (long (if inclusive? (+ end (Long/signum step)) end))
+        size (Math/toIntExact (Math/max 0 (Math/ceilDiv (Math/subtractExact end start) step)))]
     (reify ListValueReader
-      (size [_]
-        (Math/max (int 0)
-                  (int (Math/ceil (/ (Math/subtractExact end start) step)))))
+      (size [_] size)
 
       (nth [_ idx]
         (doto box
           (.writeLong (+ start (* step idx))))))))
 
-(defmethod codegen-call [:generate_series :int :int :int] [_]
+(defn delegate-exclusive-default
+  "Delegates a 3-arg codegen-call to its 4-arg variant, defaulting inclusive? to false."
+  [expr]
+  (let [{:keys [->call-code] :as result} (codegen-call (update expr :arg-types conj (types/->type :bool)))]
+    (assoc result :->call-code (fn [args] (->call-code (conj (vec args) false))))))
+
+(defmethod codegen-call [:generate_series :int :int :int] [expr]
+  (delegate-exclusive-default expr))
+
+(defmethod codegen-call [:generate_series :int :int :int :bool] [_]
   {:return-type #xt/type [:list :i64]
-   :->call-code (fn [[start end step]]
-                  `(series (long ~start) (long ~end) (long ~step)))})
+   :->call-code (fn [[start end step inclusive?]]
+                  `(series (long ~start) (long ~end) (long ~step) (boolean ~inclusive?)))})
 
 (defmethod codegen-call [:== :set :set] [_]
   (throw (UnsupportedOperationException. "TODO: `==` on sets")))

--- a/core/src/main/clojure/xtdb/expression/temporal.clj
+++ b/core/src/main/clojure/xtdb/expression/temporal.clj
@@ -742,8 +742,10 @@
 (defn- recall-with-cast3
   ([expr cast1 cast2 cast3] (recall-with-cast3 expr cast1 cast2 cast3 expr/codegen-call))
 
-  ([{[t1 t2 t3] :arg-types, :as expr} cast1 cast2 cast3 f]
-   (let [cast1-vec (if (instance? VectorType cast1) cast1 (types/->type cast1))
+  ([{arg-types :arg-types, :as expr} cast1 cast2 cast3 f]
+   (let [rest-types (subvec (vec arg-types) 3)
+         [t1 t2 t3] arg-types
+         cast1-vec (if (instance? VectorType cast1) cast1 (types/->type cast1))
          cast2-vec (if (instance? VectorType cast2) cast2 (types/->type cast2))
          cast3-vec (if (instance? VectorType cast3) cast3 (types/->type cast3))
          {ret1 :return-type, bb1 :batch-bindings, ->cc1 :->call-code}
@@ -753,11 +755,13 @@
          {ret3 :return-type, bb3 :batch-bindings, ->cc3 :->call-code}
          (expr/codegen-cast {:source-type t3, :target-type cast3-vec})
          {ret :return-type, bb :batch-bindings, ->cc :->call-code}
-         (f (assoc expr :arg-types [ret1 ret2 ret3]))]
+         (f (assoc expr :arg-types (into [ret1 ret2 ret3] rest-types)))]
      {:return-type ret
       :batch-bindings (concat bb1 bb2 bb3 bb)
-      :->call-code (fn [[a1 a2 a3]]
-                     (->cc [(->cc1 [a1]) (->cc2 [a2]) (->cc3 [a3])]))})))
+      :->call-code (fn [args]
+                     (let [[a1 a2 a3] args
+                           rest-args (subvec (vec args) 3)]
+                       (->cc (into [(->cc1 [a1]) (->cc2 [a2]) (->cc3 [a3])] rest-args))))})))
 
 (defn- recall-with-flipped-args [expr]
   (let [{ret-type :return-type, bb :batch-bindings, ->cc :->call-code}
@@ -2165,20 +2169,23 @@
      :->call-code (fn [[i-code from-code to-code origin-code]]
                     (->call-code [i-code (->from-code [from-code]) (->to-code [to-code]) (->origin-code [origin-code])]))}))
 
-(defn date-series [^LocalDate from, ^LocalDate to, ^PeriodDuration stride]
+(defn date-series [^LocalDate from, ^LocalDate to, ^PeriodDuration stride, inclusive?]
   (assert (= Duration/ZERO (.getDuration stride))
           "date-series only supports zero-duration strides")
 
   (let [period (.getPeriod stride)
         months (+ (* (.getYears period) 12) (.getMonths period))
         el-box (ValueBox.)
+        pred (if inclusive?
+               #(not (pos? (compare % to)))
+               #(neg? (compare % to)))
 
         ;; we eagerly evaluate here because (unlike the ints version)
         ;; every entry will need to calculate the one before anyway
         res (->> (iterate (fn [^LocalDate acc]
                             (.plusMonths acc months))
                           from)
-                 (into [] (take-while #(neg? (compare % to)))))]
+                 (into [] (take-while pred)))]
 
     (reify ListValueReader
       (size [_]
@@ -2188,7 +2195,10 @@
         (doto el-box
           (.writeLong (.toEpochDay ^LocalDate (nth res idx))))))))
 
-(defmethod expr/codegen-call [:generate_series :date :date :interval] [{[from-type to-type ^VectorType$Mono i-type-vec] :arg-types, :as expr}]
+(defmethod expr/codegen-call [:generate_series :date :date :interval] [expr]
+  (expr/delegate-exclusive-default expr))
+
+(defmethod expr/codegen-call [:generate_series :date :date :interval :bool] [{[from-type to-type ^VectorType$Mono i-type-vec] :arg-types, :as expr}]
   (let [from-unit (st/date-type->unit from-type)
         to-unit (st/date-type->unit to-type)
         i-unit (st/interval-type->unit i-type-vec)]
@@ -2200,22 +2210,25 @@
 
     (case i-unit
       :year-month {:return-type #xt/type [:list [:date :day]]
-                   :->call-code (fn [[x-arg y-arg stride]]
-                                  `(date-series (LocalDate/ofEpochDay ~x-arg) (LocalDate/ofEpochDay ~y-arg) ~stride))}
+                   :->call-code (fn [[x-arg y-arg stride inclusive?]]
+                                  `(date-series (LocalDate/ofEpochDay ~x-arg) (LocalDate/ofEpochDay ~y-arg) ~stride (boolean ~inclusive?)))}
       :month-day-micro (recall-with-cast3 expr [:timestamp-local :micro] [:timestamp-local :micro] [:interval :month-day-micro])
       :month-day-nano (recall-with-cast3 expr [:timestamp-local :nano] [:timestamp-local :nano] [:interval :month-day-nano]))))
 
-(defn ts-series [^LocalDateTime from, ^LocalDateTime to, ^PeriodDuration stride, write-ldt]
+(defn ts-series [^LocalDateTime from, ^LocalDateTime to, ^PeriodDuration stride, write-ldt, inclusive?]
   (let [period (.getPeriod stride)
         duration (.getDuration stride)
         el-box (ValueBox.)
+        pred (if inclusive?
+               #(not (pos? (compare % to)))
+               #(neg? (compare % to)))
 
         ;; we eagerly evaluate here because (unlike the ints version)
         ;; every entry will need to calculate the one before anyway
         res (->> (iterate (fn [^LocalDateTime acc]
                             (-> acc (.plus period) (.plus duration)))
                           from)
-                 (into [] (take-while #(neg? (compare % to)))))]
+                 (into [] (take-while pred)))]
 
     (reify ListValueReader
       (size [_] (count res))
@@ -2224,7 +2237,10 @@
         (doto el-box
           (write-ldt (nth res idx)))))))
 
-(defmethod expr/codegen-call [:generate_series :timestamp-local :timestamp-local :interval] [{[^VectorType$Mono from-type, ^VectorType$Mono to-type, ^VectorType$Mono i-type] :arg-types}]
+(defmethod expr/codegen-call [:generate_series :timestamp-local :timestamp-local :interval] [expr]
+  (expr/delegate-exclusive-default expr))
+
+(defmethod expr/codegen-call [:generate_series :timestamp-local :timestamp-local :interval :bool] [{[^VectorType$Mono from-type, ^VectorType$Mono to-type, ^VectorType$Mono i-type] :arg-types}]
   (let [from-unit (st/timestamp-type->unit from-type)
         to-unit (st/timestamp-type->unit to-type)
         i-unit (st/interval-type->unit i-type)
@@ -2234,25 +2250,29 @@
                                            :month-day-nano :nano
                                            :month-day-micro :micro))]
     {:return-type (st/->type [:list [:timestamp-local out-unit]])
-     :->call-code (fn [[from-arg to-arg i-arg]]
+     :->call-code (fn [[from-arg to-arg i-arg inclusive?]]
                     (-> `(ts-series ~(ts->ldt from-arg from-unit)
                                     ~(ts->ldt to-arg to-unit)
                                     ~i-arg
                                     ~(let [ldt-sym (gensym 'ldt)]
                                        `(fn ~'write-ldt [^ValueBox box#, ~(-> ldt-sym (expr/with-tag LocalDateTime))]
-                                          (.writeLong box# ~(ldt->ts ldt-sym out-unit)))))))}))
+                                          (.writeLong box# ~(ldt->ts ldt-sym out-unit))))
+                                    (boolean ~inclusive?))))}))
 
-(defn tstz-series [^ZonedDateTime from, ^ZonedDateTime to, ^PeriodDuration stride, write-zdt]
+(defn tstz-series [^ZonedDateTime from, ^ZonedDateTime to, ^PeriodDuration stride, write-zdt, inclusive?]
   (let [period (.getPeriod stride)
         duration (.getDuration stride)
         el-box (ValueBox.)
+        pred (if inclusive?
+               #(not (pos? (compare % to)))
+               #(neg? (compare % to)))
 
         ;; we eagerly evaluate here because (unlike the ints version)
         ;; every entry will need to calculate the one before anyway
         res (->> (iterate (fn [^ZonedDateTime acc]
                             (-> acc (.plus period) (.plus duration)))
                           from)
-                 (into [] (take-while #(neg? (compare % to)))))]
+                 (into [] (take-while pred)))]
 
     (reify ListValueReader
       (size [_] (count res))
@@ -2261,7 +2281,10 @@
         (doto el-box
           (write-zdt (nth res idx)))))))
 
-(defmethod expr/codegen-call [:generate_series :timestamp-tz :timestamp-tz :interval] [{[^VectorType$Mono from-type, ^VectorType$Mono to-type, ^VectorType$Mono i-type] :arg-types}]
+(defmethod expr/codegen-call [:generate_series :timestamp-tz :timestamp-tz :interval] [expr]
+  (expr/delegate-exclusive-default expr))
+
+(defmethod expr/codegen-call [:generate_series :timestamp-tz :timestamp-tz :interval :bool] [{[^VectorType$Mono from-type, ^VectorType$Mono to-type, ^VectorType$Mono i-type] :arg-types}]
   (let [from-unit (st/timestamp-type->unit from-type)
         to-unit (st/timestamp-type->unit to-type)
         from-tz (st/timestamp-type->tz from-type)
@@ -2276,12 +2299,13 @@
         out-tz (if (= from-tz to-tz) from-tz "UTC")]
     {:return-type (st/->type [:list [:timestamp-tz out-unit out-tz]])
      :batch-bindings [[out-tz-sym (ZoneId/of out-tz)]]
-     :->call-code (fn [[from-arg to-arg i-arg]]
+     :->call-code (fn [[from-arg to-arg i-arg inclusive?]]
                     (-> `(tstz-series ~(ts->zdt from-arg from-unit out-tz-sym)
                                       ~(ts->zdt to-arg to-unit out-tz-sym)
                                       ~i-arg
                                       ~(let [zdt-sym (gensym 'zdt)]
                                          `(fn ~'write-zdt [^ValueBox box#, ~(-> zdt-sym (expr/with-tag ZonedDateTime))]
-                                            (.writeLong box# ~(zdt->ts zdt-sym out-unit)))))))}))
+                                            (.writeLong box# ~(zdt->ts zdt-sym out-unit))))
+                                      (boolean ~inclusive?))))}))
 
 

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -25,7 +25,7 @@
            (org.antlr.v4.runtime ParserRuleContext)
            (org.apache.arrow.vector.types.pojo Field)
            (org.apache.commons.codec.binary Hex)
-           (xtdb.antlr Sql$DirectlyExecutableStatementContext Sql$GroupByClauseContext Sql$HavingClauseContext Sql$JoinSpecificationContext Sql$JoinTypeContext Sql$ObjectNameAndValueContext Sql$OrderByClauseContext Sql$QualifiedRenameColumnContext Sql$QueryBodyTermContext Sql$QuerySpecificationContext Sql$QueryTailContext Sql$RenameColumnContext Sql$SearchedWhenClauseContext Sql$SelectClauseContext Sql$SetClauseContext Sql$SimpleWhenClauseContext Sql$SortSpecificationContext Sql$SortSpecificationListContext Sql$WhenOperandContext Sql$WhereClauseContext Sql$WithTimeZoneContext SqlVisitor)
+           (xtdb.antlr Sql$DirectlyExecutableStatementContext Sql$GroupByClauseContext Sql$HavingClauseContext Sql$JoinSpecificationContext Sql$JoinTypeContext Sql$ObjectNameAndValueContext Sql$OrderByClauseContext Sql$QualifiedRenameColumnContext Sql$QueryBodyTermContext Sql$QuerySpecificationContext Sql$QueryTailContext Sql$RenameColumnContext Sql$SearchedWhenClauseContext Sql$SelectClauseContext Sql$SetClauseContext Sql$SimpleWhenClauseContext Sql$SortSpecificationContext Sql$SortSpecificationListContext Sql$WhenOperandContext Sql$WhereClauseContext Sql$WithTimeZoneContext SqlLexer SqlVisitor)
            xtdb.table.TableRef
            xtdb.util.StringUtil))
 
@@ -1244,6 +1244,11 @@
                             "PostgreSQL JSON operators currently only support string/integer literal field names"
                             {:obj-expr obj-expr :field-expr field-expr}))))
 
+(def ^:dynamic *generate-series-end-exclusive?*
+  ;; Pre-2.2 escape hatch: GENERATE_SERIES used to be end-exclusive, like RANGE.
+  ;; Set XTDB_GENERATE_SERIES_END_EXCLUSIVE=true to keep that behaviour while migrating queries to RANGE.
+  (some-> (System/getenv "XTDB_GENERATE_SERIES_END_EXCLUSIVE") Boolean/parseBoolean))
+
 (defrecord ExprPlanVisitor [env scope]
   SqlVisitor
   (visitSearchCondition [this ctx] (list* 'and (mapv (partial accept-visitor this) (.expr ctx))))
@@ -1826,10 +1831,13 @@
     (.accept (.generateSeries ctx) this))
 
   (visitGenerateSeries [this ctx]
-    (xt/template (generate_series ~(.accept (.seriesStart ctx) this)
-                                  ~(.accept (.seriesEnd ctx) this)
-                                  ~(or (some-> (.seriesStep ctx) (.accept this))
-                                       1))))
+    (let [inclusive? (and (not= SqlLexer/RANGE (.getType (.fn ctx)))
+                          (not *generate-series-end-exclusive?*))]
+      (xt/template (generate_series ~(.accept (.seriesStart ctx) this)
+                                    ~(.accept (.seriesEnd ctx) this)
+                                    ~(or (some-> (.seriesStep ctx) (.accept this))
+                                         1)
+                                    ~inclusive?))))
 
   (visitObjectExpr [this ctx] (.accept (.objectConstructor ctx) this))
 

--- a/docs/src/content/docs/reference/main/stdlib/table.md
+++ b/docs/src/content/docs/reference/main/stdlib/table.md
@@ -2,36 +2,62 @@
 title: Table functions
 ---
 
+<details>
+<summary>Changelog (last updated v2.2)</summary>
+
+v2.2: `GENERATE_SERIES` is end-inclusive
+
+: `GENERATE_SERIES(start, end)` now includes `end` in its output, matching PostgreSQL and DuckDB.
+
+  Previously, `GENERATE_SERIES` was end-exclusive — equivalent to the new `RANGE` function.
+
+  Upgrade steps:
+
+  - Either: migrate queries from `GENERATE_SERIES` to `RANGE` to keep end-exclusive behaviour.
+  - Or: leave queries as-is and accept the new inclusive semantics — most callers will want this.
+  - Escape hatch: set `XTDB_GENERATE_SERIES_END_EXCLUSIVE=true` on the node to revert `GENERATE_SERIES` to its pre-2.2 (end-exclusive) behaviour while you migrate.
+    `RANGE` is unaffected by this flag.
+
+</details>
+
 Functions usable in the `FROM` clause of a query to produce a relation.
 
 See [`table reference`](/reference/main/sql/queries#table-reference) in the query grammar for how these slot into the wider `FROM` clause alongside `VALUES`, `UNNEST`, sub-queries, and so on.
 
 ## Series-generating functions
 
-`GENERATE_SERIES(start, end [, stride])`
-: generates a series of values from `start` (inclusive) to `end` (exclusive), with the given `stride`.
+`RANGE(start, end [, stride])` (v2.2+)
+: generates a series of values from `start` (inclusive) to `end` (**exclusive**), with the given `stride`.
 
   - Works over integers (stride defaults to `1`) and temporal types (stride is an `INTERVAL`).
   - Time-zone-aware: if `start`/`end` carry a time-zone, the series honours any daylight-savings transitions between them — note the difference between adding `INTERVAL 'P1D'` (1 calendar day) and `INTERVAL 'PT24H'` (24 hours) across a DST boundary.
   - XTDB's time-zone handling is an extension to PostgreSQL's `generate_series`.
 
   ```sql
-  FROM GENERATE_SERIES(DATE '2020-01-01', DATE '2020-01-04', INTERVAL '1' DAY)
+  FROM RANGE(DATE '2020-01-01', DATE '2020-01-04', INTERVAL '1' DAY)
   -- yields: [DATE '2020-01-01', DATE '2020-01-02', DATE '2020-01-03']
 
-  FROM GENERATE_SERIES(TIMESTAMP '2020-01-01T00:00:00Z',
-                       TIMESTAMP '2020-01-01T01:00:00Z',
-                       INTERVAL 'PT15M')
+  FROM RANGE(TIMESTAMP '2020-01-01T00:00:00Z',
+             TIMESTAMP '2020-01-01T01:00:00Z',
+             INTERVAL 'PT15M')
   -- yields: [00:00Z, 00:15Z, 00:30Z, 00:45Z]
 
-  FROM GENERATE_SERIES(TIMESTAMP '2020-03-29T00:00:00Z[Europe/London]',
-                       TIMESTAMP '2020-03-31T00:00:00+01:00[Europe/London]',
-                       INTERVAL 'P1D')
+  FROM RANGE(TIMESTAMP '2020-03-29T00:00:00Z[Europe/London]',
+             TIMESTAMP '2020-03-31T00:00:00+01:00[Europe/London]',
+             INTERVAL 'P1D')
   -- yields: [2020-03-29T00:00:00Z[Europe/London], 2020-03-30T00:00:00+01:00[Europe/London]]
   ```
 
-`RANGE(start, end [, stride])` (v2.2+)
-: alias for [`GENERATE_SERIES`](#series-generating-functions).
+`GENERATE_SERIES(start, end [, stride])`
+: like `RANGE`, but with an **inclusive** end bound — matching PostgreSQL's `generate_series` semantics.
+
+  ```sql
+  FROM GENERATE_SERIES(1, 4)
+  -- yields: [1, 2, 3, 4]
+
+  FROM GENERATE_SERIES(DATE '2020-01-01', DATE '2020-01-04', INTERVAL '1' DAY)
+  -- yields: [DATE '2020-01-01', DATE '2020-01-02', DATE '2020-01-03', DATE '2020-01-04']
+  ```
 
 ## Scalar functions in FROM
 

--- a/src/test/clojure/xtdb/expression/list_test.clj
+++ b/src/test/clojure/xtdb/expression/list_test.clj
@@ -25,6 +25,18 @@
              (run-test '(generate_series 1 11 1) {}))
           "happy case with generate_series")
 
+    (t/is (= {:vec-type #xt/type :i64
+              :size 11
+              :value [1 2 3 4 5 6 7 8 9 10 11]}
+             (run-test '(generate_series 1 11 1 true) {}))
+          "inclusive")
+
+    (t/is (= {:vec-type #xt/type :i64
+              :size 10
+              :value [1 2 3 4 5 6 7 8 9 10]}
+             (run-test '(generate_series 1 11 1 false) {}))
+          "explicit exclusive")
+
     (t/is (= {:vec-type #xt/type :null
               :size nil
               :value nil}

--- a/src/test/clojure/xtdb/operator/list_test.clj
+++ b/src/test/clojure/xtdb/operator/list_test.clj
@@ -9,6 +9,14 @@
   (t/is (= [{:a 1} {:a 2} {:a 3} {:a 4} {:a 5}]
            (tu/query-ra [:list {:columns '{a (generate_series 1 6 1)}}])))
 
+  (t/is (= [{:a 1} {:a 2} {:a 3} {:a 4} {:a 5} {:a 6}]
+           (tu/query-ra [:list {:columns '{a (generate_series 1 6 1 true)}}]))
+        "inclusive")
+
+  (t/is (= [{:a 1} {:a 2} {:a 3} {:a 4} {:a 5}]
+           (tu/query-ra [:list {:columns '{a (generate_series 1 6 1 false)}}]))
+        "explicit exclusive")
+
   (t/is (= [{:a 1} {:a 2} {:a 3} {:a 4} {:a 5}]
            (tu/query-ra [:top {:limit 5}
                          [:list {:columns '{a (generate_series 1 2000000000 1)}}]]))
@@ -27,7 +35,23 @@
   (t/is (= [{:a 2} {:a 3} {:a 4}]
            (tu/query-ra [:list {:columns '{a (generate_series ?start ?stop ?step)}}]
                         {:args {:start 2 :stop 5 :step 1}}))
-        "generate_series with parameterised start, stop, step"))
+        "generate_series with parameterised start, stop, step")
+
+  (t/is (= [{:a 5} {:a 4} {:a 3} {:a 2}]
+           (tu/query-ra [:list {:columns '{a (generate_series 5 1 -1)}}]))
+        "negative step, exclusive")
+
+  (t/is (= [{:a 5} {:a 4} {:a 3} {:a 2} {:a 1}]
+           (tu/query-ra [:list {:columns '{a (generate_series 5 1 -1 true)}}]))
+        "negative step, inclusive")
+
+  (t/is (= [{:a 10} {:a 7} {:a 4}]
+           (tu/query-ra [:list {:columns '{a (generate_series 10 3 -3)}}]))
+        "negative step with stride")
+
+  (t/is (= []
+           (tu/query-ra [:list {:columns '{a (generate_series 1 5 -1)}}]))
+        "negative step, wrong direction"))
 
 (t/deftest test-batch-boundaries
   (binding [ol/*batch-size* 3]
@@ -56,4 +80,9 @@
     (t/is (= []
              (tu/query-ra [:list {:columns '{a (generate_series 1 1 1)}}]
                           {:preserve-pages? true}))
-          "Should yield no pages with empty list")))
+          "Should yield no pages with empty list")
+
+    (t/is (= [[{:a 1}]]
+             (tu/query-ra [:list {:columns '{a (generate_series 1 1 1 true)}}]
+                          {:preserve-pages? true}))
+          "Inclusive: start == end yields single element")))

--- a/src/test/clojure/xtdb/sql/generate_series_test.clj
+++ b/src/test/clojure/xtdb/sql/generate_series_test.clj
@@ -1,141 +1,12 @@
 (ns xtdb.sql.generate-series-test
   (:require [clojure.test :as t]
             [xtdb.api :as xt]
+            [xtdb.sql :as sql]
             [xtdb.test-util :as tu]))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 
-(t/deftest test-generate-series-3212
-  (t/is (= [{:xs [1 2 3]}]
-           (xt/q tu/*node* "SELECT generate_series(1, 4) xs")))
-
-  (t/is (= [{:xs [1 4 7]}]
-           (xt/q tu/*node* "SELECT generate_series(1, 8, 3) xs")))
-
-  (t/is (= [{:xs []}]
-           (xt/q tu/*node* "SELECT generate_series(10, 3) xs")))
-
-  (t/is (= [{:xs []}]
-           (xt/q tu/*node* "SELECT generate_series(1, 1) xs")))
-
-  (t/is (= [{:xs [1]}]
-           (xt/q tu/*node* "SELECT generate_series(1, 2, 2) xs")))
-
-  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo RECORDS {_id: 1, start: -1, end: 3}"]])
-
-  (t/is (= [{:xs [-1 0 1 2]}]
-           (xt/q tu/*node* "SELECT generate_series(start, end) xs FROM foo"))))
-
-(t/deftest test-generate-series-datetimes-4067
-  (t/testing "DATE"
-    (t/is (= [{:dates []}]
-             (xt/q tu/*node* "SELECT generate_series(DATE '2020-01-01', DATE '2020-01-01', INTERVAL 'P1D') dates"))
-          "single date, should return empty")
-
-    (t/is (= [{:dates [#xt/date-time "2020-01-01T00:00", #xt/date-time "2020-01-02T00:00", #xt/date-time "2020-01-03T00:00"]}]
-             (xt/q tu/*node* "SELECT generate_series(DATE '2020-01-01', DATE '2020-01-04', INTERVAL 'P1D') dates"))
-          "date range")
-
-    #_ ; FIXME reverse order is not supported yet
-    (t/is (= [{:dates [#inst "2020-01-07" #inst "2020-01-06" #inst "2020-01-05" #inst "2020-01-04" #inst "2020-01-03" #inst "2020-01-02"]}]
-             (xt/q tu/*node* "SELECT generate_series(DATE '2020-01-07', DATE '2020-01-01', INTERVAL 'P-1D') dates"))
-          "reverse order")
-
-    (t/is (= [{:date #xt/date-time "2020-01-01T00:00"}
-              {:date #xt/date-time "2020-01-03T00:00"}
-              {:date #xt/date-time "2020-01-05T00:00"}]
-             (xt/q tu/*node* "FROM generate_series(DATE '2020-01-01', DATE '2020-01-07', INTERVAL 'P2D') dates (`date`)"))
-          "multi-day interval")
-
-    (t/is (= [{:date #xt/date-time "2020-01-01T00:00", :idx 1}
-              {:date #xt/date-time "2020-01-03T00:00", :idx 2}
-              {:date #xt/date-time "2020-01-05T00:00", :idx 3}]
-             (xt/q tu/*node* "FROM generate_series(DATE '2020-01-01', DATE '2020-01-07', INTERVAL 'P2D') WITH ORDINALITY dates (`date`, idx)"))
-          "multi-day interval, WITH ORDINALITY")
-
-    (t/is (= [{:dates [#xt/date "2020-01-01", #xt/date "2020-02-01", #xt/date "2020-03-01"]}]
-             (xt/q tu/*node* "SELECT generate_series(DATE '2020-01-01', DATE '2020-04-01', INTERVAL '1' MONTH) dates"))
-          "monthly interval")
-
-    (t/is (= [{:dates [#xt/date "2020-01-01"
-                       #xt/date "2020-02-01"
-                       #xt/date "2020-03-01"]}]
-             (xt/q tu/*node* "SELECT generate_series(DATE '2020-01-01', DATE '2020-04-01', INTERVAL 'P1M') dates"))
-          "monthly interval")
-
-    (t/is (= [{:date #xt/date "2020-01-01"} {:date #xt/date "2021-01-01"}]
-             (xt/q tu/*node* "FROM generate_series(DATE '2020-01-01', DATE '2022-01-01', INTERVAL 'P1Y') dates (`date`)"))
-          "yearly interval")
-
-    (t/is (= [{:date #xt/date "2020-01-01"} {:date #xt/date "2021-01-01"}]
-             (xt/q tu/*node* "FROM generate_series(DATE '2020-01-01', DATE '2022-01-01', INTERVAL '1' YEAR) dates (`date`)"))
-          "yearly interval")
-
-    (t/is (= [{:dates [#xt/date-time "2020-01-01T00:00"
-                       #xt/date-time "2020-01-01T06:00"
-                       #xt/date-time "2020-01-01T12:00"
-                       #xt/date-time "2020-01-01T18:00"]}]
-             (xt/q tu/*node* "SELECT generate_series(DATE '2020-01-01', DATE '2020-01-02', INTERVAL 'PT6H') dates"))
-          "time interval")
-
-    (t/is (= [{:dates [#xt/date-time "2020-01-01T00:00"
-                       #xt/date-time "2020-04-02T23:59:57"
-                       #xt/date-time "2020-07-04T23:59:54"
-                       #xt/date-time "2020-10-06T23:59:51"]}]
-             (xt/q tu/*node* "SELECT generate_series(DATE '2020-01-01', DATE '2021-01-01', INTERVAL 'P3M2DT-3S') dates"))
-          "mixed interval"))
-
-  (t/testing "TIMESTAMP"
-    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00"]}]
-             (xt/q tu/*node* "SELECT generate_series(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-02 00:00:00', INTERVAL 'PT24H') timestamps")))
-
-    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00"
-                            #xt/date-time "2020-01-01T01:00"
-                            #xt/date-time "2020-01-01T02:00"]}]
-             (xt/q tu/*node* "SELECT generate_series(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-01 03:00:00', INTERVAL 'PT1H') timestamps"))
-          "hour steps")
-
-    (t/is (= [{:ts #xt/date-time "2020-01-01T00:00"}
-              {:ts #xt/date-time "2020-01-01T00:00:00.500"}
-              {:ts #xt/date-time "2020-01-01T00:00:01"}
-              {:ts #xt/date-time "2020-01-01T00:00:01.500"}
-              {:ts #xt/date-time "2020-01-01T00:00:02"}
-              {:ts #xt/date-time "2020-01-01T00:00:02.500"}]
-             (xt/q tu/*node* "FROM generate_series(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-01 00:00:03', INTERVAL 'PT0.5S') timestamps (ts)"))
-          "fractional seconds")
-
-    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00", #xt/date-time "2020-02-01T00:00"]}]
-             (xt/q tu/*node* "SELECT generate_series(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-03-01 00:00:00', INTERVAL 'P1M') timestamps"))
-          "monthly interval")
-
-    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00", #xt/date-time "2021-01-01T00:00"]}]
-             (xt/q tu/*node* "SELECT generate_series(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2022-01-01 00:00:00', INTERVAL 'P1Y') timestamps"))
-          "yearly interval")
-
-    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00"
-                            #xt/date-time "2020-04-03T00:00:03"
-                            #xt/date-time "2020-07-05T00:00:06"
-                            #xt/date-time "2020-10-07T00:00:09"]}]
-             (xt/q tu/*node* "SELECT generate_series(TIMESTAMP '2020-01-01T00:00:00', TIMESTAMP '2021-01-01T00:00:00', INTERVAL 'P3M2DT3S') timestamps"))
-          "mixed interval"))
-
-  (t/testing "TIMESTAMPTZ"
-    (t/is (= [{:timestamps [#xt/zoned-date-time "2020-03-28T00:00Z[Europe/London]"
-                            #xt/zoned-date-time "2020-03-29T00:00Z[Europe/London]"
-                            #xt/zoned-date-time "2020-03-30T01:00+01:00[Europe/London]"]}]
-             (xt/q tu/*node* "SELECT generate_series(TIMESTAMP '2020-03-28T00:00:00Z[Europe/London]', TIMESTAMP '2020-03-31T00:00:00+01:00[Europe/London]', INTERVAL 'PT24H') timestamps")))
-
-    (t/is (= [{:ts #xt/zoned-date-time "2020-03-28T00:00Z[Europe/London]"}
-              {:ts #xt/zoned-date-time "2020-03-29T00:00Z[Europe/London]"}
-              {:ts #xt/zoned-date-time "2020-03-30T00:00+01:00[Europe/London]"}]
-             (xt/q tu/*node* "FROM generate_series(TIMESTAMP '2020-03-28T00:00:00Z[Europe/London]', TIMESTAMP '2020-03-31T00:00:00+01:00[Europe/London]', INTERVAL 'P1D') timestamps (ts)")))
-
-    (t/is (= [{:ts #xt/zoned-date-time "2020-03-28T00:00Z[Europe/London]", :idx 1}
-              {:ts #xt/zoned-date-time "2020-03-29T00:00Z[Europe/London]", :idx 2}
-              {:ts #xt/zoned-date-time "2020-03-30T00:00+01:00[Europe/London]", :idx 3}]
-             (xt/q tu/*node* "FROM generate_series(TIMESTAMP '2020-03-28T00:00:00Z[Europe/London]', TIMESTAMP '2020-03-31T00:00:00+01:00[Europe/London]', INTERVAL 'P1D') WITH ORDINALITY timestamps (ts, idx)")))))
-
-(t/deftest test-range
+(t/deftest test-range-3212
   (t/is (= [{:xs [1 2 3]}]
            (xt/q tu/*node* "SELECT range(1, 4) xs")))
 
@@ -148,19 +19,234 @@
   (t/is (= [{:xs []}]
            (xt/q tu/*node* "SELECT range(1, 1) xs")))
 
+  (t/is (= [{:xs [1]}]
+           (xt/q tu/*node* "SELECT range(1, 2, 2) xs")))
+
+  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo RECORDS {_id: 1, start: -1, end: 3}"]])
+
+  (t/is (= [{:xs [-1 0 1 2]}]
+           (xt/q tu/*node* "SELECT range(start, end) xs FROM foo"))))
+
+(t/deftest test-range-datetimes-4067
   (t/testing "DATE"
+    (t/is (= [{:dates []}]
+             (xt/q tu/*node* "SELECT range(DATE '2020-01-01', DATE '2020-01-01', INTERVAL 'P1D') dates"))
+          "single date, should return empty")
+
     (t/is (= [{:dates [#xt/date-time "2020-01-01T00:00", #xt/date-time "2020-01-02T00:00", #xt/date-time "2020-01-03T00:00"]}]
-             (xt/q tu/*node* "SELECT range(DATE '2020-01-01', DATE '2020-01-04', INTERVAL 'P1D') dates"))))
+             (xt/q tu/*node* "SELECT range(DATE '2020-01-01', DATE '2020-01-04', INTERVAL 'P1D') dates"))
+          "date range")
+
+    (t/is (= [{:date #xt/date-time "2020-01-01T00:00"}
+              {:date #xt/date-time "2020-01-03T00:00"}
+              {:date #xt/date-time "2020-01-05T00:00"}]
+             (xt/q tu/*node* "FROM range(DATE '2020-01-01', DATE '2020-01-07', INTERVAL 'P2D') dates (`date`)"))
+          "multi-day interval")
+
+    (t/is (= [{:date #xt/date-time "2020-01-01T00:00", :idx 1}
+              {:date #xt/date-time "2020-01-03T00:00", :idx 2}
+              {:date #xt/date-time "2020-01-05T00:00", :idx 3}]
+             (xt/q tu/*node* "FROM range(DATE '2020-01-01', DATE '2020-01-07', INTERVAL 'P2D') WITH ORDINALITY dates (`date`, idx)"))
+          "multi-day interval, WITH ORDINALITY")
+
+    (t/is (= [{:dates [#xt/date "2020-01-01", #xt/date "2020-02-01", #xt/date "2020-03-01"]}]
+             (xt/q tu/*node* "SELECT range(DATE '2020-01-01', DATE '2020-04-01', INTERVAL '1' MONTH) dates"))
+          "monthly interval")
+
+    (t/is (= [{:dates [#xt/date "2020-01-01"
+                       #xt/date "2020-02-01"
+                       #xt/date "2020-03-01"]}]
+             (xt/q tu/*node* "SELECT range(DATE '2020-01-01', DATE '2020-04-01', INTERVAL 'P1M') dates"))
+          "monthly interval")
+
+    (t/is (= [{:date #xt/date "2020-01-01"} {:date #xt/date "2021-01-01"}]
+             (xt/q tu/*node* "FROM range(DATE '2020-01-01', DATE '2022-01-01', INTERVAL 'P1Y') dates (`date`)"))
+          "yearly interval")
+
+    (t/is (= [{:date #xt/date "2020-01-01"} {:date #xt/date "2021-01-01"}]
+             (xt/q tu/*node* "FROM range(DATE '2020-01-01', DATE '2022-01-01', INTERVAL '1' YEAR) dates (`date`)"))
+          "yearly interval")
+
+    (t/is (= [{:dates [#xt/date-time "2020-01-01T00:00"
+                       #xt/date-time "2020-01-01T06:00"
+                       #xt/date-time "2020-01-01T12:00"
+                       #xt/date-time "2020-01-01T18:00"]}]
+             (xt/q tu/*node* "SELECT range(DATE '2020-01-01', DATE '2020-01-02', INTERVAL 'PT6H') dates"))
+          "time interval")
+
+    (t/is (= [{:dates [#xt/date-time "2020-01-01T00:00"
+                       #xt/date-time "2020-04-02T23:59:57"
+                       #xt/date-time "2020-07-04T23:59:54"
+                       #xt/date-time "2020-10-06T23:59:51"]}]
+             (xt/q tu/*node* "SELECT range(DATE '2020-01-01', DATE '2021-01-01', INTERVAL 'P3M2DT-3S') dates"))
+          "mixed interval"))
 
   (t/testing "TIMESTAMP"
+    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00"]}]
+             (xt/q tu/*node* "SELECT range(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-02 00:00:00', INTERVAL 'PT24H') timestamps")))
+
     (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00"
                             #xt/date-time "2020-01-01T01:00"
                             #xt/date-time "2020-01-01T02:00"]}]
-             (xt/q tu/*node* "SELECT range(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-01 03:00:00', INTERVAL 'PT1H') timestamps"))))
+             (xt/q tu/*node* "SELECT range(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-01 03:00:00', INTERVAL 'PT1H') timestamps"))
+          "hour steps")
 
-  (t/testing "as table source"
-    (t/is (= [{:x 1} {:x 2} {:x 3}]
-             (xt/q tu/*node* "SELECT x FROM range(1, 4) xs (x)")))))
+    (t/is (= [{:ts #xt/date-time "2020-01-01T00:00"}
+              {:ts #xt/date-time "2020-01-01T00:00:00.500"}
+              {:ts #xt/date-time "2020-01-01T00:00:01"}
+              {:ts #xt/date-time "2020-01-01T00:00:01.500"}
+              {:ts #xt/date-time "2020-01-01T00:00:02"}
+              {:ts #xt/date-time "2020-01-01T00:00:02.500"}]
+             (xt/q tu/*node* "FROM range(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-01 00:00:03', INTERVAL 'PT0.5S') timestamps (ts)"))
+          "fractional seconds")
+
+    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00", #xt/date-time "2020-02-01T00:00"]}]
+             (xt/q tu/*node* "SELECT range(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-03-01 00:00:00', INTERVAL 'P1M') timestamps"))
+          "monthly interval")
+
+    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00", #xt/date-time "2021-01-01T00:00"]}]
+             (xt/q tu/*node* "SELECT range(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2022-01-01 00:00:00', INTERVAL 'P1Y') timestamps"))
+          "yearly interval")
+
+    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00"
+                            #xt/date-time "2020-04-03T00:00:03"
+                            #xt/date-time "2020-07-05T00:00:06"
+                            #xt/date-time "2020-10-07T00:00:09"]}]
+             (xt/q tu/*node* "SELECT range(TIMESTAMP '2020-01-01T00:00:00', TIMESTAMP '2021-01-01T00:00:00', INTERVAL 'P3M2DT3S') timestamps"))
+          "mixed interval"))
+
+  (t/testing "TIMESTAMPTZ"
+    (t/is (= [{:timestamps [#xt/zoned-date-time "2020-03-28T00:00Z[Europe/London]"
+                            #xt/zoned-date-time "2020-03-29T00:00Z[Europe/London]"
+                            #xt/zoned-date-time "2020-03-30T01:00+01:00[Europe/London]"]}]
+             (xt/q tu/*node* "SELECT range(TIMESTAMP '2020-03-28T00:00:00Z[Europe/London]', TIMESTAMP '2020-03-31T00:00:00+01:00[Europe/London]', INTERVAL 'PT24H') timestamps")))
+
+    (t/is (= [{:ts #xt/zoned-date-time "2020-03-28T00:00Z[Europe/London]"}
+              {:ts #xt/zoned-date-time "2020-03-29T00:00Z[Europe/London]"}
+              {:ts #xt/zoned-date-time "2020-03-30T00:00+01:00[Europe/London]"}]
+             (xt/q tu/*node* "FROM range(TIMESTAMP '2020-03-28T00:00:00Z[Europe/London]', TIMESTAMP '2020-03-31T00:00:00+01:00[Europe/London]', INTERVAL 'P1D') timestamps (ts)")))
+
+    (t/is (= [{:ts #xt/zoned-date-time "2020-03-28T00:00Z[Europe/London]", :idx 1}
+              {:ts #xt/zoned-date-time "2020-03-29T00:00Z[Europe/London]", :idx 2}
+              {:ts #xt/zoned-date-time "2020-03-30T00:00+01:00[Europe/London]", :idx 3}]
+             (xt/q tu/*node* "FROM range(TIMESTAMP '2020-03-28T00:00:00Z[Europe/London]', TIMESTAMP '2020-03-31T00:00:00+01:00[Europe/London]', INTERVAL 'P1D') WITH ORDINALITY timestamps (ts, idx)")))))
+
+(t/deftest test-generate-series-3212
+  (t/is (= [{:xs [1 2 3 4]}]
+           (xt/q tu/*node* "SELECT generate_series(1, 4) xs")))
+
+  (t/is (= [{:xs [1 4 7]}]
+           (xt/q tu/*node* "SELECT generate_series(1, 8, 3) xs")))
+
+  (t/is (= [{:xs []}]
+           (xt/q tu/*node* "SELECT generate_series(10, 3) xs")))
+
+  (t/is (= [{:xs [1]}]
+           (xt/q tu/*node* "SELECT generate_series(1, 1) xs")))
+
+  (t/is (= [{:xs [1]}]
+           (xt/q tu/*node* "SELECT generate_series(1, 2, 2) xs")))
+
+  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo RECORDS {_id: 1, start: -1, end: 3}"]])
+
+  (t/is (= [{:xs [-1 0 1 2 3]}]
+           (xt/q tu/*node* "SELECT generate_series(start, end) xs FROM foo"))))
+
+(t/deftest test-negative-step
+  (t/is (= [{:xs [5 4 3 2]}]
+           (xt/q tu/*node* "SELECT range(5, 1, -1) xs"))
+        "range, negative step")
+
+  (t/is (= [{:xs [5 4 3 2 1]}]
+           (xt/q tu/*node* "SELECT generate_series(5, 1, -1) xs"))
+        "generate_series, negative step")
+
+  (t/is (= [{:xs [10 7 4]}]
+           (xt/q tu/*node* "SELECT range(10, 3, -3) xs"))
+        "range, negative step with stride")
+
+  (t/is (= [{:xs []}]
+           (xt/q tu/*node* "SELECT range(1, 5, -1) xs"))
+        "negative step, wrong direction"))
+
+(t/deftest test-generate-series-datetimes-4067
+  (t/testing "DATE"
+    (t/is (= [{:dates [#xt/date-time "2020-01-01T00:00"]}]
+             (xt/q tu/*node* "SELECT generate_series(DATE '2020-01-01', DATE '2020-01-01', INTERVAL 'P1D') dates"))
+          "start == end")
+
+    (t/is (= [{:dates [#xt/date-time "2020-01-01T00:00", #xt/date-time "2020-01-02T00:00", #xt/date-time "2020-01-03T00:00", #xt/date-time "2020-01-04T00:00"]}]
+             (xt/q tu/*node* "SELECT generate_series(DATE '2020-01-01', DATE '2020-01-04', INTERVAL 'P1D') dates"))
+          "date range")
+
+    (t/is (= [{:date #xt/date-time "2020-01-01T00:00"}
+              {:date #xt/date-time "2020-01-03T00:00"}
+              {:date #xt/date-time "2020-01-05T00:00"}
+              {:date #xt/date-time "2020-01-07T00:00"}]
+             (xt/q tu/*node* "FROM generate_series(DATE '2020-01-01', DATE '2020-01-07', INTERVAL 'P2D') dates (`date`)"))
+          "multi-day interval")
+
+    (t/is (= [{:dates [#xt/date "2020-01-01", #xt/date "2020-02-01", #xt/date "2020-03-01", #xt/date "2020-04-01"]}]
+             (xt/q tu/*node* "SELECT generate_series(DATE '2020-01-01', DATE '2020-04-01', INTERVAL 'P1M') dates"))
+          "monthly interval")
+
+    (t/is (= [{:date #xt/date "2020-01-01"} {:date #xt/date "2021-01-01"} {:date #xt/date "2022-01-01"}]
+             (xt/q tu/*node* "FROM generate_series(DATE '2020-01-01', DATE '2022-01-01', INTERVAL 'P1Y') dates (`date`)"))
+          "yearly interval")
+
+    (t/is (= [{:dates [#xt/date-time "2020-01-01T00:00"
+                       #xt/date-time "2020-01-01T06:00"
+                       #xt/date-time "2020-01-01T12:00"
+                       #xt/date-time "2020-01-01T18:00"
+                       #xt/date-time "2020-01-02T00:00"]}]
+             (xt/q tu/*node* "SELECT generate_series(DATE '2020-01-01', DATE '2020-01-02', INTERVAL 'PT6H') dates"))
+          "time interval"))
+
+  (t/testing "TIMESTAMP"
+    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00", #xt/date-time "2020-01-02T00:00"]}]
+             (xt/q tu/*node* "SELECT generate_series(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-02 00:00:00', INTERVAL 'PT24H') timestamps")))
+
+    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00"
+                            #xt/date-time "2020-01-01T01:00"
+                            #xt/date-time "2020-01-01T02:00"
+                            #xt/date-time "2020-01-01T03:00"]}]
+             (xt/q tu/*node* "SELECT generate_series(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-01-01 03:00:00', INTERVAL 'PT1H') timestamps"))
+          "hour steps")
+
+    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00", #xt/date-time "2020-02-01T00:00", #xt/date-time "2020-03-01T00:00"]}]
+             (xt/q tu/*node* "SELECT generate_series(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2020-03-01 00:00:00', INTERVAL 'P1M') timestamps"))
+          "monthly interval")
+
+    (t/is (= [{:timestamps [#xt/date-time "2020-01-01T00:00", #xt/date-time "2021-01-01T00:00", #xt/date-time "2022-01-01T00:00"]}]
+             (xt/q tu/*node* "SELECT generate_series(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2022-01-01 00:00:00', INTERVAL 'P1Y') timestamps"))
+          "yearly interval"))
+
+  (t/testing "TIMESTAMPTZ"
+    (t/is (= [{:ts #xt/zoned-date-time "2020-03-28T00:00Z[Europe/London]"}
+              {:ts #xt/zoned-date-time "2020-03-29T00:00Z[Europe/London]"}
+              {:ts #xt/zoned-date-time "2020-03-30T00:00+01:00[Europe/London]"}
+              {:ts #xt/zoned-date-time "2020-03-31T00:00+01:00[Europe/London]"}]
+             (xt/q tu/*node* "FROM generate_series(TIMESTAMP '2020-03-28T00:00:00Z[Europe/London]', TIMESTAMP '2020-03-31T00:00:00+01:00[Europe/London]', INTERVAL 'P1D') timestamps (ts)")))))
+
+(t/deftest test-end-exclusive-escape-hatch
+  ;; XTDB_GENERATE_SERIES_END_EXCLUSIVE reverts GENERATE_SERIES to pre-2.2 (end-exclusive) behaviour,
+  ;; so existing queries can keep working while being migrated to RANGE.
+  ;;
+  ;; The env var is read at namespace load (process start) — `xt/q` goes via pgwire on a separate thread
+  ;; which won't see a `binding` in the test thread, so we test the planner output directly.
+  (t/is (not= (sql/plan "SELECT generate_series(1, 4) xs")
+              (sql/plan "SELECT range(1, 4) xs"))
+        "without the flag, GENERATE_SERIES and RANGE produce different plans")
+
+  (binding [sql/*generate-series-end-exclusive?* true]
+    (t/is (= (sql/plan "SELECT generate_series(1, 4) xs")
+             (sql/plan "SELECT range(1, 4) xs"))
+          "with the flag, GENERATE_SERIES delegates to the same plan as RANGE")
+
+    (t/is (not= (sql/plan "SELECT generate_series(1, 4) xs")
+                (binding [sql/*generate-series-end-exclusive?* false]
+                  (sql/plan "SELECT generate_series(1, 4) xs")))
+          "the flag actually changes the GENERATE_SERIES plan")))
 
 (t/deftest test-generate-series-limit-batching-4412
   (t/is (= [{:xt/id 1}

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -2456,21 +2456,21 @@ UNION ALL
     (t/is (= [{:xt/id 2, :foo 3} {:xt/id 4, :foo 5}]
              (xt/q tu/*node* q)))))
 
-(t/deftest test-generate-series-3212
+(t/deftest test-range-3212
   (t/is (= [1 2 3]
-           (->> (xt/q tu/*node* "SELECT x FROM generate_series(1, 4) xs (x)")
+           (->> (xt/q tu/*node* "SELECT x FROM range(1, 4) xs (x)")
                 (mapv :x))))
 
   (t/is (= [1 4 7]
-           (->> (xt/q tu/*node* "SELECT x FROM generate_series(1, 8, 3) xs (x)")
+           (->> (xt/q tu/*node* "SELECT x FROM range(1, 8, 3) xs (x)")
                 (mapv :x))))
 
-  (t/is (empty? (xt/q tu/*node* "SELECT x FROM generate_series(10, 3) xs (x)")))
+  (t/is (empty? (xt/q tu/*node* "SELECT x FROM range(10, 3) xs (x)")))
 
-  (t/is (empty? (-> (xt/q tu/*node* "SELECT x FROM generate_series(1, 1) xs (x)"))))
+  (t/is (empty? (-> (xt/q tu/*node* "SELECT x FROM range(1, 1) xs (x)"))))
 
   (t/is (= [1]
-           (->> (xt/q tu/*node* "SELECT x FROM generate_series(1, 2, 2) xs (x)")
+           (->> (xt/q tu/*node* "SELECT x FROM range(1, 2, 2) xs (x)")
                 (mapv :x))))
 
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo RECORDS {_id: 1, start: -1, end: 3}, {_id: 2, start: 4, end: 6}"]])
@@ -2481,16 +2481,28 @@ UNION ALL
             {:xt/id 1, :x 0}
             {:xt/id 1, :x 1}
             {:xt/id 1, :x 2}]
-           (-> (xt/q tu/*node* "SELECT _id, x FROM foo, generate_series(start, end) xs (x)")))))
+           (-> (xt/q tu/*node* "SELECT _id, x FROM foo, range(start, end) xs (x)")))))
 
-(t/deftest test-range-alias
-  (t/is (= [1 2 3]
-           (->> (xt/q tu/*node* "SELECT x FROM range(1, 4) xs (x)")
+(t/deftest test-generate-series-3212
+  (t/is (= [1 2 3 4]
+           (->> (xt/q tu/*node* "SELECT x FROM generate_series(1, 4) xs (x)")
                 (mapv :x))))
 
-  (t/is (= (sql/plan "SELECT x FROM generate_series(1, 4) xs (x)")
-           (sql/plan "SELECT x FROM range(1, 4) xs (x)"))
-        "RANGE produces the same plan as GENERATE_SERIES"))
+  (t/is (= [1]
+           (->> (xt/q tu/*node* "SELECT x FROM generate_series(1, 1) xs (x)")
+                (mapv :x))))
+
+  (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo RECORDS {_id: 1, start: -1, end: 3}, {_id: 2, start: 4, end: 6}"]])
+
+  (t/is (= [{:xt/id 2, :x 4}
+            {:xt/id 2, :x 5}
+            {:xt/id 2, :x 6}
+            {:xt/id 1, :x -1}
+            {:xt/id 1, :x 0}
+            {:xt/id 1, :x 1}
+            {:xt/id 1, :x 2}
+            {:xt/id 1, :x 3}]
+           (-> (xt/q tu/*node* "SELECT _id, x FROM foo, generate_series(start, end) xs (x)")))))
 
 (t/deftest test-function-as-from-source
   (t/testing "scalar function as FROM-clause table source produces single row"


### PR DESCRIPTION
Resolves #5382.
Closes #5361 — same core change, plus an env-var escape hatch and an updated docs target (the `GENERATE_SERIES`/`RANGE` reference moved to `stdlib/table.md` on main while #5361 was open).

## Approach

PostgreSQL and DuckDB treat `GENERATE_SERIES(start, end)` as end-inclusive.
XTDB's was end-exclusive, which broke Grafana's table-discovery queries (#5382) and surprised anyone porting Postgres SQL.

The end-exclusive behaviour is still useful for half-open range expansion, so we keep it under `RANGE` (added as an alias on main in bf77c012c, now distinguished from `GENERATE_SERIES` at parse time).
Both lower to a single 4-arity `:generate_series` IR with an explicit `inclusive?` boolean; the 3-arity codegen methods delegate to the 4-arity ones, so existing IR consumers keep working.

## Migration & escape hatch

For users on existing `GENERATE_SERIES(start, end)` queries:

- Recommended: switch to `RANGE` if you depended on end-exclusive semantics; otherwise leave the queries alone — most callers will want the inclusive semantics.
- Escape hatch: `XTDB_GENERATE_SERIES_END_EXCLUSIVE=true` reverts `GENERATE_SERIES` to its pre-2.2 (end-exclusive) behaviour by forcing `inclusive?` false in `visitGenerateSeries`, producing the same plan as `RANGE`.
  Intent is migration cover, not a long-lived setting.

Node-level env var rather than a session setting — it's a one-shot upgrade toggle, matching the convention used by `XTDB_SINGLE_WRITER` and `XTDB_JOIN_SPILL_THRESHOLD`.

## Testing notes

The escape-hatch test asserts plan-equivalence via `sql/plan` directly, not `xt/q`.
`xt/q` opens a pgwire connection and parses on the connection thread, so a `binding` in the test thread doesn't reach the visitor; the planner-only test stays on-thread and verifies the IR flips as expected.

## Test plan

- [x] `xtdb.sql.generate-series-test` — incl. new `test-end-exclusive-escape-hatch`
- [x] `xtdb.sql-test`, `xtdb.expression.list-test`, `xtdb.operator.list-test`, `xtdb.expression.temporal-test`
- [ ] CI green on full suite + integration tests