### PR TITLE
feat(observability): add replica log processing metrics

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -206,6 +206,7 @@ class Database(
                         allocator, storage.bufferPool, state, compactorForDb,
                         watchers, dbCatalog, pendingBlock, afterReplicaMsgId,
                         hasExternalSource = hasExternalSource,
+                        meterRegistry = base.meterRegistry,
                     )
 
                     override fun openLeaderSystem(

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -1,5 +1,8 @@
 package xtdb.indexer
 
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import org.apache.arrow.memory.BufferAllocator
@@ -35,8 +38,53 @@ class FollowerLogProcessor @JvmOverloads constructor(
     pendingBlock: PendingBlock?,
     afterReplicaMsgId: MessageId,
     private val hasExternalSource: Boolean,
+    private val meterRegistry: MeterRegistry? = null,
     private val maxBufferedRecords: Int = 1024,
 ) : LogProcessor.FollowerProcessor {
+
+    private val dbName = dbState.name
+
+    private fun processTimer(msgType: String): Timer? = meterRegistry?.let {
+        Timer.builder("xtdb.replica.process.timer")
+            .description("Time spent processing replica log records, by message type")
+            .tag("db", dbName)
+            .tag("msg.type", msgType)
+            .publishPercentiles(0.75, 0.85, 0.95, 0.98, 0.99, 0.999)
+            .register(it)
+    }
+
+    private val resolvedTxTimer = processTimer("ResolvedTx")
+    private val triesAddedTimer = processTimer("TriesAdded")
+    private val blockBoundaryTimer = processTimer("BlockBoundary")
+    private val blockUploadedTimer = processTimer("BlockUploaded")
+    private val triesDeletedTimer = processTimer("TriesDeleted")
+
+    private val blockBufferTimer: Timer? = meterRegistry?.let {
+        Timer.builder("xtdb.replica.block.buffer.timer")
+            .description("Time the follower spends buffering records between BlockBoundary and BlockUploaded")
+            .tag("db", dbName)
+            .publishPercentiles(0.75, 0.85, 0.95, 0.98, 0.99, 0.999)
+            .register(it)
+    }
+
+    private val bufferedRecordsSummary: DistributionSummary? = meterRegistry?.let {
+        DistributionSummary.builder("xtdb.replica.block.buffered.records")
+            .description("Number of records buffered while a follower waits for BlockUploaded")
+            .tag("db", dbName)
+            .register(it)
+    }
+
+    private var blockBufferStartSample: Timer.Sample? = null
+
+    private inline fun <R> Timer?.timed(block: () -> R): R {
+        if (this == null) return block()
+        val sample = Timer.start(meterRegistry!!)
+        try {
+            return block()
+        } finally {
+            sample.stop(this)
+        }
+    }
 
     override var pendingBlock: PendingBlock? = pendingBlock
         private set
@@ -58,7 +106,6 @@ class FollowerLogProcessor @JvmOverloads constructor(
         is ReplicaState.Failed -> s.msgId
     }
 
-    private val dbName = dbState.name
     private val blockCatalog = dbState.blockCatalog
     private val tableCatalog = dbState.tableCatalog
     private val trieCatalog = dbState.trieCatalog
@@ -85,7 +132,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
 
     private suspend fun processRecord(record: Log.Record<ReplicaMessage>) {
         when (val msg = record.message) {
-            is ReplicaMessage.ResolvedTx -> {
+            is ReplicaMessage.ResolvedTx -> resolvedTxTimer.timed {
                 liveIndex.importTx(msg)
 
                 val systemTime = msg.systemTime
@@ -120,17 +167,18 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 watchers.notifyTx(result, effectiveSrcMsgId, msg.externalSourceToken)
             }
 
-            is ReplicaMessage.TriesAdded -> {
+            is ReplicaMessage.TriesAdded -> triesAddedTimer.timed {
                 if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch)
                     addTries(msg.tries, record.logTimestamp)
 
                 watchers.notifyMsg(msg.sourceMsgId)
             }
 
-            is ReplicaMessage.BlockBoundary -> {
+            is ReplicaMessage.BlockBoundary -> blockBoundaryTimer.timed {
                 pendingBlock = PendingBlock(record.msgId, msg, maxBufferedRecords)
                 LOG.debug("[$dbName] block boundary b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=${record.msgId} — waiting for BlockUploaded...")
                 watchers.notifyMsg(msg.latestProcessedMsgId)
+                blockBufferStartSample = meterRegistry?.let { Timer.start(it) }
             }
 
             is ReplicaMessage.BlockUploaded -> error(
@@ -139,7 +187,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
 
             is ReplicaMessage.NoOp -> Unit
 
-            is ReplicaMessage.TriesDeleted -> {
+            is ReplicaMessage.TriesDeleted -> triesDeletedTimer.timed {
                 trieCatalog.deleteTries(TableRef.parse(dbState.name, msg.tableName), msg.trieKeys)
             }
         }
@@ -158,16 +206,22 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 && msg.storageEpoch == bufferPool.epoch
             ) {
                 LOG.debug("[$dbName] block uploaded b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=${record.msgId} (${pendingBlock.bufferedRecords.size} buffered)")
-                val block = parseFrom(bufferPool.getByteArray(blockFilePath(pendingBlockIdx)))
+                val bufferedRecords = blockUploadedTimer.timed {
+                    val block = parseFrom(bufferPool.getByteArray(blockFilePath(pendingBlockIdx)))
 
-                addTries(msg.tries, record.logTimestamp)
-                blockCatalog.refresh(block)
-                tableCatalog.updateFromBlockMetadata(blockCatalog.currentBlockIndex, liveIndex.blockMetadata())
-                liveIndex.nextBlock()
-                compactor.signalBlock()
+                    addTries(msg.tries, record.logTimestamp)
+                    blockCatalog.refresh(block)
+                    tableCatalog.updateFromBlockMetadata(blockCatalog.currentBlockIndex, liveIndex.blockMetadata())
+                    liveIndex.nextBlock()
+                    compactor.signalBlock()
 
-                val bufferedRecords = pendingBlock.bufferedRecords
-                this.pendingBlock = null
+                    val bufferedRecords = pendingBlock.bufferedRecords
+                    bufferedRecordsSummary?.record(bufferedRecords.size.toDouble())
+                    blockBufferTimer?.let { blockBufferStartSample?.stop(it) }
+                    blockBufferStartSample = null
+                    this.pendingBlock = null
+                    bufferedRecords
+                }
 
                 // replay buffered records — their typed notifications advance the watermarks
                 bufferedRecords.forEach { handleRecord(it) }

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -1,5 +1,7 @@
 package xtdb.indexer
 
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.*
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
@@ -8,7 +10,9 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import xtdb.api.TransactionKey
 import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
@@ -61,11 +65,13 @@ class FollowerLogProcessorTest {
     private fun makeProcessor(
         maxBufferedRecords: Int = 1024,
         hasExternalSource: Boolean = false,
+        meterRegistry: MeterRegistry? = null,
     ) =
         FollowerLogProcessor(
             allocator, bufferPool, dbState,
             compactor, watchers, null, null, afterReplicaMsgId = -1L,
             hasExternalSource = hasExternalSource,
+            meterRegistry = meterRegistry,
             maxBufferedRecords = maxBufferedRecords,
         )
 
@@ -218,6 +224,66 @@ class FollowerLogProcessorTest {
         verify { liveIndex.importTx(ext2) }
         assertEquals(1L, watchers.latestSourceMsgId,
             "latestSourceMsgId reflects only the source-log tx; ext-source txs leave it alone")
+
+        proc.close()
+    }
+
+    @Test
+    fun `records replica processing metrics`() = runTest {
+        val registry = SimpleMeterRegistry()
+        val proc = makeProcessor(meterRegistry = registry)
+
+        val blockProto = block { blockIndex = 0 }.toByteArray()
+        every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
+
+        proc.processRecords(listOf(
+            record(0, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap())),
+            record(1, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap())),
+            record(2, ReplicaMessage.BlockBoundary(0, 2)),
+            record(3, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 2, emptyList())),
+        ))
+
+        fun timerCount(msgType: String) = registry.find("xtdb.replica.process.timer")
+            .tags("db", "test", "msg.type", msgType)
+            .timer()?.count() ?: 0L
+
+        assertEquals(2L, timerCount("ResolvedTx"))
+        assertEquals(1L, timerCount("BlockBoundary"))
+        assertEquals(1L, timerCount("BlockUploaded"))
+
+        val bufferTimer = registry.find("xtdb.replica.block.buffer.timer").tag("db", "test").timer()
+        assertNotNull(bufferTimer, "block buffer timer should be registered")
+        assertEquals(1L, bufferTimer!!.count(), "one block buffer window")
+        assertTrue(bufferTimer.totalTime(java.util.concurrent.TimeUnit.NANOSECONDS) >= 0)
+
+        val bufferedRecords = registry.find("xtdb.replica.block.buffered.records").tag("db", "test").summary()
+        assertNotNull(bufferedRecords, "buffered records summary should be registered")
+        assertEquals(1L, bufferedRecords!!.count())
+        assertEquals(0.0, bufferedRecords.totalAmount(), "no records buffered when BlockUploaded follows BlockBoundary directly")
+
+        proc.close()
+    }
+
+    @Test
+    fun `buffered records summary captures size when records arrive between boundary and uploaded`() = runTest {
+        val registry = SimpleMeterRegistry()
+        val proc = makeProcessor(meterRegistry = registry)
+
+        val blockProto = block { blockIndex = 0 }.toByteArray()
+        every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
+
+        proc.processRecords(listOf(
+            record(0, ReplicaMessage.BlockBoundary(0, 0)),
+            // these get buffered while we wait for BlockUploaded
+            record(1, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap())),
+            record(2, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap())),
+            record(3, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 0, emptyList())),
+        ))
+
+        val bufferedRecords = registry.find("xtdb.replica.block.buffered.records").tag("db", "test").summary()
+        assertNotNull(bufferedRecords)
+        assertEquals(1L, bufferedRecords!!.count())
+        assertEquals(2.0, bufferedRecords.totalAmount(), "two records buffered between boundary and uploaded")
 
         proc.close()
     }


### PR DESCRIPTION
Closes #5606.
GH action runs: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Afeat%2Freplica-log-metrics

The follower-side replica log path was uninstrumented — `BlockUploader` has `block.upload.timer` but the follower's view of the same workflow was a black box. That makes it hard to tell whether a lagging follower is spending its time on `ResolvedTx` work, waiting for a `BlockUploaded` to land, or somewhere else.

Three new meters on `FollowerLogProcessor`, all tagged `db=<dbName>`:

- `xtdb.replica.process.timer` — per `handleRecord`, tagged `msg.type` so each `ReplicaMessage` variant is broken out independently.
- `xtdb.replica.block.buffer.timer` — wall time between `BlockBoundary` and the matching `BlockUploaded`.
- `xtdb.replica.block.buffered.records` — `DistributionSummary` of records buffered when the pending block resolves.

Percentiles match `block.upload.timer` (0.75 / 0.85 / 0.95 / 0.98 / 0.99 / 0.999) so the two views compare cleanly.

`MeterRegistry` is threaded through as a nullable constructor param mirroring `BlockUploader`.

## Test plan

- [x] Unit tests in `FollowerLogProcessorTest` covering per-message-type timers, the block-buffer window, and the buffered-records summary
- [x] `./gradlew :core:test --tests 'xtdb.indexer.FollowerLogProcessorTest'` passes