### PR TITLE
test(indexer): make DST tests fail fast on Watchers failure

### DIFF
--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -103,6 +103,11 @@ class LogProcessorSimTest : SimulationTestBase() {
      */
     private inner class SimExtSource(actions: List<SimAction>) : ExternalSource {
         private val iterator = actions.iterator()
+        private val watchersList = mutableListOf<Watchers>()
+
+        fun watch(watchers: Watchers) {
+            watchersList += watchers
+        }
 
         var indexedCount = 0
             private set
@@ -110,7 +115,11 @@ class LogProcessorSimTest : SimulationTestBase() {
         var inFlight = 0
             private set
 
-        val isQuiescent: Boolean get() = !iterator.hasNext() && inFlight == 0
+        val isQuiescent: Boolean
+            get() {
+                watchersList.forEach { it.exception?.let { ex -> throw ex } }
+                return !iterator.hasNext() && inFlight == 0
+            }
 
         override suspend fun onPartitionAssigned(
             partition: Int,
@@ -168,6 +177,7 @@ class LogProcessorSimTest : SimulationTestBase() {
         val dbState = DatabaseState(dbName, blockCatalog, tableCatalog, trieCatalog, liveIndex)
 
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+            .also { simExtSource.watch(it) }
         val dbStorage = DatabaseStorage(srcLog, replicaLog, bp, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, uploadDispatcher = dispatcher)
         val crashLogger = CrashLogger(allocator, bp, "sim-node")

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -4,6 +4,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
@@ -57,14 +58,10 @@ class LogProcessorSimTest : SimulationTestBase() {
     fun setUp() {
         nodeBase = openBase(openMeterRegistry = false)
         allocator = nodeBase.allocator.newChildAllocator("test", 0, Long.MAX_VALUE)
-        this.srcLog = SimLog("src", dispatcher, rand)
-        this.replicaLog = SimLog("replica", dispatcher, rand)
     }
 
     @AfterEach
     fun tearDown() {
-        replicaLog.close()
-        srcLog.close()
         allocator.close()
         nodeBase.close()
     }
@@ -333,6 +330,9 @@ class LogProcessorSimTest : SimulationTestBase() {
     @RepeatableSimulationTest
     fun `single node processes txs and flush-blocks with rebalances`(@Suppress("unused") iteration: Int) =
         runTest(timeout = 5.seconds) {
+            srcLog = SimLog("src", dispatcher + coroutineContext.job, rand)
+            replicaLog = SimLog("replica", dispatcher + coroutineContext.job, rand)
+            try {
             val rowsPerBlock = rand.nextLong(15, 25)
             val totalActions = rand.nextInt(50, 100)
             val actions = buildActions(rand, totalActions)
@@ -342,7 +342,7 @@ class LogProcessorSimTest : SimulationTestBase() {
 
             MemoryStorage(allocator, epoch = 0).use { bp ->
                 SimNode("test-db", bp, IndexerConfig(rowsPerBlock = rowsPerBlock), simExtSource).use { node ->
-                    val logProcScope = CoroutineScope(dispatcher + Job())
+                    val logProcScope = CoroutineScope(dispatcher + Job(coroutineContext.job))
                     node.openLogProcessor(logProcScope).use { logProc ->
                         val groupJob = launch(dispatcher) { srcLog.openGroupSubscription(logProc) }
 
@@ -394,11 +394,18 @@ class LogProcessorSimTest : SimulationTestBase() {
                     }
                 }
             }
+            } finally {
+                replicaLog.close()
+                srcLog.close()
+            }
         }
 
     @RepeatableSimulationTest
     fun `stable leader with sustained throughput`(@Suppress("unused") iteration: Int) =
         runTest(timeout = 5.seconds) {
+            srcLog = SimLog("src", dispatcher + coroutineContext.job, rand)
+            replicaLog = SimLog("replica", dispatcher + coroutineContext.job, rand)
+            try {
             val rowsPerBlock = rand.nextLong(15, 25)
             val indexerConfig = IndexerConfig(rowsPerBlock = rowsPerBlock)
             val totalActions = rand.nextInt(50, 100)
@@ -411,9 +418,9 @@ class LogProcessorSimTest : SimulationTestBase() {
                 SimNode("test-db", bp, indexerConfig, simExtSource).use { leader ->
                     SimNode("test-db", bp, indexerConfig, simExtSource).use { followerA ->
                         SimNode("test-db", bp, indexerConfig, simExtSource).use { followerB ->
-                            val leaderScope = CoroutineScope(dispatcher + Job())
-                            val followerScopeA = CoroutineScope(dispatcher + Job())
-                            val followerScopeB = CoroutineScope(dispatcher + Job())
+                            val leaderScope = CoroutineScope(dispatcher + Job(coroutineContext.job))
+                            val followerScopeA = CoroutineScope(dispatcher + Job(coroutineContext.job))
+                            val followerScopeB = CoroutineScope(dispatcher + Job(coroutineContext.job))
 
                             leader.openLogProcessor(leaderScope).use { leaderProc ->
                                 followerA.openLogProcessor(followerScopeA).use { followerProcA ->
@@ -504,11 +511,18 @@ class LogProcessorSimTest : SimulationTestBase() {
                     }
                 }
             }
+            } finally {
+                replicaLog.close()
+                srcLog.close()
+            }
         }
 
     @RepeatableSimulationTest
     fun `multi-node leadership changes preserve block catalog consistency`(@Suppress("unused") iteration: Int) =
         runTest(timeout = 5.seconds) {
+            srcLog = SimLog("src", dispatcher + coroutineContext.job, rand)
+            replicaLog = SimLog("replica", dispatcher + coroutineContext.job, rand)
+            try {
             val rowsPerBlock = rand.nextLong(15, 25)
             val indexerConfig = IndexerConfig(rowsPerBlock = rowsPerBlock)
             val totalActions = rand.nextInt(50, 100)
@@ -520,8 +534,8 @@ class LogProcessorSimTest : SimulationTestBase() {
             MemoryStorage(allocator, epoch = 0).use { bp ->
                 SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeA ->
                     SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeB ->
-                        val scopeA = CoroutineScope(dispatcher + Job())
-                        val scopeB = CoroutineScope(dispatcher + Job())
+                        val scopeA = CoroutineScope(dispatcher + Job(coroutineContext.job))
+                        val scopeB = CoroutineScope(dispatcher + Job(coroutineContext.job))
 
                         nodeA.openLogProcessor(scopeA).use { logProcA ->
                             nodeB.openLogProcessor(scopeB).use { logProcB ->
@@ -601,6 +615,10 @@ class LogProcessorSimTest : SimulationTestBase() {
                         }
                     }
                 }
+            }
+            } finally {
+                replicaLog.close()
+                srcLog.close()
             }
         }
 }

--- a/core/src/test/kotlin/xtdb/indexer/SimLog.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLog.kt
@@ -9,6 +9,7 @@ import xtdb.api.log.MessageId
 import xtdb.util.MsgIdUtil
 import kotlin.coroutines.coroutineContext
 import xtdb.util.debug
+import xtdb.util.error
 import xtdb.util.logger
 import java.time.Instant
 import kotlin.coroutines.CoroutineContext
@@ -81,7 +82,14 @@ internal class SimLog<M>(private val name: String, ctx: CoroutineContext, privat
             if (lag > 0) {
                 val messageCount = rand.nextInt(1, lag + 1)
                 LOG.debug("$name/processMessages: delivering $messageCount group record(s) [$nextOffset..${nextOffset + messageCount - 1}] (lag=$lag)")
-                tailSpec.processor.processRecords(topic.subList(nextOffset, nextOffset + messageCount).toList())
+                try {
+                    tailSpec.processor.processRecords(topic.subList(nextOffset, nextOffset + messageCount).toList())
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    LOG.error(e, "$name/groupConsumer: processRecords failed")
+                    throw e
+                }
                 leader.nextOffset += messageCount
             }
 
@@ -105,7 +113,14 @@ internal class SimLog<M>(private val name: String, ctx: CoroutineContext, privat
                 if (lag > 0) {
                     val messageCount = rand.nextInt(1, lag + 1)
                     LOG.debug("$name/plainConsumer: delivering $messageCount record(s) [$nextOffset..${nextOffset + messageCount - 1}] (lag=$lag)")
-                    consumer.proc.processRecords(topic.subList(nextOffset, nextOffset + messageCount).toList())
+                    try {
+                        consumer.proc.processRecords(topic.subList(nextOffset, nextOffset + messageCount).toList())
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        LOG.error(e, "$name/plainConsumer: processRecords failed")
+                        throw e
+                    }
                     consumer.nextOffset += messageCount
                 }
             }

--- a/core/src/test/kotlin/xtdb/indexer/SimLog.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLog.kt
@@ -47,7 +47,7 @@ internal class SimLog<M>(private val name: String, ctx: CoroutineContext, privat
 
     var leader: GroupConsumer<M>? = null
 
-    val job = Job()
+    val job = Job(ctx[Job])
     private val scope = CoroutineScope(ctx + job)
 
     /**

--- a/core/src/test/kotlin/xtdb/indexer/SimLogTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLogTest.kt
@@ -1,0 +1,57 @@
+package xtdb.indexer
+
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import xtdb.SimulationTestBase
+import xtdb.api.log.Log
+import kotlin.time.Duration.Companion.seconds
+
+class SimLogTest : SimulationTestBase() {
+
+    @Test
+    fun `plainConsumer processRecords failure propagates via the parent scope`() = runTest(timeout = 5.seconds) {
+        val ex = assertThrows<IllegalStateException> {
+            coroutineScope {
+                SimLog<String>("test", dispatcher + coroutineContext.job, rand).use { log ->
+                    launch(dispatcher) {
+                        log.tailAll(afterMsgId = -1) { _ -> error("plainConsumer failure") }
+                    }
+
+                    log.appendMessage("trigger")
+                    yield()
+                }
+            }
+        }
+
+        assertEquals("plainConsumer failure", ex.message)
+    }
+
+    @Test
+    fun `group consumer processRecords failure propagates via the parent scope`() = runTest(timeout = 5.seconds) {
+        val ex = assertThrows<IllegalStateException> {
+            coroutineScope {
+                SimLog<String>("test", dispatcher + coroutineContext.job, rand).use { log ->
+                    val listener = object : Log.SubscriptionListener<String> {
+                        override suspend fun onPartitionsAssigned(partitions: Collection<Int>) =
+                            Log.TailSpec<String>(afterMsgId = -1L) { _ -> error("groupConsumer failure") }
+
+                        override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+                    }
+
+                    launch(dispatcher) { log.openGroupSubscription(listener) }
+
+                    log.appendMessage("trigger")
+                    yield()
+                }
+            }
+        }
+
+        assertEquals("groupConsumer failure", ex.message)
+    }
+}


### PR DESCRIPTION
Background context: the recent #5586 fix on `main` (`2ac2569ba`) was a two-line change, but it took a 50-minute CI hang to discover.
The DST harness in `LogProcessorSimTest` silently lost the underlying test failure — the receiver was throwing immediately, but nothing surfaced that to `runTest`, so CI timed out instead of failing with the actual exception.

This PR closes three independent gaps in the DST scaffolding so future bugs of the same shape fail fast.

## Gap 1: scopes weren't parented to the test

`SimLog`'s job and per-test `logProcScope` both used fresh `Job()`s — orphaned from the test's coroutine hierarchy.
Any failure in their internal coroutines could only surface via the JVM's default uncaught-exception handler (stderr) because there was no path back to `runTest`'s scope.

Parented both to `coroutineContext.job`.
`SimLog` construction moves from `@BeforeEach` into each test body so the test's `coroutineContext` is in scope; cleanup is via `try { ... } finally { close() }`.
Behaviour-preserving on happy paths — every test still cancels at the end of the body, every `.use` block still closes its resources.

## Gap 2: SimLog never caught processRecords failures

Production's `KafkaCluster.pollingJob` wraps `processRecords` in `try/catch (Throwable)` that logs ERROR and rethrows.
`SimLog` had no such wrapper — an exception killed the delivery loop silently.

Match the Kafka shape: catch + `LOG.error` + rethrow in both `plainConsumerLoop` and `deliverGroupRecords`.
Combined with Gap 1, the rethrow now lands in the parent scope's Job, which fails the surrounding `runTest`/`coroutineScope` with the original exception.
A 50-minute CI timeout becomes an immediate, attributable failure.

`SimLogTest` codifies the contract for both subscription paths (`tailAll` and `openGroupSubscription`).
Each test wraps the failing work in `coroutineScope { ... }` so the failure surfaces locally to `assertThrows` rather than failing the outer `runTest`.

## Gap 3: the drain loop didn't consult Watchers

`LeaderLogProcessor`'s `persisterJob` is intentionally silent on failure: the inner catch calls `watchers.notifyError(e)`, then the outer `catch (_: Throwable)` swallows the rethrow.
That's a production choice — the Database scope stays alive so queries still work after ingestion stops — but in DST it means the persister can fail without anything in the scope hierarchy carrying the failure up.
The knock-on: `SimExtSource`'s iterator stalls and the test driver's `while (!simExtSource.isQuiescent) yield()` loop spins forever.

`isQuiescent` now consults every registered `Watchers.exception` before returning the boolean.
`SimNode` registers its `watchers` with the shared `SimExtSource` at construction, so the property covers every node in the test.
Drain loops throw the captured `IngestionStoppedException` on the next iteration after Watchers transitions to Failed.

## Scope

No production code changes.
The leader's silent-swallow is deliberate and stays; the failure surfacing rides on `Watchers.exception`, which is already part of the public Watchers API used by `awaitTx`/`awaitSource`.

A more aggressive option — adding `Watchers.awaitFailure()` plus per-node watchdog coroutines so any Failed transition propagates to the test scope automatically — was considered and rejected.
It would change production Watchers semantics for a test-only use case, and the existing `Watchers.exception` accessor combined with the drain-loop check covers the gap.

## Test plan

- New `SimLogTest` (2 cases) passes — pins the rethrow contract for both subscription paths.
- `LogProcessorSimTest` passes at 100 iterations across all 3 methods.
- No production behaviour change to verify against.

Refs #5586