### PR TITLE
fix(disk-cache): clean up staging file when fetch fails

### DIFF
--- a/core/src/main/kotlin/xtdb/cache/DiskCache.kt
+++ b/core/src/main/kotlin/xtdb/cache/DiskCache.kt
@@ -98,12 +98,17 @@ class DiskCache internal constructor(val rootPath: Path, val maxSizeBytes: Long)
 
             if (diskCachePath.exists())
                 completedFuture(Entry(k, diskCachePath))
-            else
-                fetch(k, createTempPath())
-                    .thenApply { tmpPath ->
+            else {
+                val tmpPath = createTempPath()
+                fetch(k, tmpPath)
+                    .thenApply {
                         tmpPath.moveTo(diskCachePath.createParentDirectories(), ATOMIC_MOVE, REPLACE_EXISTING)
                         Entry(k, diskCachePath)
                     }
+                    .whenComplete { _, ex ->
+                        if (ex != null) tmpPath.deleteIfExists()
+                    }
+            }
         }
 
     @Suppress("NAME_SHADOWING")

--- a/core/src/test/kotlin/xtdb/cache/DiskCacheTest.kt
+++ b/core/src/test/kotlin/xtdb/cache/DiskCacheTest.kt
@@ -1,0 +1,30 @@
+package xtdb.cache
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import kotlin.io.path.listDirectoryEntries
+
+class DiskCacheTest {
+
+    @Test
+    fun `staging file is cleaned up when fetch fails`(@TempDir rootPath: Path) {
+        val cache = DiskCache.Factory(rootPath).build()
+        val stagingDir = rootPath.resolve(".tmp")
+
+        val future = cache.get(Path.of("missing-key")) { _, _ ->
+            CompletableFuture.failedFuture(RuntimeException("simulated fetch failure"))
+        }
+
+        assertThrows<ExecutionException> { future.get() }
+
+        assertEquals(
+            emptyList<Path>(), stagingDir.listDirectoryEntries(),
+            "staging files should be cleaned up after fetch failure"
+        )
+    }
+}


### PR DESCRIPTION
DiskCache.get's cache-miss branch only deletes the staging file on success — thenApply runs the move on the success path, but a failed fetch leaves the file in <rootPath>/.tmp/ indefinitely. Every transient object-storage error produces an orphan; under any sustained flakiness these accumulate until the disk fills.

Fix is whenComplete to deleteIfExists on failure, which propagates the original exception verbatim rather than the rethrow-with-wrapping ceremony of exceptionally.