### PR TITLE
refactor(api): fold logClusters into the remotes lookup

### DIFF
--- a/api/src/main/kotlin/xtdb/api/log/LogTypes.kt
+++ b/api/src/main/kotlin/xtdb/api/log/LogTypes.kt
@@ -5,5 +5,3 @@ import java.time.Instant
 typealias LogOffset = Long
 typealias LogTimestamp = Instant
 typealias MessageId = Long
-
-typealias LogClusterAlias = String

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -14,7 +14,7 @@
            java.util.concurrent.TimeUnit
            org.apache.arrow.memory.BufferAllocator
            (xtdb.api TransactionKey Xtdb$Config)
-           (xtdb.api.log Log Log$Cluster$Factory Log$Factory)
+           (xtdb.api.log Log Log$Factory)
            (xtdb.arrow Relation Vector)
            (xtdb.database Database DatabaseStorage Database$Catalog Database$Config)
            xtdb.table.TableRef

--- a/core/src/main/kotlin/xtdb/NodeBase.kt
+++ b/core/src/main/kotlin/xtdb/NodeBase.kt
@@ -10,9 +10,8 @@ import xtdb.Tracer.openTracer
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
 import xtdb.api.Xtdb
-import xtdb.api.log.Log
-import xtdb.api.log.LogClusterAlias
 import xtdb.cache.DiskCache
+import xtdb.error.Incorrect
 import xtdb.cache.MemoryCache
 import xtdb.compactor.Compactor
 import xtdb.indexer.Indexer
@@ -26,7 +25,6 @@ class NodeBase(
     val allocator: BufferAllocator, private val closeAllocator: Boolean, val config: Xtdb.Config,
     val memoryCache: MemoryCache, val diskCache: DiskCache?,
     val meterRegistry: MeterRegistry?, val tracer: OtelTracer?,
-    val logClusters: Map<LogClusterAlias, Log.Cluster>,
     val remotes: Map<RemoteAlias, Remote>,
     val compactor: Compactor,
     val querySource: IQuerySource,
@@ -37,7 +35,6 @@ class NodeBase(
         compactor.close()
         querySource.close()
         remotes.values.closeAll()
-        logClusters.values.closeAll()
         memoryCache.close()
         if (closeAllocator) allocator.close()
     }
@@ -79,8 +76,18 @@ class NodeBase(
                         }
                     }
 
-                val logClusters = config.logClusters.mapValues { (_, factory) -> open { factory.open() } }
-                val remotes = config.remotes.mapValues { (_, factory) -> open { factory.open() } }
+                val collisions = config.logClusters.keys.intersect(config.remotes.keys)
+                if (collisions.isNotEmpty()) {
+                    throw Incorrect(
+                        "alias appears under both 'logClusters:' and 'remotes:': ${collisions.sorted().joinToString()}",
+                        errorCode = "xtdb/duplicate-remote-alias",
+                        data = mapOf("aliases" to collisions.sorted()),
+                    )
+                }
+
+                val remotes: Map<RemoteAlias, Remote> =
+                    (config.logClusters + config.remotes)
+                        .mapValues { (_, factory) -> open { factory.open() } }
 
                 val compactor = open { compactorFactory.create(meterReg, config.compactor.threads) }
 
@@ -96,7 +103,6 @@ class NodeBase(
                     diskCache = config.diskCache?.build(meterReg),
                     meterRegistry = meterReg,
                     tracer = config.tracer.openTracer(),
-                    logClusters = logClusters,
                     remotes = remotes,
                     compactor = compactor,
                     querySource = querySource,

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -11,7 +11,6 @@ import xtdb.ZoneIdSerde
 import xtdb.antlr.Sql
 import xtdb.api.Authenticator.Factory.SingleRootUser
 import xtdb.api.log.Log
-import xtdb.api.log.LogClusterAlias
 import xtdb.api.log.MessageId
 import xtdb.api.metrics.HealthzConfig
 import xtdb.api.metrics.TracerConfig
@@ -69,7 +68,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
     data class Config(
         var server: ServerConfig? = ServerConfig(),
         var flightSql: FlightSqlConfig? = FlightSqlConfig(),
-        var logClusters: Map<LogClusterAlias, Log.Cluster.Factory<*>> = emptyMap(),
+        var logClusters: Map<RemoteAlias, Remote.Factory<*>> = emptyMap(),
         var remotes: Map<RemoteAlias, Remote.Factory<*>> = emptyMap(),
         var log: Log.Factory = Log.inMemoryLog,
         var storage: Storage.Factory = Storage.inMemory(),
@@ -90,9 +89,9 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
         private val modules: MutableList<XtdbModule.Factory> = mutableListOf()
 
-        fun logClusters(clusters: Map<LogClusterAlias, Log.Cluster.Factory<*>>) = apply { logClusters += clusters }
+        fun logClusters(clusters: Map<RemoteAlias, Remote.Factory<*>>) = apply { logClusters += clusters }
 
-        fun logCluster(alias: LogClusterAlias, cluster: Log.Cluster.Factory<*>) =
+        fun logCluster(alias: RemoteAlias, cluster: Remote.Factory<*>) =
             apply { logClusters += alias to cluster }
 
         fun remotes(remotes: Map<RemoteAlias, Remote.Factory<*>>) = apply { this.remotes += remotes }

--- a/core/src/main/kotlin/xtdb/api/YamlSerde.kt
+++ b/core/src/main/kotlin/xtdb/api/YamlSerde.kt
@@ -77,7 +77,6 @@ object InetAddressSerde : KSerializer<InetAddress?> {
 val YAML_SERDE = Yaml(
     serializersModule = SerializersModule {
         include(Log.Factory.serializersModule)
-        include(Log.Cluster.Factory.serializersModule)
         include(Remote.Factory.serializersModule)
         include(ObjectStore.Factory.serializersModule)
         include(XtdbModule.Factory.serializersModule)

--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.selects.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.api.log.Log.*
 import xtdb.database.proto.DatabaseConfig
 import xtdb.util.MsgIdUtil
@@ -38,17 +40,17 @@ class InMemoryLog<M> @JvmOverloads constructor(
         fun epoch(epoch: Int) = apply { this.epoch = epoch }
         fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
-        override fun openSourceLog(clusters: Map<LogClusterAlias, Cluster>) =
+        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>) =
             InMemoryLog<SourceMessage>(instantSource, epoch, coroutineContext)
 
-        override fun openReadOnlySourceLog(clusters: Map<LogClusterAlias, Cluster>) =
-            ReadOnlyLog(openSourceLog(clusters))
+        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>) =
+            ReadOnlyLog(openSourceLog(remotes))
 
-        override fun openReplicaLog(clusters: Map<LogClusterAlias, Cluster>) =
+        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>) =
             InMemoryLog<ReplicaMessage>(instantSource, epoch, coroutineContext)
 
-        override fun openReadOnlyReplicaLog(clusters: Map<LogClusterAlias, Cluster>) =
-            ReadOnlyLog(openReplicaLog(clusters))
+        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>) =
+            ReadOnlyLog(openReplicaLog(remotes))
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.inMemoryLog = inMemoryLog { }

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -14,6 +14,8 @@ import kotlinx.serialization.Transient
 import kotlinx.serialization.UseSerializers
 import xtdb.DurationSerde
 import xtdb.api.PathSerde
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.api.log.Log.*
 import xtdb.database.proto.DatabaseConfig
 import xtdb.util.MsgIdUtil
@@ -378,16 +380,16 @@ class LocalLog<M>(
         fun useInstantSourceForNonTx() = apply { this.useInstantSourceForNonTx = true }
         fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
-        override fun openSourceLog(clusters: Map<LogClusterAlias, Cluster>) =
+        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>) =
             LocalLog(path, SourceMessage.Codec, instantSource, epoch, useInstantSourceForNonTx, coroutineContext)
 
-        override fun openReadOnlySourceLog(clusters: Map<LogClusterAlias, Cluster>) =
+        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>) =
             ReadOnlyLocalLog(path, SourceMessage.Codec, epoch, coroutineContext)
 
-        override fun openReplicaLog(clusters: Map<LogClusterAlias, Cluster>) =
+        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>) =
             LocalLog(path, ReplicaMessage.Codec, instantSource, epoch, useInstantSourceForNonTx, coroutineContext, logFileName = "REPLICA_LOG")
 
-        override fun openReadOnlyReplicaLog(clusters: Map<LogClusterAlias, Cluster>) =
+        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>) =
             ReadOnlyLocalLog(path, ReplicaMessage.Codec, epoch, coroutineContext, logFileName = "REPLICA_LOG")
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -11,6 +11,8 @@ import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 import xtdb.DurationSerde
 import xtdb.api.PathSerde
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.database.proto.DatabaseConfig
 import xtdb.database.proto.DatabaseConfig.LogCase.*
 import xtdb.util.MsgIdUtil.offsetToMsgId
@@ -28,31 +30,11 @@ interface MessageCodec<M> {
 
 interface Log<M> : AutoCloseable {
 
-    interface Cluster : AutoCloseable {
-
-        interface Factory<C : Cluster> {
-            fun open(): C
-
-            companion object {
-                val serializersModule = SerializersModule {
-                    polymorphic(Factory::class) {
-                        for (reg in ServiceLoader.load(Registration::class.java))
-                            reg.registerSerde(this)
-                    }
-                }
-            }
-        }
-
-        interface Registration {
-            fun registerSerde(builder: PolymorphicModuleBuilder<Factory<*>>)
-        }
-    }
-
     interface Factory {
-        fun openSourceLog(clusters: Map<LogClusterAlias, Cluster>): Log<SourceMessage>
-        fun openReadOnlySourceLog(clusters: Map<LogClusterAlias, Cluster>): Log<SourceMessage>
-        fun openReplicaLog(clusters: Map<LogClusterAlias, Cluster>): Log<ReplicaMessage>
-        fun openReadOnlyReplicaLog(clusters: Map<LogClusterAlias, Cluster>): Log<ReplicaMessage>
+        fun openSourceLog(remotes: Map<RemoteAlias, Remote>): Log<SourceMessage>
+        fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>): Log<SourceMessage>
+        fun openReplicaLog(remotes: Map<RemoteAlias, Remote>): Log<ReplicaMessage>
+        fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>): Log<ReplicaMessage>
 
         fun writeTo(dbConfig: DatabaseConfig.Builder)
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -204,7 +204,7 @@ class Database(
                         afterSourceMsgId: MessageId,
                         afterReplicaMsgId: MessageId,
                     ): LogProcessor.LeaderSystem {
-                        val extSource = dbConfig.externalSource?.open(dbName, base.logClusters, base.remotes)
+                        val extSource = dbConfig.externalSource?.open(dbName, base.remotes)
 
                         val leaderProc = LeaderLogProcessor(
                             allocator, base, storage, indexer, crashLogger,

--- a/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
@@ -4,7 +4,6 @@ import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
 import xtdb.api.TransactionKey
 import xtdb.api.log.Log
-import xtdb.api.log.LogClusterAlias
 import xtdb.api.log.LogOffset
 import xtdb.api.log.MessageId
 import xtdb.api.log.ReplicaMessage
@@ -93,7 +92,7 @@ class DatabaseStorage(
             dbConfig: Database.Config,
         ): DatabaseStorage = safelyOpening {
             val readOnly = dbConfig.isReadOnly
-            val logClusters = base.logClusters
+            val remotes = base.remotes
 
             val bufferPool = open {
                 val bp = dbConfig.storage.open(
@@ -111,16 +110,16 @@ class DatabaseStorage(
                 ?.let { TransactionKey(it.txId, it.systemTime.microsAsInstant) }
 
             val sourceLog = open {
-                val log = if (readOnly) dbConfig.log.openReadOnlySourceLog(logClusters)
-                else dbConfig.log.openSourceLog(logClusters)
+                val log = if (readOnly) dbConfig.log.openReadOnlySourceLog(remotes)
+                else dbConfig.log.openSourceLog(remotes)
 
                 validateOffsets(log, latestCompletedTx)
                 log
             }
 
             val replicaLog = open {
-                if (readOnly) dbConfig.log.openReadOnlyReplicaLog(logClusters)
-                else dbConfig.log.openReplicaLog(logClusters)
+                if (readOnly) dbConfig.log.openReadOnlyReplicaLog(remotes)
+                else dbConfig.log.openReplicaLog(remotes)
             }
 
             DatabaseStorage(sourceLog, replicaLog, bufferPool, metadataManager)

--- a/core/src/main/kotlin/xtdb/database/ExternalSource.kt
+++ b/core/src/main/kotlin/xtdb/database/ExternalSource.kt
@@ -6,8 +6,6 @@ import kotlinx.serialization.modules.polymorphic
 import xtdb.indexer.TxIndexer
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
-import xtdb.api.log.Log
-import xtdb.api.log.LogClusterAlias
 import xtdb.database.proto.DatabaseConfig
 import java.util.*
 import com.google.protobuf.Any as ProtoAny
@@ -22,7 +20,6 @@ interface ExternalSource : AutoCloseable {
         fun writeTo(dbConfig: DatabaseConfig.Builder)
         fun open(
             dbName: String,
-            clusters: Map<LogClusterAlias, Log.Cluster>,
             remotes: Map<RemoteAlias, Remote>,
         ): ExternalSource
 

--- a/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
+++ b/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
@@ -3,8 +3,9 @@ package xtdb.test.log
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.api.log.Log
-import xtdb.api.log.LogClusterAlias
 import xtdb.api.log.MessageId
 import xtdb.api.log.SourceMessage
 import xtdb.api.log.ReplicaMessage
@@ -33,16 +34,16 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
         fun instantSource(instantSource: InstantSource) = apply { this.instantSource = instantSource }
         fun messages(messages: List<SourceMessage>) = apply { this.messages = messages }
 
-        override fun openSourceLog(clusters: Map<LogClusterAlias, Log.Cluster>) = RecordingLog(instantSource, messages)
+        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>) = RecordingLog(instantSource, messages)
 
-        override fun openReadOnlySourceLog(clusters: Map<LogClusterAlias, Log.Cluster>) =
-            ReadOnlyLog(openSourceLog(clusters))
+        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>) =
+            ReadOnlyLog(openSourceLog(remotes))
 
-        override fun openReplicaLog(clusters: Map<LogClusterAlias, Log.Cluster>) =
+        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>) =
             RecordingLog<ReplicaMessage>(instantSource, emptyList())
 
-        override fun openReadOnlyReplicaLog(clusters: Map<LogClusterAlias, Log.Cluster>) =
-            ReadOnlyLog(openReplicaLog(clusters))
+        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>) =
+            ReadOnlyLog(openReplicaLog(remotes))
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) = Unit
     }

--- a/core/src/test/kotlin/xtdb/NodeBaseTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeBaseTest.kt
@@ -1,0 +1,26 @@
+package xtdb
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import xtdb.api.Xtdb
+import xtdb.api.log.KafkaCluster
+import xtdb.error.Incorrect
+
+class NodeBaseTest {
+
+    @Test
+    fun `same alias under logClusters and remotes fails node startup`() {
+        val thrown = assertThrows<Incorrect> {
+            Xtdb.openNode {
+                logCluster("conflict", KafkaCluster.ClusterFactory("localhost:9092"))
+                remote("conflict", KafkaCluster.ClusterFactory("localhost:9093"))
+            }
+        }
+
+        assertTrue(
+            thrown.message?.contains("conflict") == true,
+            "error message should reference the offending alias, was: ${thrown.message}"
+        )
+    }
+}

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -37,6 +37,8 @@ import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.Serializer
 import xtdb.DurationSerde
 import xtdb.api.PathSerde
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
 import xtdb.database.proto.DatabaseConfig
 import xtdb.kafka.proto.KafkaLogConfig
 import xtdb.kafka.proto.kafkaLogConfig
@@ -133,7 +135,7 @@ class KafkaCluster(
     val transactionalIdPrefix: String? = null,
     private val groupId: String = "xtdb",
     coroutineContext: CoroutineContext = Dispatchers.Default
-) : Log.Cluster {
+) : Remote {
     val producer = kafkaConfigMap.openProducer()
     val scope = CoroutineScope(SupervisorJob() + coroutineContext)
 
@@ -324,7 +326,7 @@ class KafkaCluster(
         var transactionalIdPrefix: String? = null,
         var groupId: String = "xtdb",
         @kotlinx.serialization.Transient var coroutineContext: CoroutineContext = Dispatchers.Default
-    ) : Log.Cluster.Factory<KafkaCluster> {
+    ) : Remote.Factory<KafkaCluster> {
 
         fun pollDuration(pollDuration: Duration) = apply { this.pollDuration = pollDuration }
         fun propertiesMap(propertiesMap: Map<String, String>) = apply { this.propertiesMap = propertiesMap }
@@ -580,22 +582,22 @@ class KafkaCluster(
     @Serializable
     @SerialName("!Kafka")
     data class LogFactory @JvmOverloads constructor(
-        val cluster: LogClusterAlias,
+        val cluster: RemoteAlias,
         val topic: String,
-        var replicaCluster: LogClusterAlias = cluster,
+        var replicaCluster: RemoteAlias = cluster,
         var replicaTopic: String = "$topic-replica",
         var autoCreateTopic: Boolean = true,
         var epoch: Int = 0,
     ) : Log.Factory {
 
-        fun replicaCluster(replicaCluster: LogClusterAlias) = apply { this.replicaCluster = replicaCluster }
+        fun replicaCluster(replicaCluster: RemoteAlias) = apply { this.replicaCluster = replicaCluster }
         fun replicaTopic(replicaTopic: String) = apply { this.replicaTopic = replicaTopic }
         fun autoCreateTopic(autoCreateTopic: Boolean) = apply { this.autoCreateTopic = autoCreateTopic }
         fun epoch(epoch: Int) = apply { this.epoch = epoch }
 
-        override fun openSourceLog(clusters: Map<LogClusterAlias, Log.Cluster>): Log<SourceMessage> {
+        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>): Log<SourceMessage> {
             val clusterAlias = this.cluster
-            val cluster = requireNotNull(clusters[clusterAlias] as? KafkaCluster) {
+            val cluster = requireNotNull(remotes[clusterAlias] as? KafkaCluster) {
                 "missing Kafka cluster: '$clusterAlias'"
             }
 
@@ -608,12 +610,12 @@ class KafkaCluster(
             return cluster.KafkaLog(SourceMessage.Codec, topic, epoch)
         }
 
-        override fun openReadOnlySourceLog(clusters: Map<LogClusterAlias, Log.Cluster>) =
-            ReadOnlyLog(openSourceLog(clusters))
+        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>) =
+            ReadOnlyLog(openSourceLog(remotes))
 
-        override fun openReplicaLog(clusters: Map<LogClusterAlias, Log.Cluster>): Log<ReplicaMessage> {
+        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>): Log<ReplicaMessage> {
             val clusterAlias = this.replicaCluster
-            val cluster = requireNotNull(clusters[clusterAlias] as? KafkaCluster) {
+            val cluster = requireNotNull(remotes[clusterAlias] as? KafkaCluster) {
                 "missing Kafka cluster: '$clusterAlias'"
             }
 
@@ -626,8 +628,8 @@ class KafkaCluster(
             return cluster.KafkaLog(ReplicaMessage.Codec, replicaTopic, epoch)
         }
 
-        override fun openReadOnlyReplicaLog(clusters: Map<LogClusterAlias, Log.Cluster>) =
-            ReadOnlyLog(openReplicaLog(clusters))
+        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>) =
+            ReadOnlyLog(openReplicaLog(remotes))
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.setOtherLog(ProtoAny.pack(kafkaLogConfig {
@@ -663,8 +665,8 @@ class KafkaCluster(
     /**
      * @suppress
      */
-    class ClusterRegistration : Log.Cluster.Registration {
-        override fun registerSerde(builder: PolymorphicModuleBuilder<Log.Cluster.Factory<*>>) {
+    class ClusterRegistration : Remote.Registration {
+        override fun registerSerde(builder: PolymorphicModuleBuilder<Remote.Factory<*>>) {
             builder.subclass(ClusterFactory::class)
         }
     }

--- a/modules/kafka/src/main/resources/META-INF/services/xtdb.api.Remote$Registration
+++ b/modules/kafka/src/main/resources/META-INF/services/xtdb.api.Remote$Registration
@@ -1,0 +1,1 @@
+xtdb.api.log.KafkaCluster$ClusterRegistration

--- a/modules/kafka/src/main/resources/META-INF/services/xtdb.api.log.Log$Cluster$Registration
+++ b/modules/kafka/src/main/resources/META-INF/services/xtdb.api.log.Log$Cluster$Registration
@@ -1,1 +1,0 @@
-xtdb.api.log.KafkaCluster$ClusterRegistration

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -13,7 +13,9 @@ import org.apache.kafka.common.errors.RecordTooLargeException
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.testcontainers.kafka.ConfluentKafkaContainer
+import xtdb.api.Xtdb
 import xtdb.api.log.Log.*
 import xtdb.api.storage.Storage
 import xtdb.database.Database
@@ -437,6 +439,28 @@ class KafkaClusterTest {
             assertArrayEquals(byteArrayOf(-1, 2), msg.payload)
 
             job2.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `node configured with Kafka cluster under remotes round-trips a tx`() {
+        val topicName = "test-remotes-${UUID.randomUUID()}"
+
+        Xtdb.openNode {
+            server { port = 0 }; flightSql = null
+            remote("my-kafka", KafkaCluster.ClusterFactory(container.bootstrapServers))
+            log(KafkaCluster.LogFactory("my-kafka", topicName))
+        }.use { node ->
+            node.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("INSERT INTO foo (_id, x) VALUES ('a', 1)")
+                    stmt.executeQuery("SELECT _id, x FROM foo").use { rs ->
+                        assertTrue(rs.next())
+                        assertEquals("a", rs.getString("_id"))
+                        assertEquals(1, rs.getInt("x"))
+                    }
+                }
+            }
         }
     }
 

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -10,8 +10,6 @@ import org.postgresql.util.PSQLException
 import xtdb.indexer.TxIndexer
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
-import xtdb.api.log.Log
-import xtdb.api.log.LogClusterAlias
 import xtdb.database.ExternalSource
 import xtdb.indexer.OpenTx
 import xtdb.indexer.TxIndexer.TxResult
@@ -51,7 +49,6 @@ class PostgresSource(
 
         override fun open(
             dbName: String,
-            clusters: Map<LogClusterAlias, Log.Cluster>,
             remotes: Map<RemoteAlias, Remote>,
         ): ExternalSource {
             val raw = remotes[remote]


### PR DESCRIPTION
## Context

The node config carried two parallel alias-keyed registries — `logClusters` and `remotes` — for the same kind of thing: a named, node-local handle for an external system the node authenticates against.
The split forced every source to know which map its alias lived in, and there was nowhere natural to point a source at a Kafka cluster the way `PostgresSource` points at a Postgres remote.

## Approach

`Log.Cluster.Factory` carried no log-specific machinery — it was a parallel scaffold of `Remote.Factory` with the same `open()` shape and the same serde-registration plumbing.
After binning it, `Log.Cluster` itself was an empty marker over `Remote`, and the variance constraint `Remote.Factory<out Log.Cluster>` had no runtime teeth — kotlinx.serialization erases the variance.
Both went.
`LogClusterAlias` followed — a bare `String` typealias with no enforcement, redundant with `RemoteAlias` once the underlying type was unified.

`KafkaCluster` now implements `Remote` directly; its `ClusterFactory` implements `Remote.Factory<KafkaCluster>` and is registered through the same `Remote.Registration` SPI as Postgres et al.
`ExternalSource.Factory.open` slims from two map arguments to one — every source's `clusters[alias]` becomes `remotes[alias] as? KafkaCluster`, with the same type-validation shape `PostgresSource` already used for `PostgresRemote`.

The operator-facing `logClusters:` YAML key stays — existing config files keep working — but its entries get merged into `remotes` at node startup, with collision detection across the two maps.
An alias appearing in both fails the node with a clear `Incorrect`; silent precedence would have been a debugging trap.

## Behaviour preservation

Largely behaviour-preserving — operator-visible config (`logClusters:` YAML key, builder methods) is unchanged.
The one new behaviour is the startup collision check: an alias appearing under both `logClusters:` and `remotes:` now fails the node, where previously the second registry would have silently shadowed the first.

## Decisions that didn't land

- **Runtime resolver wrapping both maps.**
  Paves over the split at runtime instead of dissolving it at the type level.
- **Inheritance — `Log.Cluster.Factory` extending `Remote.Factory`.**
  Cheaper to merge but keeps the redundant scaffold around.

## Test plan

- [x] `NodeBaseTest` — alias collision between `logClusters` and `remotes` throws `Incorrect` at node startup.
- [x] `KafkaClusterTest` — opens a node with a Kafka cluster registered via `remote(...)` (not `logCluster(...)`), runs INSERT + SELECT through pgwire to confirm the kafka log resolves and round-trips a tx.
- [x] `YamlSerdeTest` — existing tests still pass; `!Kafka` round-trips through the unified `Remote.Registration` SPI path.

## Out of scope

Removing the `logClusters:` YAML config key entirely.
Now that `Xtdb.Config.logClusters` and `.remotes` have identical Kotlin types (`Map<RemoteAlias, Remote.Factory<*>>`), the distinction is purely an operator-visible config-key alias — worth a follow-up once we see how operator configs settle.