### PR TITLE
fix(postgres-source): poll readPending() in streaming loop

### DIFF
--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
@@ -18,6 +18,7 @@ import java.sql.Connection
 import java.sql.DriverManager
 import java.time.Instant
 import java.util.*
+import kotlin.time.Duration.Companion.milliseconds
 
 private val LOG = PgWireDriver::class.logger
 
@@ -26,6 +27,12 @@ private const val SNAPSHOT_BATCH_SIZE = 1000
 private const val SLOT_RETRY_MAX_ATTEMPTS = 7
 private const val SLOT_RETRY_BASE_DELAY_MS = 1000L
 private val SLOT_ACTIVE_PATTERN = Regex(".*replication slot .* is active.*")
+
+private const val MAX_EMPTY_HOT_POLLS = 5
+
+// Must stay below pgjdbc's status interval (default 10s) or the server
+// times the slot out for missing keepalives.
+private val IDLE_POLL_PAUSE = 50.milliseconds
 
 class PgWireDriver(
     private val dbName: String,
@@ -193,9 +200,19 @@ class PgWireDriver(
 
         override suspend fun nextTransaction(block: suspend (PostgresDriver.Transaction) -> Unit) {
             var currentTxOps = mutableListOf<RowOp>()
+            var emptyPolls = 0
 
             while (currentCoroutineContext().isActive) {
-                val msg = runInterruptible(Dispatchers.IO) { stream.read()!! }
+                val msg = withContext(Dispatchers.IO) { stream.readPending() }
+                if (msg == null) {
+                    if (++emptyPolls >= MAX_EMPTY_HOT_POLLS) {
+                        emptyPolls = 0
+                        delay(IDLE_POLL_PAUSE)
+                    }
+                    continue
+                }
+                emptyPolls = 0
+
                 val parsed = PgOutputMessage.parse(msg)
                 LOG.trace { "[$dbName] Received ${parsed::class.simpleName}" }
 
@@ -259,8 +276,7 @@ class PgWireDriver(
             throw CancellationException("Streaming loop cancelled")
         }
 
-        // stream.close() takes a lock held by the in-progress read.
-        // replConn.close() bypasses the lock and closes the socket, releasing the slot.
+        // stream.close() is unreliable; closing replConn is what releases the slot.
         override fun close() {
             replConn.close()
         }

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -152,13 +152,8 @@ class PostgresSource(
         }
     }
 
-    /**
-     * Runs [block] with a child coroutine that force-closes [closeable] on cancellation.
-     *
-     * pgjdbc's socket reads don't respond to Thread.interrupt(), so coroutine
-     * cancellation alone can't unblock them. The child coroutine watches for
-     * cancellation and closes the resource, causing the blocked read to throw.
-     */
+    // pgjdbc reads ignore Thread.interrupt(); force-closing the resource is the
+    // only way to unblock a parked socket read on coroutine cancellation.
     private suspend fun <T : AutoCloseable, R> closeOnCancel(closeable: T, block: suspend () -> R): R =
         coroutineScope {
             val watcher = launch {
@@ -206,20 +201,18 @@ class PostgresSource(
 
     private suspend fun streamChanges(txIndexer: TxIndexer, startLsn: Long) {
         driver.openStream(startLsn).use { stream ->
-            closeOnCancel(stream) {
-                while (currentCoroutineContext().isActive) {
-                    stream.nextTransaction { tx ->
-                        val token = ProtoAny.pack(postgresSourceToken {
-                            latestCommittedLsn = tx.lsn
-                            snapshotCompleted = true
-                        }, PROTO_TAG)
+            while (currentCoroutineContext().isActive) {
+                stream.nextTransaction { tx ->
+                    val token = ProtoAny.pack(postgresSourceToken {
+                        latestCommittedLsn = tx.lsn
+                        snapshotCompleted = true
+                    }, PROTO_TAG)
 
-                        txIndexer.indexTx(token, systemTime = tx.commitTime) { openTx ->
-                            for (op in tx.ops) {
-                                writeOp(openTx, dbName, op)
-                            }
-                            TxResult.Committed()
+                    txIndexer.indexTx(token, systemTime = tx.commitTime) { openTx ->
+                        for (op in tx.ops) {
+                            writeOp(openTx, dbName, op)
                         }
+                        TxResult.Committed()
                     }
                 }
             }


### PR DESCRIPTION
Cancelling the streaming source surfaced IngestionStoppedException("Tried to write to an inactive copy operation"): closeOnCancel closed the replication connection to unblock a parked stream.read(), but pgjdbc's read() path issues a keepalive write before returning, which fails on the now-closed copy operation.

stream.read() blocks until the next message arrives, so cancellation needs closeOnCancel to tear the socket down to unblock it.
Switch to PGReplicationStream.readPending(), pgjdbc's non-blocking variant: it returns null immediately when no message is available, so we can poll it from a Kotlin loop and observe coroutine cancellation between iterations via isActive — no parked read, no force-close watcher on the streaming path.
The poll uses Debezium's adaptive backoff: 5 hot polls to catch back-to-back messages without latency, then delay(50ms) when idle.
closeOnCancel stays on the snapshot path where pgjdbc's ResultSet.next() has no readPending equivalent.

The idle pause must stay well below pgjdbc's 10s status interval or the server times the slot out.
Debezium picks 500ms as a Kafka-Connect-wide default tuned for many connectors per worker; for single-source-per-database CDC into a query system, tail latency matters more, so 50ms gives a 10x tighter wake at trivial CPU cost.

## References

- Debezium's polling loop: [`PostgresStreamingChangeEventSource.processMessages`](https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java#L258)
- Their `poll.interval.ms` default: [`CommonConnectorConfig.DEFAULT_POLL_INTERVAL_MILLIS = 500`](https://github.com/debezium/debezium/blob/main/debezium-connector-common/src/main/java/io/debezium/config/CommonConnectorConfig.java#L638)

## Test plan

- [x] `:modules:xtdb-postgres-source:integration-test` passes
- [x] `cancellation releases replication slot` stress-tested 5× post-change (was a known flake before)