### PR TITLE
fix(kafka): close SharedGroupConsumer via channel close, not cancellation

### DIFF
--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -8,6 +8,8 @@ package xtdb.api.log
 import kotlinx.coroutines.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.onClosed
+import kotlinx.coroutines.channels.onSuccess
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.selects.onTimeout
@@ -246,9 +248,14 @@ class KafkaCluster(
 
         private val pollingJob: Job = scope.launch {
             try {
-                while (isActive) {
+                var closed = false
+                while (!closed) {
                     select {
-                        commandCh.onReceive { processCommand(it) }
+                        commandCh.onReceiveCatching { result ->
+                            result
+                                .onSuccess { processCommand(it) }
+                                .onClosed { closed = true }
+                        }
 
                         if (subscriptions.isNotEmpty()) {
                             @OptIn(ExperimentalCoroutinesApi::class)
@@ -292,7 +299,8 @@ class KafkaCluster(
 
         override fun close() {
             consumer.wakeup()
-            pollingJob.cancel()
+            // closing commandCh is the shutdown signal; do not also cancel pollingJob —
+            // that races the select between observing closed-channel and observing cancellation
             commandCh.close()
             try {
                 runBlocking { withTimeout(30.seconds) { pollingJob.join() } }


### PR DESCRIPTION
The `database can resubscribe after unsubscribing` integration test was failing sporadically with `ClosedReceiveChannelException` thrown from the `SharedGroupConsumer` polling job. The exception surfaced as a test failure because it bubbles up as an unhandled coroutine exception on `Dispatchers.Default` and gets attributed to whichever test is currently running.

`SharedGroupConsumer.close()` was arming two independent shutdown signals at once — `pollingJob.cancel()` and `commandCh.close()` — but the polling loop only handled one of them gracefully. The select inside the loop sat on `commandCh.onReceive`, which throws when the channel is closed. If the channel-close branch resolved the select before cancellation reached the suspension point, the loop exited with `ClosedReceiveChannelException` instead of `CancellationException`, and the catch-all logged it as a poll-loop failure and rethrew.

Make channel close the sole shutdown signal.
The loop now uses `onReceiveCatching` and exits its `while` cleanly when the channel is closed. Cancellation from the parent scope is still handled correctly — the suspending `select` or `runInterruptible(consumer.poll)` throws `CancellationException` on cancel, which the existing `catch (CancellationException) { throw e }` arm matches.