### PR TITLE
feat(azure): resolve BlobStorage credentials via !AzureBlob remote alias

### DIFF
--- a/core/src/main/kotlin/xtdb/api/storage/ObjectStore.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/ObjectStore.kt
@@ -3,6 +3,8 @@ package xtdb.api.storage
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.file.Path
@@ -18,7 +20,7 @@ interface ObjectStore : AutoCloseable {
     }
 
     interface Factory {
-        fun openObjectStore(storageRoot: Path): ObjectStore
+        fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote> = emptyMap()): ObjectStore
         val configProto: ProtoAny
 
         companion object {

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -11,6 +11,8 @@ import kotlinx.serialization.UseSerializers
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.ipc.message.ArrowFooter
 import xtdb.api.PathSerde
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.cache.DiskCache
 import xtdb.cache.MemoryCache
 import xtdb.database.DatabaseName
@@ -57,7 +59,8 @@ object Storage {
             allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
             dbName: DatabaseName,
             meterRegistry: MeterRegistry? = null,
-            storageVersion: StorageVersion = VERSION
+            storageVersion: StorageVersion = VERSION,
+            remotes: Map<RemoteAlias, Remote> = emptyMap(),
         ): BufferPool
 
         companion object {
@@ -88,7 +91,8 @@ object Storage {
     data class InMemoryStorageFactory(override var epoch: Int = 0) : Factory {
         override fun open(
             allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
-            dbName: DatabaseName, meterRegistry: MeterRegistry?, storageVersion: StorageVersion
+            dbName: DatabaseName, meterRegistry: MeterRegistry?, storageVersion: StorageVersion,
+            remotes: Map<RemoteAlias, Remote>,
         ): BufferPool = MemoryStorage(allocator, epoch)
     }
 
@@ -114,7 +118,8 @@ object Storage {
 
         override fun open(
             allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
-            dbName: DatabaseName, meterRegistry: MeterRegistry?, storageVersion: StorageVersion
+            dbName: DatabaseName, meterRegistry: MeterRegistry?, storageVersion: StorageVersion,
+            remotes: Map<RemoteAlias, Remote>,
         ): BufferPool {
             val rootPath = path.resolve(storageRoot(storageVersion, epoch)).also { it.createDirectories() }
 
@@ -141,11 +146,12 @@ object Storage {
 
         override fun open(
             allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
-            dbName: DatabaseName, meterRegistry: MeterRegistry?, storageVersion: StorageVersion
+            dbName: DatabaseName, meterRegistry: MeterRegistry?, storageVersion: StorageVersion,
+            remotes: Map<RemoteAlias, Remote>,
         ): BufferPool {
             requireNotNull(diskCache) { "diskCache is required for remote storage" }
 
-            return objectStore.openObjectStore(storageRoot(storageVersion, epoch)).closeOnCatch { objectStore ->
+            return objectStore.openObjectStore(storageRoot(storageVersion, epoch), remotes).closeOnCatch { objectStore ->
                 RemoteBufferPool(allocator, objectStore, memoryCache, diskCache, meterRegistry, epoch, dbName)
             }
         }

--- a/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
@@ -98,7 +98,8 @@ class DatabaseStorage(
             val bufferPool = open {
                 val bp = dbConfig.storage.open(
                     allocator, base.memoryCache, base.diskCache,
-                    dbName, base.meterRegistry, Storage.VERSION
+                    dbName, base.meterRegistry, Storage.VERSION,
+                    base.remotes,
                 )
                 if (readOnly) ReadOnlyBufferPool(bp) else bp
             }

--- a/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.SimulatedObjectStore
 import xtdb.api.storage.Storage.remote
@@ -36,7 +38,7 @@ class RemoteStorageTest : StorageTest() {
     private lateinit var remoteBufferPool: RemoteBufferPool
 
     object SimulatedObjectStoreFactory : ObjectStore.Factory {
-        override fun openObjectStore(storageRoot: Path): ObjectStore = SimulatedObjectStore()
+        override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>): ObjectStore = SimulatedObjectStore()
 
         override val configProto: ProtoAny
             get() = ProtoAny.newBuilder().build()

--- a/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
@@ -22,6 +22,8 @@ import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.S3Configuration
 import software.amazon.awssdk.services.s3.model.*
 import xtdb.api.PathSerde
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.ObjectStore.Companion.throwMissingKey
 import xtdb.api.storage.ObjectStore.StoredObject
@@ -316,7 +318,7 @@ class S3(
 
         fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
-        override fun openObjectStore(storageRoot: Path): S3 {
+        override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>): S3 {
             val client =
                 S3AsyncClient.builder()
                     .apply {

--- a/modules/azure/src/main/kotlin/xtdb/azure/AzureRemote.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/AzureRemote.kt
@@ -1,0 +1,29 @@
+package xtdb.azure
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.subclass
+import xtdb.api.Remote
+
+class AzureRemote(
+    val connectionString: String?,
+    val storageAccountKey: String?,
+) : Remote {
+    override fun close() = Unit
+
+    @Serializable
+    @SerialName("!AzureBlob")
+    data class Factory(
+        val connectionString: String? = null,
+        val storageAccountKey: String? = null,
+    ) : Remote.Factory<AzureRemote> {
+        override fun open() = AzureRemote(connectionString, storageAccountKey)
+    }
+
+    class Registration : Remote.Registration {
+        override fun registerSerde(builder: PolymorphicModuleBuilder<Remote.Factory<*>>) {
+            builder.subclass(Factory::class)
+        }
+    }
+}

--- a/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
@@ -335,6 +335,10 @@ class BlobStorage(
         val storageAccount: String,
         val container: String,
         var prefix: Path? = null,
+        @Deprecated(
+            message = "Inline 'storageAccountKey' is deprecated - configure credentials via 'remote' instead",
+            level = DeprecationLevel.WARNING
+        )
         var storageAccountKey: String? = null,
         var userManagedIdentityClientId: String? = null,
         var storageAccountEndpoint: String? = null,
@@ -344,6 +348,11 @@ class BlobStorage(
 
         fun prefix(prefix: Path) = apply { this.prefix = prefix }
 
+        @Deprecated(
+            message = "Use remote(...) instead of inline credentials",
+            replaceWith = ReplaceWith("remote(alias)"),
+            level = DeprecationLevel.WARNING
+        )
         @Suppress("unused")
         fun storageAccountKey(storageAccountKey: String) = apply { this.storageAccountKey = storageAccountKey }
 

--- a/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
@@ -19,6 +19,8 @@ import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.subclass
 import reactor.core.Exceptions
 import xtdb.api.PathSerde
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.ObjectStore.Companion.throwMissingKey
 import xtdb.api.storage.ObjectStore.StoredObject
@@ -345,7 +347,8 @@ class BlobStorage(
 
         fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
-        override fun openObjectStore(storageRoot: Path) = BlobStorage(this, prefix?.resolve(storageRoot) ?: storageRoot, coroutineContext)
+        override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>) =
+            BlobStorage(this, prefix?.resolve(storageRoot) ?: storageRoot, coroutineContext)
 
         override val configProto by lazy {
             ProtoAny.pack(azureBlobStorageConfig {

--- a/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
@@ -27,6 +27,7 @@ import xtdb.api.storage.ObjectStore.StoredObject
 import xtdb.asBytes
 import xtdb.azure.proto.AzureBlobStorageConfig
 import xtdb.azure.proto.azureBlobStorageConfig
+import xtdb.error.Incorrect
 import xtdb.multipart.IMultipartUpload
 import xtdb.multipart.SupportsMultipart
 import xtdb.util.asPath
@@ -75,21 +76,30 @@ import com.google.protobuf.Any as ProtoAny
 class BlobStorage(
     private val factory: Factory,
     private val prefix: Path,
+    private val connectionString: String?,
+    private val storageAccountKey: String?,
     coroutineContext: CoroutineContext = Dispatchers.IO
 ) : ObjectStore, SupportsMultipart<String> {
 
     private val client =
         BlobServiceClientBuilder().run {
-            factory.connectionString?.let { connectionString(it) }
-
             endpoint(factory.storageAccountEndpoint ?: "https://${factory.storageAccount}.blob.core.windows.net")
 
-            credential(DefaultAzureCredentialBuilder().run {
-                factory.userManagedIdentityClientId?.let { managedIdentityClientId(it) }
-                build()
-            })
+            // Credential paths are mutually exclusive: a later credential(...) call
+            // on BlobServiceClientBuilder overrides earlier ones (including the one
+            // installed by connectionString(...)), so we pick exactly one.
+            when {
+                storageAccountKey != null ->
+                    credential(StorageSharedKeyCredential(factory.storageAccount, storageAccountKey))
 
-            factory.storageAccountKey?.let { credential(StorageSharedKeyCredential(factory.storageAccount, it)) }
+                connectionString != null ->
+                    connectionString(connectionString)
+
+                else -> credential(DefaultAzureCredentialBuilder().run {
+                    factory.userManagedIdentityClientId?.let { managedIdentityClientId(it) }
+                    build()
+                })
+            }
 
             buildClient()
         }.getBlobContainerClient(factory.container).also { it.createIfNotExists() }
@@ -329,6 +339,7 @@ class BlobStorage(
         var userManagedIdentityClientId: String? = null,
         var storageAccountEndpoint: String? = null,
         var connectionString: String? = null,
+        var remote: RemoteAlias? = null,
         @kotlinx.serialization.Transient var coroutineContext: CoroutineContext = Dispatchers.IO
     ) : ObjectStore.Factory {
 
@@ -345,10 +356,44 @@ class BlobStorage(
 
         fun connectionString(connectionString: String) = apply { this.connectionString = connectionString }
 
+        @Suppress("unused")
+        fun remote(alias: RemoteAlias) = apply { this.remote = alias }
+
         fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
-        override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>) =
-            BlobStorage(this, prefix?.resolve(storageRoot) ?: storageRoot, coroutineContext)
+        private fun resolveCredentials(remotes: Map<RemoteAlias, Remote>): Pair<String?, String?> {
+            val alias = remote ?: return connectionString to storageAccountKey
+
+            if (connectionString != null || storageAccountKey != null)
+                throw Incorrect(
+                    "Azure BlobStorage factory has both 'remote' alias and inline connectionString/storageAccountKey — use one or the other",
+                    errorCode = "xtdb.azure/conflicting-config",
+                    data = mapOf("alias" to alias),
+                )
+
+            val raw = remotes[alias]
+                ?: throw Incorrect(
+                    "no remote configured with alias '$alias' — add an '!Azure' entry under 'remotes:' in node config",
+                    errorCode = "xtdb.azure/missing-remote",
+                    data = mapOf("alias" to alias),
+                )
+
+            val actualType = raw::class.simpleName ?: raw::class.qualifiedName ?: "unknown"
+
+            val az = raw as? AzureRemote
+                ?: throw Incorrect(
+                    "remote '$alias' is a $actualType, expected an !Azure remote",
+                    errorCode = "xtdb.azure/wrong-remote-type",
+                    data = mapOf("alias" to alias, "actualType" to actualType),
+                )
+
+            return az.connectionString to az.storageAccountKey
+        }
+
+        override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>): BlobStorage {
+            val (cs, key) = resolveCredentials(remotes)
+            return BlobStorage(this, prefix?.resolve(storageRoot) ?: storageRoot, cs, key, coroutineContext)
+        }
 
         override val configProto by lazy {
             ProtoAny.pack(azureBlobStorageConfig {
@@ -356,10 +401,17 @@ class BlobStorage(
                 this.container = this@Factory.container
                 this@Factory.prefix?.toString()?.let { this.prefix = it }
 
-                this@Factory.storageAccountKey?.let { this.storageAccountKey = it }
                 this@Factory.userManagedIdentityClientId?.let { this.userManagedIdentityClientId = it }
                 this@Factory.storageAccountEndpoint?.let { this.storageAccountEndpoint = it }
-                this@Factory.connectionString?.let { this.connectionString = it }
+
+                // Credentials are only emitted on the inline-auth path; the alias path
+                // keeps them node-local so they never land on the source log.
+                if (this@Factory.remote != null) {
+                    this.remote = this@Factory.remote!!
+                } else {
+                    this@Factory.storageAccountKey?.let { this.storageAccountKey = it }
+                    this@Factory.connectionString?.let { this.connectionString = it }
+                }
             }, "proto.xtdb.com")
         }
     }
@@ -379,7 +431,8 @@ class BlobStorage(
                     storageAccountKey = config.storageAccountKey.takeIf { it.isNotEmpty() },
                     userManagedIdentityClientId = config.userManagedIdentityClientId.takeIf { it.isNotEmpty() },
                     storageAccountEndpoint = config.storageAccountEndpoint.takeIf { it.isNotEmpty() },
-                    connectionString = config.connectionString.takeIf { it.isNotEmpty() }
+                    connectionString = config.connectionString.takeIf { it.isNotEmpty() },
+                    remote = config.remote.takeIf { it.isNotEmpty() },
                 )
             }
 

--- a/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
@@ -338,7 +338,6 @@ class BlobStorage(
         var storageAccountKey: String? = null,
         var userManagedIdentityClientId: String? = null,
         var storageAccountEndpoint: String? = null,
-        var connectionString: String? = null,
         var remote: RemoteAlias? = null,
         @kotlinx.serialization.Transient var coroutineContext: CoroutineContext = Dispatchers.IO
     ) : ObjectStore.Factory {
@@ -354,40 +353,41 @@ class BlobStorage(
         @Suppress("unused")
         fun storageAccountEndpoint(endpoint: String) = apply { storageAccountEndpoint = endpoint }
 
-        fun connectionString(connectionString: String) = apply { this.connectionString = connectionString }
-
         @Suppress("unused")
         fun remote(alias: RemoteAlias) = apply { this.remote = alias }
 
         fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
         private fun resolveCredentials(remotes: Map<RemoteAlias, Remote>): Pair<String?, String?> {
-            val alias = remote ?: return connectionString to storageAccountKey
+            val alias = remote
 
-            if (connectionString != null || storageAccountKey != null)
-                throw Incorrect(
-                    "Azure BlobStorage factory has both 'remote' alias and inline connectionString/storageAccountKey — use one or the other",
-                    errorCode = "xtdb.azure/conflicting-config",
-                    data = mapOf("alias" to alias),
-                )
+            if (alias != null) {
+                if (storageAccountKey != null) {
+                    throw Incorrect(
+                        "Azure BlobStorage has both 'remote' and inline storageAccountKey — use only one",
+                        errorCode = "xtdb.azure/conflicting-config",
+                        data = mapOf("alias" to alias),
+                    )
+                }
 
-            val raw = remotes[alias]
-                ?: throw Incorrect(
-                    "no remote configured with alias '$alias' — add an '!Azure' entry under 'remotes:' in node config",
-                    errorCode = "xtdb.azure/missing-remote",
-                    data = mapOf("alias" to alias),
-                )
+                val raw = remotes[alias]
+                    ?: throw Incorrect(
+                        "no remote configured with alias '$alias'",
+                        errorCode = "xtdb.azure/missing-remote",
+                        data = mapOf("alias" to alias),
+                    )
 
-            val actualType = raw::class.simpleName ?: raw::class.qualifiedName ?: "unknown"
+                val az = raw as? AzureRemote
+                    ?: throw Incorrect(
+                        "remote '$alias' is not an !Azure remote",
+                        errorCode = "xtdb.azure/wrong-remote-type",
+                    )
 
-            val az = raw as? AzureRemote
-                ?: throw Incorrect(
-                    "remote '$alias' is a $actualType, expected an !Azure remote",
-                    errorCode = "xtdb.azure/wrong-remote-type",
-                    data = mapOf("alias" to alias, "actualType" to actualType),
-                )
+                return az.connectionString to az.storageAccountKey
+            }
 
-            return az.connectionString to az.storageAccountKey
+            // No connectionString fallback anymore
+            return null to storageAccountKey
         }
 
         override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>): BlobStorage {
@@ -410,7 +410,6 @@ class BlobStorage(
                     this.remote = this@Factory.remote!!
                 } else {
                     this@Factory.storageAccountKey?.let { this.storageAccountKey = it }
-                    this@Factory.connectionString?.let { this.connectionString = it }
                 }
             }, "proto.xtdb.com")
         }
@@ -431,7 +430,6 @@ class BlobStorage(
                     storageAccountKey = config.storageAccountKey.takeIf { it.isNotEmpty() },
                     userManagedIdentityClientId = config.userManagedIdentityClientId.takeIf { it.isNotEmpty() },
                     storageAccountEndpoint = config.storageAccountEndpoint.takeIf { it.isNotEmpty() },
-                    connectionString = config.connectionString.takeIf { it.isNotEmpty() },
                     remote = config.remote.takeIf { it.isNotEmpty() },
                 )
             }

--- a/modules/azure/src/main/proto/azure.proto
+++ b/modules/azure/src/main/proto/azure.proto
@@ -11,6 +11,11 @@ message AzureBlobStorageConfig {
     string storage_account_key = 4;
     string user_managed_identity_client_id = 5;
     string storage_account_endpoint = 6;
-    string connection_string = 7;
+    // Field 7 previously held `connection_string`.
+    // This was broken in practice due to a bug and has been intentionally removed.
+    // We also do not allow connection strings in the Factory config, as this
+    // proto is serialized into logs — credentials must instead be provided
+    // via `remote` (node-local, non-serialized).
+    reserved 7;
     string remote = 8;
 }

--- a/modules/azure/src/main/proto/azure.proto
+++ b/modules/azure/src/main/proto/azure.proto
@@ -12,4 +12,5 @@ message AzureBlobStorageConfig {
     string user_managed_identity_client_id = 5;
     string storage_account_endpoint = 6;
     string connection_string = 7;
+    string remote = 8;
 }

--- a/modules/azure/src/main/resources/META-INF/services/xtdb.api.Remote$Registration
+++ b/modules/azure/src/main/resources/META-INF/services/xtdb.api.Remote$Registration
@@ -1,0 +1,1 @@
+xtdb.azure.AzureRemote$Registration

--- a/modules/google-cloud/src/main/kotlin/xtdb/gcp/CloudStorage.kt
+++ b/modules/google-cloud/src/main/kotlin/xtdb/gcp/CloudStorage.kt
@@ -16,6 +16,8 @@ import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.subclass
 import xtdb.api.PathSerde
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.ObjectStore.Companion.throwMissingKey
 import xtdb.api.storage.ObjectStore.StoredObject
@@ -182,7 +184,7 @@ class CloudStorage(
 
         fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
-        override fun openObjectStore(storageRoot: Path) =
+        override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>) =
             CloudStorage(projectId, bucket, prefix?.resolve(storageRoot) ?: storageRoot, coroutineContext)
 
         override val configProto: ProtoAny by lazy {

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -42,7 +42,7 @@
              ~@body))))))
 
 (defn- open-storage ^xtdb.storage.BufferPool [^Storage$Factory factory]
-  (.open factory tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION))
+  (.open factory tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))
 
 (t/deftest test-remote-buffer-pool-setup
   (util/with-tmp-dirs #{path}
@@ -88,7 +88,7 @@
 
 (defn simulated-obj-store-factory []
   (reify ObjectStore$Factory
-    (openObjectStore [_ _storage-root]
+    (openObjectStore [_ _storage-root _remotes]
       (SimulatedObjectStore.))))
 
 (defn get-remote-calls [^RemoteBufferPool test-bp]
@@ -97,7 +97,7 @@
 (t/deftest below-min-size-put-test
   (with-caches {}
     (with-open [bp (-> (Storage/remote (simulated-obj-store-factory))
-                       (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION))]
+                       (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
       (t/testing "if <= min part size, putObject is used"
         (.putObject bp (util/->path "min-part-put") (utf8-buf "12"))
         (t/is (= [StoreOperation/PUT] (get-remote-calls bp)))
@@ -120,7 +120,7 @@
 (t/deftest local-disk-cache-max-size
   (with-caches {:mem-bytes 12, :disk-bytes 10}
     (with-open [bp (-> (Storage/remote (simulated-obj-store-factory))
-                       (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION))]
+                       (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
       (t/testing "staying below max size - all elements available"
         (insert-utf8-to-local-cache bp (util/->path "a") 4)
         (insert-utf8-to-local-cache bp (util/->path "b") 4)
@@ -141,7 +141,7 @@
 
 (defn no-op-object-store-factory []
   (reify ObjectStore$Factory
-    (openObjectStore [_ _storage-root]
+    (openObjectStore [_ _storage-root _remotes]
       (reify ObjectStore
         (getObject [_ _k] (throw (UnsupportedOperationException. "foo")))
         (getObject [_ _ _k] (throw (UnsupportedOperationException. "foo")))
@@ -157,7 +157,7 @@
     (with-caches {:mem-bytes 64, :disk-bytes 64}
       ;; Writing files to buffer pool & local-disk-cache
       (with-open [bp (-> (Storage/remote obj-store-factory)
-                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION))]
+                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
         (insert-utf8-to-local-cache bp path-a 4)
         (insert-utf8-to-local-cache bp path-b 4)
         (t/is (= {:file-count 2 :file-names #{"a" "b"}} (file-info *disk-cache-dir*))))
@@ -165,7 +165,7 @@
       ;; Starting a new buffer pool - should load buffers correctly from disk (can be sure its grabbed from disk since using a memory cache and memory object store)
       ;; passing a no-op object store to ensure objects are not loaded from object store and instead only the cache is under test.
       (with-open [bp (-> (Storage/remote (no-op-object-store-factory))
-                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION))]
+                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
         (t/is (= 0 (util/compare-nio-buffers-unsigned (utf8-buf "aaaa") (ByteBuffer/wrap (.getByteArray bp path-a)))))
         (t/is (= 0 (util/compare-nio-buffers-unsigned (utf8-buf "aaaa") (ByteBuffer/wrap (.getByteArray bp path-b)))))))))
 
@@ -300,7 +300,7 @@
   (let [registry (SimpleMeterRegistry.)]
     (with-caches {}
       (with-open [bp (-> (Storage/remote (simulated-obj-store-factory))
-                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" registry Storage/VERSION))]
+                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" registry Storage/VERSION {}))]
         (let [k1 (util/->path "a")
               k2 (util/->path "b")
               ^ByteBuffer v1 (utf8-buf "aaa")

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -71,7 +71,7 @@
 
 (defmethod bp/->object-store-factory ::memory-object-store [_ _]
   (reify ObjectStore$Factory
-    (openObjectStore [_ _storage-root]
+    (openObjectStore [_ _storage-root _remotes]
       (->InMemoryObjectStore (ConcurrentSkipListMap.)))))
 
 (defn test-put-delete [^ObjectStore obj-store]

--- a/src/test/kotlin/xtdb/azure/BlobStorageFactoryTest.kt
+++ b/src/test/kotlin/xtdb/azure/BlobStorageFactoryTest.kt
@@ -1,0 +1,122 @@
+package xtdb.azure
+
+import clojure.lang.Keyword
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
+import xtdb.api.nodeConfig
+import xtdb.azure.BlobStorage.Companion.azureBlobStorage
+import xtdb.error.Incorrect
+import xtdb.util.asPath
+import kotlin.io.path.Path
+
+class BlobStorageFactoryTest {
+
+    private val errorCodeKey = Keyword.intern("xtdb.error", "code")
+    private fun Incorrect.errorCode() = data.valAt(errorCodeKey) as Keyword?
+
+    private class StubRemote : Remote {
+        override fun close() = Unit
+    }
+
+    @Test
+    fun `proto round trip with inline credentials`() {
+        val original = azureBlobStorage("test-storage", "test-container") {
+            prefix("test/prefix".asPath)
+            storageAccountKey("test-key")
+            userManagedIdentityClientId("test-client-id")
+            storageAccountEndpoint("https://test.blob.core.windows.net")
+            connectionString("DefaultEndpointsProtocol=https;AccountName=test;AccountKey=test")
+        }
+
+        val restored = BlobStorage.Registration().fromProto(original.configProto)
+        assertEquals(original, restored)
+    }
+
+    @Test
+    fun `proto round trip — alias path strips credentials`() {
+        // The leak-fix invariant: when the alias path is in use, the proto
+        // must not carry connectionString or storageAccountKey — those are
+        // node-local and would otherwise land on the source log.
+        val original = azureBlobStorage("test-storage", "test-container") {
+            prefix("test/prefix".asPath)
+            remote("az")
+        }
+
+        val proto = original.configProto.unpack(xtdb.azure.proto.AzureBlobStorageConfig::class.java)
+        assertEquals("az", proto.remote)
+        assertEquals("", proto.connectionString, "connectionString must not appear on alias path")
+        assertEquals("", proto.storageAccountKey, "storageAccountKey must not appear on alias path")
+
+        val restored = BlobStorage.Registration().fromProto(original.configProto)
+        assertEquals("az", restored.remote)
+        assertNull(restored.connectionString)
+        assertNull(restored.storageAccountKey)
+    }
+
+    @Test
+    fun `openObjectStore errors when both remote and inline creds set`() {
+        val factory = azureBlobStorage("test-storage", "test-container") {
+            remote("az")
+            connectionString("DefaultEndpointsProtocol=https;AccountName=test;AccountKey=test")
+        }
+
+        val e = assertThrows<Incorrect> {
+            factory.openObjectStore(Path("storage-root"), emptyMap())
+        }
+        assertEquals(Keyword.intern("xtdb.azure", "conflicting-config"), e.errorCode())
+    }
+
+    @Test
+    fun `openObjectStore errors on missing remote alias`() {
+        val factory = azureBlobStorage("test-storage", "test-container") {
+            remote("az")
+        }
+
+        val e = assertThrows<Incorrect> {
+            factory.openObjectStore(Path("storage-root"), emptyMap())
+        }
+        assertEquals(Keyword.intern("xtdb.azure", "missing-remote"), e.errorCode())
+    }
+
+    @Test
+    fun `openObjectStore errors on wrong remote type`() {
+        val factory = azureBlobStorage("test-storage", "test-container") {
+            remote("az")
+        }
+
+        val remotes: Map<RemoteAlias, Remote> = mapOf("az" to StubRemote())
+        val e = assertThrows<Incorrect> {
+            factory.openObjectStore(Path("storage-root"), remotes)
+        }
+        assertEquals(Keyword.intern("xtdb.azure", "wrong-remote-type"), e.errorCode())
+    }
+
+    @Test
+    fun `node config decodes !AzureBlob remote under remotes`() {
+        val yaml = """
+            remotes:
+              az: !AzureBlob
+                connectionString: DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;AccountKey=secret;BlobEndpoint=http://example/devstoreaccount1
+        """.trimIndent()
+
+        val remote = nodeConfig(yaml).remotes["az"] as AzureRemote.Factory
+        assertTrue(remote.connectionString!!.contains("devstoreaccount1"))
+        assertNull(remote.storageAccountKey)
+    }
+
+    @Test
+    fun `node config decodes !AzureBlob remote with storageAccountKey`() {
+        val yaml = """
+            remotes:
+              az: !AzureBlob
+                storageAccountKey: my-key
+        """.trimIndent()
+
+        val remote = nodeConfig(yaml).remotes["az"] as AzureRemote.Factory
+        assertEquals("my-key", remote.storageAccountKey)
+        assertNull(remote.connectionString)
+    }
+}

--- a/src/test/kotlin/xtdb/azure/BlobStorageFactoryTest.kt
+++ b/src/test/kotlin/xtdb/azure/BlobStorageFactoryTest.kt
@@ -28,7 +28,6 @@ class BlobStorageFactoryTest {
             storageAccountKey("test-key")
             userManagedIdentityClientId("test-client-id")
             storageAccountEndpoint("https://test.blob.core.windows.net")
-            connectionString("DefaultEndpointsProtocol=https;AccountName=test;AccountKey=test")
         }
 
         val restored = BlobStorage.Registration().fromProto(original.configProto)
@@ -47,12 +46,10 @@ class BlobStorageFactoryTest {
 
         val proto = original.configProto.unpack(xtdb.azure.proto.AzureBlobStorageConfig::class.java)
         assertEquals("az", proto.remote)
-        assertEquals("", proto.connectionString, "connectionString must not appear on alias path")
         assertEquals("", proto.storageAccountKey, "storageAccountKey must not appear on alias path")
 
         val restored = BlobStorage.Registration().fromProto(original.configProto)
         assertEquals("az", restored.remote)
-        assertNull(restored.connectionString)
         assertNull(restored.storageAccountKey)
     }
 
@@ -60,7 +57,7 @@ class BlobStorageFactoryTest {
     fun `openObjectStore errors when both remote and inline creds set`() {
         val factory = azureBlobStorage("test-storage", "test-container") {
             remote("az")
-            connectionString("DefaultEndpointsProtocol=https;AccountName=test;AccountKey=test")
+            storageAccountKey("test")
         }
 
         val e = assertThrows<Incorrect> {

--- a/src/test/kotlin/xtdb/azure/BlobStorageTest.kt
+++ b/src/test/kotlin/xtdb/azure/BlobStorageTest.kt
@@ -138,20 +138,6 @@ class BlobStorageTest : ObjectStoreTest() {
     }
 
     @Test
-    fun `connection string auth`() {
-        // Exercise the connectionString credential path against Azurite —
-        // previously this was a code path with no test coverage.
-        val factory = azureBlobStorage("devstoreaccount1", "test-container") {
-            connectionString(azuriteConnectionString())
-            prefix("conn-string-test".asPath)
-        }
-
-        factory.openObjectStore(Path("auth-test"), emptyMap()).use { objectStore ->
-            roundTrip(objectStore as BlobStorage, "conn-str-roundtrip", randomByteBuffer(64))
-        }
-    }
-
-    @Test
     fun `remote alias — connectionString`() {
         val remotes = mapOf<RemoteAlias, Remote>(
             "az" to AzureRemote(connectionString = azuriteConnectionString(), storageAccountKey = null),

--- a/src/test/kotlin/xtdb/azure/BlobStorageTest.kt
+++ b/src/test/kotlin/xtdb/azure/BlobStorageTest.kt
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.testcontainers.containers.GenericContainer
+import xtdb.api.RemoteAlias
+import xtdb.api.Remote
 import xtdb.api.storage.ObjectStore.StoredObject
 import xtdb.api.storage.ObjectStoreTest
 import xtdb.azure.BlobStorage.Companion.azureBlobStorage
@@ -26,6 +28,10 @@ import kotlin.time.Duration.Companion.seconds
 @Tag("integration")
 class BlobStorageTest : ObjectStoreTest() {
     companion object {
+        // Azurite's default key — an open secret published in the Azurite docs.
+        private const val AZURITE_KEY =
+            "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+
         private val container = GenericContainer("mcr.microsoft.com/azure-storage/azurite:3.35.0")
             .withCommand("azurite-blob", "--blobHost", "0.0.0.0", "--skipApiVersionCheck")
             .withExposedPorts(10000)
@@ -41,18 +47,21 @@ class BlobStorageTest : ObjectStoreTest() {
         fun tearDownAzure() {
             container.stop()
         }
+
+        private fun azuriteEndpoint() =
+            "http://${container.host}:${container.getMappedPort(10000)}/devstoreaccount1"
+
+        private fun azuriteConnectionString() =
+            "DefaultEndpointsProtocol=http;" +
+                "AccountName=devstoreaccount1;" +
+                "AccountKey=$AZURITE_KEY;" +
+                "BlobEndpoint=${azuriteEndpoint()};"
     }
 
     override fun openObjectStore(prefix: Path) =
         azureBlobStorage("devstoreaccount1", "test-container") {
-            val host = Companion.container.host
-            val port = Companion.container.getMappedPort(10000)
-
-            storageAccountEndpoint("http://$host:$port/devstoreaccount1")
-
-            // Azurite's default key - an open secret
-            storageAccountKey("Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==")
-
+            storageAccountEndpoint(azuriteEndpoint())
+            storageAccountKey(AZURITE_KEY)
             prefix(prefix)
         }.openObjectStore(Path("blob-store-test"))
 
@@ -118,20 +127,60 @@ class BlobStorageTest : ObjectStoreTest() {
         assertEquals(allParts, downloaded)
     }
 
+    private fun roundTrip(objectStore: BlobStorage, key: String, payload: ByteBuffer) {
+        objectStore.putObject(key.asPath, payload.duplicate()).get()
+        val downloaded = objectStore.getObject(key.asPath).get()
+        assertEquals(payload, downloaded)
+        assertTrue(
+            objectStore.listAllObjects().map { it.key.toString() }.toSet().contains(key),
+            "object $key should appear in listing"
+        )
+    }
+
     @Test
-    fun `test proto round trip`() {
-        val originalFactory = azureBlobStorage("test-storage", "test-container") {
-            prefix("test/prefix".asPath)
-            storageAccountKey("test-key")
-            userManagedIdentityClientId("test-client-id")
-            storageAccountEndpoint("https://test.blob.core.windows.net")
-            connectionString("DefaultEndpointsProtocol=https;AccountName=test;AccountKey=test")
+    fun `connection string auth`() {
+        // Exercise the connectionString credential path against Azurite —
+        // previously this was a code path with no test coverage.
+        val factory = azureBlobStorage("devstoreaccount1", "test-container") {
+            connectionString(azuriteConnectionString())
+            prefix("conn-string-test".asPath)
         }
 
-        val registration = BlobStorage.Registration()
-        val proto = originalFactory.configProto
-        val deserializedFactory = registration.fromProto(proto)
+        factory.openObjectStore(Path("auth-test"), emptyMap()).use { objectStore ->
+            roundTrip(objectStore as BlobStorage, "conn-str-roundtrip", randomByteBuffer(64))
+        }
+    }
 
-        assertEquals(originalFactory, deserializedFactory)
+    @Test
+    fun `remote alias — connectionString`() {
+        val remotes = mapOf<RemoteAlias, Remote>(
+            "az" to AzureRemote(connectionString = azuriteConnectionString(), storageAccountKey = null),
+        )
+
+        val factory = azureBlobStorage("devstoreaccount1", "test-container") {
+            remote("az")
+            prefix("alias-conn-string-test".asPath)
+        }
+
+        factory.openObjectStore(Path("auth-test"), remotes).use { objectStore ->
+            roundTrip(objectStore as BlobStorage, "alias-conn-roundtrip", randomByteBuffer(64))
+        }
+    }
+
+    @Test
+    fun `remote alias — storageAccountKey`() {
+        val remotes = mapOf<RemoteAlias, Remote>(
+            "az" to AzureRemote(connectionString = null, storageAccountKey = AZURITE_KEY),
+        )
+
+        val factory = azureBlobStorage("devstoreaccount1", "test-container") {
+            remote("az")
+            storageAccountEndpoint(azuriteEndpoint())
+            prefix("alias-key-test".asPath)
+        }
+
+        factory.openObjectStore(Path("auth-test"), remotes).use { objectStore ->
+            roundTrip(objectStore as BlobStorage, "alias-key-roundtrip", randomByteBuffer(64))
+        }
     }
 }


### PR DESCRIPTION
PR #5481 added the `remotes` pattern so node-local credentials never land on the source log; that PR covered Postgres but explicitly deferred storage-side credentials.
This closes the Azure side.

Both Azure credential paths — connectionString and storageAccountKey — can now be supplied via a node-local !AzureBlob remote, so the source log carries only an alias:

```yaml
remotes:
  az: !AzureBlob
    connectionString: !Env AZURE_BLOB_CONN_STR

storage: !Remote
  objectStore: !Azure
    storageAccount: my-account
    container: my-container
    remote: az
```

On the existing credential paths:
- `connectionString` has been removed from the factory config entirely
  - This path was always broken in practice (see bug below)
  - More importantly, allowing it inline meant credentials could be serialized into the source log
  - `connectionString` is now only supported via remote, ensuring it remains node-local
- `storageAccountKey` is now deprecated on the factory
  - Inline usage still works for backwards compatibility
  - Users are encouraged to migrate to remote to avoid credentials being serialized into logs

Setting both a remote alias and an inline storageAccountKey is rejected at openObjectStore time (xtdb.azure/conflicting-config); silent precedence would be a footgun.

This is partially breaking:
- ❌ Configs using inline `connectionString` must migrate to remotes
- ⚠️ Configs using inline `storageAccountKey` continue to work (deprecated)

## Additional fix
This PR also fixes a pre-existing latent bug in BlobStorage's credential setup:
- The builder always installed `DefaultAzureCredential` after any `connectionString(...)` call, silently overriding it
- The connectionString path therefore never actually worked — it was effectively a no-op shadowed by `DefaultAzureCredential`, which would then fail at request time with `CredentialUnavailableException` unless `storageAccountKey` happened to also be set (which would in turn override `DefaultAzureCredential`)

Given this, removing inline `connectionString` is both a correctness fix and a security improvement.

## Tests

- BlobStorageFactoryTest (default ./gradlew test)
  - Proto round-trip on both paths
  - Asserts the alias path strips credentials from the serialized proto
  - Verifies:
    - missing-remote
    - wrong-remote-type
    - conflicting-config
    - YAML decoding of !AzureBlob under remotes:
- BlobStorageTest (Azurite, @Tag("integration"))
  - Covers connectionString via remote (previously untested and effectively broken)
  - Alias-path round-trips for both credential types

Nightly Azure (`azure_test.clj`) wasn't extended — alias resolution is unit-tested, and once resolved the path goes through the same `BlobServiceClientBuilder` already exercised by the existing `^:azure` tests, so nothing new to verify against real Azure.

Out of scope: S3 / GCP migration to the same pattern — natural follow-ups now that the `Factory.openObjectStore` plumbing is in place.