### PR TITLE
feat(flight-sql): wire bulk ingest via CommandStatementIngest (#5080)

### DIFF
--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -172,31 +172,32 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             override fun prepare(): Unit =
                 throw Incorrect("Bulk ingest does not support prepare", "xtdb.adbc/bulk-ingest-no-prepare")
 
-            private var rel: Relation? = null
+            private var docs: Relation? = null
 
             override fun close() {
-                rel.also { rel = null }?.close()
+                docs.also { docs = null }?.close()
             }
 
             override fun bind(root: VectorSchemaRoot) {
-                this.rel?.close()
-                rel = Relation.fromRoot(node.allocator, root)
+                this.docs?.close()
+                docs = Relation(node.allocator, root.schema).closeOnCatch { copy ->
+                    Relation.fromRoot(node.allocator, root).use { src ->
+                        src.rowCopier(copy).copyRange(0, src.rowCount)
+                    }
+                    copy
+                }
             }
 
             override fun bind(rel: RelationReader) {
-                this.rel = rel.openDirectSlice(node.allocator)
+                this.docs = rel.openDirectSlice(node.allocator)
             }
 
             override fun executeUpdate(): UpdateResult {
-                return (rel.also { this.rel = null } ?: return UpdateResult(0))
-                    .use { rel ->
-                        // TODO valid-from/valid-to for the batch
-                        node.executeTx(dbName, listOf(TxOp.PutDocs(schemaName, tableName, docs = rel)))
-
-                        close()
-
-                        UpdateResult(rel.rowCount.toLong())
-                    }
+                val docs = docs.also { this.docs = null } ?: return UpdateResult(0)
+                val rowCount = docs.rowCount.toLong()
+                // TODO valid-from/valid-to for the batch
+                executeDml(TxOp.PutDocs(schemaName, tableName, docs = docs))
+                return UpdateResult(rowCount)
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -13,6 +13,8 @@ import org.apache.arrow.flight.sql.FlightSqlProducer
 import org.apache.arrow.flight.sql.NoOpFlightSqlProducer
 import org.apache.arrow.flight.sql.impl.FlightSql.*
 import org.apache.arrow.flight.sql.impl.FlightSql.ActionEndTransactionRequest.EndTransaction
+import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementIngest.TableDefinitionOptions.TableExistsOption
+import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementIngest.TableDefinitionOptions.TableNotExistOption
 import xtdb.database.DatabaseName
 import org.apache.arrow.adbc.core.AdbcStatement
 import org.apache.arrow.memory.BufferAllocator
@@ -25,6 +27,7 @@ import org.apache.arrow.vector.VectorUnloader
 import org.apache.arrow.vector.complex.DenseUnionVector
 import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.Schema
+import org.apache.arrow.adbc.core.BulkIngestMode
 import xtdb.adbc.XtdbConnection
 import xtdb.api.Xtdb
 import xtdb.arrow.Relation
@@ -212,6 +215,59 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
                 if (cmd.hasTransactionId()) cmd.transactionId else null,
                 dbNameFromContext(ctx)
             )
+
+            ackStream.sendDoPutUpdateRes(allocator)
+        } catch (t: Throwable) {
+            ackStream.onError(t)
+        }
+    }
+
+    override fun acceptPutStatementBulkIngest(
+        cmd: CommandStatementIngest,
+        ctx: CallContext?,
+        flightStream: FlightStream,
+        ackStream: StreamListener<PutResult>
+    ): Runnable = Runnable {
+        try {
+            if (cmd.hasTableDefinitionOptions()) {
+                val tdo = cmd.tableDefinitionOptions
+                val ifExists = tdo.ifExists
+                if (ifExists != TableExistsOption.TABLE_EXISTS_OPTION_UNSPECIFIED
+                    && ifExists != TableExistsOption.TABLE_EXISTS_OPTION_APPEND
+                ) throw CallStatus.INVALID_ARGUMENT
+                    .withDescription("Bulk ingest only supports append-on-exists for now (got $ifExists)")
+                    .toRuntimeException()
+                val ifNotExist = tdo.ifNotExist
+                if (ifNotExist != TableNotExistOption.TABLE_NOT_EXIST_OPTION_UNSPECIFIED
+                    && ifNotExist != TableNotExistOption.TABLE_NOT_EXIST_OPTION_CREATE
+                ) throw CallStatus.INVALID_ARGUMENT
+                    .withDescription("Bulk ingest cannot honour fail-if-not-exist: XTDB auto-creates tables on insert (got $ifNotExist)")
+                    .toRuntimeException()
+            }
+
+            val dbName = dbNameFromContext(ctx)
+
+            if (cmd.hasCatalog() && cmd.catalog.isNotEmpty() && cmd.catalog != dbName)
+                throw CallStatus.INVALID_ARGUMENT
+                    .withDescription("Bulk ingest catalog must match the connection catalog (got '${cmd.catalog}', connection '$dbName')")
+                    .toRuntimeException()
+
+            val tableName = cmd.table
+            if ('.' in tableName) throw CallStatus.INVALID_ARGUMENT
+                .withDescription("Bulk ingest table name must not contain '.'; use the schema field for schema-qualified targets (got '$tableName')")
+                .toRuntimeException()
+
+            val dbSchemaName = if (cmd.hasSchema()) cmd.schema else "public"
+            val txHandle = if (cmd.hasTransactionId()) cmd.transactionId else null
+
+            connectionFor(txHandle, dbName)
+                .bulkIngest("$dbSchemaName.$tableName", BulkIngestMode.CREATE_APPEND)
+                .use { stmt ->
+                    while (flightStream.next()) {
+                        stmt.bind(flightStream.root)
+                        stmt.executeUpdate()
+                    }
+                }
 
             ackStream.sendDoPutUpdateRes(allocator)
         } catch (t: Throwable) {

--- a/src/test/java/xtdb/api/AdbcTest.kt
+++ b/src/test/java/xtdb/api/AdbcTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.shouldBe
 import org.apache.arrow.adbc.core.AdbcStatement.QueryResult
 import org.apache.arrow.adbc.core.BulkIngestMode
 import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -118,6 +119,40 @@ class AdbcTest {
                         res.consumeAsMaps() shouldBe listOf(
                             mapOf("_id" to 10L, "product" to "Widget", "price" to 99.99),
                             mapOf("_id" to 20L, "product" to "Gadget", "price" to 149.99),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `bulkIngest with standalone allocator VSR binding`() {
+        val standaloneAl = RootAllocator()
+        val rows = listOf(
+            mapOf("_id" to 100, "name" to "standalone-first"),
+            mapOf("_id" to 200, "name" to "standalone-second"),
+        )
+
+        AdbcDriverFactory().getDriver(allocator).open(emptyMap()).use { db ->
+            db.connect().use { conn ->
+                conn.bulkIngest("standalone_test", BulkIngestMode.CREATE_APPEND).use { stmt ->
+                    Relation.openFromRows(standaloneAl, rows).use { rel ->
+                        rel.openAsRoot(standaloneAl).use { root ->
+                            stmt.bind(root)
+                        }
+                    }
+                    standaloneAl.close()
+                    val result = stmt.executeUpdate()
+                    result.affectedRows shouldBe 2
+                }
+
+                conn.createStatement().use { stmt ->
+                    stmt.setSqlQuery("SELECT * FROM standalone_test ORDER BY _id")
+                    stmt.executeQuery().use { res ->
+                        res.consumeAsMaps() shouldBe listOf(
+                            mapOf("_id" to 100L, "name" to "standalone-first"),
+                            mapOf("_id" to 200L, "name" to "standalone-second"),
                         )
                     }
                 }

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -1,22 +1,36 @@
 package xtdb
 
+import com.google.protobuf.Any as ProtoAny
 import org.apache.arrow.adbc.core.AdbcConnection
 import org.apache.arrow.adbc.core.AdbcConnection.GetObjectsDepth
 import org.apache.arrow.adbc.core.AdbcDatabase
 import org.apache.arrow.adbc.driver.flightsql.FlightSqlDriver
+import org.apache.arrow.flight.AsyncPutListener
 import org.apache.arrow.flight.CallOption
 import org.apache.arrow.flight.FlightClient
+import org.apache.arrow.flight.FlightDescriptor
 import org.apache.arrow.flight.FlightInfo
+import org.apache.arrow.flight.FlightRuntimeException
 import org.apache.arrow.flight.GetSessionOptionsRequest
 import org.apache.arrow.flight.Location
 import org.apache.arrow.flight.NoOpSessionOptionValueVisitor
 import org.apache.arrow.flight.sql.FlightSqlClient
+import org.apache.arrow.flight.sql.FlightSqlClient.ExecuteIngestOptions
+import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementIngest
+import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementIngest.TableDefinitionOptions
+import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementIngest.TableDefinitionOptions.TableExistsOption
+import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementIngest.TableDefinitionOptions.TableNotExistOption
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.BigIntVector
 import org.apache.arrow.vector.VarBinaryVector
+import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.ipc.ReadChannel
 import org.apache.arrow.vector.ipc.message.MessageSerializer
+import org.apache.arrow.vector.types.Types
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
 import org.apache.arrow.vector.types.pojo.Schema
 import org.apache.arrow.vector.util.Text
 import java.io.ByteArrayInputStream
@@ -38,6 +52,7 @@ class FlightSqlAdbcTest {
     private lateinit var al: BufferAllocator
     private lateinit var db: AdbcDatabase
     private lateinit var conn: AdbcConnection
+    private lateinit var flightClient: FlightClient
     private lateinit var fsqlClient: FlightSqlClient
 
     private val emptyCallOpts = arrayOf<CallOption>()
@@ -55,7 +70,7 @@ class FlightSqlAdbcTest {
         db = FlightSqlDriver(al).open(mapOf("uri" to "grpc+tcp://127.0.0.1:${flightPort}"))
         conn = db.connect()
 
-        val flightClient = FlightClient.builder(al, Location.forGrpcInsecure("127.0.0.1", flightPort)).build()
+        flightClient = FlightClient.builder(al, Location.forGrpcInsecure("127.0.0.1", flightPort)).build()
         fsqlClient = FlightSqlClient(flightClient)
     }
 
@@ -203,6 +218,171 @@ class FlightSqlAdbcTest {
             assertTrue(rdr.vectorSchemaRoot.rowCount > 0, "Expected catalog rows with table data")
         }
     }
+
+    // -- Bulk ingest --
+
+    private fun defaultIngestTdo(): TableDefinitionOptions =
+        TableDefinitionOptions.newBuilder()
+            .setIfNotExist(TableNotExistOption.TABLE_NOT_EXIST_OPTION_CREATE)
+            .setIfExists(TableExistsOption.TABLE_EXISTS_OPTION_APPEND)
+            .build()
+
+    private fun ingestOpts(
+        table: String,
+        catalog: String? = null,
+        schema: String? = null,
+        tdo: TableDefinitionOptions = defaultIngestTdo(),
+    ) = ExecuteIngestOptions(table, tdo, catalog, schema, null)
+
+    private val usersSchema = Schema(listOf(
+        Field("_id", FieldType.notNullable(Types.MinorType.BIGINT.type), null),
+        Field("n", FieldType.notNullable(Types.MinorType.BIGINT.type), null),
+    ))
+
+    private fun <R> usersRoot(rows: List<Pair<Long, Long>>, block: (VectorSchemaRoot) -> R): R =
+        VectorSchemaRoot.create(usersSchema, al).use { root ->
+            val idVec = root.getVector("_id") as BigIntVector
+            val nVec = root.getVector("n") as BigIntVector
+            rows.forEachIndexed { i, (id, n) -> idVec.setSafe(i, id); nVec.setSafe(i, n) }
+            root.rowCount = rows.size
+            block(root)
+        }
+
+    private fun assertUsersTableContains(table: String, expected: List<Map<String, Long>>) {
+        conn.createStatement().use { stmt ->
+            stmt.setSqlQuery("SELECT _id, n FROM $table ORDER BY _id")
+            stmt.executeQuery().reader.use { rdr ->
+                assertTrue(rdr.loadNextBatch())
+                Relation.fromRoot(al, rdr.vectorSchemaRoot).use { rel ->
+                    assertEquals(expected, rel.toMaps(SNAKE_CASE_STRING))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test FlightSQL bulk ingest via executeIngest`() {
+        usersRoot(listOf(1L to 10L, 2L to 20L)) { root ->
+            fsqlClient.executeIngest(root, ingestOpts("users"), *emptyCallOpts)
+        }
+        assertUsersTableContains("users", listOf(
+            mapOf("_id" to 1L, "n" to 10L),
+            mapOf("_id" to 2L, "n" to 20L),
+        ))
+    }
+
+    @Test
+    fun `test FlightSQL bulk ingest within an FSQL transaction`() {
+        val txn = fsqlClient.beginTransaction(*emptyCallOpts)
+        usersRoot(listOf(1L to 100L)) { root ->
+            fsqlClient.executeIngest(root, ingestOpts("users"), txn, *emptyCallOpts)
+        }
+        fsqlClient.commit(txn, *emptyCallOpts)
+
+        assertUsersTableContains("users", listOf(mapOf("_id" to 1L, "n" to 100L)))
+    }
+
+    @Test
+    fun `test FlightSQL bulk ingest rolled back doesn't persist`() {
+        usersRoot(listOf(1L to 1L)) { root ->
+            fsqlClient.executeIngest(root, ingestOpts("users"), *emptyCallOpts)
+        }
+
+        val txn = fsqlClient.beginTransaction(*emptyCallOpts)
+        usersRoot(listOf(99L to 999L)) { root ->
+            fsqlClient.executeIngest(root, ingestOpts("users"), txn, *emptyCallOpts)
+        }
+        fsqlClient.rollback(txn, *emptyCallOpts)
+
+        assertUsersTableContains("users", listOf(mapOf("_id" to 1L, "n" to 1L)))
+    }
+
+    @Test
+    fun `test FlightSQL bulk ingest honours cmd_schema`() {
+        usersRoot(listOf(1L to 10L)) { root ->
+            fsqlClient.executeIngest(root, ingestOpts("users", schema = "my_schema"), *emptyCallOpts)
+        }
+        assertUsersTableContains("my_schema.users", listOf(mapOf("_id" to 1L, "n" to 10L)))
+    }
+
+    private fun assertIngestRejected(
+        opts: ExecuteIngestOptions,
+        descriptionContains: String,
+    ) {
+        usersRoot(listOf(1L to 0L)) { root ->
+            val ex = assertThrows(FlightRuntimeException::class.java) {
+                fsqlClient.executeIngest(root, opts, *emptyCallOpts)
+            }
+            assertTrue(
+                ex.message?.contains(descriptionContains) == true,
+                "expected message containing '$descriptionContains', got: ${ex.message}"
+            )
+        }
+    }
+
+    @Test
+    fun `test FlightSQL bulk ingest rejects per-call catalog override`() {
+        assertIngestRejected(ingestOpts("users", catalog = "some_other_catalog"), "catalog")
+    }
+
+    @Test
+    fun `test FlightSQL bulk ingest rejects fail-if-not-exist`() {
+        val tdo = TableDefinitionOptions.newBuilder()
+            .setIfNotExist(TableNotExistOption.TABLE_NOT_EXIST_OPTION_FAIL)
+            .setIfExists(TableExistsOption.TABLE_EXISTS_OPTION_APPEND)
+            .build()
+        assertIngestRejected(ingestOpts("users", tdo = tdo), "fail-if-not-exist")
+    }
+
+    @Test
+    fun `test FlightSQL bulk ingest rejects fail-if-exists`() {
+        val tdo = TableDefinitionOptions.newBuilder()
+            .setIfNotExist(TableNotExistOption.TABLE_NOT_EXIST_OPTION_CREATE)
+            .setIfExists(TableExistsOption.TABLE_EXISTS_OPTION_FAIL)
+            .build()
+        assertIngestRejected(ingestOpts("users", tdo = tdo), "append-on-exists")
+    }
+
+    @Test
+    fun `test FlightSQL bulk ingest rejects dotted table name`() {
+        assertIngestRejected(ingestOpts("my_schema.users"), "must not contain '.'")
+    }
+
+    private fun multiBatchIngest(table: String, batches: List<List<Pair<Long, Long>>>) {
+        val cmd = CommandStatementIngest.newBuilder()
+            .setTable(table)
+            .setTableDefinitionOptions(defaultIngestTdo())
+            .build()
+        val descriptor = FlightDescriptor.command(ProtoAny.pack(cmd).toByteArray())
+        VectorSchemaRoot.create(usersSchema, al).use { root ->
+            val idVec = root.getVector("_id") as BigIntVector
+            val nVec = root.getVector("n") as BigIntVector
+            val listener = flightClient.startPut(descriptor, root, AsyncPutListener())
+            for (batch in batches) {
+                batch.forEachIndexed { i, (id, n) -> idVec.setSafe(i, id); nVec.setSafe(i, n) }
+                root.rowCount = batch.size
+                listener.putNext()
+            }
+            listener.completed()
+            listener.getResult()
+        }
+    }
+
+    @Test
+    fun `test FlightSQL bulk ingest streams multiple batches`() {
+        multiBatchIngest("users", listOf(
+            listOf(1L to 10L, 2L to 20L),
+            listOf(3L to 30L, 4L to 40L),
+        ))
+        assertUsersTableContains("users", listOf(
+            mapOf("_id" to 1L, "n" to 10L),
+            mapOf("_id" to 2L, "n" to 20L),
+            mapOf("_id" to 3L, "n" to 30L),
+            mapOf("_id" to 4L, "n" to 40L),
+        ))
+    }
+
+    // -- Error handling --
 
     @Test
     fun `test ADBC getObjects at ALL depth doesn't crash on IPC parse`() {


### PR DESCRIPTION
## Summary

`cur.adbc_ingest(arrow_table, mode='create_append')` now lands a `pyarrow.Table` (or any Arrow-shaped data) in XTDB in a single round trip — the headline Arrow ergonomic that XTDB has been missing for non-JVM clients.

## Context

Documented in [`adbc-bugs.md` #3b](https://github.com/xtdb/driver-examples/blob/adbc-testing/adbc-bugs.md) on the driver-examples branch.
Without bulk ingest, callers had to shred their Arrow data into rows and round-trip through `executemany("INSERT … VALUES (?, …)")` — paying parameterised-INSERT overhead per row, losing some Arrow type fidelity, and giving up the "Arrow stream stays Arrow" pitch that's most of why someone reaches for ADBC over pgwire in the first place.

Iteration toward umbrella #5132; advances sub-issue #5080.

## Implementation

`XtdbProducer.acceptPutStatementBulkIngest` overrides the FSQL surface and delegates to the existing in-process `XtdbConnection.bulkIngest(targetTableName, BulkIngestMode.CREATE_APPEND)`.
Each Arrow batch from the `FlightStream` is bound to the statement and executed; the per-batch lifecycle keeps us off a "hold the whole stream in memory" path and matches how `XtdbStatement` already works for parameterised DML.

**Mode handling is intentionally narrow, and rejections are loud.** XTDB has implicit table creation, so the meaningful FSQL-mode distinctions collapse to:

- `ifExists`: `UNSPECIFIED` / `APPEND` accepted (XTDB upserts on `_id`). `FAIL` and `REPLACE` rejected with `INVALID_ARGUMENT` — would need an existence check / `ERASE` step we don't have today.
- `ifNotExist`: `UNSPECIFIED` / `CREATE` accepted. `FAIL` rejected — we can't honour "fail if not exist" because XTDB will auto-create on insert; silently accepting it would violate the FSQL contract.
- `cmd.catalog` per-call override: rejected. Connection-scoped catalog (headers / session) stays the only source of truth.
- `cmd.schema` per-call override: honoured (falls back to `"public"` when unset).

Rejections go through `CallStatus.INVALID_ARGUMENT.withDescription(...).toRuntimeException()` so the explanatory message reaches the client instead of being flattened to a generic gRPC INTERNAL.

## Test plan

- `AdbcTest.test FlightSQL bulk ingest via executeIngest` — round-trips a 2-row Arrow batch through `FlightSqlClient.executeIngest`, asserts the rows come back via `SELECT`.
- `AdbcTest.test FlightSQL bulk ingest within an FSQL transaction` — begins an FSQL transaction, ingests within it, commits, asserts visibility.
- `AdbcTest.test FlightSQL bulk ingest rejects per-call catalog override` — sets `cmd.catalog`, asserts `INVALID_ARGUMENT` with descriptive message.
- `AdbcTest.test FlightSQL bulk ingest rejects fail-if-not-exist` — sets `ifNotExist == FAIL`, asserts `INVALID_ARGUMENT`.
- 13/13 `xtdb.AdbcTest` tests green.
- End-to-end verified against a freshly-built integration node:

  ```python
  cur.adbc_ingest("people", arrow_table, mode="create_append")
  # → 5 rows of mixed types (string / int32 / double-with-null / date32 / bool)
  # → land in XTDB in ~12 ms; SELECT round-trips with types preserved.
  ```

No reflection or boxed-math warnings.

## Scope

- Read-only on table-existence policy.
  `replace` and `create-with-fail` reject upfront; deferring to a follow-up that wires existence/erase plumbing.
- The validation suite's bulk ingest tests stay skipped (`statement_bulk_ingest=False` in `xtdb.py`) because the suite's fixtures build tables without `_id` and XTDB rejects rows without it.
  This is an XTDB data-model concern rather than an ADBC plumbing concern; not in scope of this PR.
