### PR TITLE
fix(indexer): branch ResolvedTx fallback on hasExternalSource (resolves #5586)

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -196,6 +196,7 @@ class Database(
 
             if (indexerConfig.enabled) {
                 val blockUploader = BlockUploader(storage, state, compactorForDb, dbCatalog, base.meterRegistry)
+                val hasExternalSource = dbConfig.externalSource != null
 
                 val procFactory = object : LogProcessor.ProcessorFactory {
                     override fun openFollower(
@@ -203,7 +204,8 @@ class Database(
                         afterReplicaMsgId: MessageId,
                     ) = FollowerLogProcessor(
                         allocator, storage.bufferPool, state, compactorForDb,
-                        watchers, dbCatalog, pendingBlock, afterReplicaMsgId
+                        watchers, dbCatalog, pendingBlock, afterReplicaMsgId,
+                        hasExternalSource = hasExternalSource,
                     )
 
                     override fun openLeaderSystem(
@@ -240,7 +242,8 @@ class Database(
                         allocator, storage.bufferPool, state, state.liveIndex,
                         blockUploader, replicaProducer,
                         watchers, dbCatalog,
-                        afterReplicaMsgId
+                        afterReplicaMsgId,
+                        hasExternalSource = hasExternalSource,
                     )
                 }
 

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -34,6 +34,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
     private val dbCatalog: Database.Catalog?,
     pendingBlock: PendingBlock?,
     afterReplicaMsgId: MessageId,
+    private val hasExternalSource: Boolean,
     private val maxBufferedRecords: Int = 1024,
 ) : LogProcessor.FollowerProcessor {
 
@@ -113,7 +114,9 @@ class FollowerLogProcessor @JvmOverloads constructor(
                     if (msg.committed) TransactionResult.Committed(txKey)
                     else TransactionResult.Aborted(txKey, msg.error)
 
-                val effectiveSrcMsgId = msg.srcMsgId ?: watchers.latestSourceMsgId
+                // Handling for pre-`f3eb8d7d9` ResolvedTx records — see #5586.
+                val effectiveSrcMsgId = msg.srcMsgId
+                    ?: if (hasExternalSource) watchers.latestSourceMsgId else msg.txId
                 watchers.notifyTx(result, effectiveSrcMsgId, msg.externalSourceToken)
             }
 

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -30,6 +30,7 @@ class TransitionLogProcessor(
     private val watchers: Watchers,
     private val dbCatalog: Database.Catalog?,
     afterReplicaMsgId: MessageId,
+    private val hasExternalSource: Boolean,
 ) : LogProcessor.TransitionProcessor {
 
     override var latestReplicaMsgId: MessageId = afterReplicaMsgId
@@ -81,7 +82,9 @@ class TransitionLogProcessor(
                     if (msg.committed) TransactionResult.Committed(txKey)
                     else TransactionResult.Aborted(txKey, msg.error)
 
-                val effectiveSrcMsgId = msg.srcMsgId ?: watchers.latestSourceMsgId
+                // Handling for pre-`f3eb8d7d9` ResolvedTx records — see #5586.
+                val effectiveSrcMsgId = msg.srcMsgId
+                    ?: if (hasExternalSource) watchers.latestSourceMsgId else msg.txId
                 watchers.notifyTx(result, effectiveSrcMsgId, msg.externalSourceToken)
             }
 

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -58,10 +58,15 @@ class FollowerLogProcessorTest {
         allocator.close()
     }
 
-    private fun makeProcessor(maxBufferedRecords: Int = 1024) =
+    private fun makeProcessor(
+        maxBufferedRecords: Int = 1024,
+        hasExternalSource: Boolean = false,
+    ) =
         FollowerLogProcessor(
             allocator, bufferPool, dbState,
-            compactor, watchers, null, null, afterReplicaMsgId = -1L, maxBufferedRecords
+            compactor, watchers, null, null, afterReplicaMsgId = -1L,
+            hasExternalSource = hasExternalSource,
+            maxBufferedRecords = maxBufferedRecords,
         )
 
     private fun <M> record(offset: Long, message: M) =
@@ -178,7 +183,7 @@ class FollowerLogProcessorTest {
         // Reproduces #5580: an ext-source ResolvedTx (srcMsgId=null) followed by a BlockBoundary
         // whose latestProcessedMsgId reflects the leader's still-default source watermark would
         // previously violate `srcMsgId >= latestSourceMsgId` on the follower.
-        val proc = makeProcessor()
+        val proc = makeProcessor(hasExternalSource = true)
 
         val blockProto = block { blockIndex = 0 }.toByteArray()
         every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
@@ -200,7 +205,7 @@ class FollowerLogProcessorTest {
 
     @Test
     fun `mixed ext-source and source-log ResolvedTxs advance the right watermarks`() = runTest {
-        val proc = makeProcessor()
+        val proc = makeProcessor(hasExternalSource = true)
 
         val ext0 = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
         val src1 = ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap(), srcMsgId = 1)

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -206,7 +206,8 @@ class LogProcessorSimTest : SimulationTestBase() {
                 allocator, bp, dbState, liveIndex,
                 blockUploader,
                 replicaProducer, watchers, null,
-                afterReplicaMsgId
+                afterReplicaMsgId,
+                hasExternalSource = false,
             )
 
         override fun openFollower(
@@ -217,7 +218,8 @@ class LogProcessorSimTest : SimulationTestBase() {
                 allocator, bp, dbState,
                 mockk<Compactor.ForDatabase>(relaxed = true),
                 watchers, null, pendingBlock,
-                afterReplicaMsgId
+                afterReplicaMsgId,
+                hasExternalSource = false,
             )
 
         fun openLogProcessor(scope: CoroutineScope) =

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -90,6 +90,7 @@ class LogProcessorTest {
                     BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null),
                     replicaProducer, watchers, dbCatalog = null,
                     afterReplicaMsgId = afterReplicaMsgId,
+                    hasExternalSource = false,
                 )
 
             override fun openFollower(
@@ -100,6 +101,7 @@ class LogProcessorTest {
                     allocator, bufferPool, dbState,
                     mockk(relaxed = true), watchers, null, pendingBlock,
                     afterReplicaMsgId,
+                    hasExternalSource = false,
                 )
         }
 

--- a/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
@@ -51,11 +51,12 @@ class TransitionLogProcessorTest {
         allocator.close()
     }
 
-    private fun makeProcessor() =
+    private fun makeProcessor(hasExternalSource: Boolean = false) =
         TransitionLogProcessor(
             allocator, bufferPool, dbState, liveIndex,
             blockUploader, replicaProducer,
-            watchers, null, afterReplicaMsgId = -1L
+            watchers, null, afterReplicaMsgId = -1L,
+            hasExternalSource = hasExternalSource,
         )
 
     private fun <M> record(offset: Long, message: M) =
@@ -81,7 +82,7 @@ class TransitionLogProcessorTest {
         // Companion to the FollowerLogProcessorTest case: the transition path must also keep
         // ext-source txs from bumping latestSourceMsgId, so the subsequent BlockBoundary's
         // latestProcessedMsgId (= leader's still-default -1) doesn't violate the Watchers invariant.
-        val proc = makeProcessor()
+        val proc = makeProcessor(hasExternalSource = true)
 
         val extTx = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
         proc.processRecords(listOf(

--- a/src/test/clojure/xtdb/log_test.clj
+++ b/src/test/clojure/xtdb/log_test.clj
@@ -366,14 +366,8 @@
         (t/testing "shouldn't have flushed another block / re-read the flush block"
           (t/is (= ["l00-rc-b00.arrow"] (tu/read-files-from-bp-path node "tables/public$docs/meta/"))))))))
 
-;; Direct demonstration of the cause: a ResolvedTx whose src_msg_id field is absent
-;; on the wire (pre-f3eb8d7d9 record OR new-format ext-source — wire-indistinguishable)
-;; advances latestTxId but leaves latestSourceMsgId at the seed.
-;;
-;; Read-only mode prevents the source-log subscription from opening
-;; (Database.kt:251), so no Kafka rebalance, no leader transition. The follower still
-;; tails the replica log though — replay happens, gap forms, we observe it.
-(t/deftest no-srcmsgid-replay-leaves-watcher-gap-5586
+;; Read-only mode isolates follower replay from leader transition. See #5586.
+(t/deftest no-srcmsgid-replay-advances-watermark-5586
   (let [source-log (InMemoryLog. (InstantSource/system) 0)
         replica-log (InMemoryLog. (InstantSource/system) 0)
         log-factory (reify Log$Factory
@@ -391,24 +385,18 @@
                                        (.log log-factory)
                                        (.readOnlyDatabases true)))]
       (let [primary (.databaseOrNull (db/<-node node) "xtdb")]
-        ;; await replay — latestTxId reaches 0 once the follower processes our record
         (.awaitTxBlocking primary 0 (Duration/ofSeconds 5))
 
         (let [watchers (.getWatchers primary)]
-          (t/is (= 0 (.getLatestTxId watchers))
-                "replay processed the ResolvedTx, advancing latestTxId")
-          (t/is (= -1 (.getLatestSourceMsgId watchers))
-                "but latestSourceMsgId stayed at the seed — this is the gap"))))))
+          (t/is (= 0 (.getLatestTxId watchers)))
+          (t/is (= 0 (.getLatestSourceMsgId watchers))
+                "watermark advances to txId on a non-ext-source db"))))))
 
-;; End-to-end shape: the gap above propagates into a leader transition, where the
-;; source-log delivers a msgId the indexer maps to a txId already in latestTxId.
-;; Watchers trips on the duplicate via the `txId > latestTxId` invariant.
-
-(t/deftest no-srcmsgid-replay-trips-leader-5586
+;; DetachDatabase substitutes for a regular Tx — same notifyTx path, no Arrow payload.
+;; See #5586.
+(t/deftest no-srcmsgid-replay-leader-transition-clean-5586
   (let [source-log (InMemoryLog. (InstantSource/system) 0)
         replica-log (InMemoryLog. (InstantSource/system) 0)
-        ;; Custom Log.Factory returning our pre-existing instances rather than fresh
-        ;; ones — that's how we sneak the crafted records into the node's startup view.
         log-factory (reify Log$Factory
                       (openSourceLog [_ _] source-log)
                       (openReadOnlySourceLog [_ _] (ReadOnlyLog. source-log))
@@ -416,25 +404,20 @@
                       (openReadOnlyReplicaLog [_ _] (ReadOnlyLog. replica-log))
                       (writeTo [_ _]))]
 
-    ;; Pre-populate the replica log: ResolvedTx with srcMsgId left null. The encoder
-    ;; (ReplicaMessage.kt:141 — `srcMsgId?.let { srcMsgId = it }`) elides the tag,
-    ;; producing byte-for-byte the wire shape of a pre-PR record.
     (.appendMessageBlocking replica-log
                             (ReplicaMessage$ResolvedTx. 0 (Instant/now)
                                                         true nil {} nil nil nil))
 
-    ;; Pre-populate the source log: DetachDatabase("missing-db") at offset 0 → msgId 0,
-    ;; colliding with the replica's txId. DetachDatabase exercises the same notifyTx
-    ;; path as a regular Tx without needing an arrow-encoded payload (the missing db
-    ;; makes dbCatalog.detach throw Anomaly.Caller, which the handler catches before
-    ;; reaching notifyTx with srcMsgId=0).
-    (.appendMessageBlocking source-log (SourceMessage$DetachDatabase. "missing-db"))
+    ;; offset 0 mirrors replay's txId — leader skips it
+    (.appendMessageBlocking source-log (SourceMessage$DetachDatabase. "missing-db-0"))
+
+    ;; offset 1 — what we're awaiting
+    (.appendMessageBlocking source-log (SourceMessage$DetachDatabase. "missing-db-1"))
 
     (with-open [node (xtn/start-node (doto (Xtdb$Config.) (.log log-factory)))]
       (let [primary (.databaseOrNull (db/<-node node) "xtdb")]
-        ;; awaitSource(1) will never resolve cleanly — the leader trips on msgId 0,
-        ;; Watchers transitions to Failed via notifyError, the await surfaces it.
-        ;; IngestionStoppedException's message is "Ingestion stopped (msgId: …): <cause>"
-        (t/is (thrown-with-msg? IngestionStoppedException
-                                #"txId 0 <= latestTxId 0"
-                                (.awaitSourceBlocking primary 1 (Duration/ofSeconds 5))))))))
+        (.awaitSourceBlocking primary 1 (Duration/ofSeconds 5))
+        (let [watchers (.getWatchers primary)]
+          (t/is (= 1 (.getLatestSourceMsgId watchers)))
+          (t/is (nil? (.getException watchers))
+                "no IngestionStoppedException — leader transitioned cleanly"))))))


### PR DESCRIPTION
The receiver-side split for tx-id / source-msg-id added in #5580 (`f3eb8d7d9` and follow-ups) introduced an optional `src_msg_id` field on `ReplicaMessage.ResolvedTx`. Records written by pre-`f3eb8d7d9` leaders don't have that field on the wire. The receiver's `srcMsgId ?: latestSourceMsgId` fallback then no-ops on every replayed pre-PR record — `latestTxId` advances from `msg.txId` but `latestSourceMsgId` doesn't, opening a trailing gap that survives into the next leader transition.

The leader resumes its source-log subscription from `latestSourceMsgId`. The next source-log record is delivered with `msgId > latestSourceMsgId` but `msgId <= latestTxId` (replay already accounted for it). The indexer assigns `txId = msgId` (`indexer.clj`'s `indexTx`); `Watchers.notifyTx` rejects the duplicate via `check(txId > it.latestTxId)`, surfacing as `IngestionStoppedException: txId N <= latestTxId N`.

Branch the receiver's `?:` on whether the *receiving* database has external-source configured:

- No ext-source — fall back to `txId`. Recovers the pre-PR `txId == msgId` contract that all source-log records on this db follow.
- Ext-source — keep current behaviour. Either the record genuinely has no source-log msgId (postgres-source, post-PR ext-source), or it does but the bug doesn't fire — leader assigns new `txId` from `latestCompletedTx + 1`, never from `msgId`, so a stale `latestSourceMsgId` cannot trip the invariant.

The asymmetry is intentional and `hasExternalSource` flows from `dbConfig.externalSource != null` at receiver construction.

The `else` arm exists for replica-log records written by pre-`f3eb8d7d9` leaders. Once every record past the latest finished block was written by post-fix code, the arm is unreachable on that cluster. Whether to keep it indefinitely or remove it in a future release is open; see #5586 for the discussion.

Tests in `xtdb.log-test` exercise the end-to-end shape: pre-PR-shape ResolvedTx in the replica log, fresh source-log message, leader transitions cleanly. The existing `FollowerLogProcessorTest` / `TransitionLogProcessorTest` ext-source cases now pass `hasExternalSource = true`; the new helper default is `false`.

Refs #5586