### PR TITLE
refactor(flight-sql): delegate prepared statements to XtdbStatement (#5270)

### DIFF
--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -45,22 +45,12 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
     interface XtdbStatement : AdbcStatement {
         fun bind(rel: RelationReader): Unit = unsupported("bind(RelationReader) not supported")
-
-        /**
-         * Take ownership of [rel] as the statement's parameters, bypassing the defensive copy
-         * that [bind] performs. The caller MUST NOT close [rel]; the statement owns it from
-         * this point and will close it on the next [bind] / [bindOwning] / [close].
-         *
-         * [rel] must be allocated by an allocator compatible with the statement's connection
-         * (typically the node's allocator or one of its descendants).
-         */
-        fun bindOwning(rel: Relation): Unit = unsupported("bindOwning(Relation) not supported")
     }
 
     override fun createStatement() = object : XtdbStatement {
         private var sql: String? = null
         private var prepared: PreparedQuery? = null
-        private var args: Relation? = null
+        private var args: RelationReader? = null
 
         private fun clearArgs() {
             args.also { args = null }?.close()
@@ -93,20 +83,18 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
 
         override fun bind(root: VectorSchemaRoot) {
-            Relation.fromRoot(node.allocator, root).use(::bind)
-        }
-
-        override fun bind(rel: RelationReader) {
             clearArgs()
-            args = Relation(node.allocator, rel.schema).closeOnCatch { copy ->
-                rel.rowCopier(copy).copyRange(0, rel.rowCount)
+            args = Relation(node.allocator, root.schema).closeOnCatch { copy ->
+                Relation.fromRoot(node.allocator, root).use { src ->
+                    src.rowCopier(copy).copyRange(0, src.rowCount)
+                }
                 copy
             }
         }
 
-        override fun bindOwning(rel: Relation) {
+        override fun bind(rel: RelationReader) {
             clearArgs()
-            args = rel
+            args = rel.openSlice(node.allocator)
         }
 
         override fun executeQuery(): QueryResult {

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -45,6 +45,16 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
     interface XtdbStatement : AdbcStatement {
         fun bind(rel: RelationReader): Unit = unsupported("bind(RelationReader) not supported")
+
+        /**
+         * Take ownership of [rel] as the statement's parameters, bypassing the defensive copy
+         * that [bind] performs. The caller MUST NOT close [rel]; the statement owns it from
+         * this point and will close it on the next [bind] / [bindOwning] / [close].
+         *
+         * [rel] must be allocated by an allocator compatible with the statement's connection
+         * (typically the node's allocator or one of its descendants).
+         */
+        fun bindOwning(rel: Relation): Unit = unsupported("bindOwning(Relation) not supported")
     }
 
     override fun createStatement() = object : XtdbStatement {
@@ -92,6 +102,11 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
                 rel.rowCopier(copy).copyRange(0, rel.rowCount)
                 copy
             }
+        }
+
+        override fun bindOwning(rel: Relation) {
+            clearArgs()
+            args = rel
         }
 
         override fun executeQuery(): QueryResult {

--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -244,8 +244,10 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
     ): Runnable = Runnable {
         val ps = requireNotNull(stmts[cmd.preparedStatementHandle]) { "invalid ps-id" }
         try {
-            ps.xtdbStmt.bindOwning(flightStream.toRelation(node.allocator))
-            ps.xtdbStmt.executeUpdate()
+            flightStream.toRelation(node.allocator).use { acc ->
+                ps.xtdbStmt.bind(acc)
+                ps.xtdbStmt.executeUpdate()
+            }
             ackStream.sendDoPutUpdateRes(allocator)
         } catch (t: Throwable) {
             ackStream.onError(t)

--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -14,38 +14,30 @@ import org.apache.arrow.flight.sql.NoOpFlightSqlProducer
 import org.apache.arrow.flight.sql.impl.FlightSql.*
 import org.apache.arrow.flight.sql.impl.FlightSql.ActionEndTransactionRequest.EndTransaction
 import xtdb.database.DatabaseName
+import org.apache.arrow.adbc.core.AdbcStatement
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.UInt4Vector
 import org.apache.arrow.vector.VarCharVector
 import org.apache.arrow.vector.VectorLoader
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.VectorUnloader
 import org.apache.arrow.vector.complex.DenseUnionVector
+import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.adbc.XtdbConnection
 import xtdb.api.Xtdb
-import xtdb.arrow.ArrowUnloader
 import xtdb.arrow.Relation
-import xtdb.arrow.RelationReader
-import xtdb.arrow.Vector
 import xtdb.arrow.VectorType
 import xtdb.asBytes
 import xtdb.ResultCursor
-import xtdb.arrow.VectorType.Companion.ofType
-import xtdb.arrow.withName
 import xtdb.kw
-import xtdb.query.PreparedQuery
 import xtdb.tx.TxOp
 import xtdb.util.closeAll
 import xtdb.util.closeOnCatch
-import xtdb.util.safeMapIndexed
 import xtdb.util.logger
 import xtdb.util.requiringResolve
 import xtdb.util.serializeAsMessageInterruptibly
 import xtdb.util.warn
-import java.io.ByteArrayOutputStream
-import java.nio.channels.Channels
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
@@ -91,46 +83,29 @@ private fun isDml(sql: String, dbName: DatabaseName): Boolean {
     return opKeyword?.name in setOf("insert", "update", "delete", "erase")
 }
 
-private fun FlightStream.toRows(allocator: BufferAllocator): List<List<Any?>> {
-    val rows = ArrayList<List<Any?>>()
-
-    Relation.fromRoot(allocator, root).use { rel ->
-        while (next()) {
-            rel.loadFromArrow(root)
-            rows.addAll(rel.toTuples())
-        }
-    }
-
-    return rows
-}
-
-private fun FlightStream.toBytes(allocator: BufferAllocator): ByteArray =
-    ByteArrayOutputStream().use { out ->
-        val rootUnl = VectorUnloader(root)
-        Relation(allocator, root.schema.fields.mapIndexed { idx, f -> f.withName("?_$idx") })
-            .use { rel ->
-                rel.startUnload(Channels.newChannel(out), ArrowUnloader.Mode.STREAM).use { unl ->
-                    while (next()) {
-                        rootUnl.recordBatch.use { rb -> rel.load(rb) }
-                        unl.writePage()
-                    }
-                    unl.end()
-
-                    out.toByteArray()
-                }
+private fun FlightStream.toRelation(allocator: BufferAllocator): Relation =
+    Relation(allocator, root.schema).closeOnCatch { acc ->
+        Relation(allocator, root.schema).use { batch ->
+            val copier = batch.rowCopier(acc)
+            while (next()) {
+                batch.loadFromArrow(root)
+                copier.copyRange(0, batch.rowCount)
             }
+        }
+        acc
     }
+
+private val AdbcStatement.QueryResult.schema: Schema
+    get() = reader.vectorSchemaRoot.schema
 
 private class PreparedStatement(
-    val sql: String,
-    val txHandle: TxHandle?,
-    val dbName: DatabaseName,
-    val prepdQuery: PreparedQuery?,
-    var cursor: ResultCursor? = null
+    val xtdbStmt: XtdbConnection.XtdbStatement,
+    var queryResult: AdbcStatement.QueryResult? = null
 ) : AutoCloseable {
     override fun close() {
-        cursor?.close()
-        cursor = null
+        queryResult?.close()
+        queryResult = null
+        xtdbStmt.close()
     }
 }
 
@@ -249,27 +224,16 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         flightStream: FlightStream,
         ackStream: StreamListener<PutResult>
     ): Runnable = Runnable {
-        // TODO in tx?
-        val psId = cmd.preparedStatementHandle
-
-        stmts
-            .computeIfPresent(psId) { _, ps ->
-                // TODO we likely needn't take these out and put them back.
-                val row = flightStream.toRows(allocator).firstOrNull().orEmpty()
-
-                val newArgs = row.safeMapIndexed { idx, v ->
-                    Vector.fromList(allocator, "?_$idx", listOf(v))
-                }
-
-                RelationReader.from(newArgs, 1).closeOnCatch { argsRel ->
-                    ps.cursor?.close()
-                    ps.cursor = ps.prepdQuery?.openQuery(argsRel, QueryOpts())
-                    ps
-                }
-            }
-            .also { requireNotNull(it) { "invalid ps-id" } }
-
-        ackStream.onCompleted()
+        val ps = requireNotNull(stmts[cmd.preparedStatementHandle]) { "invalid ps-id" }
+        try {
+            flightStream.next()
+            ps.queryResult?.close()
+            ps.xtdbStmt.bind(flightStream.root)
+            ps.queryResult = ps.xtdbStmt.executeQuery()
+            ackStream.onCompleted()
+        } catch (t: Throwable) {
+            ackStream.onError(t)
+        }
     }
 
     override fun acceptPutPreparedStatementUpdate(
@@ -278,14 +242,10 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         flightStream: FlightStream,
         ackStream: StreamListener<PutResult>
     ): Runnable = Runnable {
-        // NOTE atm the PSs are either created within a tx and then assumed to be within that tx
-        // my mental model would be that you could create a PS outside a tx and then use it inside,
-        // but (maybe out of date?) this doesn't seem possible in FSQL.
         val ps = requireNotNull(stmts[cmd.preparedStatementHandle]) { "invalid ps-id" }
-
-        val op = TxOp.SqlBytes(ps.sql, flightStream.toBytes(allocator))
         try {
-            execDml(op, ps.txHandle, ps.dbName)
+            ps.xtdbStmt.bindOwning(flightStream.toRelation(node.allocator))
+            ps.xtdbStmt.executeUpdate()
             ackStream.sendDoPutUpdateRes(allocator)
         } catch (t: Throwable) {
             ackStream.onError(t)
@@ -345,8 +305,9 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         cmd: CommandPreparedStatementQuery, ctx: CallContext?, descriptor: FlightDescriptor
     ): FlightInfo {
         val psId = cmd.preparedStatementHandle
-
         val ps = requireNotNull(stmts[psId]) { "invalid ps-id" }
+
+        val queryResult = ps.queryResult ?: ps.xtdbStmt.executeQuery().also { ps.queryResult = it }
 
         val ticket = Ticket(
             ProtoAny.pack(
@@ -356,11 +317,8 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
             ).toByteArray()
         )
 
-        val cursor = checkNotNull(ps.cursor ?: ps.prepdQuery?.openQuery(null, QueryOpts())) { "invalid ps-id" }
-
-        ps.cursor = cursor
         return FlightInfo(
-            resultTypesToSchema(cursor.resultTypes),
+            queryResult.schema,
             descriptor,
             listOf(FlightEndpoint(ticket)),
             -1,
@@ -372,7 +330,9 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         ticket: CommandPreparedStatementQuery, ctx: CallContext?, listener: ServerStreamListener
     ) {
         val ps = requireNotNull(stmts[ticket.preparedStatementHandle]) { "invalid ps-id" }
-        handleGetStream(checkNotNull(ps.cursor) { "cursor not open" }, listener)
+        val queryResult = checkNotNull(ps.queryResult) { "no cursor open for ps-id" }
+        ps.queryResult = null
+        streamArrowReader(queryResult.reader, listener)
     }
 
     override fun createPreparedStatement(
@@ -383,28 +343,19 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         val psId = newHandle()
         val sql = req.queryBytes.toStringUtf8()
         val dbName = dbNameFromContext(ctx)
-        val pq = defaultConnectionFor(dbName).prepareSql(sql)
-        val ps = PreparedStatement(
-            sql,
-            if (req.hasTransactionId()) req.transactionId else null,
-            dbName,
-            pq.takeIf { !isDml(sql, dbName) }
-        )
-
-        stmts[psId] = ps
+        val txHandle = if (req.hasTransactionId()) req.transactionId else null
+        val xtdbStmt = connectionFor(txHandle, dbName).createStatement().also {
+            it.setSqlQuery(sql)
+            it.prepare()
+        }
+        stmts[psId] = PreparedStatement(xtdbStmt)
 
         listener.onNext(
             packResult(
                 ActionCreatePreparedStatementResult.newBuilder()
                     .setPreparedStatementHandle(psId)
                     .setParameterSchema(
-                        ByteString.copyFrom(
-                            Schema(
-                                (0 until pq.paramCount).map { idx ->
-                                    "$$idx" ofType VectorType.fromLegs()
-                                }
-                            ).serializeAsMessageInterruptibly()
-                        )
+                        ByteString.copyFrom(xtdbStmt.parameterSchema.serializeAsMessageInterruptibly())
                     )
                     .build()
             )
@@ -418,9 +369,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         ctx: CallContext?,
         listener: StreamListener<Result>
     ) {
-        val ps = stmts.remove(req.preparedStatementHandle)
-        ps?.cursor?.close()
-
+        stmts.remove(req.preparedStatementHandle)?.close()
         listener.onCompleted()
     }
 

--- a/src/test/clojure/xtdb/flight_sql_test.clj
+++ b/src/test/clojure/xtdb/flight_sql_test.clj
@@ -140,6 +140,35 @@
       (t/is (= #{{:name "James"} {:name "Matt"} {:name "Håkan"} {:name "Dan"}}
                (q))))))
 
+(t/deftest test-prepared-stmt-no-params
+  ;; Exercises getFlightInfoPreparedStatement's lazy executeQuery branch:
+  ;; with no params the client skips setParameters/acceptPutPreparedStatementQuery
+  ;; entirely and the cursor must be opened on demand at getFlightInfo time.
+  (xt/execute-tx tu/*node* [[:put-docs :users {:xt/id "jms", :name "James"}]])
+
+  (with-open [ps (.prepare *client* "SELECT users.name FROM users" empty-call-opts)]
+    (t/is (= [{:name "James"}]
+             (-> (.execute ps empty-call-opts)
+                 (flight-info->rows))))))
+
+(t/deftest test-prepared-stmt-explicit-close-mid-session
+  ;; Locks in xtdbStmt.close() running cleanly when an explicit close happens
+  ;; mid-session (i.e. not at producer shutdown). Exercises both branches of
+  ;; PreparedStatement.close(): with a populated queryResult (after execute)
+  ;; and after the queryResult has been streamed away (set to null by
+  ;; getStreamPreparedStatement).
+  (xt/execute-tx tu/*node* [[:put-docs :users {:xt/id "jms", :name "James"}]])
+
+  (t/testing "close after execute, before streaming — queryResult populated"
+    (let [ps (.prepare *client* "SELECT users.name FROM users" empty-call-opts)]
+      (.execute ps empty-call-opts)
+      (.close ps)))
+
+  (t/testing "close after streaming — queryResult cleared"
+    (let [ps (.prepare *client* "SELECT users.name FROM users" empty-call-opts)]
+      (-> (.execute ps empty-call-opts) flight-info->rows)
+      (.close ps))))
+
 (t/deftest test-dml-via-query-path-returns-helpful-error
   ;; #5082 - DML sent through executeQuery path should give a clear error
   (let [ex (t/is (thrown? org.apache.arrow.flight.FlightRuntimeException

--- a/src/test/clojure/xtdb/flight_sql_test.clj
+++ b/src/test/clojure/xtdb/flight_sql_test.clj
@@ -141,9 +141,6 @@
                (q))))))
 
 (t/deftest test-prepared-stmt-no-params
-  ;; Exercises getFlightInfoPreparedStatement's lazy executeQuery branch:
-  ;; with no params the client skips setParameters/acceptPutPreparedStatementQuery
-  ;; entirely and the cursor must be opened on demand at getFlightInfo time.
   (xt/execute-tx tu/*node* [[:put-docs :users {:xt/id "jms", :name "James"}]])
 
   (with-open [ps (.prepare *client* "SELECT users.name FROM users" empty-call-opts)]
@@ -152,11 +149,6 @@
                  (flight-info->rows))))))
 
 (t/deftest test-prepared-stmt-explicit-close-mid-session
-  ;; Locks in xtdbStmt.close() running cleanly when an explicit close happens
-  ;; mid-session (i.e. not at producer shutdown). Exercises both branches of
-  ;; PreparedStatement.close(): with a populated queryResult (after execute)
-  ;; and after the queryResult has been streamed away (set to null by
-  ;; getStreamPreparedStatement).
   (xt/execute-tx tu/*node* [[:put-docs :users {:xt/id "jms", :name "James"}]])
 
   (t/testing "close after execute, before streaming — queryResult populated"


### PR DESCRIPTION
## Summary

Folds `XtdbProducer.PreparedStatement` onto the in-process `XtdbStatement` introduced in #5526.
FSQL's `XtdbProducer` stops carrying its own parallel copy of `prepare → bind → execute`; the four gRPC callbacks become thin protocol shims that delegate to the held `XtdbStatement`.

Net diff on `XtdbProducer.kt`: **+42 / -94 lines (-52 net)**, same behaviour, one implementation behind two surfaces.

## Depends on

#5526 — adds the in-process `XtdbStatement` lifecycle this branch delegates to. Now merged on `main`.

## What changes

`PreparedStatement` shrinks to `(xtdbStmt, queryResult?)`.
The four callbacks:

- **`createPreparedStatement`** — opens an `XtdbStatement` on `connectionFor(txHandle, dbName)`, sets the SQL, calls `prepare()`, replies with `xtdbStmt.parameterSchema`.
- **`acceptPutPreparedStatementQuery`** — single-batch `flightStream.next()`, then `xtdbStmt.bind(flightStream.root)` and `xtdbStmt.executeQuery()`. The query path takes one batch of params per FlightSQL contract.
- **`acceptPutPreparedStatementUpdate`** — accumulates all batches from the `FlightStream` into a `Relation` via the new `toRelation` helper, then `bind(args); executeUpdate()`. DML is one-shot so we accumulate; query is streaming so we don't.
- **`getFlightInfoPreparedStatement`** — opens the cursor on demand if no `queryResult` is held yet. This is the path no-params clients hit (they skip `acceptPutPreparedStatementQuery` entirely); `test-prepared-stmt-no-params` covers it.
- **`getStreamPreparedStatement`** — drains the held `QueryResult.reader` via the existing `streamArrowReader` helper.

## Implementation notes

**Tx routing moves from execute-time to create-time.**
Previously `execDml(op, ps.txHandle, ps.dbName)` looked up the connection on each DML; now `createPreparedStatement` looks it up upfront via `connectionFor(txHandle, dbName)`, and the `XtdbStatement` carries that connection's tx state for the whole lifecycle.
Same end behaviour — the in-tx Clojure test (`test-prepared-stmts-in-tx`) confirms.

**New helper `FlightStream.toRelation(allocator)`** — accumulates all batches in the stream into a single Relation in `allocator`. Used by the DML path only. Uses `closeOnCatch` for the accumulator's lifetime and hoists the row-copier out of the per-batch loop.

**Private extension property `AdbcStatement.QueryResult.schema`** — localises the `.reader.vectorSchemaRoot.schema` chain to a single declaration, so call sites read as `queryResult.schema`.

**Drops as dead code**: `FlightStream.toRows`, `FlightStream.toBytes`, the `safeMapIndexed` parameter-rename loop, the inline parameter-schema generation in `createPreparedStatement`, the parallel `prepdQuery` / `cursor` / `sql` / `dbName` / `txHandle` fields on `PreparedStatement`, and a handful of unused imports.

**Knock-on benefit**: the adbc-drivers/validation suite — which talks to FSQL over the wire — now transitively exercises the in-process `XtdbStatement`.
Pre-this-work the suite tested FSQL's parallel impl and any in-process improvements were invisible to it.

## Validation suite delta

Combined with #5526, vs refset's pre-#5270 baseline:

| | baseline | with both PRs |
|---|---|---|
| passed | 16 | **100** |
| failed | 49 | 47 |
| skipped | 77 | 80 |
| errored | 13 | 14 |

+84 passes, mostly category 4 (`AdbcStatement.prepare()` returning INTERNAL) collapsing to zero.

## Test plan

- [x] `xtdb.flight_sql_test` — 9/9 green, including the new `test-prepared-stmt-no-params` that locks in the no-params lazy-cursor-open branch.
- [x] `xtdb.api.AdbcTest` — green.
- [x] `xtdb.InProcessAdbcTest` — green.
- [x] No reflection or boxed-math warnings.
- [x] adbc-drivers/validation suite — local run shows the +84 swing above.
