### PR TITLE
feat(flight-sql): expose current catalog/schema via session options (#5132)

### DIFF
--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -424,6 +424,22 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         listener.onCompleted()
     }
 
+    // -- Session options --
+
+    override fun getSessionOptions(
+        request: GetSessionOptionsRequest,
+        ctx: CallContext?,
+        listener: StreamListener<GetSessionOptionsResult>
+    ) {
+        val conn = defaultConnectionFor(dbNameFromContext(ctx))
+        val opts = mapOf(
+            "catalog" to SessionOptionValueFactory.makeSessionOptionValue(conn.currentCatalog),
+            "schema" to SessionOptionValueFactory.makeSessionOptionValue(conn.currentDbSchema),
+        )
+        listener.onNext(GetSessionOptionsResult(opts))
+        listener.onCompleted()
+    }
+
     // -- Metadata endpoints --
 
     private fun metadataFlightInfo(cmd: Message, schema: Schema, descriptor: FlightDescriptor): FlightInfo {

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -7,7 +7,9 @@ import org.apache.arrow.adbc.driver.flightsql.FlightSqlDriver
 import org.apache.arrow.flight.CallOption
 import org.apache.arrow.flight.FlightClient
 import org.apache.arrow.flight.FlightInfo
+import org.apache.arrow.flight.GetSessionOptionsRequest
 import org.apache.arrow.flight.Location
+import org.apache.arrow.flight.NoOpSessionOptionValueVisitor
 import org.apache.arrow.flight.sql.FlightSqlClient
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
@@ -155,6 +157,20 @@ class FlightSqlAdbcTest {
         val rows = fsqlClient.getSqlInfo(intArrayOf(), *emptyCallOpts).readRows()
         assertTrue(rows.isNotEmpty(), "Expected at least one info row")
     }
+
+    @Test
+    fun `test FlightSQL getSessionOptions returns catalog and schema`() {
+        val result = fsqlClient.getSessionOptions(GetSessionOptionsRequest(), *emptyCallOpts)
+
+        val asString = object : NoOpSessionOptionValueVisitor<String?>() {
+            override fun visit(value: String) = value
+        }
+        val opts = result.sessionOptions
+        assertEquals("xtdb", opts["catalog"]?.acceptVisitor(asString))
+        assertEquals("public", opts["schema"]?.acceptVisitor(asString))
+    }
+
+    // -- ADBC metadata (through FlightSQL ADBC client) --
 
     // getInfo via ADBC client hits a bug in GetInfoMetadataReader.processRootFromStream
     // (allocates on the wrong root). Tested at the FlightSQL level via `test FlightSQL getSqlInfo` instead.


### PR DESCRIPTION
## Summary

`XtdbProducer` now overrides `getSessionOptions` to surface the current catalog and schema as FlightSQL session options under the well-known keys `catalog` and `schema`. Read-only — `setSessionOptions` / `closeSession` deliberately stay `UNIMPLEMENTED` (see Implementation notes).

## Context

Documented in [`adbc-bugs.md` #4](https://github.com/xtdb/driver-examples/blob/adbc-testing/adbc-bugs.md) on the driver-examples branch.
Calling `adbc_current_catalog` / `adbc_current_db_schema` from Python `adbc_driver_flightsql` came back as:

```
ProgrammingError: NOT_FOUND: [Flight SQL] failed to get current catalog:
  Not Found: [Flight SQL] current catalog not supported
```

The Go-driver-based ADBC clients (Python / C / R) read these by querying FlightSQL session options under the keys `catalog` and `schema`.
`XtdbProducer` didn't override `getSessionOptions`, so the calls came back `UNIMPLEMENTED` from `NoOpFlightSqlProducer` and the driver surfaced the error above.

Discovered while running the [adbc-drivers/validation](https://github.com/adbc-drivers/validation) suite against XTDB nightly during the broader #5132 work — the suite's `test_current_catalog` was passing vacuously because `xtdb.py` set `current_catalog=None`.

Iteration toward umbrella #5132.

## Implementation notes

`getCurrentCatalog()` / `getCurrentDbSchema()` already exist on `XtdbConnection` (jarohen, `d6705d512a`).
The override just looks up the per-database default connection via `defaultConnectionFor(dbNameFromContext(ctx))` and packages the two values as `SessionOptionValueString` results.

**Why read-only.** `setSessionOptions` and `closeSession` stay `UNIMPLEMENTED` on purpose:

- We don't have per-session state today.
  The default connection is shared across all gRPC calls hitting a database, so accepting a `setSessionOptions("catalog", "x")` would mutate the shared connection's catalog visible to every other caller — not what the client expects from a session option.
- Real session-scoped overrides need `ServerSessionMiddleware` wiring first, which is its own piece of work.
  Filing as follow-up if/when a client actually wants `setCurrentCatalog`.

**Java client caveat.** The Java `FlightSqlConnection` ADBC client (0.23) doesn't query `getSessionOptions` at all — it inherits `AdbcConnection`'s default which throws `notImplemented`.
So Java's wire-side `getCurrentCatalog` stays unsupported until upstream wires it up.
This PR is specifically for the Go-driver-based clients.

## Test plan

- New Kotlin test: `AdbcTest.test FlightSQL getSessionOptions returns catalog and schema` — asserts the FSQL surface returns `catalog="xtdb"` and `schema="public"` via `FlightSqlClient.getSessionOptions`.
- Full `:test --tests 'xtdb.AdbcTest.*'` — 10/10 passing.
- End-to-end verified against a freshly-rebuilt dev node:
  ```python
  c.adbc_current_catalog        # 'xtdb'
  c.adbc_current_db_schema      # 'public'
  ```
- Validation suite (`adbc-drivers/validation`) — `test_current_catalog` flipped from skip-vacuous to pass-asserting after the corresponding `xtdb.py` quirk flip on the [driver-examples sister branch](https://github.com/tggreene/driver-examples/tree/tim/adbc-testing).
  Full suite 102 pass / 45 fail / 80 skip / 14 error (was 100 / 47 / 80 / 14 before this change).

## Scope

- Read-only.
  `setSessionOptions` / `closeSession` deferred until per-session state exists.
- Doesn't fix the Java FlightSQL ADBC client's `getCurrentCatalog` — that needs upstream Apache ADBC work, not in scope.
- Sister change on `xtdb/driver-examples` flips `current_catalog` / `current_schema` in `xtdb.py` from `None` to `"xtdb"` / `"public"` and moves the resolved entry in `adbc-bugs.md`.
  See [tggreene/driver-examples tim/adbc-testing](https://github.com/tggreene/driver-examples/tree/tim/adbc-testing).