### PR TITLE
refactor(postgres-source)!: drop ProtoAny wrap on resume token

### DIFF
--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -30,7 +30,7 @@ import com.google.protobuf.Any as ProtoAny
 
 private val LOG = PostgresSource::class.logger
 
-private const val PROTO_TAG = "proto.xtdb.com"
+private const val PROTO_TAG_PREFIX = "proto.xtdb.com"
 
 class PostgresSource(
     private val dbName: String,
@@ -81,11 +81,11 @@ class PostgresSource(
                 slotName = this@Factory.slotName
                 publicationName = this@Factory.publicationName
                 schemaIncludeList += this@Factory.schemaIncludeList
-            }, PROTO_TAG)
+            }, PROTO_TAG_PREFIX)
         }
 
         class Registration : ExternalSource.Registration {
-            override val protoTag: String get() = "$PROTO_TAG/xtdb.postgres.proto.PostgresSourceConfig"
+            override val protoTag: String get() = "$PROTO_TAG_PREFIX/xtdb.postgres.proto.PostgresSourceConfig"
 
             override fun fromProto(msg: ProtoAny): ExternalSource.Factory {
                 val config = msg.unpack(PostgresSourceConfig::class.java)

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -110,7 +110,7 @@ class PostgresSource(
     ) {
         LOG.info("[$dbName] Partition $partition assigned (slot=$slotName)")
 
-        val token = afterToken?.let { ProtoAny.parseFrom(it).unpack(PostgresSourceToken::class.java) }
+        val token = afterToken?.let { PostgresSourceToken.parseFrom(it) }
         LOG.debug { "[$dbName] Recovered token: ${token ?: "none"}" }
 
         try {
@@ -168,10 +168,10 @@ class PostgresSource(
         driver.openSnapshot().use { snapshot ->
             closeOnCancel(snapshot) {
                 for (batch in snapshot.batches()) {
-                    val token = ProtoAny.pack(postgresSourceToken {
+                    val token = postgresSourceToken {
                         latestCommittedLsn = snapshot.slotLsn
                         snapshotCompleted = false
-                    }, PROTO_TAG).toByteArray()
+                    }.toByteArray()
 
                     txIndexer.indexTx(token) { openTx ->
                         for (op in batch) {
@@ -181,10 +181,10 @@ class PostgresSource(
                     }
                 }
 
-                val completeToken = ProtoAny.pack(postgresSourceToken {
+                val completeToken = postgresSourceToken {
                     latestCommittedLsn = snapshot.slotLsn
                     snapshotCompleted = true
-                }, PROTO_TAG).toByteArray()
+                }.toByteArray()
 
                 LOG.debug { "[$dbName] Writing snapshot-complete marker" }
                 txIndexer.indexTx(completeToken) {
@@ -200,10 +200,10 @@ class PostgresSource(
         driver.openStream(startLsn).use { stream ->
             while (currentCoroutineContext().isActive) {
                 stream.nextTransaction { tx ->
-                    val token = ProtoAny.pack(postgresSourceToken {
+                    val token = postgresSourceToken {
                         latestCommittedLsn = tx.lsn
                         snapshotCompleted = true
-                    }, PROTO_TAG).toByteArray()
+                    }.toByteArray()
 
                     txIndexer.indexTx(token, systemTime = tx.commitTime) { openTx ->
                         for (op in tx.ops) {


### PR DESCRIPTION
Follow-up to #5567 / #5571.

## Context

#5571 made `PostgresSource` serialise its `PostgresSourceToken` ⇆ `ProtoAny` ⇆ `ByteArray` at its own boundary (the framework SPI is now plain `ByteArray`).
The `Any` envelope was load-bearing back when the framework dispatched on `type_url` to find a parser.
With the SPI handing `PostgresSource` opaque bytes, the envelope is dead weight — the source already knows what proto to parse.

## Changes

`PostgresSource` now serialises `PostgresSourceToken` directly to bytes on emit and `parseFrom`s on resume.
`ProtoAny` and the `PROTO_TAG_PREFIX` constant stay live for the *config* registration path (`Factory.writeTo` / `Registration.fromProto`), where Any's `type_url` is still doing real work — dispatching between source factories at config-load time.

Second commit is a clarity rename: `PROTO_TAG` → `PROTO_TAG_PREFIX`.
`Any.pack(message, typeUrlPrefix)` appends `/<message-fullname>` to the second arg, so the constant is a *prefix*, not a full tag.

## Wire compat

This is the wire-incompatible piece of the #5567 migration that #5571 left out.
Pre-upgrade `PostgresSource` resume tokens are Any-shaped envelopes (`type_url` + `value` sub-fields); post-upgrade `PostgresSource` parses raw bytes as a `PostgresSourceToken` and won't decode the older shape.
An existing CDC stream therefore can't be resumed across the upgrade — the source has to be re-attached, snapshot included.
The user explicitly accepted this on #5567: anyone running `PostgresSource` today is in a position to recreate their dbs.

## Test plan

- `xtdb-postgres-source` module — `PostgresSourceToken` round-trips at the source's own boundary.
- `ExternalSourceTokenTest`, `ExternalSourceTest` — framework-side token round-trip and watcher threading; transparent to the change.