### PR TITLE
test(indexer): drop Indexer mock from LogProcessorSimTest

### DIFF
--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -19,32 +19,28 @@ import xtdb.RepeatableSimulationTest
 import xtdb.SimulationTestBase
 import xtdb.SimulationTestUtils.Companion.createTrieCatalog
 import xtdb.api.IndexerConfig
-import xtdb.api.TransactionKey
 import xtdb.api.log.*
 import xtdb.api.log.Log
 import xtdb.api.log.MessageId
 import xtdb.api.log.ReplicaMessage
-import xtdb.arrow.VectorReader
-import xtdb.arrow.VectorType
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
+import xtdb.database.ExternalSource
+import xtdb.database.ExternalSourceToken
 import xtdb.error.Incorrect
+import xtdb.indexer.TxIndexer.TxResult
 import xtdb.storage.MemoryStorage
 import xtdb.table.TableRef
-import xtdb.time.InstantUtil.asMicros
 import xtdb.trie.Trie.dataFilePath
 import xtdb.trie.Trie.metaFilePath
-import xtdb.tx.TxOp
-import xtdb.tx.toArrowBytes
 import xtdb.util.asIid
 import xtdb.util.debug
 import xtdb.util.logger
 import java.nio.ByteBuffer
-import java.time.Instant
-import java.time.ZoneId
+import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
 
 private val LOG = LogProcessorSimTest::class.logger
@@ -75,69 +71,96 @@ class LogProcessorSimTest : SimulationTestBase() {
 
     private val docsTable = TableRef("test-db", "public", "docs")
 
-    private fun simIndexer(al: BufferAllocator, dbName: String, dbStorage: DatabaseStorage, dbState: DatabaseState) =
-        object : Indexer.ForDatabase {
-            private fun commitTx(openTx: OpenTx, txKey: TransactionKey, committed: Boolean): ReplicaMessage.ResolvedTx {
-                with(Indexer) { openTx.addTxRow(dbName, txKey, if (committed) null else Incorrect("aborted")) }
-                val tableData = openTx.serializeTableData()
-                dbState.liveIndex.commitTx(openTx)
-                openTx.close()
-                return ReplicaMessage.ResolvedTx(
-                    txId = txKey.txId,
-                    systemTime = txKey.systemTime,
-                    committed = committed,
-                    error = null,
-                    tableData = tableData
-                )
-            }
+    private sealed interface SimAction {
+        data class Commit(val rows: List<UUID>) : SimAction
+        data object Abort : SimAction
+    }
 
-            override fun indexTx(
-                msgId: MessageId, msgTimestamp: Instant, txOps: VectorReader?,
-                systemTime: Instant?, defaultTz: ZoneId?, user: String?, userMetadata: Any?
-            ): ReplicaMessage.ResolvedTx {
-                val txKey = TransactionKey(msgId, systemTime ?: msgTimestamp)
-                val committed = rand.nextFloat() > 0.1f
-                val openTx = OpenTx(al, nodeBase, dbStorage, dbState, txKey, externalSourceToken = null)
-
-                if (committed) {
-                    val table = openTx.table(docsTable)
-                    val rowCount = rand.nextInt(1, 6)
-                    repeat(rowCount) {
-                        val id = java.util.UUID(rand.nextLong(), rand.nextLong())
-                        table.logPut(
-                            ByteBuffer.wrap(id.asIid),
-                            txKey.systemTime.asMicros,
-                            Long.MAX_VALUE
-                        ) {
-                            table.docWriter.vectorFor("_id", VectorType.UUID.arrowType, false).writeObject(id)
-                            table.docWriter.vectorFor("tx_id", VectorType.I64.arrowType, false).writeLong(msgId)
-                            table.docWriter.endStruct()
-                        }
-                    }
-                }
-
-                return commitTx(openTx, txKey, committed)
-            }
-
-            override fun addTxRow(txKey: TransactionKey, error: Throwable?): ReplicaMessage.ResolvedTx {
-                val openTx = OpenTx(al, nodeBase, dbStorage, dbState, txKey, externalSourceToken = null)
-                return commitTx(openTx, txKey, committed = error == null)
-            }
-
-            override fun close() {}
+    private fun buildActions(rand: kotlin.random.Random, count: Int): List<SimAction> =
+        List(count) {
+            if (rand.nextFloat() > 0.1f) {
+                val rowCount = rand.nextInt(1, 6)
+                SimAction.Commit(List(rowCount) { UUID(rand.nextLong(), rand.nextLong()) })
+            } else SimAction.Abort
         }
 
-    private fun simIndexerWrapper(dbName: String, dbStorage: DatabaseStorage) = object : Indexer {
-        override fun openForDatabase(
-            allocator: BufferAllocator, state: DatabaseState,
-            liveIndex: LiveIndex, crashLogger: CrashLogger, txIndexer: TxIndexer,
-        ) = simIndexer(allocator, dbName, dbStorage, state)
+    /**
+     * Test-side `ExternalSource`. Holds a pre-built sequence of `SimAction`s; its
+     * `onPartitionAssigned` drains the iterator through whichever node is currently leader,
+     * calling `txIndexer.indexTx { … }` from inside the leader's coroutine scope.
+     *
+     * A single instance is shared across all `SimNode`s in a test. Leadership transitions
+     * surface as fresh `onPartitionAssigned` invocations on the same instance — the iterator
+     * is shared, so the next leader resumes draining from where the previous left off.
+     * `close()` is a no-op so the per-`LeaderLogProcessor` `extSource.close()` doesn't tear
+     * down the shared instance.
+     *
+     * Putting `indexTx` inside `onPartitionAssigned` (rather than calling it from the test
+     * driver against a stale `TxIndexer` reference) is what keeps the leader's allocator
+     * accounting clean across rebalances: `indexTx` allocates an `OpenTx` from the
+     * leader's allocator; if `LeaderLogProcessor.close()` runs while that `OpenTx` is still
+     * live, `allocator.close()` throws on the outstanding allocation. Holding the call
+     * inside `onPartitionAssigned` ties its lifetime to the leader's scope — `extJob.cancel()`
+     * propagates cancellation through `indexTx`'s inner catch, which closes the `OpenTx`
+     * before the allocator does.
+     */
+    private inner class SimExtSource(actions: List<SimAction>) : ExternalSource {
+        private val iterator = actions.iterator()
+
+        var indexedCount = 0
+            private set
+
+        var inFlight = 0
+            private set
+
+        val isQuiescent: Boolean get() = !iterator.hasNext() && inFlight == 0
+
+        override suspend fun onPartitionAssigned(
+            partition: Int,
+            afterToken: ExternalSourceToken?,
+            txIndexer: TxIndexer,
+        ) {
+            while (iterator.hasNext()) {
+                yield()
+                val action = iterator.next()
+                inFlight++
+                try {
+                    txIndexer.indexTx(externalSourceToken = null) { openTx ->
+                        when (action) {
+                            is SimAction.Commit -> {
+                                val table = openTx.table(docsTable)
+                                for (id in action.rows) {
+                                    table.logPut(
+                                        ByteBuffer.wrap(id.asIid),
+                                        openTx.systemFrom,
+                                        Long.MAX_VALUE,
+                                    ) {
+                                        table.docWriter.writeObject(
+                                            mapOf("_id" to id, "tx_id" to openTx.txKey.txId),
+                                        )
+                                    }
+                                }
+                                TxResult.Committed()
+                            }
+
+                            SimAction.Abort -> TxResult.Aborted(Incorrect("aborted"))
+                        }
+                    }
+                    indexedCount++
+                } finally {
+                    inFlight--
+                }
+            }
+        }
 
         override fun close() {}
     }
 
     private inner class SimNode(
-        dbName: String, val bp: MemoryStorage, indexerConfig: IndexerConfig,
+        dbName: String,
+        val bp: MemoryStorage,
+        indexerConfig: IndexerConfig,
+        private val simExtSource: SimExtSource,
     ) : LogProcessor.ProcessorFactory, AutoCloseable {
 
         val blockCatalog = BlockCatalog(dbName, null)
@@ -151,16 +174,19 @@ class LogProcessorSimTest : SimulationTestBase() {
         val dbStorage = DatabaseStorage(srcLog, replicaLog, bp, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, uploadDispatcher = dispatcher)
         val crashLogger = CrashLogger(allocator, bp, "sim-node")
-        val indexer = simIndexerWrapper(dbName, dbStorage)
 
         override fun openLeaderSystem(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
             afterReplicaMsgId: MessageId,
         ): LogProcessor.LeaderSystem {
+            // Fresh `Indexer` per leadership transition is fine — the outer Indexer is
+            // stateless and `close()` is a no-op; the per-database `Indexer.ForDatabase` is
+            // closed by `LeaderLogProcessor.close()` via its existing flow.
+            val indexer = nodeBase.indexerFactory.create(nodeBase)
             val proc = LeaderLogProcessor(
                 allocator, nodeBase, dbStorage, indexer, crashLogger,
                 dbState, blockUploader, watchers,
-                extSource = null, replicaProducer = replicaProducer,
+                extSource = simExtSource, replicaProducer = replicaProducer,
                 skipTxs = emptySet(), dbCatalog = null,
                 partition = 0, afterReplicaMsgId = afterReplicaMsgId,
                 afterToken = null,
@@ -198,7 +224,6 @@ class LogProcessorSimTest : SimulationTestBase() {
             LogProcessor(this, dbStorage, dbState, watchers, blockUploader, scope)
 
         override fun close() {
-            indexer.close()
             dbState.close()
         }
     }
@@ -236,15 +261,6 @@ class LogProcessorSimTest : SimulationTestBase() {
             }
         }
     }
-
-    private fun emptyTx(): SourceMessage.Tx =
-        SourceMessage.Tx(
-            txOps = emptyList<TxOp>().toArrowBytes(allocator),
-            systemTime = null,
-            defaultTz = ZoneId.of("UTC"),
-            user = null,
-            userMetadata = null
-        )
 
     private fun abortedTxIds(): Set<MessageId> =
         replicaLog.topic.map { it.message }
@@ -285,78 +301,83 @@ class LogProcessorSimTest : SimulationTestBase() {
         }
     }
 
+    private fun replicaTxIds(): List<MessageId> =
+        replicaLog.topic.map { it.message }
+            .filterIsInstance<ReplicaMessage.ResolvedTx>()
+            .map { it.txId }
+
+    private fun assertReplicaTxInvariants() {
+        val replicaTxIds = replicaTxIds()
+        assertEquals(
+            replicaTxIds, replicaTxIds.sorted(),
+            "replica txIds should be monotonically increasing"
+        )
+        assertEquals(
+            replicaTxIds.size, replicaTxIds.toSet().size,
+            "replica should have no duplicate txIds"
+        )
+    }
+
+    private fun assertBlockBoundariesMatchUploads(replicaMessages: List<ReplicaMessage>) {
+        val boundaries = replicaMessages.filterIsInstance<ReplicaMessage.BlockBoundary>().map { it.blockIndex }
+        val uploads = replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>().map { it.blockIndex }
+        assertEquals(boundaries, uploads, "every BlockBoundary should have a matching BlockUploaded")
+        assertEquals(
+            boundaries.indices.map { it.toLong() }, boundaries,
+            "block indices should be contiguous starting from 0"
+        )
+    }
+
     @RepeatableSimulationTest
     fun `single node processes txs and flush-blocks with rebalances`(@Suppress("unused") iteration: Int) =
         runTest(timeout = 5.seconds) {
             val rowsPerBlock = rand.nextLong(15, 25)
+            val totalActions = rand.nextInt(50, 100)
+            val actions = buildActions(rand, totalActions)
+            val simExtSource = SimExtSource(actions)
+            val srcLogEventCount = rand.nextInt(20, 40)
+            LOG.debug("test: $totalActions actions, $srcLogEventCount srcLogEvents (rowsPerBlock=$rowsPerBlock)")
+
             MemoryStorage(allocator, epoch = 0).use { bp ->
-                SimNode("test-db", bp, IndexerConfig(rowsPerBlock = rowsPerBlock)).use { node ->
+                SimNode("test-db", bp, IndexerConfig(rowsPerBlock = rowsPerBlock), simExtSource).use { node ->
                     val logProcScope = CoroutineScope(dispatcher + Job())
                     node.openLogProcessor(logProcScope).use { logProc ->
                         val groupJob = launch(dispatcher) { srcLog.openGroupSubscription(logProc) }
 
                         launch(dispatcher) {
-                            val totalActions = rand.nextInt(50, 100)
-                            LOG.debug("test: will perform $totalActions actions (rowsPerBlock=$rowsPerBlock)")
-                            repeat(totalActions) { _ ->
+                            repeat(srcLogEventCount) {
                                 yield()
-
-                                when (rand.nextInt(100)) {
-                                    in 0..<80 -> srcLog.appendMessage(emptyTx())
-                                    in 80..<95 -> srcLog.rebalanceTrigger.send(Unit)
-                                    else -> srcLog.appendMessage(SourceMessage.FlushBlock(null))
+                                if (rand.nextInt(100) < 50) {
+                                    srcLog.rebalanceTrigger.send(Unit)
+                                } else {
+                                    srcLog.appendMessage(SourceMessage.FlushBlock(null))
                                 }
                             }
-                            val lastSrcMsgId = srcLog.latestSubmittedMsgId
-                            if (lastSrcMsgId >= 0) node.watchers.awaitSource(lastSrcMsgId)
+                            while (!simExtSource.isQuiescent) yield()
+
+                            replicaLog.awaitAllDelivered()
                         }.join()
 
                         groupJob.cancel()
                         logProcScope.cancel()
 
-                        val sourceTxIds = srcLog.topic
-                            .filter { it.message is SourceMessage.Tx || it.message is SourceMessage.LegacyTx }
-                            .map { it.msgId }
-
-                        val replicaTxIds = replicaLog.topic
-                            .map { it.message }
-                            .filterIsInstance<ReplicaMessage.ResolvedTx>()
-                            .map { it.txId }
-
+                        assertReplicaTxInvariants()
                         assertEquals(
-                            sourceTxIds,
-                            replicaTxIds,
-                            "every source tx should appear on the replica, in order"
-                        )
-                        assertEquals(
-                            replicaTxIds,
-                            replicaTxIds.sorted(),
-                            "replica txIds should be monotonically increasing"
-                        )
-                        assertEquals(
-                            replicaTxIds.size,
-                            replicaTxIds.toSet().size,
-                            "replica should have no duplicate txIds"
+                            simExtSource.indexedCount, replicaTxIds().size,
+                            "every successfully-indexed action should appear on the replica"
                         )
 
                         val replicaMessages = replicaLog.topic.map { it.message }
-                        val boundaries =
-                            replicaMessages.filterIsInstance<ReplicaMessage.BlockBoundary>().map { it.blockIndex }
-                        val uploads =
-                            replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>().map { it.blockIndex }
-                        assertEquals(boundaries, uploads, "every BlockBoundary should have a matching BlockUploaded")
+                        assertBlockBoundariesMatchUploads(replicaMessages)
 
-                        assertEquals(
-                            boundaries.indices.map { it.toLong() }, boundaries,
-                            "block indices should be contiguous starting from 0"
-                        )
-
-                        val expectedBlockIndex = uploads.maxOfOrNull { it }
+                        val expectedBlockIndex =
+                            replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>().maxOfOrNull { it.blockIndex }
                         assertEquals(
                             expectedBlockIndex, node.blockCatalog.currentBlockIndex,
                             "block catalog should match latest uploaded block"
                         )
 
+                        val replicaTxIds = replicaTxIds()
                         if (replicaTxIds.isNotEmpty()) {
                             val lastReplicaTx = replicaMessages
                                 .filterIsInstance<ReplicaMessage.ResolvedTx>().last()
@@ -378,11 +399,16 @@ class LogProcessorSimTest : SimulationTestBase() {
         runTest(timeout = 5.seconds) {
             val rowsPerBlock = rand.nextLong(15, 25)
             val indexerConfig = IndexerConfig(rowsPerBlock = rowsPerBlock)
+            val totalActions = rand.nextInt(50, 100)
+            val actions = buildActions(rand, totalActions)
+            val simExtSource = SimExtSource(actions)
+            val srcLogEventCount = rand.nextInt(5, 15)
+            LOG.debug("test: stable-leader $totalActions actions, $srcLogEventCount FlushBlocks (rowsPerBlock=$rowsPerBlock)")
 
             MemoryStorage(allocator, epoch = 0).use { bp ->
-                SimNode("test-db", bp, indexerConfig).use { leader ->
-                    SimNode("test-db", bp, indexerConfig).use { followerA ->
-                        SimNode("test-db", bp, indexerConfig).use { followerB ->
+                SimNode("test-db", bp, indexerConfig, simExtSource).use { leader ->
+                    SimNode("test-db", bp, indexerConfig, simExtSource).use { followerA ->
+                        SimNode("test-db", bp, indexerConfig, simExtSource).use { followerB ->
                             val leaderScope = CoroutineScope(dispatcher + Job())
                             val followerScopeA = CoroutineScope(dispatcher + Job())
                             val followerScopeB = CoroutineScope(dispatcher + Job())
@@ -398,26 +424,23 @@ class LogProcessorSimTest : SimulationTestBase() {
                                             launch(dispatcher) { srcLog.openGroupSubscription(followerProcB) }
 
                                         launch(dispatcher) {
-                                            val totalTxs = rand.nextInt(50, 100)
-                                            LOG.debug("test: stable-leader will perform $totalTxs txs (rowsPerBlock=$rowsPerBlock)")
-                                            repeat(totalTxs) { _ ->
+                                            repeat(srcLogEventCount) {
                                                 yield()
-
-                                                when (rand.nextInt(100)) {
-                                                    in 0..<95 -> srcLog.appendMessage(emptyTx())
-                                                    else -> srcLog.appendMessage(SourceMessage.FlushBlock(null))
-                                                }
+                                                srcLog.appendMessage(SourceMessage.FlushBlock(null))
                                             }
-
-                                            srcLog.appendMessage(emptyTx())
-                                            val lastSrcMsgId = srcLog.latestSubmittedMsgId
-                                            if (lastSrcMsgId >= 0) {
-                                                leader.watchers.awaitSource(lastSrcMsgId)
-                                                followerA.watchers.awaitSource(lastSrcMsgId)
-                                                followerB.watchers.awaitSource(lastSrcMsgId)
-                                            }
-
+                                            while (!simExtSource.isQuiescent) yield()
                                             replicaLog.awaitAllDelivered()
+
+                                            // Anchor the per-node `latestTxId` to the latest replica tx so the
+                                            // convergence assertions below see consistent state across nodes.
+                                            val lastReplicaTxId = replicaLog.topic.map { it.message }
+                                                .filterIsInstance<ReplicaMessage.ResolvedTx>()
+                                                .maxOfOrNull { it.txId }
+                                            if (lastReplicaTxId != null) {
+                                                leader.watchers.awaitTx(lastReplicaTxId)
+                                                followerA.watchers.awaitTx(lastReplicaTxId)
+                                                followerB.watchers.awaitTx(lastReplicaTxId)
+                                            }
                                         }.join()
 
                                         groupJobLeader.cancel()
@@ -427,51 +450,20 @@ class LogProcessorSimTest : SimulationTestBase() {
                                         followerScopeA.cancel()
                                         followerScopeB.cancel()
 
-                                        val sourceTxIds = srcLog.topic
-                                            .filter { it.message is SourceMessage.Tx || it.message is SourceMessage.LegacyTx }
-                                            .map { it.msgId }
-
-                                        val replicaTxIds = replicaLog.topic
-                                            .map { it.message }
-                                            .filterIsInstance<ReplicaMessage.ResolvedTx>()
-                                            .map { it.txId }
-
+                                        assertReplicaTxInvariants()
                                         assertEquals(
-                                            sourceTxIds,
-                                            replicaTxIds,
-                                            "every source tx should appear on the replica, in order"
-                                        )
-                                        assertEquals(
-                                            replicaTxIds,
-                                            replicaTxIds.sorted(),
-                                            "replica txIds should be monotonically increasing"
-                                        )
-                                        assertEquals(
-                                            replicaTxIds.size,
-                                            replicaTxIds.toSet().size,
-                                            "replica should have no duplicate txIds"
+                                            simExtSource.indexedCount, replicaTxIds().size,
+                                            "every successfully-indexed action should appear on the replica"
                                         )
 
                                         val replicaMessages = replicaLog.topic.map { it.message }
-                                        val boundaries =
-                                            replicaMessages.filterIsInstance<ReplicaMessage.BlockBoundary>()
-                                                .map { it.blockIndex }
-                                        val uploads = replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>()
-                                            .map { it.blockIndex }
-                                        assertEquals(
-                                            boundaries,
-                                            uploads,
-                                            "every BlockBoundary should have a matching BlockUploaded"
-                                        )
-
-                                        assertEquals(
-                                            boundaries.indices.map { it.toLong() }, boundaries,
-                                            "block indices should be contiguous starting from 0"
-                                        )
+                                        assertBlockBoundariesMatchUploads(replicaMessages)
 
                                         val nodes = listOf(leader, followerA, followerB)
 
-                                        val expectedBlockIndex = uploads.maxOfOrNull { it }
+                                        val expectedBlockIndex =
+                                            replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>()
+                                                .maxOfOrNull { it.blockIndex }
                                         for (node in nodes) {
                                             assertEquals(
                                                 expectedBlockIndex, node.blockCatalog.currentBlockIndex,
@@ -482,13 +474,8 @@ class LogProcessorSimTest : SimulationTestBase() {
                                         val expectedLatestCompletedTx = leader.liveIndex.latestCompletedTx
                                         val expectedBlockCatalogTx = leader.blockCatalog.latestCompletedTx
                                         val expectedProcessedMsgId = leader.blockCatalog.latestProcessedMsgId
-                                        val expectedSourceWatermark = leader.watchers.latestSourceMsgId
 
                                         for (node in nodes) {
-                                            assertEquals(
-                                                expectedSourceWatermark, node.watchers.latestSourceMsgId,
-                                                "all nodes should converge on the same source watermark"
-                                            )
                                             assertEquals(
                                                 expectedProcessedMsgId, node.blockCatalog.latestProcessedMsgId,
                                                 "all nodes should agree on latestProcessedMsgId"
@@ -522,10 +509,15 @@ class LogProcessorSimTest : SimulationTestBase() {
         runTest(timeout = 5.seconds) {
             val rowsPerBlock = rand.nextLong(15, 25)
             val indexerConfig = IndexerConfig(rowsPerBlock = rowsPerBlock)
+            val totalActions = rand.nextInt(50, 100)
+            val actions = buildActions(rand, totalActions)
+            val simExtSource = SimExtSource(actions)
+            val srcLogEventCount = rand.nextInt(20, 40)
+            LOG.debug("test: multi-node $totalActions actions, $srcLogEventCount srcLogEvents (rowsPerBlock=$rowsPerBlock)")
 
             MemoryStorage(allocator, epoch = 0).use { bp ->
-                SimNode("test-db", bp, indexerConfig).use { nodeA ->
-                    SimNode("test-db", bp, indexerConfig).use { nodeB ->
+                SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeA ->
+                    SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeB ->
                         val scopeA = CoroutineScope(dispatcher + Job())
                         val scopeB = CoroutineScope(dispatcher + Job())
 
@@ -535,25 +527,26 @@ class LogProcessorSimTest : SimulationTestBase() {
                                 val groupJobB = launch(dispatcher) { srcLog.openGroupSubscription(logProcB) }
 
                                 launch(dispatcher) {
-                                    val totalActions = rand.nextInt(50, 100)
-                                    LOG.debug("test: multi-node will perform $totalActions actions (rowsPerBlock=$rowsPerBlock)")
-                                    repeat(totalActions) { _ ->
+                                    repeat(srcLogEventCount) {
                                         yield()
-                                        when (rand.nextInt(100)) {
-                                            in 0..<80 -> srcLog.appendMessage(emptyTx())
-                                            in 80..<95 -> srcLog.rebalanceTrigger.send(Unit)
-                                            else -> srcLog.appendMessage(SourceMessage.FlushBlock(null))
+                                        if (rand.nextInt(100) < 50) {
+                                            srcLog.rebalanceTrigger.send(Unit)
+                                        } else {
+                                            srcLog.appendMessage(SourceMessage.FlushBlock(null))
                                         }
                                     }
-
-                                    srcLog.appendMessage(emptyTx())
-                                    val lastSrcMsgId = srcLog.latestSubmittedMsgId
-                                    if (lastSrcMsgId >= 0) {
-                                        nodeA.watchers.awaitSource(lastSrcMsgId)
-                                        nodeB.watchers.awaitSource(lastSrcMsgId)
-                                    }
-
+                                    while (!simExtSource.isQuiescent) yield()
                                     replicaLog.awaitAllDelivered()
+
+                                    // Anchor the per-node `latestTxId` to the latest replica tx so the
+                                    // convergence assertions below see consistent state across nodes.
+                                    val lastReplicaTxId = replicaLog.topic.map { it.message }
+                                        .filterIsInstance<ReplicaMessage.ResolvedTx>()
+                                        .maxOfOrNull { it.txId }
+                                    if (lastReplicaTxId != null) {
+                                        nodeA.watchers.awaitTx(lastReplicaTxId)
+                                        nodeB.watchers.awaitTx(lastReplicaTxId)
+                                    }
                                 }.join()
 
                                 groupJobA.cancel()
@@ -561,46 +554,14 @@ class LogProcessorSimTest : SimulationTestBase() {
                                 scopeA.cancel()
                                 scopeB.cancel()
 
-                                val sourceTxIds = srcLog.topic
-                                    .filter { it.message is SourceMessage.Tx || it.message is SourceMessage.LegacyTx }
-                                    .map { it.msgId }
-
-                                val replicaTxIds = replicaLog.topic
-                                    .map { it.message }
-                                    .filterIsInstance<ReplicaMessage.ResolvedTx>()
-                                    .map { it.txId }
-
+                                assertReplicaTxInvariants()
                                 assertEquals(
-                                    sourceTxIds,
-                                    replicaTxIds,
-                                    "every source tx should appear on the replica, in order"
-                                )
-                                assertEquals(
-                                    replicaTxIds,
-                                    replicaTxIds.sorted(),
-                                    "replica txIds should be monotonically increasing"
-                                )
-                                assertEquals(
-                                    replicaTxIds.size,
-                                    replicaTxIds.toSet().size,
-                                    "replica should have no duplicate txIds"
+                                    simExtSource.indexedCount, replicaTxIds().size,
+                                    "every successfully-indexed action should appear on the replica"
                                 )
 
                                 val replicaMessages = replicaLog.topic.map { it.message }
-                                val boundaries = replicaMessages.filterIsInstance<ReplicaMessage.BlockBoundary>()
-                                    .map { it.blockIndex }
-                                val uploads = replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>()
-                                    .map { it.blockIndex }
-                                assertEquals(
-                                    boundaries,
-                                    uploads,
-                                    "every BlockBoundary should have a matching BlockUploaded"
-                                )
-
-                                assertEquals(
-                                    boundaries.indices.map { it.toLong() }, boundaries,
-                                    "block indices should be contiguous starting from 0"
-                                )
+                                assertBlockBoundariesMatchUploads(replicaMessages)
 
                                 val expectedBlockIndex = replicaMessages
                                     .filterIsInstance<ReplicaMessage.BlockUploaded>()
@@ -613,11 +574,6 @@ class LogProcessorSimTest : SimulationTestBase() {
                                 assertEquals(
                                     expectedBlockIndex, nodeB.blockCatalog.currentBlockIndex,
                                     "node B block catalog should match latest uploaded block"
-                                )
-
-                                assertEquals(
-                                    nodeA.watchers.latestSourceMsgId, nodeB.watchers.latestSourceMsgId,
-                                    "both nodes should converge on the same source watermark"
                                 )
 
                                 assertEquals(


### PR DESCRIPTION
Resolves #5577.

## Context

`LogProcessorSimTest` mocked `Indexer.ForDatabase` to coin-flip commit/abort and write 1–5 random rows per tx.
The mock was the only meaningful behavioural test-stub coupling that would block the eventual `Indexer`→`LeaderLogProcessor` collapse (#5565 increment 3) — every other `Indexer` reference in tests is a placeholder that disappears with the ctor param.

Replaces the mock with a `SimExtSource : ExternalSource` shim.
Actions are decided up front from the seeded `rand` (`Commit(rows: List<UUID>) | Abort`); a single shared `SimExtSource` is plumbed into every `SimNode`, and its `onPartitionAssigned` drains a shared iterator through whichever node is currently leader via `txIndexer.indexTx { … }`.
The real `Indexer` is constructed inline at `openLeaderSystem` from `nodeBase.indexerFactory`.
The simulation now exercises the real source-log decode and persister paths end-to-end.

## Implementation notes

### `indexTx` lives inside `onPartitionAssigned`

An earlier draft had the test driver fetching the current `TxIndexer` from a `MutableStateFlow<TxIndexer?>` and calling `indexTx` directly.
That made the driver responsible for `OpenTx` lifetime: `LeaderLogProcessor.indexTx` allocates an `OpenTx` from the leader's allocator, and if `LLP.close()` ran while that `OpenTx` was still held by the driver coroutine (outside LLP's scope), `allocator.close()` threw on the outstanding allocation.

The fix is structural: hold the `indexTx` call inside `SimExtSource.onPartitionAssigned`.
That runs inside the leader's `extJob` — when revocation cancels `extJob`, `indexTx`'s inner catch closes the `OpenTx` before the allocator does.

### Pre-built `List<SimAction>` + shared iterator

`SimExtSource` holds `actions.iterator()`; each `onPartitionAssigned` invocation drains it through the current leader.
Leadership transitions surface as fresh `onPartitionAssigned` invocations on the same instance — the iterator is shared, so the next leader resumes draining from where the previous left off.
`close()` is a no-op so the per-`LeaderLogProcessor` `extSource.close()` doesn't tear down the shared instance.

`isQuiescent = !iterator.hasNext() && inFlight == 0` is the driver's barrier between action dispatch and assertions.
`inFlight` increments before each `indexTx` and decrements in `finally`, so cancellation accounting stays correct under mid-action revoke.

### Per-row writes use `docWriter.writeObject(map)`

Same shape as `PostgresSource.writeOp`, rather than the old per-vector `vectorFor(...).writeObject(...) / .writeLong(...) / .endStruct()` plumbing.
Equivalent on the wire, much shorter, grounds the test in the real-world ext-source idiom.

### No trailing source-log Tx

An earlier iteration used a trailing `emptyTx()` to anchor follower watermarks (its `ResolvedTx` carries `srcMsgId` and propagates through replica).
That tripped the `txId > latestTxId` invariant in `Watchers.notifyTx` once a few ext-source actions had run.

The reason: source-log Txs assign `txId == msgId` (in `IndexerForDatabase.indexTx` via `serde/->TxKey msg-id system-time`); ext-source actions assign `txId = (liveIndex.latestCompletedTx?.txId ?: -1) + 1` — an independent counter.
Once 72 ext-source actions advance the counter to 72, a trailing source-log Tx with `msgId = 12` claims `txId = 12`, and `notifyTx(txId=12)` against `watchers.latestTxId=72` fails `12 > 72`.

In production, source-log Txs and ext-source actions don't mix in the same database — the test was the only place stitching them together.
Watermark anchoring at end-of-test now goes through `replicaLog.awaitAllDelivered()` plus per-node `watchers.awaitTx(lastReplicaTxId)` instead of `awaitSource`.

### Dropped the cross-node `latestSourceMsgId` equality assertion

A node that was leader at any point carries `latestSourceMsgId` advances through `notifyMsg` (FlushBlocks etc.) that purely-follower nodes never see — `FlushBlock(null)` produces no replica record to propagate them.
The assertion was brittle by construction; the convergence checks that actually matter (`latestProcessedMsgId`, `blockCatalog.latestCompletedTx`, `liveIndex.latestCompletedTx`) all hold.

## Scope

This PR is the test refactor only.
The follower-watermark conflation (#5580) it surfaced is fixed by independent commits already on `main` (`e9c670392`, `3e307aff6`, `db74fc6c2`).
The eventual `Indexer`→`LeaderLogProcessor` collapse — the motivation for dropping the mock — is the deferred increment 3 of #5565; not in scope here.

## Test plan

- [x] `./gradlew :xtdb-core:property-test --tests 'xtdb.indexer.LogProcessorSimTest'` — 300/300 iterations green across all three test methods.
- [x] `./gradlew :xtdb-core:test` — 273/273 green; no regressions.

Generated with [Claude Code](https://claude.com/claude-code)