### PR TITLE
fix(indexer): consolidate Watchers watermarks (resolves #5580)

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
@@ -57,7 +57,8 @@ sealed interface ReplicaMessage {
                                 },
                                 it.tableDataMap.mapValues { (_, v) -> v.toByteArray() },
                                 dbOp,
-                                it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }?.toByteArray()
+                                it.externalSourceToken.takeIf { _ -> it.hasExternalSourceToken() }?.toByteArray(),
+                                if (it.hasSrcMsgId()) it.srcMsgId else null,
                             )
                         }
 
@@ -111,6 +112,9 @@ sealed interface ReplicaMessage {
         val tableData: Map<String, ByteArray>,
         val dbOp: DbOp? = null,
         val externalSourceToken: ExternalSourceToken? = null,
+        // Set when this tx came from the source log (then equal to its source-log msgId);
+        // null for ext-source txs whose `txId` is an independent counter.
+        val srcMsgId: MessageId? = null,
     ) : ProtobufMessage() {
         override fun toLogMessage() = replicaLogMessage {
             resolvedTx = resolvedTx {
@@ -134,6 +138,7 @@ sealed interface ReplicaMessage {
                     null -> {}
                 }
                 this@ResolvedTx.externalSourceToken?.let { externalSourceToken = ByteString.copyFrom(it) }
+                this@ResolvedTx.srcMsgId?.let { srcMsgId = it }
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/api/log/Watchers.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Watchers.kt
@@ -7,14 +7,25 @@ import xtdb.database.ExternalSourceToken
 
 class Watchers(latestTxId: TxId, latestSourceMsgId: MessageId, externalSourceToken: ExternalSourceToken? = null) {
 
-    private sealed interface State
+    private sealed interface State {
+        val latestSourceMsgId: MessageId
+        val latestTxId: TxId
+        val externalSourceToken: ExternalSourceToken?
+    }
 
     private data class Active(
-        val latestSourceMsgId: MessageId, val latestTxId: TxId, val latestTxResult: TransactionResult?,
-        val externalSourceToken: ExternalSourceToken? = null,
+        override val latestSourceMsgId: MessageId,
+        override val latestTxId: TxId,
+        val latestTxResult: TransactionResult?,
+        override val externalSourceToken: ExternalSourceToken? = null,
     ) : State
 
-    private data class Failed(val exception: IngestionStoppedException) : State
+    private data class Failed(
+        override val latestSourceMsgId: MessageId,
+        override val latestTxId: TxId,
+        override val externalSourceToken: ExternalSourceToken?,
+        val exception: IngestionStoppedException,
+    ) : State
 
     private val state = MutableStateFlow<State>(Active(latestSourceMsgId, latestTxId, null, externalSourceToken))
 
@@ -34,8 +45,8 @@ class Watchers(latestTxId: TxId, latestSourceMsgId: MessageId, externalSourceTok
         }
     }
 
-    val latestSourceMsgId get() = state.value.activeOrThrow().latestSourceMsgId
-    val externalSourceToken: ExternalSourceToken? get() = state.value.activeOrThrow().externalSourceToken
+    val latestSourceMsgId: MessageId get() = state.value.latestSourceMsgId
+    val externalSourceToken: ExternalSourceToken? get() = state.value.externalSourceToken
 
     val exception
         get() = when (val v = state.value) {
@@ -70,7 +81,12 @@ class Watchers(latestTxId: TxId, latestSourceMsgId: MessageId, externalSourceTok
 
     fun notifyError(exception: Throwable) {
         state.updateIfActive {
-            Failed(exception as? IngestionStoppedException ?: IngestionStoppedException(null, exception))
+            Failed(
+                latestSourceMsgId = it.latestSourceMsgId,
+                latestTxId = it.latestTxId,
+                externalSourceToken = it.externalSourceToken,
+                exception = exception as? IngestionStoppedException ?: IngestionStoppedException(null, exception),
+            )
         }
     }
 

--- a/core/src/main/kotlin/xtdb/api/log/Watchers.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Watchers.kt
@@ -46,6 +46,7 @@ class Watchers(latestTxId: TxId, latestSourceMsgId: MessageId, externalSourceTok
     }
 
     val latestSourceMsgId: MessageId get() = state.value.latestSourceMsgId
+    val latestTxId: TxId get() = state.value.latestTxId
     val externalSourceToken: ExternalSourceToken? get() = state.value.externalSourceToken
 
     val exception

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -171,7 +171,15 @@ class Database(
                 blockCatalog.latestProcessedMsgId ?: -1,
                 offsetToMsgId(storage.sourceLog.epoch, -1)
             )
-            val watchers = Watchers(sourceMsgId, sourceMsgId, blockCatalog.externalSourceToken)
+            // tx-id and source-msg-id can diverge under ext-source — seed them independently:
+            // tx-id from the live-index's last committed tx, source-msg-id from the persisted
+            // block-catalog watermark (or the source-log epoch floor on a fresh epoch).
+            val txId = state.liveIndex.latestCompletedTx?.txId ?: -1L
+            val watchers = Watchers(
+                latestTxId = txId,
+                latestSourceMsgId = sourceMsgId,
+                externalSourceToken = blockCatalog.externalSourceToken,
+            )
 
             val crashLogger = CrashLogger(allocator, storage.bufferPool, base.config.nodeId)
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -192,16 +192,14 @@ class Database(
                 val procFactory = object : LogProcessor.ProcessorFactory {
                     override fun openFollower(
                         pendingBlock: PendingBlock?,
-                        afterSourceMsgId: MessageId,
                         afterReplicaMsgId: MessageId,
                     ) = FollowerLogProcessor(
                         allocator, storage.bufferPool, state, compactorForDb,
-                        watchers, dbCatalog, pendingBlock, afterSourceMsgId, afterReplicaMsgId
+                        watchers, dbCatalog, pendingBlock, afterReplicaMsgId
                     )
 
                     override fun openLeaderSystem(
                         replicaProducer: Log.AtomicProducer<ReplicaMessage>,
-                        afterSourceMsgId: MessageId,
                         afterReplicaMsgId: MessageId,
                     ): LogProcessor.LeaderSystem {
                         val extSource = dbConfig.externalSource?.open(dbName, base.remotes)
@@ -214,7 +212,6 @@ class Database(
                             skipTxs = indexerConfig.skipTxs.toSet(),
                             dbCatalog = dbCatalog,
                             partition = 0,
-                            afterSourceMsgId = afterSourceMsgId,
                             afterReplicaMsgId = afterReplicaMsgId,
                             // watchers has the latest token from replica log replay,
                             // which may be ahead of blockCatalog if no block boundary was flushed.
@@ -230,13 +227,12 @@ class Database(
 
                     override fun openTransition(
                         replicaProducer: Log.AtomicProducer<ReplicaMessage>,
-                        afterSourceMsgId: MessageId,
                         afterReplicaMsgId: MessageId,
                     ) = TransitionLogProcessor(
                         allocator, storage.bufferPool, state, state.liveIndex,
                         blockUploader, replicaProducer,
                         watchers, dbCatalog,
-                        afterSourceMsgId, afterReplicaMsgId
+                        afterReplicaMsgId
                     )
                 }
 

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -73,7 +73,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
 
     private val ReplicaMessage.stale get() =
         when (this) {
-            is ReplicaMessage.ResolvedTx -> txId <= watchers.latestSourceMsgId
+            is ReplicaMessage.ResolvedTx -> txId <= watchers.latestTxId
             is ReplicaMessage.TriesAdded -> sourceMsgId <= watchers.latestSourceMsgId
             is ReplicaMessage.BlockBoundary -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
             is ReplicaMessage.BlockUploaded -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
@@ -113,7 +113,8 @@ class FollowerLogProcessor @JvmOverloads constructor(
                     if (msg.committed) TransactionResult.Committed(txKey)
                     else TransactionResult.Aborted(txKey, msg.error)
 
-                watchers.notifyTx(result, msg.txId, msg.externalSourceToken)
+                val effectiveSrcMsgId = msg.srcMsgId ?: watchers.latestSourceMsgId
+                watchers.notifyTx(result, effectiveSrcMsgId, msg.externalSourceToken)
             }
 
             is ReplicaMessage.TriesAdded -> {

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -33,15 +33,11 @@ class FollowerLogProcessor @JvmOverloads constructor(
     private val watchers: Watchers,
     private val dbCatalog: Database.Catalog?,
     pendingBlock: PendingBlock?,
-    afterSourceMsgId: MessageId,
     afterReplicaMsgId: MessageId,
     private val maxBufferedRecords: Int = 1024,
 ) : LogProcessor.FollowerProcessor {
 
     override var pendingBlock: PendingBlock? = pendingBlock
-        private set
-
-    override var latestSourceMsgId: MessageId = afterSourceMsgId
         private set
 
     private sealed interface ReplicaState {
@@ -77,8 +73,8 @@ class FollowerLogProcessor @JvmOverloads constructor(
 
     private val ReplicaMessage.stale get() =
         when (this) {
-            is ReplicaMessage.ResolvedTx -> txId <= latestSourceMsgId
-            is ReplicaMessage.TriesAdded -> sourceMsgId <= latestSourceMsgId
+            is ReplicaMessage.ResolvedTx -> txId <= watchers.latestSourceMsgId
+            is ReplicaMessage.TriesAdded -> sourceMsgId <= watchers.latestSourceMsgId
             is ReplicaMessage.BlockBoundary -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
             is ReplicaMessage.BlockUploaded -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
             is ReplicaMessage.NoOp -> false
@@ -117,7 +113,6 @@ class FollowerLogProcessor @JvmOverloads constructor(
                     if (msg.committed) TransactionResult.Committed(txKey)
                     else TransactionResult.Aborted(txKey, msg.error)
 
-                latestSourceMsgId = msg.txId
                 watchers.notifyTx(result, msg.txId, msg.externalSourceToken)
             }
 
@@ -125,14 +120,12 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch)
                     addTries(msg.tries, record.logTimestamp)
 
-                latestSourceMsgId = msg.sourceMsgId
                 watchers.notifyMsg(msg.sourceMsgId)
             }
 
             is ReplicaMessage.BlockBoundary -> {
                 pendingBlock = PendingBlock(record.msgId, msg, maxBufferedRecords)
                 LOG.debug("[$dbName] block boundary b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=${record.msgId} — waiting for BlockUploaded...")
-                latestSourceMsgId = msg.latestProcessedMsgId
                 watchers.notifyMsg(msg.latestProcessedMsgId)
             }
 

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -163,6 +163,7 @@ class LeaderLogProcessor(
                 } else null
 
                 val resolvedTx = indexer.addTxRow(txKey, error)
+                    .copy(srcMsgId = msgId)
                     .let { if (error == null) it.copy(dbOp = DbOp.Attach(msg.dbName, msg.config)) else it }
 
                 appendToReplica(resolvedTx)
@@ -185,6 +186,7 @@ class LeaderLogProcessor(
                 } else null
 
                 val resolvedTx = indexer.addTxRow(txKey, error)
+                    .copy(srcMsgId = msgId)
                     .let { if (error == null) it.copy(dbOp = DbOp.Detach(msg.dbName)) else it }
 
                 appendToReplica(resolvedTx)
@@ -219,7 +221,7 @@ class LeaderLogProcessor(
         val txKey = TransactionKey(resolvedTx.txId, resolvedTx.systemTime)
         val txResult = if (resolvedTx.committed) Committed(txKey) else Aborted(txKey, resolvedTx.error)
 
-        appendToReplica(resolvedTx)
+        appendToReplica(resolvedTx.copy(srcMsgId = srcMsgId))
         liveIndex.importTx(resolvedTx)
 
         val effectiveSrcMsgId = srcMsgId ?: watchers.latestSourceMsgId

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -51,7 +51,6 @@ class LeaderLogProcessor(
     private val skipTxs: Set<MessageId>,
     private val dbCatalog: Database.Catalog?,
     partition: Int,
-    afterSourceMsgId: MessageId,
     afterReplicaMsgId: MessageId,
     afterToken: ExternalSourceToken?,
     private val instantSource: InstantSource = InstantSource.system(),
@@ -91,9 +90,6 @@ class LeaderLogProcessor(
     }
 
     override var pendingBlock: PendingBlock? = null
-        private set
-
-    override var latestSourceMsgId: MessageId = afterSourceMsgId
         private set
 
     override var latestReplicaMsgId: MessageId = afterReplicaMsgId
@@ -151,7 +147,6 @@ class LeaderLogProcessor(
                 if (expectedBlockIdx != null && expectedBlockIdx == (blockCatalog.currentBlockIndex ?: -1L)) {
                     finishBlock(msgId, watchers.externalSourceToken)
                 }
-                latestSourceMsgId = msgId
                 watchers.notifyMsg(msgId)
             }
 
@@ -174,7 +169,6 @@ class LeaderLogProcessor(
                 liveIndex.importTx(resolvedTx)
 
                 val result = if (error == null) Committed(txKey) else Aborted(txKey, error)
-                latestSourceMsgId = msgId
                 watchers.notifyTx(result, msgId, null)
             }
 
@@ -197,7 +191,6 @@ class LeaderLogProcessor(
                 liveIndex.importTx(resolvedTx)
 
                 val result = if (error == null) Committed(txKey) else Aborted(txKey, error)
-                latestSourceMsgId = msgId
                 watchers.notifyTx(result, msgId, null)
             }
 
@@ -210,13 +203,11 @@ class LeaderLogProcessor(
 
                 appendToReplica(TriesAdded(msg.storageVersion, msg.storageEpoch, msg.tries, sourceMsgId = msgId))
 
-                latestSourceMsgId = msgId
                 watchers.notifyMsg(msgId)
             }
 
             // TODO this one's going after 2.2
             is SourceMessage.BlockUploaded -> {
-                latestSourceMsgId = msgId
                 watchers.notifyMsg(msgId)
             }
         }
@@ -231,7 +222,7 @@ class LeaderLogProcessor(
         appendToReplica(resolvedTx)
         liveIndex.importTx(resolvedTx)
 
-        val effectiveSrcMsgId = srcMsgId?.also { latestSourceMsgId = it } ?: latestSourceMsgId
+        val effectiveSrcMsgId = srcMsgId ?: watchers.latestSourceMsgId
         watchers.notifyTx(txResult, effectiveSrcMsgId, resolvedTx.externalSourceToken)
 
         if (liveIndex.isFull())

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -29,7 +29,6 @@ class LogProcessor(
 ) : Log.SubscriptionListener<SourceMessage>, AutoCloseable {
 
     interface Processor<M> : Log.RecordProcessor<M>, AutoCloseable {
-        val latestSourceMsgId: MessageId
         val latestReplicaMsgId: MessageId
     }
 
@@ -50,19 +49,16 @@ class LogProcessor(
     interface ProcessorFactory {
         fun openLeaderSystem(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
-            afterSourceMsgId: MessageId,
             afterReplicaMsgId: MessageId,
         ): LeaderSystem
 
         fun openTransition(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
-            afterSourceMsgId: MessageId,
             afterReplicaMsgId: MessageId,
         ): TransitionProcessor
 
         fun openFollower(
             pendingBlock: PendingBlock?,
-            afterSourceMsgId: MessageId,
             afterReplicaMsgId: MessageId,
         ): FollowerProcessor
     }
@@ -81,16 +77,15 @@ class LogProcessor(
     }
 
     private fun openFollowerSystem(
-        latestSourceMsgId: MessageId,
         latestReplicaMsgId: MessageId,
         pendingBlock: PendingBlock? = null,
     ): FollowerSystem =
-        procFactory.openFollower(pendingBlock, latestSourceMsgId, latestReplicaMsgId).closeOnCatch { proc ->
+        procFactory.openFollower(pendingBlock, latestReplicaMsgId).closeOnCatch { proc ->
             LOG.info {
                 buildString {
                     append("[$dbName] starting follower: ")
                     append("pending block: ${pendingBlock != null}, ")
-                    append("src: $latestSourceMsgId, ")
+                    append("src: ${watchers.latestSourceMsgId}, ")
                     append("replica: $latestReplicaMsgId")
                 }
             }
@@ -100,7 +95,7 @@ class LogProcessor(
 
     @Volatile
     private var sys: SubSystem =
-        dbState.blockCatalog.let { openFollowerSystem(it.latestProcessedMsgId ?: -1, it.boundaryReplicaMsgId ?: -1) }
+        openFollowerSystem(dbState.blockCatalog.boundaryReplicaMsgId ?: -1)
 
     init {
         meterRegistry?.let { reg ->
@@ -138,11 +133,7 @@ class LogProcessor(
 
                         val pendingBlock = followerProc.pendingBlock
 
-                        procFactory.openTransition(
-                            replicaProducer,
-                            followerProc.latestSourceMsgId,
-                            followerProc.latestReplicaMsgId
-                        )
+                        procFactory.openTransition(replicaProducer, followerProc.latestReplicaMsgId)
                             .use { transition ->
                                 if (pendingBlock != null) {
                                     LOG.debug("[$dbName] transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
@@ -153,14 +144,14 @@ class LogProcessor(
                                     transition.processRecords(pendingBlock.bufferedRecords)
                                 }
 
-                                val latestSourceMsgId = transition.latestSourceMsgId
                                 LOG.debug("[$dbName] transition: opening leader processor")
 
-                                val sys = procFactory.openLeaderSystem(replicaProducer, latestSourceMsgId, replayTarget)
+                                val sys = procFactory.openLeaderSystem(replicaProducer, replayTarget)
                                 this.sys = sys
 
-                                LOG.info("[$dbName] leader startup complete, resuming after $latestSourceMsgId")
-                                Log.TailSpec(latestSourceMsgId, sys.proc)
+                                val resumeMsgId = watchers.latestSourceMsgId
+                                LOG.info("[$dbName] leader startup complete, resuming after $resumeMsgId")
+                                Log.TailSpec(resumeMsgId, sys.proc)
                             }
                     }
                 } catch (e: InterruptedException) {
@@ -186,7 +177,7 @@ class LogProcessor(
                 // and close() only releases the allocator — watermark fields remain readable.
                 oldSys.close()
                 val proc = oldSys.proc
-                this.sys = openFollowerSystem(proc.latestSourceMsgId, proc.latestReplicaMsgId, proc.pendingBlock)
+                this.sys = openFollowerSystem(proc.latestReplicaMsgId, proc.pendingBlock)
             }
 
             is FollowerSystem -> {

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -43,7 +43,7 @@ class TransitionLogProcessor(
 
     private val ReplicaMessage.stale get() =
         when (this) {
-            is ReplicaMessage.ResolvedTx -> txId <= watchers.latestSourceMsgId
+            is ReplicaMessage.ResolvedTx -> txId <= watchers.latestTxId
             is ReplicaMessage.TriesAdded -> sourceMsgId <= watchers.latestSourceMsgId
             is ReplicaMessage.BlockBoundary -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
             is ReplicaMessage.BlockUploaded -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
@@ -55,10 +55,7 @@ class TransitionLogProcessor(
         val msgId = record.msgId
         when (val msg = record.message) {
             is ReplicaMessage.ResolvedTx -> {
-                val latestTxId = liveIndex.latestCompletedTx?.txId
-                if (latestTxId == null || msg.txId > latestTxId) {
-                    liveIndex.importTx(msg)
-                }
+                liveIndex.importTx(msg)
                 val txKey = TransactionKey(msg.txId, msg.systemTime)
                 if (msg.committed) {
                     when (val dbOp = msg.dbOp) {
@@ -84,7 +81,8 @@ class TransitionLogProcessor(
                     if (msg.committed) TransactionResult.Committed(txKey)
                     else TransactionResult.Aborted(txKey, msg.error)
 
-                watchers.notifyTx(result, msg.txId, msg.externalSourceToken)
+                val effectiveSrcMsgId = msg.srcMsgId ?: watchers.latestSourceMsgId
+                watchers.notifyTx(result, effectiveSrcMsgId, msg.externalSourceToken)
             }
 
             is ReplicaMessage.TriesAdded -> {

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -29,12 +29,8 @@ class TransitionLogProcessor(
     private val replicaProducer: Log.AtomicProducer<ReplicaMessage>,
     private val watchers: Watchers,
     private val dbCatalog: Database.Catalog?,
-    afterSourceMsgId: MessageId,
     afterReplicaMsgId: MessageId,
 ) : LogProcessor.TransitionProcessor {
-
-    override var latestSourceMsgId: MessageId = afterSourceMsgId
-        private set
 
     override var latestReplicaMsgId: MessageId = afterReplicaMsgId
         private set
@@ -47,8 +43,8 @@ class TransitionLogProcessor(
 
     private val ReplicaMessage.stale get() =
         when (this) {
-            is ReplicaMessage.ResolvedTx -> txId <= latestSourceMsgId
-            is ReplicaMessage.TriesAdded -> sourceMsgId <= latestSourceMsgId
+            is ReplicaMessage.ResolvedTx -> txId <= watchers.latestSourceMsgId
+            is ReplicaMessage.TriesAdded -> sourceMsgId <= watchers.latestSourceMsgId
             is ReplicaMessage.BlockBoundary -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
             is ReplicaMessage.BlockUploaded -> blockIndex <= (blockCatalog.currentBlockIndex ?: -1)
             is ReplicaMessage.NoOp -> false
@@ -88,7 +84,6 @@ class TransitionLogProcessor(
                     if (msg.committed) TransactionResult.Committed(txKey)
                     else TransactionResult.Aborted(txKey, msg.error)
 
-                latestSourceMsgId = msg.txId
                 watchers.notifyTx(result, msg.txId, msg.externalSourceToken)
             }
 
@@ -102,21 +97,18 @@ class TransitionLogProcessor(
                         )
                     }
                 }
-                latestSourceMsgId = msg.sourceMsgId
                 watchers.notifyMsg(msg.sourceMsgId)
             }
 
             is ReplicaMessage.BlockBoundary -> {
                 LOG.debug("[$dbName] block boundary b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=$msgId")
                 blockUploader.uploadBlock(replicaProducer, msgId, msg)
-                latestSourceMsgId = msg.latestProcessedMsgId
                 watchers.notifyMsg(msg.latestProcessedMsgId)
             }
 
             // previously I errored here, but we need to just ignore them -
             // the transition proc submits a BlockUploaded as part of finishing the BlockBoundary messages.
             is ReplicaMessage.BlockUploaded -> {
-                latestSourceMsgId = msg.latestProcessedMsgId
                 watchers.notifyMsg(msg.latestProcessedMsgId)
             }
 

--- a/core/src/main/proto/xtdb/log/proto/replica-log.proto
+++ b/core/src/main/proto/xtdb/log/proto/replica-log.proto
@@ -35,6 +35,10 @@ message ResolvedTx {
     }
 
     bytes external_source_token = 8;
+
+    // Set when this tx came from the source log; absent for ext-source txs whose tx_id is an
+    // independent counter rather than a source-log msgId.
+    int64 src_msg_id = 9 [features.field_presence = EXPLICIT];
 }
 
 message BlockBoundary {

--- a/core/src/test/kotlin/xtdb/api/log/WatchersTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/WatchersTest.kt
@@ -50,6 +50,23 @@ class WatchersTest {
     }
 
     @Test
+    fun `seeded latestTxId can lag latestSourceMsgId`() = runTest(timeout = 1.seconds) {
+        // Production shape from #5580: ext-source databases persist `latestProcessedMsgId` via
+        // the block catalog (a source-msg-id watermark) and `latestCompletedTx` separately (a
+        // tx-id watermark). On restart the source watermark is generally ahead of the tx
+        // watermark. Watchers must accept an incoming ResolvedTx whose txId == seedTxId+1 even
+        // though srcMsgId is well below it; pre-fix, Database.open seeded `latestTxId` from
+        // `sourceMsgId` and the next ResolvedTx tripped the `txId > latestTxId` invariant.
+        val watchers = Watchers(latestTxId = 5, latestSourceMsgId = 100)
+
+        val tx6 = TransactionResult.Committed(TransactionKey(6, Instant.parse("2026-05-01T00:00:00Z")))
+        // ext-source path: srcMsgId stays at the prior latestSourceMsgId.
+        watchers.notifyTx(tx6, watchers.latestSourceMsgId, null)
+
+        assertEquals(tx6, watchers.awaitTx(6))
+    }
+
+    @Test
     fun `notifyMsg advances specified watermarks`() = runTest(timeout = 1.seconds) {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -112,7 +112,7 @@ class ExternalSourceTest {
             allocator, nodeBase, dbStorage, indexer, crashLogger,
             dbState, blockUploader, watchers, extSource, replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterSourceMsgId = -1, afterReplicaMsgId = -1, afterToken = afterToken, ctx = ctx
+            partition = 0, afterReplicaMsgId = -1, afterToken = afterToken, ctx = ctx
         )
     }
 

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -140,6 +140,7 @@ class ExternalSourceTest {
             val resolved = replicaMessages[0] as ReplicaMessage.ResolvedTx
             assertEquals(true, resolved.committed)
             assertEquals(0L, resolved.txId)
+            assertNull(resolved.srcMsgId, "ext-source ResolvedTx should not carry a source-log msgId")
         }
     }
 

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -56,10 +56,10 @@ class FollowerLogProcessorTest {
         allocator.close()
     }
 
-    private fun makeProcessor(afterSourceMsgId: Long = -1L, maxBufferedRecords: Int = 1024) =
+    private fun makeProcessor(maxBufferedRecords: Int = 1024) =
         FollowerLogProcessor(
             allocator, bufferPool, dbState,
-            compactor, watchers, null, null, afterSourceMsgId = afterSourceMsgId, afterReplicaMsgId = -1L, maxBufferedRecords
+            compactor, watchers, null, null, afterReplicaMsgId = -1L, maxBufferedRecords
         )
 
     private fun <M> record(offset: Long, message: M) =
@@ -83,7 +83,7 @@ class FollowerLogProcessorTest {
     @Test
     fun `ResolvedTx skips already-applied transactions`() = runTest {
         watchers = Watchers(latestTxId = 42, latestSourceMsgId = 42)
-        val proc = makeProcessor(afterSourceMsgId = 42)
+        val proc = makeProcessor()
 
         val tx40 = ReplicaMessage.ResolvedTx(40, Instant.now(), true, null, emptyMap())
         val tx42 = ReplicaMessage.ResolvedTx(42, Instant.now(), true, null, emptyMap())
@@ -107,7 +107,7 @@ class FollowerLogProcessorTest {
         blockCatalog = BlockCatalog("test", startBlock)
         dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = 1000, latestSourceMsgId = 1000)
-        val proc = makeProcessor(afterSourceMsgId = 1000)
+        val proc = makeProcessor()
 
         val staleRecords = listOf(
             record(0, ReplicaMessage.ResolvedTx(500, Instant.now(), true, null, emptyMap())),
@@ -121,7 +121,7 @@ class FollowerLogProcessorTest {
         proc.processRecords(staleRecords)
 
         verify(exactly = 0) { liveIndex.importTx(any()) }
-        assert(proc.latestSourceMsgId == 1000L) { "latestSourceMsgId should not have changed" }
+        assert(watchers.latestSourceMsgId == 1000L) { "latestSourceMsgId should not have changed" }
 
         proc.close()
     }
@@ -154,7 +154,7 @@ class FollowerLogProcessorTest {
     @Test
     fun `processes messages after skipping stale ones`() = runTest {
         watchers = Watchers(latestTxId = 1000, latestSourceMsgId = 1000)
-        val proc = makeProcessor(afterSourceMsgId = 1000)
+        val proc = makeProcessor()
 
         val tx1001 = ReplicaMessage.ResolvedTx(1001, Instant.now(), true, null, emptyMap())
 
@@ -166,7 +166,7 @@ class FollowerLogProcessorTest {
         ))
 
         verify { liveIndex.importTx(tx1001) }
-        assert(proc.latestSourceMsgId == 1001L)
+        assert(watchers.latestSourceMsgId == 1001L)
 
         proc.close()
     }

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -24,6 +24,8 @@ import xtdb.storage.BufferPool
 import xtdb.trie.TrieCatalog
 import java.time.Instant
 
+private fun txKeyAt(txId: Long) = TransactionKey(txId, Instant.EPOCH)
+
 class FollowerLogProcessorTest {
 
     private lateinit var allocator: RootAllocator
@@ -85,9 +87,9 @@ class FollowerLogProcessorTest {
         watchers = Watchers(latestTxId = 42, latestSourceMsgId = 42)
         val proc = makeProcessor()
 
-        val tx40 = ReplicaMessage.ResolvedTx(40, Instant.now(), true, null, emptyMap())
-        val tx42 = ReplicaMessage.ResolvedTx(42, Instant.now(), true, null, emptyMap())
-        val tx43 = ReplicaMessage.ResolvedTx(43, Instant.now(), true, null, emptyMap())
+        val tx40 = ReplicaMessage.ResolvedTx(40, Instant.now(), true, null, emptyMap(), srcMsgId = 40)
+        val tx42 = ReplicaMessage.ResolvedTx(42, Instant.now(), true, null, emptyMap(), srcMsgId = 42)
+        val tx43 = ReplicaMessage.ResolvedTx(43, Instant.now(), true, null, emptyMap(), srcMsgId = 43)
 
         proc.processRecords(listOf(record(0, tx40), record(1, tx42), record(2, tx43)))
 
@@ -110,12 +112,12 @@ class FollowerLogProcessorTest {
         val proc = makeProcessor()
 
         val staleRecords = listOf(
-            record(0, ReplicaMessage.ResolvedTx(500, Instant.now(), true, null, emptyMap())),
+            record(0, ReplicaMessage.ResolvedTx(500, Instant.now(), true, null, emptyMap(), srcMsgId = 500)),
             record(1, ReplicaMessage.TriesAdded(1, 1, emptyList(), sourceMsgId = 600)),
             record(2, ReplicaMessage.BlockBoundary(1, 700)),
             record(3, ReplicaMessage.BlockUploaded(1, 1, 1, 800, emptyList())),
             // at the boundary — should also be skipped
-            record(4, ReplicaMessage.ResolvedTx(1000, Instant.now(), true, null, emptyMap())),
+            record(4, ReplicaMessage.ResolvedTx(1000, Instant.now(), true, null, emptyMap(), srcMsgId = 1000)),
         )
 
         proc.processRecords(staleRecords)
@@ -156,7 +158,7 @@ class FollowerLogProcessorTest {
         watchers = Watchers(latestTxId = 1000, latestSourceMsgId = 1000)
         val proc = makeProcessor()
 
-        val tx1001 = ReplicaMessage.ResolvedTx(1001, Instant.now(), true, null, emptyMap())
+        val tx1001 = ReplicaMessage.ResolvedTx(1001, Instant.now(), true, null, emptyMap(), srcMsgId = 1001)
 
         proc.processRecords(listOf(
             // stale
@@ -167,6 +169,50 @@ class FollowerLogProcessorTest {
 
         verify { liveIndex.importTx(tx1001) }
         assert(watchers.latestSourceMsgId == 1001L)
+
+        proc.close()
+    }
+
+    @Test
+    fun `ext-source ResolvedTx does not advance latestSourceMsgId`() = runTest {
+        // Reproduces #5580: an ext-source ResolvedTx (srcMsgId=null) followed by a BlockBoundary
+        // whose latestProcessedMsgId reflects the leader's still-default source watermark would
+        // previously violate `srcMsgId >= latestSourceMsgId` on the follower.
+        val proc = makeProcessor()
+
+        val blockProto = block { blockIndex = 0 }.toByteArray()
+        every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
+
+        val extTx = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
+        proc.processRecords(listOf(
+            record(0, extTx),
+            record(1, ReplicaMessage.BlockBoundary(0, -1)),
+            record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, -1, emptyList())),
+        ))
+
+        verify { liveIndex.importTx(extTx) }
+        assertEquals(-1L, watchers.latestSourceMsgId,
+            "ext-source ResolvedTx must not bump latestSourceMsgId")
+        assertEquals(0L, blockCatalog.currentBlockIndex)
+
+        proc.close()
+    }
+
+    @Test
+    fun `mixed ext-source and source-log ResolvedTxs advance the right watermarks`() = runTest {
+        val proc = makeProcessor()
+
+        val ext0 = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
+        val src1 = ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap(), srcMsgId = 1)
+        val ext2 = ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap(), srcMsgId = null)
+
+        proc.processRecords(listOf(record(0, ext0), record(1, src1), record(2, ext2)))
+
+        verify { liveIndex.importTx(ext0) }
+        verify { liveIndex.importTx(src1) }
+        verify { liveIndex.importTx(ext2) }
+        assertEquals(1L, watchers.latestSourceMsgId,
+            "latestSourceMsgId reflects only the source-log tx; ext-source txs leave it alone")
 
         proc.close()
     }

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -75,7 +75,7 @@ class LeaderLogProcessorTest {
             dbState, blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterSourceMsgId = -1, afterReplicaMsgId = -1, afterToken = null,
+            partition = 0, afterReplicaMsgId = -1, afterToken = null,
         )
     }
 
@@ -130,7 +130,7 @@ class LeaderLogProcessorTest {
             dbState, blockUploader, Watchers(latestTxId = -1, latestSourceMsgId = -1),
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterSourceMsgId = -1, afterReplicaMsgId = -1, afterToken = null,
+            partition = 0, afterReplicaMsgId = -1, afterToken = null,
         )
 
         val now = Instant.now()
@@ -196,7 +196,7 @@ class LeaderLogProcessorTest {
             dbState, blockUploader, Watchers(latestTxId = -1, latestSourceMsgId = -1),
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterSourceMsgId = -1, afterReplicaMsgId = -1, afterToken = null,
+            partition = 0, afterReplicaMsgId = -1, afterToken = null,
         )
 
         val now = Instant.now()

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -155,7 +155,6 @@ class LogProcessorSimTest : SimulationTestBase() {
 
         override fun openLeaderSystem(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
-            afterSourceMsgId: MessageId,
             afterReplicaMsgId: MessageId,
         ): LogProcessor.LeaderSystem {
             val proc = LeaderLogProcessor(
@@ -163,7 +162,7 @@ class LogProcessorSimTest : SimulationTestBase() {
                 dbState, blockUploader, watchers,
                 extSource = null, replicaProducer = replicaProducer,
                 skipTxs = emptySet(), dbCatalog = null,
-                partition = 0, afterSourceMsgId = afterSourceMsgId, afterReplicaMsgId = afterReplicaMsgId,
+                partition = 0, afterReplicaMsgId = afterReplicaMsgId,
                 afterToken = null,
                 ctx = dispatcher
             )
@@ -175,26 +174,24 @@ class LogProcessorSimTest : SimulationTestBase() {
 
         override fun openTransition(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
-            afterSourceMsgId: MessageId,
             afterReplicaMsgId: MessageId,
         ): LogProcessor.TransitionProcessor =
             TransitionLogProcessor(
                 allocator, bp, dbState, liveIndex,
                 blockUploader,
                 replicaProducer, watchers, null,
-                afterSourceMsgId, afterReplicaMsgId
+                afterReplicaMsgId
             )
 
         override fun openFollower(
             pendingBlock: PendingBlock?,
-            afterSourceMsgId: MessageId,
             afterReplicaMsgId: MessageId,
         ): LogProcessor.FollowerProcessor =
             FollowerLogProcessor(
                 allocator, bp, dbState,
                 mockk<Compactor.ForDatabase>(relaxed = true),
                 watchers, null, pendingBlock,
-                afterSourceMsgId, afterReplicaMsgId
+                afterReplicaMsgId
             )
 
         fun openLogProcessor(scope: CoroutineScope) =

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -63,7 +63,6 @@ class LogProcessorTest {
         object : LogProcessor.ProcessorFactory {
             override fun openLeaderSystem(
                 replicaProducer: Log.AtomicProducer<ReplicaMessage>,
-                afterSourceMsgId: MessageId,
                 afterReplicaMsgId: MessageId,
             ): LogProcessor.LeaderSystem {
                 val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
@@ -73,7 +72,7 @@ class LogProcessorTest {
                     dbState, blockUploader, watchers,
                     extSource = null, replicaProducer = replicaProducer,
                     skipTxs = emptySet(), dbCatalog = null,
-                    partition = 0, afterSourceMsgId = afterSourceMsgId, afterReplicaMsgId = afterReplicaMsgId,
+                    partition = 0, afterReplicaMsgId = afterReplicaMsgId,
                     afterToken = null,
                 )
                 return object : LogProcessor.LeaderSystem {
@@ -84,26 +83,23 @@ class LogProcessorTest {
 
             override fun openTransition(
                 replicaProducer: Log.AtomicProducer<ReplicaMessage>,
-                afterSourceMsgId: MessageId,
                 afterReplicaMsgId: MessageId,
             ): LogProcessor.TransitionProcessor =
                 TransitionLogProcessor(
                     allocator, bufferPool, dbState, dbState.liveIndex,
                     BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null),
                     replicaProducer, watchers, dbCatalog = null,
-                    afterSourceMsgId = afterSourceMsgId,
                     afterReplicaMsgId = afterReplicaMsgId,
                 )
 
             override fun openFollower(
                 pendingBlock: PendingBlock?,
-                afterSourceMsgId: MessageId,
                 afterReplicaMsgId: MessageId,
             ): LogProcessor.FollowerProcessor =
                 FollowerLogProcessor(
                     allocator, bufferPool, dbState,
                     mockk(relaxed = true), watchers, null, pendingBlock,
-                    afterSourceMsgId, afterReplicaMsgId,
+                    afterReplicaMsgId,
                 )
         }
 

--- a/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
@@ -3,6 +3,7 @@ package xtdb.indexer
 import io.mockk.*
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -66,11 +67,31 @@ class TransitionLogProcessorTest {
 
         val txId = 100L
         proc.processRecords(listOf(
-            record(0, ReplicaMessage.ResolvedTx(txId, Instant.now(), true, null, emptyMap())),
+            record(0, ReplicaMessage.ResolvedTx(txId, Instant.now(), true, null, emptyMap(), srcMsgId = txId)),
             record(1, ReplicaMessage.BlockBoundary(0, txId)),
         ))
 
         coVerify { blockUploader.uploadBlock(replicaProducer, 1, any()) }
+
+        proc.close()
+    }
+
+    @Test
+    fun `ext-source ResolvedTx does not advance latestSourceMsgId`() = runTest {
+        // Companion to the FollowerLogProcessorTest case: the transition path must also keep
+        // ext-source txs from bumping latestSourceMsgId, so the subsequent BlockBoundary's
+        // latestProcessedMsgId (= leader's still-default -1) doesn't violate the Watchers invariant.
+        val proc = makeProcessor()
+
+        val extTx = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
+        proc.processRecords(listOf(
+            record(0, extTx),
+            record(1, ReplicaMessage.BlockBoundary(0, -1)),
+        ))
+
+        verify { liveIndex.importTx(extTx) }
+        assertEquals(-1L, watchers.latestSourceMsgId,
+            "ext-source ResolvedTx must not bump latestSourceMsgId")
 
         proc.close()
     }

--- a/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
@@ -50,11 +50,11 @@ class TransitionLogProcessorTest {
         allocator.close()
     }
 
-    private fun makeProcessor(afterSourceMsgId: Long = -1L) =
+    private fun makeProcessor() =
         TransitionLogProcessor(
             allocator, bufferPool, dbState, liveIndex,
             blockUploader, replicaProducer,
-            watchers, null, afterSourceMsgId, afterReplicaMsgId = -1L
+            watchers, null, afterReplicaMsgId = -1L
         )
 
     private fun <M> record(offset: Long, message: M) =


### PR DESCRIPTION
Resolves #5580.

## Context

The original receiver-side fix landed as f3eb9d9, was reverted upstream, and a production node hit a follow-on bug that exposed a deeper issue. `Database.open` was constructing `Watchers(sourceMsgId, sourceMsgId, blockCatalog.externalSourceToken)` — both watermarks seeded from a source-msg-id. That worked while the wire format conflated tx-id and source-msg-id, but the receiver-side fix's whole point is to make those two number spaces independent for ext-source databases. Production failure:

```
java.lang.IllegalStateException: txId 699339053 <= latestTxId 699339100
    at xtdb.api.log.Watchers.notifyTx(Watchers.kt:56)
```

Same bug class as the original report; different watermark; positional seed where the two args have the same `Long` type, so the conflation slipped through review.

A first attempt at fixing it consolidated `latestSourceMsgId` and `latestTxId` reads onto Watchers, which was the right architectural move but exposed a new failure mode: `${watchers.latestSourceMsgId}` inside an informational `LOG.info` ran inside a synchronous Kafka rebalance callback (`SharedGroupConsumer.processCommand`'s `onPartitionsRevokedSync`). On an ext-source database whose `PostgresSource` had failed earlier (slot already exists), Watchers was in `Failed` state. The throwing scalar getter killed the polling job mid-`Unregister` — orphaning the unregister continuation, leaving a permanently-suspended child on `Database.scope.job`, and hanging `cancelAndJoin` forever. `partial snapshot failure when slot already exists` integration test reproduced reliably.

Audit: every synchronous getter caller wants *value* semantics, not throwing. Throwing belongs only to the suspending awaiters (`awaitTx`, `awaitSource`), where "give me when X happens" needs to surface "X will never happen" as an exception rather than block. The non-throwing `.exception` getter was already there for callers that want to disambiguate Failed state — under-adopted because the throwing getters look easier.

So: reshape Watchers so scalar reads can't poison synchronous call paths, then build the consolidation and the receiver-side fix on a foundation that's safe by construction.

## Changes

Three commits, in order:

1. **`tidy(log): Watchers scalars survive into Failed state`** (`db74fc6c2`) — lift `latestSourceMsgId`, `latestTxId`, `externalSourceToken` onto the `State` sealed interface so both `Active` and `Failed` carry them; `notifyError` snapshots the current scalars when constructing `Failed`. Public scalar getters read `state.value.X` directly — infallible. The `activeState: Flow<Active>` mapping that drives `awaitTx` / `awaitSource` keeps the `activeOrThrow` path unchanged. Pre-requisite for the consolidation.

2. **`refactor(indexer): make Watchers the sole owner of latestSourceMsgId`** (`3e307aff6`) — drop `latestSourceMsgId` from the `LogProcessor.Processor` interface, the per-processor `var`s on Leader / Follower / Transition, and the `afterSourceMsgId` ctor params. Reads at every former site go through `watchers.latestSourceMsgId`: staleness checks (`txId <= watchers.latestSourceMsgId`, `sourceMsgId <= watchers.latestSourceMsgId`), `effectiveSrcMsgId = srcMsgId ?: watchers.latestSourceMsgId` in the leader's `handleResolvedTx`, the follower-startup log message, the leader's resume-after handoff. Behaviour-preserving — every former `latestSourceMsgId = X` site already paired with a `notifyMsg(X)` / `notifyTx(..., X, ...)`, so Watchers was tracking the same value. Safe because of commit 1.

3. **`fix(indexer): split source-msg-id from tx-id on the receiver side`** (`e9c670392`) — adds optional `int64 src_msg_id` to the `ResolvedTx` proto with edition-2023 explicit field presence; leader stamps it on the wire (source-log path → `msgId`, ext-source path → null); receiver staleness reads `watchers.latestTxId`; `effectiveSrcMsgId = msg.srcMsgId ?: watchers.latestSourceMsgId` mirrors the leader's pattern. `Database.open` seeds `latestTxId` from `state.liveIndex.latestCompletedTx?.txId ?: -1L` instead of `sourceMsgId` (the actual production-bug fix). Authored against the architecture of commit 2 — no per-processor `var latestTxId` ever introduced. Removes the redundant inner txId dedup in `TransitionLogProcessor.processRecord` (subsumed by the new staleness path).

## Test plan

- New regression case `WatchersTest.seeded latestTxId can lag latestSourceMsgId` — seeds the production shape (`latestTxId = 5, latestSourceMsgId = 100`) and confirms the next `notifyTx(txKey(6, …))` doesn't trip the `txId > latestTxId` invariant.
- New cases on Follower and Transition for the ext-source path: `ext-source ResolvedTx does not advance latestSourceMsgId` (the original failure scenario), `mixed ext-source and source-log ResolvedTxs advance the right watermarks` (alternating sequence).
- `ExternalSourceTest` asserts `srcMsgId` is null on ext-source `ResolvedTx`.
- Full `:xtdb-core:test` green (no reflection / boxed-math warnings).
- `:modules:xtdb-postgres-source:integration-test` green (7 tests, ~28 s). The previously-hanging `partial snapshot failure when slot already exists` test completes cleanly in ~11 s.

## Scope

Out of scope, for follow-up:

- Distinct types for `TxId` and `MessageId` (currently both `Long` aliases) — would close the bug class at compile time. Larger refactor.
- `BlockCatalog.latestProcessedMsgId` fallback to `latestCompletedTx?.txId` — misleading code shape but safe in practice.
- `LeaderLogProcessor.handleSourceLogRecord` building `TransactionKey(msgId, …)` for AttachDatabase / DetachDatabase. Currently unreachable by ext-source.