### PR TITLE
feat(pgwire): granular tx-commit timers (submit/execute/await)

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -88,7 +88,8 @@
                  ^CompositeMeterRegistry metrics-registry
                  default-tz, ^AtomicReference !await-token
                  system, close-fn,
-                 query-timer, ^Counter query-error-counter, ^Counter tx-error-counter]
+                 query-timer, ^Counter query-error-counter, ^Counter tx-error-counter
+                 tx-await-timer]
   Xtdb
   (getAllocator [_] allocator)
 
@@ -170,7 +171,8 @@
   (executeTx [this db-name tx-ops tx-opts]
     (let [tx-id (.getTxId (.submitTx this db-name tx-ops tx-opts))
           db (.databaseOrNull db-cat db-name)
-          {:keys [tx-id system-time committed? error]} (await-msg-result this db tx-id)]
+          {:keys [tx-id system-time committed? error]} (metrics/record-callable! tx-await-timer
+                                                                                 (await-msg-result this db tx-id))]
       (Xtdb$ExecutedTx. tx-id system-time committed? error)))
 
   Xtdb$XtdbInternal
@@ -188,7 +190,8 @@
   (execute-tx [this tx-ops opts]
     (let [tx-id (xtp/submit-tx this tx-ops opts)
           db (.databaseOrNull db-cat ^String (:default-db opts))]
-      (await-msg-result this db tx-id)))
+      (metrics/record-callable! tx-await-timer
+                                (await-msg-result this db tx-id))))
 
   (open-sql-query [this query query-opts]
     (let [query-opts (-> query-opts (with-query-opts-defaults this))]
@@ -292,7 +295,9 @@
                             (assoc :query-timer (metrics/add-timer metrics-registry "query.timer"
                                                                    {:description "indicates the timings for queries"})
                                    :query-error-counter (metrics/add-counter metrics-registry "query.error")
-                                   :tx-error-counter (metrics/add-counter metrics-registry "tx.error"))))]
+                                   :tx-error-counter (metrics/add-counter metrics-registry "tx.error")
+                                   :tx-await-timer (metrics/add-timer metrics-registry "node.tx.await"
+                                                                      {:description "Time spent in executeTx waiting for the indexer to catch up to a just-submitted tx (sync-path indexer await)."}))))]
     node))
 
 (defmethod ig/halt-key! :xtdb/node [_ node]

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -557,7 +557,7 @@
   (swap! conn-state dissoc :transaction)
   (close-all-portals conn))
 
-(defn cmd-commit [{:keys [^Xtdb node conn-state default-db ^BufferAllocator allocator, tx-error-counter, tx-latency-timer] :as conn}]
+(defn cmd-commit [{:keys [^Xtdb node conn-state default-db ^BufferAllocator allocator, tx-error-counter, tx-latency-timer, tx-submit-timer, tx-execute-timer] :as conn}]
   (let [{:keys [transaction session]} @conn-state
         {:keys [failed dml-buf system-time access-mode default-tz async? user-metadata]} transaction
         {:keys [parameters]} session]
@@ -579,14 +579,18 @@
                                                                                  [op])))
                                                                    (util/safe-mapv #(xt-log/open-tx-op % allocator {:default-tz default-tz})))]
                                         (if async?
-                                          (let [tx-id (with-auth-check conn (.submitTx node default-db tx-ops tx-opts))
+                                          (let [tx-id (with-auth-check conn
+                                                        (metrics/record-callable! tx-submit-timer
+                                                                                  (.submitTx node default-db tx-ops tx-opts)))
                                                 msg-id (.getTxId tx-id)]
                                             (swap! conn-state (fn [cs]
                                                                 (-> cs
                                                                     (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {default-db [msg-id]}))
                                                                     (assoc :latest-submitted-tx {:tx-id msg-id})))))
 
-                                          (let [tx (with-auth-check conn (.executeTx node default-db tx-ops tx-opts))
+                                          (let [tx (with-auth-check conn
+                                                     (metrics/record-callable! tx-execute-timer
+                                                                               (.executeTx node default-db tx-ops tx-opts)))
                                                 msg-id (.getTxId tx)]
                                             (swap! conn-state (fn [cs]
                                                                 (-> cs
@@ -1794,7 +1798,7 @@
   freed at the end of this function. So the connections lifecycle should be totally enclosed over the lifetime of a connect call.
 
   See comment 'Connection lifecycle'."
-  [{:keys [node, ^Authenticator authn, server-state, port, allocator, query-error-counter, tx-error-counter, tx-latency-timer, ^Counter total-connections-counter, ^Counter cancelled-connections-counter, query-timer, query-tracer] :as server} ^Socket conn-socket]
+  [{:keys [node, ^Authenticator authn, server-state, port, allocator, query-error-counter, tx-error-counter, tx-latency-timer, tx-submit-timer, tx-execute-timer, ^Counter total-connections-counter, ^Counter cancelled-connections-counter, query-timer, query-tracer] :as server} ^Socket conn-socket]
   (let [close-promise (promise)
         {:keys [cid !closing?] :as conn} (util/with-close-on-catch [_ conn-socket]
                                            (let [cid (:next-cid (swap! server-state update :next-cid (fnil inc 0)))
@@ -1821,6 +1825,8 @@
                     :query-tracer query-tracer
                     :tx-error-counter tx-error-counter
                     :tx-latency-timer tx-latency-timer
+                    :tx-submit-timer tx-submit-timer
+                    :tx-execute-timer tx-execute-timer
                     :cancelled-connections-counter cancelled-connections-counter)]
 
     (try
@@ -1916,6 +1922,8 @@
            query-timer (when metrics-registry (metrics/add-timer metrics-registry "query.timer" {}))
            tx-error-counter (when metrics-registry (metrics/add-counter metrics-registry "tx.error"))
            tx-latency-timer (when metrics-registry (metrics/add-timer metrics-registry "pgwire.tx.latency" {}))
+           tx-submit-timer (when metrics-registry (metrics/add-timer metrics-registry "pgwire.tx.submit" {:description "Time spent in async-path Node.submitTx (log append + ack)."}))
+           tx-execute-timer (when metrics-registry (metrics/add-timer metrics-registry "pgwire.tx.execute" {:description "Time spent in sync-path Node.executeTx (log append + indexer await)."}))
            total-connections-counter (when metrics-registry (metrics/add-counter metrics-registry "pgwire.total_connections"))
            cancelled-connections-counter (when metrics-registry (metrics/add-counter metrics-registry "pgwire.cancelled_connections")) 
            server (map->Server {:allocator allocator
@@ -1951,6 +1959,8 @@
                          :query-tracer (when query-tracing? tracer)
                          :tx-error-counter tx-error-counter
                          :tx-latency-timer tx-latency-timer
+                         :tx-submit-timer tx-submit-timer
+                         :tx-execute-timer tx-execute-timer
                          :total-connections-counter total-connections-counter
                          :cancelled-connections-counter cancelled-connections-counter)
            accept-thread (-> (Thread/ofVirtual)

--- a/src/test/clojure/xtdb/metrics_test.clj
+++ b/src/test/clojure/xtdb/metrics_test.clj
@@ -169,6 +169,22 @@ $$"])
         (let [^Timer timer (.timer (.find registry "pgwire.tx.latency"))]
           (t/is (= (.count timer) 3)))))))
 
+(t/deftest test-pgwire-tx-submit-and-execute-timers
+  (let [node (xtn/start-node tu/*node-opts*)
+        registry (.getMeterRegistry (util/node-base node))
+        timer-count #(.count ^Timer (.timer (.find registry %)))]
+
+    (with-open [conn (jdbc/get-connection node)]
+      (jdbc/execute! conn ["INSERT INTO foo (_id, a) VALUES (1, 42)"])
+      (t/is (= 1 (timer-count "pgwire.tx.execute")) "sync commit bumps execute timer")
+      (t/is (= 0 (timer-count "pgwire.tx.submit")) "sync commit does not bump submit timer")
+
+      (jdbc/execute! conn ["BEGIN READ WRITE WITH (ASYNC = TRUE)"])
+      (jdbc/execute! conn ["INSERT INTO foo (_id, a) VALUES (2, 43)"])
+      (jdbc/execute! conn ["COMMIT"])
+      (t/is (= 1 (timer-count "pgwire.tx.submit")) "async commit bumps submit timer")
+      (t/is (= 1 (timer-count "pgwire.tx.execute")) "async commit does not bump execute timer"))))
+
 (t/deftest test-block-uploaded-timer
   (let [node (xtn/start-node tu/*node-opts*)
         registry (.getMeterRegistry (util/node-base node))]

--- a/src/test/clojure/xtdb/metrics_test.clj
+++ b/src/test/clojure/xtdb/metrics_test.clj
@@ -185,6 +185,20 @@ $$"])
       (t/is (= 1 (timer-count "pgwire.tx.submit")) "async commit bumps submit timer")
       (t/is (= 1 (timer-count "pgwire.tx.execute")) "async commit does not bump execute timer"))))
 
+(t/deftest test-tx-await-timer
+  (let [node (xtn/start-node tu/*node-opts*)
+        registry (.getMeterRegistry (util/node-base node))
+        timer-count #(.count ^Timer (.timer (.find registry "node.tx.await")))]
+
+    (with-open [conn (jdbc/get-connection node)]
+      (jdbc/execute! conn ["INSERT INTO foo (_id, a) VALUES (1, 42)"])
+      (t/is (= 1 (timer-count)) "sync commit records the indexer-await time")
+
+      (jdbc/execute! conn ["BEGIN READ WRITE WITH (ASYNC = TRUE)"])
+      (jdbc/execute! conn ["INSERT INTO foo (_id, a) VALUES (2, 43)"])
+      (jdbc/execute! conn ["COMMIT"])
+      (t/is (= 1 (timer-count)) "async commit does not bump the await timer"))))
+
 (t/deftest test-block-uploaded-timer
   (let [node (xtn/start-node tu/*node-opts*)
         registry (.getMeterRegistry (util/node-base node))]


### PR DESCRIPTION
## Why

We had a single `pgwire.tx.latency` timer wrapping the whole DML body of `cmd-commit`.
When a sync commit was slow we couldn't tell whether time went to log append, indexer await, or something else — which came up while looking at sync `executeTx` latency over pgwire.

## What's added

Two new pgwire-level timers, sitting underneath the existing `pgwire.tx.latency`:

- `pgwire.tx.submit` — wraps `Node.submitTx` on the async-tx path (`BEGIN ... WITH (ASYNC = TRUE)`).
- `pgwire.tx.execute` — wraps `Node.executeTx` on the sync path.

And one node-level timer underneath `pgwire.tx.execute`:

- `node.tx.await` — wraps the `await-msg-result` call inside `executeTx`, isolating the indexer-catchup half.

Together: `pgwire.tx.execute` − `node.tx.await` ≈ log-append cost; `node.tx.await` ≈ indexer-await cost.

## Decisions

- Kept `pgwire.tx.latency` as-is — back-compat for existing dashboards.
- Put `node.tx.await` on the node, not pgwire, so it also covers programmatic `xtp/execute-tx` callers rather than just pgwire commits.
- Deliberately didn't instrument the parse / `open-tx-op` phases inside `cmd-commit` — small and predictable, and the user flagged that we should be conservative about adding timers on hot paths.
- Considered but didn't add a per-database timer around `Database.Catalog.awaitAll` (the indexer-catchup wait on the *query* path).
  Worth doing, but lives on the query hot path and wants more thought; left as a follow-up.

## Tests

`test-pgwire-tx-submit-and-execute-timers` and `test-tx-await-timer` in `xtdb.metrics-test` exercise both sync and async commit paths and assert the right timers move.