### PR TITLE
fix(order-by): delete external-sort tmp dir on cursor close

### DIFF
--- a/core/src/main/clojure/xtdb/operator/order_by.clj
+++ b/core/src/main/clojure/xtdb/operator/order_by.clj
@@ -256,7 +256,8 @@
   (close [_]
     (util/try-close read-rel)
     (util/try-close loader)
-    (util/try-close in-cursor)))
+    (util/try-close in-cursor)
+    (when sort-dir (util/delete-dir sort-dir))))
 
 (defmethod lp/emit-expr :order-by [{:keys [opts relation]} args]
   (let [{:keys [order-specs]} opts]

--- a/src/test/clojure/xtdb/operator/order_by_test.clj
+++ b/src/test/clojure/xtdb/operator/order_by_test.clj
@@ -3,8 +3,11 @@
             [xtdb.api :as xt]
             [xtdb.node :as xtn]
             [xtdb.operator.order-by :as order-by]
-            [xtdb.test-util :as tu])
-  (:import (java.time Instant Duration ZoneId)))
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util])
+  (:import (java.nio.file Files)
+           (java.nio.file.attribute FileAttribute)
+           (java.time Instant Duration ZoneId)))
 
 (t/use-fixtures :each tu/with-allocator)
 
@@ -70,6 +73,34 @@
                              [::tu/pages batches]]
                             {}))
             "spilling to disk"))))
+
+(t/deftest test-order-by-spill-cleans-up
+  (let [parent (Files/createTempDirectory "test-spill-" (make-array FileAttribute 0))]
+    (try
+      (with-redefs [util/tmp-dir (fn
+                                   ([] (Files/createTempDirectory parent "" (make-array FileAttribute 0)))
+                                   ([prefix] (Files/createTempDirectory parent prefix (make-array FileAttribute 0))))]
+        (binding [order-by/*block-size* 10]
+          (let [data (map-indexed (fn [i d] {:a d :b i})
+                                  (repeatedly 1000 #(rand-int 1000000)))
+                batches (mapv vec (partition-all 13 data))]
+
+            (t/testing "happy path — loader fully drained"
+              (tu/query-ra [:order-by {:order-specs '[[a] [b]]}
+                            [::tu/pages batches]]
+                           {})
+              (t/is (empty? (.list (.toFile parent)))
+                    "spill dir cleaned up after full drain"))
+
+            (t/testing "early close — LIMIT 1 closes cursor before loader exhausts"
+              (tu/query-ra [:top {:limit 1}
+                            [:order-by {:order-specs '[[a] [b]]}
+                             [::tu/pages batches]]]
+                           {})
+              (t/is (empty? (.list (.toFile parent)))
+                    "spill dir cleaned up after early cursor close")))))
+      (finally
+        (util/delete-dir parent)))))
 
 (t/deftest test-order-by-temporal-range-5269
   ;; #5269 — IOOBE in ORDER BY DESC with external sort.


### PR DESCRIPTION
When external sort spills, OrderByCursor creates a tmp directory via util/tmp-dir, stores the path on a `sort-dir` field, and then never references it again. The close method releases the loader and in-cursor but doesn't touch the directory.

The bug has been present since the original "Basic external sort" commit (be15933bc, Jul 2023): the field was wired up but the close-time delete never landed. Easy oversight — load-next-batch deletes the final sorted file once the loader exhausts, so on the happy path the directory is left empty, which doesn't show up in functional testing.

Two ways the leak manifests:

- Happy path: the sorted file is deleted but `sort-dir` itself is left behind, so /tmp accumulates one empty `external-sort*` directory per spilling query.
- Early close (LIMIT short-circuit, exception, query cancellation): the sorted-file delete lives inside load-next-batch and only fires when loadNextPage returns false. If the cursor is closed while the loader still has pages, the file's full size leaks in addition to the directory.

Single-line fix in close: walk-and-delete the tmp dir if present. delete-dir covers the dir, the leftover sorted file, and any pre-merge intermediates stranded by a mid-merge throw, all in one sweep.

Kept the existing intermediate-file deletion in external-sort (around k-way-merge) and the file-delete-on-loader-exhaustion in load-next-batch. Both are peak-disk-usage optimisations rather than cleanup-of-last-resort: without the in-loop intermediate delete, peak disk grows to roughly (log₄(N) + 1) × D for N initial spill files of total size D — 3-7× the input size for non-trivial sorts. Close-time sweep complements them rather than replacing them.

Out of scope: a similar staging-file leak in DiskCache.get when the fetch future fails, and whether /tmp should have a free-bytes probe in /healthz/alive. Both worth follow-ups; neither belongs in this fix.