### PR TITLE
refactor(api)!: drop ProtoAny from ExternalSourceToken SPI

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
@@ -57,7 +57,7 @@ sealed interface ReplicaMessage {
                                 },
                                 it.tableDataMap.mapValues { (_, v) -> v.toByteArray() },
                                 dbOp,
-                                it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }
+                                it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }?.toByteArray()
                             )
                         }
 
@@ -68,14 +68,14 @@ sealed interface ReplicaMessage {
                         ReplicaLogMessage.MessageCase.BLOCK_BOUNDARY -> msg.blockBoundary.let {
                             BlockBoundary(
                                 it.blockIndex, it.latestProcessedMsgId,
-                                it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }
+                                it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }?.toByteArray()
                             )
                         }
 
                         ReplicaLogMessage.MessageCase.BLOCK_UPLOADED -> msg.blockUploaded.let {
                             BlockUploaded(
                                 it.storageVersion, it.storageEpoch, it.blockIndex, it.latestProcessedMsgId, it.triesList,
-                                it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }
+                                it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }?.toByteArray()
                             )
                         }
 
@@ -133,7 +133,7 @@ sealed interface ReplicaMessage {
 
                     null -> {}
                 }
-                this@ResolvedTx.externalSourceToken?.let { externalSourceToken = it }
+                this@ResolvedTx.externalSourceToken?.let { externalSourceToken = ByteString.copyFrom(it) }
             }
         }
     }
@@ -160,7 +160,7 @@ sealed interface ReplicaMessage {
             blockBoundary = blockBoundary {
                 this.blockIndex = this@BlockBoundary.blockIndex
                 this.latestProcessedMsgId = this@BlockBoundary.latestProcessedMsgId
-                this@BlockBoundary.externalSourceToken?.let { this.externalSourceToken = it }
+                this@BlockBoundary.externalSourceToken?.let { this.externalSourceToken = ByteString.copyFrom(it) }
             }
         }
     }
@@ -178,7 +178,7 @@ sealed interface ReplicaMessage {
                 this.blockIndex = this@BlockUploaded.blockIndex
                 this.latestProcessedMsgId = this@BlockUploaded.latestProcessedMsgId
                 tries.addAll(this@BlockUploaded.tries)
-                this@BlockUploaded.externalSourceToken?.let { this.externalSourceToken = it }
+                this@BlockUploaded.externalSourceToken?.let { this.externalSourceToken = ByteString.copyFrom(it) }
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/api/log/SourceMessage.kt
+++ b/core/src/main/kotlin/xtdb/api/log/SourceMessage.kt
@@ -85,7 +85,7 @@ sealed interface SourceMessage {
                             SourceLogMessage.MessageCase.BLOCK_UPLOADED -> msg.blockUploaded.let {
                                 BlockUploaded(
                                     it.storageVersion, it.storageEpoch, it.blockIndex, it.latestProcessedMsgId, it.triesList,
-                                    it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }
+                                    it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }?.toByteArray()
                                 )
                             }
 
@@ -96,7 +96,7 @@ sealed interface SourceMessage {
                                     defaultTz = ZoneId.of(it.defaultTz),
                                     user = if (it.hasUser()) it.user else null,
                                     userMetadata = if (it.userMetadata.isEmpty) null else it.userMetadata.toByteArray(),
-                                    externalSourceToken = it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }
+                                    externalSourceToken = it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }?.toByteArray()
                                 )
                             }
 
@@ -121,7 +121,7 @@ sealed interface SourceMessage {
                 defaultTz = this@Tx.defaultTz.id
                 this@Tx.user?.let { user = it }
                 this@Tx.userMetadata?.let { userMetadata = ByteString.copyFrom(it) }
-                this@Tx.externalSourceToken?.let { externalSourceToken = it }
+                this@Tx.externalSourceToken?.let { externalSourceToken = ByteString.copyFrom(it) }
             }
         }
 
@@ -193,7 +193,7 @@ sealed interface SourceMessage {
                 this.blockIndex = this@BlockUploaded.blockIndex
                 this.latestProcessedMsgId = this@BlockUploaded.latestProcessedMsgId
                 tries.addAll(this@BlockUploaded.tries)
-                this@BlockUploaded.externalSourceToken?.let { this.externalSourceToken = it }
+                this@BlockUploaded.externalSourceToken?.let { this.externalSourceToken = ByteString.copyFrom(it) }
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
@@ -1,5 +1,6 @@
 package xtdb.catalog
 
+import com.google.protobuf.ByteString
 import xtdb.database.ExternalSourceToken
 import xtdb.api.TransactionKey
 import xtdb.api.log.MessageId
@@ -83,7 +84,7 @@ class BlockCatalog(
             boundaryReplicaMsgId?.let { this.boundaryReplicaMsgId = it }
             this.tableNames.addAll(tables.map { it.sym.toString() })
             secondaryDatabases?.let { this.secondaryDatabases.putAll(it) }
-            externalSourceToken?.let { this.externalSourceToken = it }
+            externalSourceToken?.let { this.externalSourceToken = ByteString.copyFrom(it) }
         }
     }
 
@@ -103,7 +104,7 @@ class BlockCatalog(
         get() = latestBlock?.let { block -> block.boundaryReplicaMsgId.takeIf { block.hasBoundaryReplicaMsgId() } }
 
     val externalSourceToken: ExternalSourceToken?
-        get() = latestBlock?.takeIf { it.hasExternalSourceToken() }?.externalSourceToken
+        get() = latestBlock?.takeIf { it.hasExternalSourceToken() }?.externalSourceToken?.toByteArray()
 
     val allTables: List<TableRef> get() = latestBlock?.tableNamesList.orEmpty().map { TableRef.parse(dbName, it) }
 

--- a/core/src/main/kotlin/xtdb/database/ExternalSource.kt
+++ b/core/src/main/kotlin/xtdb/database/ExternalSource.kt
@@ -10,7 +10,7 @@ import xtdb.database.proto.DatabaseConfig
 import java.util.*
 import com.google.protobuf.Any as ProtoAny
 
-typealias ExternalSourceToken = ProtoAny
+typealias ExternalSourceToken = ByteArray
 
 interface ExternalSource : AutoCloseable {
 

--- a/core/src/main/proto/xtdb/log/proto/log.proto
+++ b/core/src/main/proto/xtdb/log/proto/log.proto
@@ -2,7 +2,6 @@ edition = "2023";
 
 package xtdb.log.proto;
 
-import "google/protobuf/any.proto";
 import "xtdb/database/proto/db.proto";
 
 option java_multiple_files = true;
@@ -26,7 +25,7 @@ message Tx {
     string default_tz = 3;
     string user = 4;
     bytes user_metadata = 5;
-    google.protobuf.Any external_source_token = 6;
+    bytes external_source_token = 6;
 }
 
 message BlockUploaded {
@@ -35,7 +34,7 @@ message BlockUploaded {
     int64 block_index = 3;
     int64 latest_processed_msg_id = 4;
     repeated TrieDetails tries = 5;
-    google.protobuf.Any external_source_token = 6;
+    bytes external_source_token = 6;
 }
 
 message FlushBlock {

--- a/core/src/main/proto/xtdb/log/proto/replica-log.proto
+++ b/core/src/main/proto/xtdb/log/proto/replica-log.proto
@@ -2,7 +2,6 @@ edition = "2023";
 
 package xtdb.log.proto;
 
-import "google/protobuf/any.proto";
 import "xtdb/log/proto/log.proto";
 
 option java_multiple_files = true;
@@ -35,13 +34,13 @@ message ResolvedTx {
         DetachDatabase detach_database = 7;
     }
 
-    google.protobuf.Any external_source_token = 8;
+    bytes external_source_token = 8;
 }
 
 message BlockBoundary {
     int64 block_index = 1;
     int64 latest_processed_msg_id = 2;
-    google.protobuf.Any external_source_token = 3;
+    bytes external_source_token = 3;
 }
 
 message NoOp {}

--- a/core/src/main/proto/xtdb/meta/block/proto/block.proto
+++ b/core/src/main/proto/xtdb/meta/block/proto/block.proto
@@ -2,7 +2,6 @@ edition = "2023";
 
 package xtdb.block.proto;
 
-import "google/protobuf/any.proto";
 import "xtdb/log/proto/log.proto";
 import "xtdb/database/proto/db.proto";
 
@@ -47,5 +46,5 @@ message Block {
     int64 boundary_replica_msg_id = 6;
 
     // opaque token tracking how far the leader consumed an external source (e.g. CDC offset)
-    google.protobuf.Any external_source_token = 7;
+    bytes external_source_token = 7;
 }

--- a/core/src/test/kotlin/xtdb/api/log/ExternalSourceTokenTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/ExternalSourceTokenTest.kt
@@ -1,7 +1,5 @@
 package xtdb.api.log
 
-import com.google.protobuf.Any as ProtoAny
-import com.google.protobuf.StringValue
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import xtdb.block.proto.Block
@@ -9,7 +7,7 @@ import xtdb.catalog.BlockCatalog
 
 class ExternalSourceTokenTest {
 
-    private val testToken: ProtoAny = ProtoAny.pack(StringValue.of("kafka-offset:42"))
+    private val testToken: ByteArray = "kafka-offset:42".toByteArray()
 
     @Test
     fun `BlockBoundary round-trips external source token`() {
@@ -22,7 +20,7 @@ class ExternalSourceTokenTest {
         assertEquals(1, decoded.blockIndex)
         assertEquals(100, decoded.latestProcessedMsgId)
         assertNotNull(decoded.externalSourceToken)
-        assertEquals(testToken, decoded.externalSourceToken)
+        assertArrayEquals(testToken, decoded.externalSourceToken)
     }
 
     @Test
@@ -44,7 +42,7 @@ class ExternalSourceTokenTest {
 
         assertInstanceOf(ReplicaMessage.BlockUploaded::class.java, decoded)
         decoded as ReplicaMessage.BlockUploaded
-        assertEquals(testToken, decoded.externalSourceToken)
+        assertArrayEquals(testToken, decoded.externalSourceToken)
     }
 
     @Test
@@ -55,7 +53,7 @@ class ExternalSourceTokenTest {
 
         assertInstanceOf(SourceMessage.BlockUploaded::class.java, decoded)
         decoded as SourceMessage.BlockUploaded
-        assertEquals(testToken, decoded.externalSourceToken)
+        assertArrayEquals(testToken, decoded.externalSourceToken)
     }
 
     @Test
@@ -74,7 +72,7 @@ class ExternalSourceTokenTest {
 
         val parsed = Block.parseFrom(block.toByteArray())
         assertTrue(parsed.hasExternalSourceToken())
-        assertEquals(testToken, parsed.externalSourceToken)
+        assertArrayEquals(testToken, parsed.externalSourceToken.toByteArray())
     }
 
     @Test
@@ -94,7 +92,7 @@ class ExternalSourceTokenTest {
         )
         blockCatalog.refresh(block)
 
-        assertEquals(testToken, blockCatalog.externalSourceToken)
+        assertArrayEquals(testToken, blockCatalog.externalSourceToken)
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -1,6 +1,5 @@
 package xtdb.database
 
-import com.google.protobuf.StringValue
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.cancelAndJoin
@@ -35,7 +34,6 @@ import java.time.InstantSource
 import java.time.ZoneId
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.milliseconds
-import com.google.protobuf.Any as ProtoAny
 
 class ExternalSourceTest {
 
@@ -202,14 +200,14 @@ class ExternalSourceTest {
         val lp = leaderProc(watchers = watchers, extSource = extSource, ctx = coroutineContext)
 
         try {
-            val token = ProtoAny.pack(StringValue.of("kafka-offset:42"))
+            val token = "kafka-offset:42".toByteArray()
             extSource.channel.send(token)
 
             delay(500.milliseconds)
 
             val watcherToken = watchers.externalSourceToken
             assertNotNull(watcherToken)
-            assertEquals("kafka-offset:42", watcherToken!!.unpack(StringValue::class.java).value)
+            assertArrayEquals(token, watcherToken)
         } finally {
             lp.close()
         }

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -110,7 +110,7 @@ class PostgresSource(
     ) {
         LOG.info("[$dbName] Partition $partition assigned (slot=$slotName)")
 
-        val token = afterToken?.unpack(PostgresSourceToken::class.java)
+        val token = afterToken?.let { ProtoAny.parseFrom(it).unpack(PostgresSourceToken::class.java) }
         LOG.debug { "[$dbName] Recovered token: ${token ?: "none"}" }
 
         try {
@@ -171,7 +171,7 @@ class PostgresSource(
                     val token = ProtoAny.pack(postgresSourceToken {
                         latestCommittedLsn = snapshot.slotLsn
                         snapshotCompleted = false
-                    }, PROTO_TAG)
+                    }, PROTO_TAG).toByteArray()
 
                     txIndexer.indexTx(token) { openTx ->
                         for (op in batch) {
@@ -184,7 +184,7 @@ class PostgresSource(
                 val completeToken = ProtoAny.pack(postgresSourceToken {
                     latestCommittedLsn = snapshot.slotLsn
                     snapshotCompleted = true
-                }, PROTO_TAG)
+                }, PROTO_TAG).toByteArray()
 
                 LOG.debug { "[$dbName] Writing snapshot-complete marker" }
                 txIndexer.indexTx(completeToken) {
@@ -203,7 +203,7 @@ class PostgresSource(
                     val token = ProtoAny.pack(postgresSourceToken {
                         latestCommittedLsn = tx.lsn
                         snapshotCompleted = true
-                    }, PROTO_TAG)
+                    }, PROTO_TAG).toByteArray()
 
                     txIndexer.indexTx(token, systemTime = tx.commitTime) { openTx ->
                         for (op in tx.ops) {


### PR DESCRIPTION
Resolves #5567.
Sub-issue of #5564.

## Context

`ExternalSourceToken` was a typealias for `com.google.protobuf.Any`, so external-source authors had to depend on Google protobuf to mint and read tokens.
That's a transport choice leaking through what should be an opaque "where am I in the upstream feed" handle.
The SPI now hands sources a plain `ByteArray`.

## Approach

The issue listed three migration paths.
The chosen shape is essentially path 2 ("adapter at the SPI boundary"), but with a twist that simplifies things: `PostgresSource` is the only current `ExternalSourceToken` user, and it already wraps its own `PostgresSourceToken` proto in a `ProtoAny`.
So the adapter lives **inside the source** that wants protobuf, not at the framework boundary.
Future sources never touch Google protobuf at all.

That simplification carries a useful consequence.
Protobuf encodes `Any` and `bytes` fields identically on the wire (length-delimited at the same tag).
Swapping the five proto fields from `Any` to `bytes` at the same field numbers, while keeping `PostgresSource` emitting `ProtoAny.toByteArray()` as the token, leaves existing on-disk replica logs and block files reading cleanly — no migration window, no path-1 deprecation field needed.

## Wire compat

The `breaking change` label is technically correct — the Kotlin SPI signature changed for any out-of-tree source author — but the on-disk wire format does not break.
Existing replica-log and block files written under `Any`-typed fields parse correctly under the new `bytes`-typed schema, and `PostgresSource` keeps emitting Any-shaped bytes for the token payload, so resume tokens remain interpretable across the upgrade.

## Implementation notes

The five token-bearing proto fields move from `google.protobuf.Any` to `bytes` at the same field numbers:

- `Tx.external_source_token` (`log.proto` #6)
- `BlockUploaded.external_source_token` (`log.proto` #6)
- `ResolvedTx.external_source_token` (`replica-log.proto` #8)
- `BlockBoundary.external_source_token` (`replica-log.proto` #3)
- `Block.external_source_token` (`block.proto` #7)

`ByteString ⇆ ByteArray` conversions land at the encode/decode sites in `ReplicaMessage`, `SourceMessage`, and `BlockCatalog`.
Everything else that mentions `ExternalSourceToken` (`Watchers`, `OpenTx`, `LeaderLogProcessor`, `BlockUploader`, `FollowerLogProcessor`, `TransitionLogProcessor`, `Database`) is transparent to the typealias change.

## Test plan

- `ExternalSourceTokenTest` — token round-trips through every persisted location.
- `ExternalSourceTest` — leader-log-processor end-to-end with watcher threading.
- `LogProcessorSimTest` — simulation path.
- `xtdb-postgres-source` module — `ProtoAny` pack/unpack at the source's own boundary.
- Full root-module suite locally: 1464/1465. The single failure was an Arrow leak-detector trip in `xtdb.indexer-test/can-ingest-ts-devices-mini-with-stop-start-and-reach-same-state` — a CSV ingestion test that doesn't touch external sources; passed 3/3 in isolation on this branch and CI is green.