### PR TITLE
fix(test): serialise Rust lang tests to avoid concurrent database startup

### DIFF
--- a/lang/rust/Dockerfile
+++ b/lang/rust/Dockerfile
@@ -8,6 +8,6 @@ COPY src/ src/
 RUN cargo fetch
 
 ENTRYPOINT ["cargo"]
-CMD ["test"]
+CMD ["test", "--", "--test-threads=1"]
 
 COPY tests/ tests/


### PR DESCRIPTION
InMemoryLog.commit() has a circular dependency on Dispatchers.Default that can deadlock when the number of concurrent in-memory database startups exceeds the thread pool size (N databases need N+1 threads). The 5 Rust tests each create a playground database concurrently, needing 6 threads — exceeding the 4 available on CI runners.

Running the Rust tests serially sidesteps this by ensuring only one playground database is created at a time.

See #5535