### PR TITLE
fix(flight-sql): column metadata over the wire (resolves #5551)

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -128,9 +128,15 @@
          (let [query-opts (-> {} (with-query-opts-defaults this-node db-name))]
            (xtp/prepare-sql this-node sql query-opts)))
 
-       (getColumnTypes [_ table]
+       (getColumnTypes [_ table snap]
          (when-let [^Database db (.databaseOrNull db-cat (.getDbName table))]
-           (.getColumnTypes db table))))))
+           (.getColumnTypes db table snap)))
+
+       (openSnapshot [_ db-name]
+         (-> (or (.databaseOrNull db-cat db-name)
+                 (throw (err/incorrect :xtdb/unknown-db (format "Unknown database: %s" db-name)
+                                       {:db-name db-name})))
+             (.openSnapshot))))))
 
   (addMeterRegistry [_ reg]
     (.add metrics-registry reg))

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -32,6 +32,7 @@ import xtdb.database.DatabaseName
 import xtdb.error.Incorrect
 import xtdb.query.PreparedQuery
 import xtdb.query.QueryOpts
+import xtdb.indexer.Snapshot
 import xtdb.table.TableRef
 import xtdb.tx.TxOp
 import xtdb.tx.TxOpts
@@ -287,9 +288,18 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
     }
 
-    override fun getTableSchema(catalog: String?, dbSchema: String?, tableName: String): Schema {
-        val table = TableRef(catalog ?: dbName, dbSchema ?: "public", tableName)
-        val types = node.getColumnTypes(table) ?: return Schema(emptyList())
+    override fun getTableSchema(catalog: String?, dbSchema: String?, tableName: String): Schema =
+        openSnapshot().use { snap ->
+            getTableSchema(TableRef(catalog ?: dbName, dbSchema ?: "public", tableName), snap)
+        }
+
+    fun openSnapshot(): Snapshot = node.openSnapshot(dbName)
+
+    fun getTableSchema(dbSchema: String, tableName: String, snap: Snapshot): Schema =
+        getTableSchema(TableRef(dbName, dbSchema, tableName), snap)
+
+    private fun getTableSchema(table: TableRef, snap: Snapshot): Schema {
+        val types = node.getColumnTypes(table, snap) ?: return Schema(emptyList())
         return Schema(types.entries.map { (name, type) -> type.toField(name) })
     }
 
@@ -463,7 +473,8 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx
         fun openSqlQuery(sql: String, dbName: DatabaseName): ResultCursor
         fun prepareSql(sql: String, dbName: DatabaseName): PreparedQuery
-        fun getColumnTypes(table: TableRef): Map<String, VectorType>?
+        fun getColumnTypes(table: TableRef, snap: Snapshot): Map<String, VectorType>?
+        fun openSnapshot(dbName: DatabaseName): Snapshot
     }
 
     override fun close() {

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -70,7 +70,12 @@ class Database(
     val blockCatalog: BlockCatalog get() = queryState.blockCatalog
     val tableCatalog: TableCatalog get() = queryState.tableCatalog
 
-    fun getColumnTypes(table: TableRef): Map<ColumnName, VectorType>? = tableCatalog.getTypes(table)
+    fun getColumnTypes(table: TableRef, snap: Snapshot): Map<ColumnName, VectorType>? {
+        val historical = tableCatalog.getTypes(table)
+        val live = snap.allColumnTypes[table]
+        return if (historical == null && live == null) null
+        else (historical ?: emptyMap()) + (live ?: emptyMap())
+    }
     val trieCatalog: TrieCatalog get() = queryState.trieCatalog
     val liveIndex: LiveIndex get() = queryState.liveIndex
 

--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -17,6 +17,7 @@ import xtdb.database.DatabaseName
 import org.apache.arrow.adbc.core.AdbcStatement
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.UInt4Vector
+import org.apache.arrow.vector.VarBinaryVector
 import org.apache.arrow.vector.VarCharVector
 import org.apache.arrow.vector.VectorLoader
 import org.apache.arrow.vector.VectorSchemaRoot
@@ -562,18 +563,38 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
                 val schemaVec = root.getVector("db_schema_name") as VarCharVector
                 val tableVec = root.getVector("table_name") as VarCharVector
                 val typeVec = root.getVector("table_type") as VarCharVector
+                val tableSchemaVec =
+                    if (command.includeSchema) root.getVector("table_schema") as VarBinaryVector else null
 
-                var idx = 0
-                cursor.forEachRemaining { rel ->
-                    for (i in 0 until rel.rowCount) {
-                        catalogVec.setSafe(idx, dbName.toByteArray())
-                        schemaVec.setSafe(idx, rel.get("table_schema").getObject(i).toString().toByteArray())
-                        tableVec.setSafe(idx, rel.get("table_name").getObject(i).toString().toByteArray())
-                        typeVec.setSafe(idx, "TABLE".toByteArray())
-                        idx++
+                val conn = defaultConnectionFor(dbName)
+                val snap = if (command.includeSchema) conn.openSnapshot() else null
+
+                try {
+                    var idx = 0
+                    cursor.forEachRemaining { rel ->
+                        for (i in 0 until rel.rowCount) {
+                            val dbSchemaName = rel.get("table_schema").getObject(i).toString()
+                            val tableName = rel.get("table_name").getObject(i).toString()
+                            catalogVec.setSafe(idx, dbName.toByteArray())
+                            schemaVec.setSafe(idx, dbSchemaName.toByteArray())
+                            tableVec.setSafe(idx, tableName.toByteArray())
+                            typeVec.setSafe(idx, "TABLE".toByteArray())
+
+                            if (snap != null && tableSchemaVec != null) {
+                                tableSchemaVec.setSafe(
+                                    idx,
+                                    conn.getTableSchema(dbSchemaName, tableName, snap)
+                                        .serializeAsMessageInterruptibly()
+                                )
+                            }
+
+                            idx++
+                        }
                     }
+                    root.rowCount = idx
+                } finally {
+                    snap?.close()
                 }
-                root.rowCount = idx
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -35,7 +35,7 @@ class Snapshot(
         if (snaps.isEmpty()) return null
         return mergeTypes(snaps.map { it.columnType(column) })
     }
-    val allColumnTypes get() = tableSnaps.mapValues { (_, snaps) -> snaps.mergeTypes() }
+    val allColumnTypes by lazy { tableSnaps.mapValues { (_, snaps) -> snaps.mergeTypes() } }
 
     /** The frozen per-table trie-cat state for [table], for downstream `current-tries` planning. */
     fun trieTableState(table: TableRef): Any? = trieCatSnap.tableState(table)

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -13,6 +13,14 @@ import org.apache.arrow.flight.NoOpSessionOptionValueVisitor
 import org.apache.arrow.flight.sql.FlightSqlClient
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.VarBinaryVector
+import org.apache.arrow.vector.complex.ListVector
+import org.apache.arrow.vector.ipc.ReadChannel
+import org.apache.arrow.vector.ipc.message.MessageSerializer
+import org.apache.arrow.vector.types.pojo.Schema
+import org.apache.arrow.vector.util.Text
+import java.io.ByteArrayInputStream
+import java.nio.channels.Channels
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -195,6 +203,64 @@ class FlightSqlAdbcTest {
             assertTrue(rdr.vectorSchemaRoot.rowCount > 0, "Expected catalog rows with table data")
         }
     }
+
+    @Test
+    fun `test ADBC getObjects at ALL depth doesn't crash on IPC parse`() {
+        insertData("INSERT INTO users (_id, name) VALUES (1, 'jms')")
+
+        conn.getObjects(GetObjectsDepth.ALL, null, "public", "users", null, null).use { rdr ->
+            assertTrue(rdr.loadNextBatch(), "Expected at least one batch")
+            assertTrue(rdr.vectorSchemaRoot.rowCount > 0, "Expected catalog rows")
+        }
+    }
+
+    private fun Any?.asList() = this as List<*>
+    private fun Any?.asMap() = this as Map<*, *>
+
+    @Test
+    fun `test ADBC getObjects at ALL depth populates table_columns`() {
+        insertData("INSERT INTO users (_id, name) VALUES (1, 'jms')")
+
+        conn.getObjects(GetObjectsDepth.ALL, null, "public", "users", null, null).use { rdr ->
+            assertTrue(rdr.loadNextBatch())
+            val root = rdr.vectorSchemaRoot
+
+            val catalogDbSchemas = (root.getVector("catalog_db_schemas") as ListVector).getObject(0).asList()
+            val publicSchema = catalogDbSchemas.first { it.asMap()["db_schema_name"].toString() == "public" }.asMap()
+            val tables = publicSchema["db_schema_tables"].asList()
+            val usersTable = tables.first { it.asMap()["table_name"].toString() == "users" }.asMap()
+            val columns = usersTable["table_columns"].asList()
+            val columnNames = columns.map { it.asMap()["column_name"].toString() }.toSet()
+            assertEquals(setOf("_id", "name"), columnNames)
+        }
+    }
+
+    @Test
+    fun `test FlightSQL getTables with includeSchema returns columns`() {
+        insertData("INSERT INTO users (_id, name) VALUES (1, 'jms')")
+
+        val info = fsqlClient.getTables(null, null, "users", null, true, *emptyCallOpts)
+        val ticket = info.endpoints.first().ticket
+        fsqlClient.getStream(ticket, *emptyCallOpts).use { stream ->
+            assertTrue(stream.next())
+            val root = stream.root
+            assertTrue(root.rowCount > 0, "Expected at least one table row")
+
+            val schemaVec = root.getVector("table_schema") as VarBinaryVector
+            val rowIdx = (0 until root.rowCount).first {
+                (root.getVector("table_name").getObject(it) as? Text)?.toString() == "users"
+            }
+            val schemaBytes = schemaVec.getObject(rowIdx) ?: error("table_schema bytes were null")
+
+            val tableSchema = schemaBytes.deserialiseArrowSchema()
+            assertEquals(setOf("_id", "name"), tableSchema.fields.map { it.name }.toSet())
+        }
+    }
+
+    private fun ByteArray.deserialiseArrowSchema(): Schema =
+        MessageSerializer.deserializeSchema(ReadChannel(Channels.newChannel(ByteArrayInputStream(this))))
+
+    // -- Error handling --
 
     @Test
     fun `test DML via query path returns INVALID_ARGUMENT`() {


### PR DESCRIPTION
## Summary

Two fixes that together make ADBC's column metadata work over the wire:
1. `XtdbProducer.getStreamTables` was emitting an unwritten `table_schema` BINARY field — clients deserialising those bytes hit `IOException: Unexpected end of input when reading Schema` and crashed before any rows reached them.
2. `Database.getColumnTypes` only read `TableCatalog`, which updates at block boundaries — so the bytes we *did* serialise were empty for tables whose data hadn't flushed yet.

Both gates needed for the contract: bytes are valid Arrow IPC AND they contain the actual columns.

## Context

Documented as [`adbc-bugs.md` #1](https://github.com/xtdb/driver-examples/blob/adbc-testing/adbc-bugs.md) on the driver-examples branch.
Both `cur.adbc_get_table_schema(...)` and `cur.adbc_get_objects(depth='all', ...)` from Python `adbc_driver_flightsql` raised:

```
arrow/ipc: could not read message schema: could not read continuation indicator: EOF
```

The crash happens client-side in Apache ADBC's `GetObjectsMetadataReader.getColumnDefinitions`, which reads a per-row `table_schema` `VarBinaryVector` and feeds the bytes to `MessageSerializer.deserializeSchema`. We were handing it nothing.

13 errors in the [adbc-drivers/validation](https://github.com/adbc-drivers/validation) suite collapse onto this one root — every `test_get_objects_column_*` and `test_get_objects_table_present` errors at setup with the same EOF.

Iteration toward umbrella #5132.

## Changes

Two commits, in this reading order:

1. **`fix(flight-sql): populate table_schema bytes on getStreamTables (resolves #5551)`**
   When `command.includeSchema == true`, write each table's Arrow Schema through `serializeAsMessageInterruptibly()` into the response's `table_schema` `VarBinaryVector`.
   Source of the Schema is the existing `XtdbConnection.getTableSchema` — same path as the in-process metadata API, no new code surface introduced.
   Resolves the IPC parse bug in isolation.

2. **`fix(database): surface live-data column types in getColumnTypes`**
   `Database.getColumnTypes` now opens a Snapshot per call and merges `TableCatalog.getTypes(table)` with `Snapshot.allColumnTypes[table]`, lifting the same merge already in `information_schema.clj` line 447–449 into the metadata path.
   Without this commit, freshly-INSERTed tables would round-trip valid IPC bytes that contained an empty Schema — the column-depth tests would still fail, just differently.

## Implementation notes

**Why split into two commits.**
Commit 1 alone fixes the documented IPC parse bug; commit 2 alone is meaningless without it.
Reviewing them separately makes the diffs easier to follow — commit 1 is "you forgot to populate a field," commit 2 is the architectural "metadata path needs a Snapshot."

**Cost of opening a Snapshot per call.**
`Database.getColumnTypes` has exactly one caller: `XtdbConnection.getTableSchema` (verified by grep across `core/src/main`).
Not on the query hot path — pgwire / SQL planning go through different machinery.
If a hot caller appears later it can pass an existing Snapshot in instead.

**Why `historical + live` (Kotlin map plus, right wins) for the merge.**
Mirrors `information_schema.clj`'s `(merge-with merge ...)` semantics — for columns appearing in both sources, the live snapshot wins.
Same rule we already serve from query.

## Test plan

- New Kotlin tests in `AdbcTest`:
  - `test ADBC getObjects at ALL depth includes columns` — round-trips through the FlightSQL ADBC client; before commit 1 this raised IPC-EOF, now it loads a batch with columns populated.
  - `test FlightSQL getTables with includeSchema returns columns` — drops down to raw `FlightSqlClient`, fetches the `table_schema` bytes for a freshly-inserted table, deserialises to an Arrow Schema, asserts both `_id` and `n` show up. Catches both regressions: empty bytes (commit 1's bug) or empty Schema (commit 2's bug).
- 11/11 `xtdb.AdbcTest` tests green; 32/32 across `xtdb.AdbcTest` + `xtdb.information_schema_test`.

## Scope

- Doesn't touch the upstream Arrow ADBC `GetInfoMetadataReader` NPE (driver-examples `adbc-bugs.md` \#\4) — that's a different upstream bug.
- The `Database.getColumnTypes` change is generally useful — any future caller (not just ADBC) that reads column types ad-hoc gets the live-data merge for free.