### PR TITLE
fix(log): eliminate InMemoryLog deadlock on concurrent database startup

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -1,9 +1,10 @@
 package xtdb.api.log
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.selects.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -13,41 +14,34 @@ import xtdb.api.log.Log.*
 import xtdb.database.proto.DatabaseConfig
 import xtdb.util.MsgIdUtil
 import xtdb.util.MsgIdUtil.msgIdToOffset
-import xtdb.util.MsgIdUtil.offsetToMsgId
 import xtdb.database.proto.inMemoryLog
 import java.time.Instant
 import java.time.InstantSource
 import java.time.temporal.ChronoUnit.MICROS
-import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 
-class InMemoryLog<M> @JvmOverloads constructor(
+class InMemoryLog<M>(
     private val instantSource: InstantSource,
     override val epoch: Int,
-    coroutineContext: CoroutineContext = Dispatchers.Default
 ) : Log<M> {
-    private val scope = CoroutineScope(coroutineContext)
 
     @SerialName("!InMemory")
     @Serializable
     data class Factory(
         @Transient var instantSource: InstantSource = InstantSource.system(),
         var epoch: Int = 0,
-        @Transient var coroutineContext: CoroutineContext = Dispatchers.Default
     ) : Log.Factory {
         fun instantSource(instantSource: InstantSource) = apply { this.instantSource = instantSource }
         fun epoch(epoch: Int) = apply { this.epoch = epoch }
-        fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
         override fun openSourceLog(remotes: Map<RemoteAlias, Remote>) =
-            InMemoryLog<SourceMessage>(instantSource, epoch, coroutineContext)
+            InMemoryLog<SourceMessage>(instantSource, epoch)
 
         override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>) =
             ReadOnlyLog(openSourceLog(remotes))
 
         override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>) =
-            InMemoryLog<ReplicaMessage>(instantSource, epoch, coroutineContext)
+            InMemoryLog<ReplicaMessage>(instantSource, epoch)
 
         override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>) =
             ReadOnlyLog(openReplicaLog(remotes))
@@ -57,36 +51,28 @@ class InMemoryLog<M> @JvmOverloads constructor(
         }
     }
 
-    internal data class NewMessage<M>(
-        val message: M,
-        val onCommit: CompletableDeferred<MessageMetadata>
-    )
-
-    private val appendCh: Channel<NewMessage<M>> = Channel(100)
-    private val committedCh = appendCh.receiveAsFlow()
-        .map { (message, onCommit) ->
-            // we only use the instantSource for Tx messages so that the tests
-            // that check files can be deterministic
-            val ts = if (message is SourceMessage.Tx || message is SourceMessage.LegacyTx) instantSource.instant() else Instant.now()
-
-            val record = Record(epoch, ++latestSubmittedOffset, ts.truncatedTo(MICROS), message)
-            onCommit.complete(MessageMetadata(epoch, record.logOffset, ts.truncatedTo(MICROS)))
-            record
-        }
-        .shareIn(scope, SharingStarted.Eagerly, REPLAY_BUFFER_SIZE)
+    private val committedCh = MutableSharedFlow<Record<M>>(replay = REPLAY_BUFFER_SIZE)
 
     companion object {
         private const val REPLAY_BUFFER_SIZE = 4096
     }
 
+    private val mutex = Mutex()
+
     @Volatile
     override var latestSubmittedOffset: LogOffset = -1
         private set
 
-    override suspend fun appendMessage(message: M): MessageMetadata =
-        CompletableDeferred<MessageMetadata>()
-            .also { scope.launch { appendCh.send(NewMessage(message, it)) } }
-            .await()
+    // Mutex ensures offset assignment + emission are atomic,
+    // so subscribers always see records in offset order.
+    // We only use the instantSource for Tx messages so that the tests
+    // that check files can be deterministic.
+    override suspend fun appendMessage(message: M): MessageMetadata = mutex.withLock {
+        val ts = if (message is SourceMessage.Tx || message is SourceMessage.LegacyTx) instantSource.instant() else Instant.now()
+        val record = Record(epoch, ++latestSubmittedOffset, ts.truncatedTo(MICROS), message)
+        committedCh.emit(record)
+        MessageMetadata(epoch, record.logOffset, ts.truncatedTo(MICROS))
+    }
 
     override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer<M> {
         override fun openTx() = object : AtomicProducer.Tx<M> {
@@ -173,7 +159,5 @@ class InMemoryLog<M> @JvmOverloads constructor(
         }
     }
 
-    override fun close() {
-        runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
-    }
+    override fun close() {}
 }

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -46,7 +46,7 @@ class LocalLog<M>(
     private val instantSource: InstantSource,
     override val epoch: Int,
     val useInstantSourceForNonTx: Boolean,
-    coroutineContext: CoroutineContext = Dispatchers.Default,
+    coroutineContext: CoroutineContext = Dispatchers.IO,
     logFileName: String = "LOG"
 ) : Log<M> {
     private val scope = CoroutineScope(coroutineContext)
@@ -371,7 +371,7 @@ class LocalLog<M>(
         @Transient var instantSource: InstantSource = InstantSource.system(),
         var epoch: Int = 0,
         var useInstantSourceForNonTx: Boolean = false,
-        @Transient var coroutineContext: CoroutineContext = Dispatchers.Default
+        @Transient var coroutineContext: CoroutineContext = Dispatchers.IO
     ) : Log.Factory {
 
         @Suppress("unused")

--- a/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
@@ -1,8 +1,13 @@
 package xtdb.api.log
 
+import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import xtdb.api.log.Log.AtomicProducer.Companion.withTx
+import java.time.InstantSource
+import java.util.concurrent.Executors
+import kotlin.time.Duration.Companion.seconds
 
 class InMemoryLogTest {
 
@@ -18,6 +23,31 @@ class InMemoryLogTest {
 
             // Still null because InMemoryLog has no persistence
             assertNull(log.readLastMessage())
+        }
+    }
+
+    @Test
+    fun `commit does not deadlock on a single-threaded dispatcher`() {
+        // commit() uses runBlocking internally. The old Channel pipeline needed a
+        // Dispatchers.Default thread to process the message, so a single-threaded
+        // dispatcher would deadlock: runBlocking blocked the only thread while the
+        // pipeline needed it to complete the deferred.
+        val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+
+        try {
+            val log = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+
+            runBlocking(dispatcher) {
+                withTimeout(5.seconds) {
+                    log.openAtomicProducer("test").withTx { tx ->
+                        tx.appendMessage(ReplicaMessage.NoOp)
+                    }
+                }
+            }
+
+            assertEquals(0, log.latestSubmittedOffset)
+        } finally {
+            dispatcher.close()
         }
     }
 }


### PR DESCRIPTION
## Summary

- Rewrite InMemoryLog to process messages inline instead of through a Channel→SharedFlow coroutine pipeline, eliminating a circular dependency on `Dispatchers.Default` that deadlocked when multiple in-memory databases started concurrently
- Remove the now-unused `coroutineContext` parameter from InMemoryLog and its Factory
- Default LocalLog's dispatcher to `Dispatchers.IO` (it does file I/O, and the larger thread pool mitigates the same `runBlocking` deadlock shape)

## Context

The old `appendMessage` dispatched work to a separate coroutine via `scope.launch` on `Dispatchers.Default`, and `commit()` called this through `runBlocking`. With N concurrent databases exhausting the Default pool, `runBlocking` blocked the only available threads while the pipeline needed them to complete — deadlock.

The fix replaces the pipeline with a `MutableSharedFlow` and a coroutine `Mutex`. `appendMessage` now runs inline on the caller's coroutine. `commit()` still uses `runBlocking`, but the work inside (`mutex.withLock`) suspends cooperatively within its event loop with no thread-pool dependency.

Fixes #5535

## Test plan

- [x] New regression test: `commit does not deadlock on a single-threaded dispatcher` (verified it deadlocks against the old code, passes with the fix)
- [x] `InMemoryLogTest`, `LogProcessorTest`, `LogProcessorSimTest`, `LeaderLogProcessorTest`, `ExternalSourceTest` pass
- [x] Full `./gradlew test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)