### PR TITLE
feat(sql): FOR VALID_TIME ONLY — clamp + page elision

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -554,6 +554,7 @@ querySystemTimePeriodSpecification
 
 queryValidTimePeriodSpecification
    : 'FOR' 'VALID_TIME' tableTimePeriodSpecification
+   | 'FOR' 'VALID_TIME' ONLY 'FROM' from=expr 'TO' to=expr
    | 'FOR' ALL 'VALID_TIME'
    ;
 

--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -83,6 +83,7 @@
 
 (s/def ::for-valid-time (s/nilable ::temporal-filter))
 (s/def ::for-system-time (s/nilable ::temporal-filter))
+(s/def ::clamp-valid-time? (s/nilable boolean?))
 
 (defmulti ra-expr
   (fn [expr]

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -44,7 +44,7 @@
 (defmethod lp/ra-expr :scan [_]
   (s/cat :op #{:scan}
          :opts (s/keys :req-un [::table ::columns]
-                       :opt-un [::lp/for-valid-time ::lp/for-system-time])))
+                       :opt-un [::lp/for-valid-time ::lp/for-system-time ::lp/clamp-valid-time?])))
 
 (definterface IScanEmitter
   (emitScan [^xtdb.query.IQuerySource$QueryCatalog db-cat scan-expr scan-vec-types param-types]))
@@ -324,7 +324,7 @@
 
                                (let [merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) #(trie/filter-pages % filter-opts))]
                                (cond-> (ScanCursor. allocator (vec col-names) col-preds
-                                                    temporal-bounds
+                                                    temporal-bounds (boolean (:clamp-valid-time? scan-opts))
                                                     !segments (.iterator ^Iterable merge-tasks)
                                                     schema args)
                                  (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -311,7 +311,8 @@
                            (util/with-close-on-catch [!segments (LinkedList.)]
 
                              (let [filter-opts {:query-bounds temporal-bounds
-                                                :projects-temporal-cols? (boolean (some #{"_valid_from" "_valid_to" "_system_from" "_system_to"} col-names))}]
+                                                :projects-temporal-cols? (boolean (some #{"_valid_from" "_valid_to" "_system_from" "_system_to"} col-names))
+                                                :clamp-valid-time? (boolean (:clamp-valid-time? scan-opts))}]
 
                                (doseq [{:keys [^String trie-key]} (-> (cat/trie-state trie-catalog table)
                                                                       (cat/current-tries)

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -262,10 +262,16 @@
 (defrecord TableTimePeriodSpecificationVisitor [expr-visitor]
   SqlVisitor
   (visitQueryValidTimePeriodSpecification [this ctx]
-    (if (.ALL ctx)
-      :all-time
-      (-> (.tableTimePeriodSpecification ctx)
-          (.accept this))))
+    (cond
+      (.ALL ctx) {:for-valid-time :all-time}
+
+      (.ONLY ctx) {:for-valid-time [:in
+                                    (-> ctx (.from) (.accept expr-visitor))
+                                    (-> ctx (.to) (.accept expr-visitor))]
+                   :clamp-valid-time? true}
+
+      :else {:for-valid-time (-> (.tableTimePeriodSpecification ctx)
+                                 (.accept this))}))
 
   (visitQuerySystemTimePeriodSpecification [this ctx]
     (if (.ALL ctx)
@@ -310,7 +316,7 @@
    plan])
 
 (defrecord BaseTable [env, ^TableRef table-ref
-                      for-valid-time for-system-time
+                      for-valid-time clamp-valid-time? for-system-time
                       table-alias unique-table-alias cols
                       ^Map !reqd-cols]
   Scope
@@ -345,6 +351,7 @@
        (cond-> [:scan (cond-> {:table table-ref
                                :columns scan-cols}
                         for-vt (assoc :for-valid-time for-vt)
+                        clamp-valid-time? (assoc :clamp-valid-time? true)
                         for-st (assoc :for-system-time for-st))]
          (or valid-time-col? sys-time-col?) (wrap-temporal-periods scan-cols valid-time-col? sys-time-col?))])))
 
@@ -690,13 +697,15 @@
                         1 (.accept ^ParserRuleContext (first specs) (->TableTimePeriodSpecificationVisitor expr-visitor))
                         :else (add-err! env (->MultipleTimePeriodSpecifications))))]
 
-              ;; HACK we scan `xt.not_found` until a not-found table can be an error, #4467
-              (->BaseTable env (or table (table/->ref default-db "xt" "not_found"))
-                           (<-table-time-period-specification (.queryValidTimePeriodSpecification ctx))
-                           (<-table-time-period-specification (.querySystemTimePeriodSpecification ctx))
-                           table-alias unique-table-alias
-                           (->insertion-ordered-set (or cols table-cols))
-                           (HashMap.)))))))
+              (let [{:keys [for-valid-time clamp-valid-time?]}
+                    (<-table-time-period-specification (.queryValidTimePeriodSpecification ctx))]
+                ;; HACK we scan `xt.not_found` until a not-found table can be an error, #4467
+                (->BaseTable env (or table (table/->ref default-db "xt" "not_found"))
+                             for-valid-time clamp-valid-time?
+                             (<-table-time-period-specification (.querySystemTimePeriodSpecification ctx))
+                             table-alias unique-table-alias
+                             (->insertion-ordered-set (or cols table-cols))
+                             (HashMap.))))))))
 
   (visitJoinTable [this ctx]
     (let [l (-> (.tableReference ctx 0) (.accept this))

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -2923,23 +2923,18 @@
   (plan-rel [{{:keys [default-db]} :env}]
     [:rename {:prefix unique-table-alias}
      [:scan (cond-> {:table (table/->ref default-db (symbol table-name))
-                     :columns (vec (.keySet !reqd-cols))}
+                     :columns (vec (.keySet !reqd-cols))
+                     :clamp-valid-time? true}
               for-valid-time (assoc :for-valid-time for-valid-time))]]))
 
 (def ^:private vf-col (->col-sym "_valid_from"))
 (def ^:private vt-col (->col-sym "_valid_to"))
 
 (defn- dml-stmt-valid-time-portion [from-expr to-expr]
+  ;; The DML scan sets `:clamp-valid-time? true` so `_valid_from` / `_valid_to` arrive
+  ;; clamped to `[from-expr, to-expr)` — no post-scan clamp needed.
   {:for-valid-time [:in (or from-expr time/start-of-time) to-expr]
-   :projection [{vf-col (xt/template
-                         (greatest ~vf-col (cast (coalesce ~from-expr xtdb/start-of-time) #xt/type :instant)))}
-
-                {vt-col (if to-expr
-                          (xt/template
-                           (least (coalesce ~vt-col xtdb/end-of-time)
-                                  (coalesce (cast ~to-expr #xt/type :instant) xtdb/end-of-time)))
-
-                          vt-col)}]})
+   :projection [vf-col vt-col]})
 
 (defrecord DmlValidTimeExtentsVisitor [env scope]
   SqlVisitor
@@ -3027,6 +3022,7 @@
           [:order-by {:order-specs [[_iid] [_valid_from]]}
            [:scan {:table ~table
                    :for-valid-time [:in ~valid-from ~valid-to]
+                   :clamp-valid-time? true
                    :columns [_iid _valid_from _valid_to
                              ~@known-cols]}]]]]]]])))
 

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -104,7 +104,7 @@
         (.setPageLimit page-limit))
       (.build)))
 
-(defn filter-pages [pages {:keys [^TemporalBounds query-bounds projects-temporal-cols?]}]
+(defn filter-pages [pages {:keys [^TemporalBounds query-bounds projects-temporal-cols? clamp-valid-time?]}]
   ;; Pages are categorised by what they can do to the result:
   ;;
   ;; - **emit** — rows in this page can appear in the output.
@@ -113,7 +113,8 @@
   ;;   Temporal bounds match the query; content predicate need not.
   ;; - **constrain** — rows here can affect the bounds of the resulting polygons.
   ;;   Temporal bounds disjoint from the query but overlapping the emit envelope.
-  ;;   We exclude these if the query doesn't project temporal columns
+  ;;   We exclude these if the caller doesn't observe their contribution: either the query doesn't
+  ;;   project temporal columns, or it projects them clamped to the query bounds.
 
   (let [leaves (ArrayList.)
         min-query-recency (long (min (.getLower (.getValidTime query-bounds))
@@ -156,7 +157,7 @@
                             ;; none of the rows in that file can affect the rows in the emit set.
                             (<= smallest-system-from (.getMaxSystemFrom tm))
 
-                            (if projects-temporal-cols?
+                            (if (and projects-temporal-cols? (not clamp-valid-time?))
                               ;; keep candidates whose vt overlaps the emit envelope
                               ;; (covers both supersede and constrain — the latter feed `_valid_from` etc.).
                               (and (.intersects (TemporalDimension. (.getMinValidFrom tm) (.getMaxValidTo tm))
@@ -165,7 +166,8 @@
                                        (>= page-recency smallest-system-from)))
 
                               ;; keep only candidates that vt-intersect the query itself
-                              ;; (supersede only; constrain-only contribution is wasted I/O)
+                              ;; (supersede only; constrain-only contribution is wasted I/O —
+                              ;; either nobody reads vt cols, or their contribution would be clamped away)
                               (temporal-intersects? page)))]
 
               (.add leaves page)))

--- a/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
@@ -18,18 +18,23 @@ import xtdb.util.safeMap
 import java.util.*
 import java.util.Comparator.comparing
 import java.util.function.Consumer
+import kotlin.math.max
+import kotlin.math.min
 
 class ScanCursor(
     private val al: BufferAllocator,
 
     private val colNames: List<ColumnName>, private val colPreds: Map<ColumnName, SelectionSpec>,
-    private val temporalBounds: TemporalBounds,
+    private val temporalBounds: TemporalBounds, private val clampValidTime: Boolean,
 
     private val segments: List<Segment<*>>,
     private val mergeTasks: Iterator<MergeTask>,
 
     private val schema: Map<String, Any>, private val args: RelationReader
 ) : ICursor {
+
+    private val vtLower = temporalBounds.validTime.lower
+    private val vtUpper = temporalBounds.validTime.upper
 
     override val cursorType get() = "scan"
     override val childCursors get() = emptyList<ICursor>()
@@ -89,7 +94,9 @@ class ScanCursor(
                                     temporalBounds.intersects(validFrom, validTo, sysFrom, sysTo)
                                     && validFrom != validTo && sysFrom != sysTo
                                 ) {
-                                    bitemporalConsumer.accept(leafPtr.relIdx, idx, validFrom, validTo, sysFrom, sysTo)
+                                    val outValidFrom = if (clampValidTime) max(validFrom, vtLower) else validFrom
+                                    val outValidTo = if (clampValidTime) min(validTo, vtUpper) else validTo
+                                    bitemporalConsumer.accept(leafPtr.relIdx, idx, outValidFrom, outValidTo, sysFrom, sysTo)
                                 }
                             }
                         }

--- a/src/test/clojure/xtdb/segment/merge_plan_test.clj
+++ b/src/test/clojure/xtdb/segment/merge_plan_test.clj
@@ -274,4 +274,11 @@
     (t/is (= #{0 1}
              (->> (trie/filter-pages pages {:query-bounds query-bounds, :projects-temporal-cols? false})
                   (into #{} (map :page))))
-          "with :projects-temporal-cols? false: emit and supersede kept; constrain-only dropped")))
+          "with :projects-temporal-cols? false: emit and supersede kept; constrain-only dropped")
+
+    (t/is (= #{0 1}
+             (->> (trie/filter-pages pages {:query-bounds query-bounds
+                                            :projects-temporal-cols? true
+                                            :clamp-valid-time? true})
+                  (into #{} (map :page))))
+          "with :clamp-valid-time? true: constrain-only dropped even though temporal cols are projected — its only contribution would be clamped away")))

--- a/src/test/clojure/xtdb/sql/temporal_test.clj
+++ b/src/test/clojure/xtdb/sql/temporal_test.clj
@@ -149,6 +149,56 @@
         (t/is (= [{:last-updated "3000"}]
                  (query-at "SELECT last_updated FROM foo FOR ALL VALID_TIME WHERE foo._VALID_TIME CONTAINS DATE '3500-01-01'" tx)))))))
 
+(t/deftest valid-time-only-clamps-projection
+  ;; FOR VALID_TIME ONLY FROM X TO Y clamps the projected _valid_from / _valid_to
+  ;; to within [X, Y); the plain FROM/TO form returns the row's stored bounds.
+
+  (let [tx (xt/execute-tx tu/*node* [[:put-docs {:into :foo, :valid-from #inst "2000", :valid-to #inst "2010"}
+                                       {:xt/id 1, :v "decade"}]
+                                      [:put-docs {:into :foo, :valid-from #inst "2004", :valid-to #inst "2006"}
+                                       {:xt/id 2, :v "inside"}]])]
+
+    (t/testing "ONLY clamps when stored polygon extends outside the window"
+      (t/is (= [{:xt/id 1, :v "decade",
+                 :valid-from (time/->zdt #inst "2003"), :valid-to (time/->zdt #inst "2007")}]
+               (query-at "SELECT _id, v, _valid_from AS valid_from, _valid_to AS valid_to FROM foo
+                          FOR VALID_TIME ONLY FROM TIMESTAMP '2003-01-01 00:00:00+00:00' TO TIMESTAMP '2007-01-01 00:00:00+00:00'
+                          WHERE _id = 1"
+                         tx))))
+
+    (t/testing "without ONLY, projected bounds are the row's stored bounds"
+      (t/is (= [{:xt/id 1, :v "decade",
+                 :valid-from (time/->zdt #inst "2000"), :valid-to (time/->zdt #inst "2010")}]
+               (query-at "SELECT _id, v, _valid_from AS valid_from, _valid_to AS valid_to FROM foo
+                          FOR VALID_TIME FROM TIMESTAMP '2003-01-01 00:00:00+00:00' TO TIMESTAMP '2007-01-01 00:00:00+00:00'
+                          WHERE _id = 1"
+                         tx))))
+
+    (t/testing "ONLY is a no-op when the row's polygon is fully inside the window"
+      (t/is (= [{:xt/id 2, :v "inside",
+                 :valid-from (time/->zdt #inst "2004"), :valid-to (time/->zdt #inst "2006")}]
+               (query-at "SELECT _id, v, _valid_from AS valid_from, _valid_to AS valid_to FROM foo
+                          FOR VALID_TIME ONLY FROM TIMESTAMP '2003-01-01 00:00:00+00:00' TO TIMESTAMP '2007-01-01 00:00:00+00:00'
+                          WHERE _id = 2"
+                         tx))))
+
+    (t/testing "ONLY clamps only the side that exceeds the window"
+      (t/is (= [{:xt/id 1,
+                 :valid-from (time/->zdt #inst "2005"), :valid-to (time/->zdt #inst "2010")}]
+               (query-at "SELECT _id, _valid_from AS valid_from, _valid_to AS valid_to FROM foo
+                          FOR VALID_TIME ONLY FROM TIMESTAMP '2005-01-01 00:00:00+00:00' TO TIMESTAMP '2020-01-01 00:00:00+00:00'
+                          WHERE _id = 1"
+                         tx))
+            "lower bound clamped, upper preserved")
+
+      (t/is (= [{:xt/id 1,
+                 :valid-from (time/->zdt #inst "2000"), :valid-to (time/->zdt #inst "2005")}]
+               (query-at "SELECT _id, _valid_from AS valid_from, _valid_to AS valid_to FROM foo
+                          FOR VALID_TIME ONLY FROM TIMESTAMP '1990-01-01 00:00:00+00:00' TO TIMESTAMP '2005-01-01 00:00:00+00:00'
+                          WHERE _id = 1"
+                         tx))
+            "upper bound clamped, lower preserved"))))
+
 (t/deftest app-time-multiple-tables
   (let [tx (xt/execute-tx tu/*node* [[:put-docs {:into :foo, :valid-from #inst "2000", :valid-to #inst "2001"}
                                       {:xt/id :foo-doc, :last-updated "2001"}]

--- a/src/test/clojure/xtdb/tracer_test.clj
+++ b/src/test/clojure/xtdb/tracer_test.clj
@@ -190,9 +190,6 @@
                           [{:name "query.cursor.project"
                             :attributes {"cursor.page_count" "0" "cursor.row_count" "0" "cursor.type" "project"},
                             :children []}
-                           {:name "query.cursor.project"
-                            :attributes {"cursor.page_count" "0" "cursor.row_count" "0" "cursor.type" "project"},
-                            :children []}
                            {:name "query.cursor.rename"
                             :attributes {"cursor.page_count" "0" "cursor.row_count" "0" "cursor.type" "rename"},
                             :children []}

--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -173,7 +173,25 @@
                                 ["l0-current-block-01" nil [20190101 20250101 20200101]]
                                 ["l0-current-block-02" nil [20220101 Long/MAX_VALUE 20190101]]]
                                opts))
-              "recency doesn't filter, temporal metadata does filter, if valid-time bounding files come earlier in system time they don't need to get taken")))))
+              "recency doesn't filter, temporal metadata does filter, if valid-time bounding files come earlier in system time they don't need to get taken")))
+
+    (t/testing ":clamp-valid-time? drops constrain-only tries"
+      ;; Block 01 emits (vt 20200101 → 20250101, extending beyond the query);
+      ;; Block 02 is constrain-only — vt 20220101 → 20240101 sits inside Block 01's
+      ;; envelope but is disjoint from the query 20200101 → 20210101.
+      ;; Under clamp, Block 02's only contribution would be a `_valid_to` push-out
+      ;; that the projection clamps back inside the query, so reading it is wasted I/O.
+      (let [tries [["l0-current-block-01" nil [20200101 20250101]]
+                   ["l0-current-block-02" nil [20220101 20240101]]]
+            base-opts {:query-bounds (tu/->temporal-bounds 20200101 20210101)}]
+
+        (t/is (= #{"l0-current-block-01" "l0-current-block-02"}
+                 (filter-tries tries (assoc base-opts :projects-temporal-cols? true)))
+              "constrain-only kept when the query projects unclamped temporal cols")
+
+        (t/is (= #{"l0-current-block-01"}
+                 (filter-tries tries (assoc base-opts :projects-temporal-cols? true :clamp-valid-time? true)))
+              "constrain-only dropped under clamp, even though temporal cols are projected")))))
 
 (t/deftest test-partitions
   (t/is (= #{{:level 1,

--- a/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-1.edn
@@ -1,26 +1,12 @@
 [:project
  {:projections
-  [_iid
-   {_valid_from
-    (greatest
-     _valid_from
-     (cast
-      (coalesce (current-timestamp) xtdb/start-of-time)
-      #xt/type :instant))}
-   {_valid_to
-    (least
-     (coalesce _valid_to xtdb/end-of-time)
-     (coalesce
-      (cast xtdb/end-of-time #xt/type :instant)
-      xtdb/end-of-time))}]}
- [:project
-  {:projections
-   [{_iid u.1/_iid}
-    {_valid_from u.1/_valid_from}
-    {_valid_to u.1/_valid_to}]}
-  [:rename
-   {:prefix u.1}
-   [:scan
-    {:table #xt/table t1,
-     :columns [{col1 (== col1 30)} _valid_to _valid_from _iid],
-     :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]]
+  [{_iid u.1/_iid}
+   {_valid_from u.1/_valid_from}
+   {_valid_to u.1/_valid_to}]}
+ [:rename
+  {:prefix u.1}
+  [:scan
+   {:table #xt/table t1,
+    :columns [{col1 (== col1 30)} _valid_to _valid_from _iid],
+    :clamp-valid-time? true,
+    :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-2.edn
@@ -1,26 +1,12 @@
 [:project
  {:projections
-  [_iid
-   {_valid_from
-    (greatest
-     _valid_from
-     (cast
-      (coalesce (current-timestamp) xtdb/start-of-time)
-      #xt/type :instant))}
-   {_valid_to
-    (least
-     (coalesce _valid_to xtdb/end-of-time)
-     (coalesce
-      (cast xtdb/end-of-time #xt/type :instant)
-      xtdb/end-of-time))}]}
- [:project
-  {:projections
-   [{_iid t1.1/_iid}
-    {_valid_from t1.1/_valid_from}
-    {_valid_to t1.1/_valid_to}]}
-  [:rename
-   {:prefix t1.1}
-   [:scan
-    {:table #xt/table t1,
-     :columns [{col1 (== col1 30)} _valid_to _valid_from _iid],
-     :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]]
+  [{_iid t1.1/_iid}
+   {_valid_from t1.1/_valid_from}
+   {_valid_to t1.1/_valid_to}]}
+ [:rename
+  {:prefix t1.1}
+  [:scan
+   {:table #xt/table t1,
+    :columns [{col1 (== col1 30)} _valid_to _valid_from _iid],
+    :clamp-valid-time? true,
+    :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
@@ -1,31 +1,19 @@
 [:project
  {:projections
-  [_iid
-   {_valid_from
-    (greatest
+  [{_iid u.1/_iid}
+   {_valid_from u.1/_valid_from}
+   {_valid_to u.1/_valid_to}
+   {first_name ?_2}
+   {id u.1/id}]}
+ [:rename
+  {:prefix u.1}
+  [:scan
+   {:table #xt/table users,
+    :columns
+    [_valid_to
+     {id (== id ?_3)}
      _valid_from
-     (cast (coalesce ?_0 xtdb/start-of-time) #xt/type :instant))}
-   {_valid_to
-    (least
-     (coalesce _valid_to xtdb/end-of-time)
-     (coalesce (cast ?_1 #xt/type :instant) xtdb/end-of-time))}
-   first_name
-   id]}
- [:project
-  {:projections
-   [{_iid u.1/_iid}
-    {_valid_from u.1/_valid_from}
-    {_valid_to u.1/_valid_to}
-    {first_name ?_2}
-    {id u.1/id}]}
-  [:rename
-   {:prefix u.1}
-   [:scan
-    {:table #xt/table users,
-     :columns
-     [_valid_to
-      {id (== id ?_3)}
-      _valid_from
-      {first_name (or (not (boolean (=== ?_2 first_name))))}
-      _iid],
-     :for-valid-time [:in ?_0 ?_1]}]]]]
+     {first_name (or (not (boolean (=== ?_2 first_name))))}
+     _iid],
+    :clamp-valid-time? true,
+    :for-valid-time [:in ?_0 ?_1]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
@@ -1,32 +1,17 @@
 [:project
  {:projections
-  [_iid
-   {_valid_from
-    (greatest
+  [{_iid t1.1/_iid}
+   {_valid_from t1.1/_valid_from}
+   {_valid_to t1.1/_valid_to}
+   {col1 ?_0}]}
+ [:rename
+  {:prefix t1.1}
+  [:scan
+   {:table #xt/table t1,
+    :columns
+    [{col1 (or (not (boolean (=== ?_0 col1))))}
+     _valid_to
      _valid_from
-     (cast
-      (coalesce (current-timestamp) xtdb/start-of-time)
-      #xt/type :instant))}
-   {_valid_to
-    (least
-     (coalesce _valid_to xtdb/end-of-time)
-     (coalesce
-      (cast xtdb/end-of-time #xt/type :instant)
-      xtdb/end-of-time))}
-   col1]}
- [:project
-  {:projections
-   [{_iid t1.1/_iid}
-    {_valid_from t1.1/_valid_from}
-    {_valid_to t1.1/_valid_to}
-    {col1 ?_0}]}
-  [:rename
-   {:prefix t1.1}
-   [:scan
-    {:table #xt/table t1,
-     :columns
-     [{col1 (or (not (boolean (=== ?_0 col1))))}
-      _valid_to
-      _valid_from
-      _iid],
-     :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]]
+     _iid],
+    :clamp-valid-time? true,
+    :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-delete.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-delete.edn
@@ -8,4 +8,5 @@
   [:scan
    {:table #xt/table users,
     :columns [_valid_to _valid_from _iid],
+    :clamp-valid-time? true,
     :for-valid-time :all-time}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-update.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-update.edn
@@ -13,4 +13,5 @@
      _valid_from
      {first_name (or (not (boolean (=== "Sue" first_name))))}
      _iid],
+    :clamp-valid-time? true,
     :for-valid-time :all-time}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
@@ -1,21 +1,12 @@
 [:project
  {:projections
-  [_iid
-   {_valid_from
-    (greatest
-     _valid_from
-     (cast
-      (coalesce #xt/date "2020-05-01" xtdb/start-of-time)
-      #xt/type :instant))}
-   {_valid_to _valid_to}]}
- [:project
-  {:projections
-   [{_iid u.1/_iid}
-    {_valid_from u.1/_valid_from}
-    {_valid_to u.1/_valid_to}]}
-  [:rename
-   {:prefix u.1}
-   [:scan
-    {:table #xt/table users,
-     :columns [_valid_to {id (== id ?_0)} _valid_from _iid],
-     :for-valid-time [:in #xt/date "2020-05-01" nil]}]]]]
+  [{_iid u.1/_iid}
+   {_valid_from u.1/_valid_from}
+   {_valid_to u.1/_valid_to}]}
+ [:rename
+  {:prefix u.1}
+  [:scan
+   {:table #xt/table users,
+    :columns [_valid_to {id (== id ?_0)} _valid_from _iid],
+    :clamp-valid-time? true,
+    :for-valid-time [:in #xt/date "2020-05-01" nil]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
@@ -13,4 +13,5 @@
    [:scan
     {:table #xt/table foo,
      :columns [_valid_to bar baz quux _valid_from _iid],
+     :clamp-valid-time? true,
      :for-valid-time :all-time}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
@@ -32,4 +32,5 @@
     {:table #xt/table foo,
      :columns
      [_valid_to bar baz _system_time _valid_from _valid_time _iid],
+     :clamp-valid-time? true,
      :for-valid-time :all-time}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
@@ -1,33 +1,21 @@
 [:project
  {:projections
-  [_iid
-   {_valid_from
-    (greatest
+  [{_iid u.1/_iid}
+   {_valid_from u.1/_valid_from}
+   {_valid_to u.1/_valid_to}
+   {first_name "Sue"}
+   {id u.1/id}
+   {last_name u.1/last_name}]}
+ [:rename
+  {:prefix u.1}
+  [:scan
+   {:table #xt/table users,
+    :columns
+    [_valid_to
+     last_name
+     {id (== id ?_0)}
      _valid_from
-     (cast
-      (coalesce #xt/date "2021-07-01" xtdb/start-of-time)
-      #xt/type :instant))}
-   {_valid_to _valid_to}
-   first_name
-   id
-   last_name]}
- [:project
-  {:projections
-   [{_iid u.1/_iid}
-    {_valid_from u.1/_valid_from}
-    {_valid_to u.1/_valid_to}
-    {first_name "Sue"}
-    {id u.1/id}
-    {last_name u.1/last_name}]}
-  [:rename
-   {:prefix u.1}
-   [:scan
-    {:table #xt/table users,
-     :columns
-     [_valid_to
-      last_name
-      {id (== id ?_0)}
-      _valid_from
-      {first_name (or (not (boolean (=== "Sue" first_name))))}
-      _iid],
-     :for-valid-time [:in #xt/date "2021-07-01" nil]}]]]]
+     {first_name (or (not (boolean (=== "Sue" first_name))))}
+     _iid],
+    :clamp-valid-time? true,
+    :for-valid-time [:in #xt/date "2021-07-01" nil]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-1.edn
@@ -1,32 +1,17 @@
 [:project
  {:projections
-  [_iid
-   {_valid_from
-    (greatest
+  [{_iid u.1/_iid}
+   {_valid_from u.1/_valid_from}
+   {_valid_to u.1/_valid_to}
+   {col1 30}]}
+ [:rename
+  {:prefix u.1}
+  [:scan
+   {:table #xt/table t1,
+    :columns
+    [{col1 (or (not (boolean (=== 30 col1))))}
+     _valid_to
      _valid_from
-     (cast
-      (coalesce (current-timestamp) xtdb/start-of-time)
-      #xt/type :instant))}
-   {_valid_to
-    (least
-     (coalesce _valid_to xtdb/end-of-time)
-     (coalesce
-      (cast xtdb/end-of-time #xt/type :instant)
-      xtdb/end-of-time))}
-   col1]}
- [:project
-  {:projections
-   [{_iid u.1/_iid}
-    {_valid_from u.1/_valid_from}
-    {_valid_to u.1/_valid_to}
-    {col1 30}]}
-  [:rename
-   {:prefix u.1}
-   [:scan
-    {:table #xt/table t1,
-     :columns
-     [{col1 (or (not (boolean (=== 30 col1))))}
-      _valid_to
-      _valid_from
-      _iid],
-     :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]]
+     _iid],
+    :clamp-valid-time? true,
+    :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-2.edn
@@ -1,32 +1,17 @@
 [:project
  {:projections
-  [_iid
-   {_valid_from
-    (greatest
+  [{_iid t1.1/_iid}
+   {_valid_from t1.1/_valid_from}
+   {_valid_to t1.1/_valid_to}
+   {col1 30}]}
+ [:rename
+  {:prefix t1.1}
+  [:scan
+   {:table #xt/table t1,
+    :columns
+    [{col1 (or (not (boolean (=== 30 col1))))}
+     _valid_to
      _valid_from
-     (cast
-      (coalesce (current-timestamp) xtdb/start-of-time)
-      #xt/type :instant))}
-   {_valid_to
-    (least
-     (coalesce _valid_to xtdb/end-of-time)
-     (coalesce
-      (cast xtdb/end-of-time #xt/type :instant)
-      xtdb/end-of-time))}
-   col1]}
- [:project
-  {:projections
-   [{_iid t1.1/_iid}
-    {_valid_from t1.1/_valid_from}
-    {_valid_to t1.1/_valid_to}
-    {col1 30}]}
-  [:rename
-   {:prefix t1.1}
-   [:scan
-    {:table #xt/table t1,
-     :columns
-     [{col1 (or (not (boolean (=== 30 col1))))}
-      _valid_to
-      _valid_from
-      _iid],
-     :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]]
+     _iid],
+    :clamp-valid-time? true,
+    :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]


### PR DESCRIPTION
Builds on #5520's recent constrain-only page elision (`56c971884`).
That commit recovered single-entity *read* perf when no temporal columns are projected, but UPDATE / PATCH inherently project `_valid_from` / `_valid_to`, so the optimisation didn't fire on the *write* path.
A 291-trie production listing showed 35 historical tries in the constrain-only bucket — the bucket this PR reaches.

`FOR VALID_TIME ONLY FROM X TO Y` is a SELECT-side surface that says explicitly: "the projected `_valid_from` / `_valid_to` are clamped within `[X, Y)`."
Once that fact is surfaced, downstream layers can drop work that would otherwise be wasted under the eventual clamp.
UPDATE / DELETE / PATCH always implicitly mean ONLY, so they wire onto the same flag and finally see the constrain-elision win.

## Approach

Two facts surface from the SQL caller into the scan op:

- `:projects-temporal-cols?` — caller will read temporal cols (existing).
- `:clamp-valid-time?` — caller's projected vt cols will be clamped to query bounds (new).

Consumers derive their behaviour from those two facts:

- `ScanCursor` clamps `_valid_from` / `_valid_to` at the polygon-segment loop (two `max`/`min` calls before `BitemporalConsumer.accept`).
- `filter-pages` / `filter-tries` keep constrain-only pages iff `(and projects-temporal-cols? (not clamp-valid-time?))`.

I rejected the plan-layer alternative — wrapping scan with `(greatest _valid_from X)` / `(least _valid_to Y)`, mirroring UPDATE today.
That'd cost an extra vector pass per query, *and* would block UPDATE / DELETE / PATCH from simplifying their post-scan clamp away.
The scan-loop clamp is two lines next to an `intersects()` check that already drops segments fully outside `[X, Y)`; the clamp only does work for partial-overlap segments.

## Three commits

1. **`feat(sql): FOR VALID_TIME ONLY FROM X TO Y`** — grammar (`Sql.g4`), visitor (returns a map `{:for-valid-time …, :clamp-valid-time? …}` so two facts can flow through), `ScanCursor` clamp.
2. **`feat(scan): drop constrain-only pages under :clamp-valid-time?`** — `filter-pages` extends to take the new flag; phase-2 condition becomes `(if (and projects-temporal-cols? (not clamp-valid-time?)) envelope-branch query-branch)`. `filter-tries` is a thin delegate so picks up the flag automatically.
3. **`feat(sql): UPDATE / DELETE / PATCH use clamped scans`** — DML scans set `:clamp-valid-time? true`; UPDATE / DELETE drop their post-scan `(greatest …)` / `(least …)` projection; PATCH leaves `PatchGapsCursor`'s `coerceAtLeast` / `coerceAtMost` in place (it composes idempotently).

## Behaviour-preserving notes

- **PATCH** keeps `PatchGapsCursor`'s clamp.
  Adding `:clamp-valid-time? true` to its scan only changes *which* layer does the clamp; the final emitted `_valid_from` / `_valid_to` are unchanged.
- **UPDATE / DELETE** drop `dml-stmt-valid-time-portion`'s `(greatest _valid_from from-expr)` projection.
  `(greatest scan_vf, X)` over `scan_vf = max(stored_vf, X)` reduces to `scan_vf` — pure idempotence.
  The visible side-effect: the optimiser collapses what's now a pass-through project, so the tracer test sees one fewer `query.cursor.project` for UPDATE.
- The `visitQueryValidTimePeriodSpecification` visitor return shape changed from a tagged value to a map (because two facts need to surface).
  `visitQuerySystemTimePeriodSpecification` still returns the tagged value — there's no `FOR SYSTEM_TIME ONLY` in scope and the asymmetry isn't worth a preemptive refactor.

## Tests

- New `valid-time-only-clamps-projection` SQL test covers ONLY's clamp behaviour end-to-end (clamp engages, no-op when fully inside, one-sided clamps).
- Extended `test-projects-temporal-cols-flag` (page-level) and added a `clamp-valid-time` block in `test-filter-tries` (trie-level) so the page elision is unit-tested at both layers.
- `=plan-file` expectations regenerated for the affected DML deftests; `test-transaction-tracing` updated for the now-collapsed project layer.

## Out of scope

- `FOR SYSTEM_TIME ONLY` — symmetric extension if useful, not pulled in here.