### PR TITLE
feat(scan): drop constrain-only pages without temporal cols (#5520)

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -310,16 +310,19 @@
 
                            (util/with-close-on-catch [!segments (LinkedList.)]
 
-                             (doseq [{:keys [^String trie-key]} (-> (cat/trie-state trie-catalog table)
-                                                                    (cat/current-tries)
-                                                                    (cat/filter-tries {:query-bounds temporal-bounds}))]
-                               (.add !segments
-                                     (BufferPoolSegment. allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
+                             (let [filter-opts {:query-bounds temporal-bounds
+                                                :projects-temporal-cols? (boolean (some #{"_valid_from" "_valid_to" "_system_from" "_system_to"} col-names))}]
 
-                             (doseq [^TableSnapshot live-table-snap live-table-snaps]
-                               (.add !segments (.getSegment live-table-snap)))
+                               (doseq [{:keys [^String trie-key]} (-> (cat/trie-state trie-catalog table)
+                                                                      (cat/current-tries)
+                                                                      (cat/filter-tries filter-opts))]
+                                 (.add !segments
+                                       (BufferPoolSegment. allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
 
-                             (let [merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) #(trie/filter-pages % {:query-bounds temporal-bounds}))]
+                               (doseq [^TableSnapshot live-table-snap live-table-snaps]
+                                 (.add !segments (.getSegment live-table-snap)))
+
+                               (let [merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) #(trie/filter-pages % filter-opts))]
                                (cond-> (ScanCursor. allocator (vec col-names) col-preds
                                                     temporal-bounds
                                                     !segments (.iterator ^Iterable merge-tasks)
@@ -339,7 +342,7 @@
                                                                                                                  (update-keys
                                                                                                                   (update-vals (into {} (filter val) (or pushdown-iids {}))
                                                                                                                                (fn [s] {:iids s}))
-                                                                                                                  str)))))))))))}))))
+                                                                                                                  str))))))))))))}))))
 
 (defmethod lp/emit-expr :scan [scan-expr {:keys [^IScanEmitter scan-emitter db-cat scan-vec-types, param-types]}]
   (assert db-cat)

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -104,18 +104,17 @@
         (.setPageLimit page-limit))
       (.build)))
 
-(defn filter-pages
-  "Returns the subset of pages that contribute to the query result.
+(defn filter-pages [pages {:keys [^TemporalBounds query-bounds projects-temporal-cols?]}]
+  ;; Pages are categorised by what they can do to the result:
+  ;;
+  ;; - **emit** — rows in this page can appear in the output.
+  ;;   Temporal bounds match the query AND content predicate (`testMetadata`) matches.
+  ;; - **supersede** — rows here can affect an emit row's multiplicity - whether it's duplicated (U-shaped) or filtered out.
+  ;;   Temporal bounds match the query; content predicate need not.
+  ;; - **constrain** — rows here can affect the bounds of the resulting polygons.
+  ;;   Temporal bounds disjoint from the query but overlapping the emit envelope.
+  ;;   We exclude these if the query doesn't project temporal columns
 
-  Pages are categorised by what they can do to the result:
-
-  - **emit** — rows in this page can appear in the output.
-    Temporal bounds match the query AND content predicate (`testMetadata`) matches.
-  - **supersede** — rows here can affect an emit row's multiplicity - whether it's duplicated (U-shaped) or filtered out.
-    Temporal bounds match the query; content predicate need not.
-  - **constrain** — rows here can affect the bounds of the resulting polygons.
-    Temporal bounds disjoint from the query but overlapping the emit envelope."
-  [pages {:keys [^TemporalBounds query-bounds]}]
   (let [leaves (ArrayList.)
         min-query-recency (long (min (.getLower (.getValidTime query-bounds))
                                      (.getLower (.getSystemTime query-bounds))))
@@ -146,8 +145,8 @@
                      (Temporal/intersectsSystemTime temporal-metadata query-bounds)
                      (conj page)))))
 
-        ;; Phase 2 — for each non-emitted candidate, keep it if it may supersede/constrain the polygons in the result.
         (when (seq leaves)
+          ;; Phase 2 - include all of the pages that may affect the rows in phase 1.
           (let [envelope-vt (TemporalDimension. smallest-valid-from largest-valid-to)]
             (doseq [^Segment$PageMeta page non-emit-candidates
                     :let [tm (.getTemporalMetadata page)
@@ -157,13 +156,18 @@
                             ;; none of the rows in that file can affect the rows in the emit set.
                             (<= smallest-system-from (.getMaxSystemFrom tm))
 
-                            ;; if the valid-time of the page doesn't intersect the valid-time envelope of the emit set,
-                            ;; then it can't affect the result.
-                            (.intersects (TemporalDimension. (.getMinValidFrom tm) (.getMaxValidTo tm))
-                                         envelope-vt)
+                            (if projects-temporal-cols?
+                              ;; keep candidates whose vt overlaps the emit envelope
+                              ;; (covers both supersede and constrain — the latter feed `_valid_from` etc.).
+                              (and (.intersects (TemporalDimension. (.getMinValidFrom tm) (.getMaxValidTo tm))
+                                                envelope-vt)
+                                   (or (>= page-recency smallest-valid-from)
+                                       (>= page-recency smallest-system-from)))
 
-                            (or (>= page-recency smallest-valid-from)
-                                (>= page-recency smallest-system-from)))]
+                              ;; keep only candidates that vt-intersect the query itself
+                              ;; (supersede only; constrain-only contribution is wasted I/O)
+                              (temporal-intersects? page)))]
+
               (.add leaves page)))
 
           (vec leaves))))))

--- a/src/test/clojure/xtdb/segment/merge_plan_test.clj
+++ b/src/test/clojure/xtdb/segment/merge_plan_test.clj
@@ -51,24 +51,28 @@
 
         (t/is (= #{1} (->> (trie/filter-pages [(->mock-page 0 false vt0 vt3 sf1 (dec sf2))
                                                (->mock-page 1 true vt1 vt2 sf2 sf2)]
-                                              {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)})
+                                              {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)
+                                               :projects-temporal-cols? true})
                            ->pages))
               "Take page 1. Page 0 system from strictly before page 1.")
         (t/is (= #{0 1} (->> (trie/filter-pages [(->mock-page 0 false vt0 (inc vt1) sf1 sf2)
                                                  (->mock-page 1 true vt1 vt2 sf2 sf2)]
-                                                {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)})
+                                                {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)
+                                                 :projects-temporal-cols? true})
                              ->pages))
               "Take page 1. Page 0 system from overlaps.")
 
         (t/is (= #{1} (->> (trie/filter-pages [(->mock-page 0 false vt0 vt1 sf1 (inc sf2))
                                                (->mock-page 1 true vt1 vt2 sf2 sf2)]
-                                              {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)})
+                                              {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)
+                                               :projects-temporal-cols? true})
                            ->pages))
               "Take page 1. Page 0 valid-time strictly before page 1.")
 
         (t/is (= #{0 1} (->> (trie/filter-pages [(->mock-page 0 false vt0 (inc vt1) sf1 (inc sf2))
                                                  (->mock-page 1 true vt1 vt2 sf2 sf2)]
-                                                {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)})
+                                                {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)
+                                                 :projects-temporal-cols? true})
                              ->pages))
               "Take page 1. Page 0 valid-time overlpas."))
 
@@ -76,13 +80,15 @@
         ;; TODO could we filter page 0 in the two assertions below?
         (t/is (= #{0 1} (->> (trie/filter-pages [(->mock-page 0 false vt0 vt2 sf1 sf2)
                                                  (->mock-page 1 true vt1 vt2 sf2 sf2)]
-                                                {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE (inc sf2) Long/MAX_VALUE)})
+                                                {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE (inc sf2) Long/MAX_VALUE)
+                                                 :projects-temporal-cols? true})
                              ->pages))
               "Take page 1. Page 0 system from overlaps. Query system-time bounds don't touch page 0")
 
         (t/is (= #{0 1} (->> (trie/filter-pages [(->mock-page 0 false vt0 vt1 sf1 (inc sf2))
                                                  (->mock-page 1 true (dec vt1) vt2 sf2 sf2)]
-                                                {:query-bounds (tu/->temporal-bounds (inc vt1) Long/MAX_VALUE sf1 Long/MAX_VALUE)})
+                                                {:query-bounds (tu/->temporal-bounds (inc vt1) Long/MAX_VALUE sf1 Long/MAX_VALUE)
+                                                 :projects-temporal-cols? true})
                              ->pages))
               "Take page 1. Page 0 valid-time overlpas. Query valid-time bounds don't touch page 0")))
 
@@ -92,40 +98,52 @@
 
         (t/is (= #{1} (->> (trie/filter-pages [(->mock-page 1 true vt1 vt2 sf2 sf2)
                                                (->mock-page 2 false vt2 vt3 sf3 sf3)]
-                                              {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)})
+                                              {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)
+                                               :projects-temporal-cols? true})
                            ->pages))
               "Take page 1. Page 2 doesn't overlap in valid-time")
 
         (t/is (= #{1 2} (->> (trie/filter-pages [(->mock-page 1 true vt1 (inc vt2) sf2 sf2)
                                                  (->mock-page 2 false vt2 vt3 sf3 sf3)]
-                                                {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)})
+                                                {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)
+                                                 :projects-temporal-cols? true})
                              ->pages))
               "Take page 1. Page 2 overlaps in valid-time")
 
         (t/is (= #{1 2} (->> (trie/filter-pages [(->mock-page 1 true vt1 (inc vt2) sf2 sf2)
                                                  (->mock-page 2 false vt2 (inc vt3) sf3 sf3)]
-                                                {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)})
+                                                {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 Long/MAX_VALUE)
+                                                 :projects-temporal-cols? true})
                              ->pages))
               "Take page 1. Page 2 can bound page 1 and we can't filter newer pages (no constraints on query system-time)."))
 
       (t/testing "Constraints on query bounds"
-        ;; TODO can 2 be filtered here?
         (t/is (= #{1 2} (->> (trie/filter-pages [(->mock-page 1 true vt1 (inc vt2) sf2 sf2)
                                                  (->mock-page 2 false vt2 vt3 sf3 sf3)]
-                                                {:query-bounds (tu/->temporal-bounds vt1 (dec vt2) sf1 Long/MAX_VALUE)})
+                                                {:query-bounds (tu/->temporal-bounds vt1 (dec vt2) sf1 Long/MAX_VALUE)
+                                                 :projects-temporal-cols? true})
                              ->pages))
-              "Take page 1. Page 2 overlaps in valid-time")
+              "Take page 1 and page 2. Page 2 is constrain-only — kept because the query projects temporal cols.")
+
+        (t/is (= #{1} (->> (trie/filter-pages [(->mock-page 1 true vt1 (inc vt2) sf2 sf2)
+                                               (->mock-page 2 false vt2 vt3 sf3 sf3)]
+                                              {:query-bounds (tu/->temporal-bounds vt1 (dec vt2) sf1 Long/MAX_VALUE)
+                                               :projects-temporal-cols? false})
+                           ->pages))
+              "Take page 1 only. Page 2 is constrain-only — dropped because the query projects no temporal col.")
 
         (t/is (= #{1} (->> (trie/filter-pages [(->mock-page 1 true vt1 (inc vt2) sf2 sf3)
                                                (->mock-page 2 false vt2 (inc vt3) sf3 sf3)]
-                                              {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 sf3)})
+                                              {:query-bounds (tu/->temporal-bounds vt0 Long/MAX_VALUE sf1 sf3)
+                                               :projects-temporal-cols? true})
                            ->pages))
               "Take page 1. Page 2 can bound page 1 and we can filter newer pages because of query system-time constraints.")))
 
     (t/is (= #{0 1 2} (->> (trie/filter-pages [(->mock-page 0 true vt0 Long/MAX_VALUE sf1 sf1)
                                                (->mock-page 1 false vt1 vt2 sf2 sf2)
                                                (->mock-page 2 false vt2 vt3 sf3 sf3)]
-                                              {:query-bounds (TemporalBounds.)})
+                                              {:query-bounds (TemporalBounds.)
+                                               :projects-temporal-cols? true})
                            ->pages))
           "All pages pages need to be taken if later pages bound valid-time")))
 
@@ -135,10 +153,13 @@
                             #inst "2021-01-01" #inst "2022-01-01" #inst "2023-01-01"])]
 
     (letfn [(query-bounds+temporal-page-metadata->pages [temporal-page-metadata query-bounds]
+              ;; this deftest covers temporal filtering, not the constrain-drop optimisation;
+              ;; the helper pins `:projects-temporal-cols? true` so the assertions below
+              ;; reflect the unoptimised behaviour.
               (->> (trie/filter-pages
                     (for [[page min-vf max-vt] temporal-page-metadata]
                       (->mock-page page min-vf max-vt))
-                    {:query-bounds query-bounds})
+                    {:query-bounds query-bounds, :projects-temporal-cols? true})
                    (mapv :page)))]
 
       (t/testing "non intersecting pages and no retrospective updates"
@@ -213,7 +234,8 @@
   (t/is (= [1]
            (->> (trie/filter-pages [(->MockPage 1 true (tu/->temporal-metadata 20251205 Long/MAX_VALUE) Long/MAX_VALUE)
                                     (->MockPage 2 false (tu/->temporal-metadata 20250706 Long/MAX_VALUE 20250707 20251208) 20250707)]
-                                   {:query-bounds (tu/->temporal-bounds 20251212 Long/MAX_VALUE)})
+                                   {:query-bounds (tu/->temporal-bounds 20251212 Long/MAX_VALUE)
+                                    :projects-temporal-cols? true})
 
                 (mapv :page)))))
 
@@ -226,6 +248,30 @@
         query-bounds (tu/->temporal-bounds 20260101 (inc 20260101) 20260101 (inc 20260101))]
 
     (t/is (= []
-             (->> (trie/filter-pages [page] {:query-bounds query-bounds})
+             (->> (trie/filter-pages [page] {:query-bounds query-bounds, :projects-temporal-cols? true})
                   (mapv :page)))
           "page recency 20250101 fails `min(query.lower) < page.recency` (20260101 ≮ 20250101)")))
+
+(t/deftest test-projects-temporal-cols-flag
+  ;; The four corners of the optimisation:
+  ;;
+  ;; - emit page (vt-intersects-query, content matches): kept under both flag values.
+  ;; - supersede page (vt-intersects-query, content fails): kept under both flag values
+  ;;   (still affects multiplicity).
+  ;; - constrain-only page (vt-disjoint from query, vt-overlaps emit envelope): kept when
+  ;;   flag is true; dropped when flag is false (its only contribution is to a temporal
+  ;;   column the consumer doesn't write).
+  (let [pages [(->mock-page 0 true 0 30 0 0)         ; emit
+               (->mock-page 1 false 0 30 0 0)        ; supersede — vt-intersects, content fails
+               (->mock-page 2 true 15 25 0 0)]       ; constrain-only — vt 15→25, disjoint from query 0→10, overlaps envelope 0→30
+        query-bounds (tu/->temporal-bounds 0 10)]
+
+    (t/is (= #{0 1 2}
+             (->> (trie/filter-pages pages {:query-bounds query-bounds, :projects-temporal-cols? true})
+                  (into #{} (map :page))))
+          "with :projects-temporal-cols? true: emit, supersede, and constrain-only all kept")
+
+    (t/is (= #{0 1}
+             (->> (trie/filter-pages pages {:query-bounds query-bounds, :projects-temporal-cols? false})
+                  (into #{} (map :page))))
+          "with :projects-temporal-cols? false: emit and supersede kept; constrain-only dropped")))

--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -78,7 +78,7 @@
       (->> (into #{} (map :trie-key)))))
 
 (t/deftest earilier-recency-files-can-effect-splitting-in-later-buckets-4097
-  (let [opts {:query-bounds (tu/->temporal-bounds 20220101 20220102)}]
+  (let [opts {:query-bounds (tu/->temporal-bounds 20220101 20220102), :projects-temporal-cols? true}]
     (t/is (= #{"l0-recency-2019-block-00" "l0-current-block-00"}
              (filter-tries [["l0-recency-2019-block-00" nil [20190101 20210101]]
                             ["l0-current-block-00" nil [20200101 Long/MAX_VALUE 20190101]]]
@@ -88,7 +88,7 @@
 (t/deftest test-filter-tries
   (let [current-time 20200101]
     (t/testing "recency filtering (temporal metadata always overlaps the query)"
-      (let [opts {:query-bounds (tu/->temporal-bounds current-time (inc current-time))}]
+      (let [opts {:query-bounds (tu/->temporal-bounds current-time (inc current-time)), :projects-temporal-cols? true}]
         (t/is (empty? (filter-tries [] opts)))
 
         (t/is (= #{"l0-current-block-02" "l0-current-block-01" "l0-current-block-00"}
@@ -112,10 +112,14 @@
                                opts))
               "newer recency files get taken"))
 
-      (let [all-st-opts {:query-bounds (tu/->temporal-bounds current-time (inc current-time) Long/MIN_VALUE Long/MAX_VALUE)}
-            all-vt-opts {:query-bounds (tu/->temporal-bounds Long/MIN_VALUE Long/MAX_VALUE current-time (inc current-time))}
-            st-range-opts {:query-bounds (tu/->temporal-bounds current-time (inc current-time) current-time Long/MAX_VALUE)}
-            vt-range-opts {:query-bounds (tu/->temporal-bounds current-time Long/MAX_VALUE current-time (inc current-time))}]
+      (let [all-st-opts {:query-bounds (tu/->temporal-bounds current-time (inc current-time) Long/MIN_VALUE Long/MAX_VALUE)
+                         :projects-temporal-cols? true}
+            all-vt-opts {:query-bounds (tu/->temporal-bounds Long/MIN_VALUE Long/MAX_VALUE current-time (inc current-time))
+                         :projects-temporal-cols? true}
+            st-range-opts {:query-bounds (tu/->temporal-bounds current-time (inc current-time) current-time Long/MAX_VALUE)
+                           :projects-temporal-cols? true}
+            vt-range-opts {:query-bounds (tu/->temporal-bounds current-time Long/MAX_VALUE current-time (inc current-time))
+                           :projects-temporal-cols? true}]
 
         (t/is (= #{"l01-current-block-00" "l01-recency-2019-block-01" "l01-current-block-01" "l01-recency-2021-block-01"}
                  (filter-tries [["l01-current-block-00"      nil      [20200101 Long/MAX_VALUE]]
@@ -144,7 +148,7 @@
               "system-time range or valid-time range can filter certain pages")))
 
     (t/testing "filtering via temporal metadata"
-      (let [opts {:query-bounds (tu/->temporal-bounds current-time Long/MAX_VALUE)}]
+      (let [opts {:query-bounds (tu/->temporal-bounds current-time Long/MAX_VALUE), :projects-temporal-cols? true}]
 
         (t/is (= #{"l0-current-block-00" "l0-current-block-01"}
                  (filter-tries [["l0-recency-2021-block-00" 20210101 [20180101 20190101]]
@@ -154,7 +158,7 @@
                                opts))
               "recency doesn't filter, temporal metadata does filter"))
 
-      (let [opts {:query-bounds (tu/->temporal-bounds current-time 20210101)}]
+      (let [opts {:query-bounds (tu/->temporal-bounds current-time 20210101), :projects-temporal-cols? true}]
 
         (t/is (= #{"l0-current-block-01" "l0-current-block-02"}
                  (filter-tries [["l0-current-block-00" nil [20100101 20190101]]


### PR DESCRIPTION
Resolves #5520.

#5520 describes why constrain-only pages are wasted I/O on queries that don't project any temporal column — `BitemporalConsumer` opens no writer for the slots those pages would contribute to.
This PR wires the optimisation through `filter-pages` and `scan`.

## Implementation notes

- Phase 2's `:when` switches on `:projects-temporal-cols?` with **different bounds per branch**, not a shared base predicate plus extras.
  Projecting → vt overlaps the *envelope*; not projecting → vt intersects the *query*.
  Neither check subsumes the other in general — they're against different bounds, and the `if` picks the right one for what each branch keeps (broad: supersede + constrain; narrow: supersede only).

- The four-temporal-col set in `scan` is inlined as a literal, not `xtdb.types/temporal-col-name?`.
  That predicate also returns true for `_iid`, which is unaffected by polygon splits and so shouldn't trigger the conservative branch.
  The four names mirror what `BitemporalConsumer` opens writers for; if that ever drifts, this set must too.

- `col-names` at the scan call site already covers both projection columns and `:select`-clause columns.
  So a `WHERE _valid_from > X` query whose projection contains no temporal column still correctly conserves — the predicate column is in `col-names`.

- `:projects-temporal-cols?` is a required opt with no default.
  Forgetting to pass it fails immediately on the destructured nil rather than silently picking a wrong branch.

## Test coverage

A new `test-projects-temporal-cols-flag` covers the four corners — emit, supersede, constrain-only kept (under `true`), constrain-only dropped (under `false`).
The TODO at `merge_plan_test.clj:112` is resolved by splitting the existing assertion into two parallel ones, one per flag value.

Existing tests pass `:projects-temporal-cols? true` — they assert the unoptimised behaviour and continue to do so.

## Follow-ups

- Property test asserting scan-output invariance under the flag toggle.
- Benchmark against the trie listing in #5520 (37 → 2 tries loaded for an as-of-now `SELECT COUNT(*)`).