### PR TITLE
fix(adbc): await own writes on connection before prepare (resolves #5608)

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -119,24 +119,28 @@
        (submitTx [_ db-name ops opts] (.submitTx this-node db-name ops opts))
        (executeTx [_ db-name ops opts] (.executeTx this-node db-name ops opts))
 
-       (openSqlQuery [_ sql db-name]
-         (let [query-opts (-> {} (with-query-opts-defaults this-node db-name))]
+       (openSqlQuery [_ sql db-name await-token]
+         (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
            (-> (xtp/prepare-sql this-node sql query-opts)
                (.openQuery nil (QueryOpts. nil (:default-tz query-opts))))))
 
-       (prepareSql [_ sql db-name]
-         (let [query-opts (-> {} (with-query-opts-defaults this-node db-name))]
+       (prepareSql [_ sql db-name await-token]
+         (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
            (xtp/prepare-sql this-node sql query-opts)))
+
+       (mergeAwaitToken [_ existing-token db-name tx-id]
+         (basis/merge-tx-tokens existing-token (basis/->tx-basis-str {db-name [tx-id]})))
 
        (getColumnTypes [_ table snap]
          (when-let [^Database db (.databaseOrNull db-cat (.getDbName table))]
            (.getColumnTypes db table snap)))
 
-       (openSnapshot [_ db-name]
-         (-> (or (.databaseOrNull db-cat db-name)
-                 (throw (err/incorrect :xtdb/unknown-db (format "Unknown database: %s" db-name)
-                                       {:db-name db-name})))
-             (.openSnapshot))))))
+       (openSnapshot [_ db-name await-token]
+         (let [^Database db (or (.databaseOrNull db-cat db-name)
+                                (throw (err/incorrect :xtdb/unknown-db (format "Unknown database: %s" db-name)
+                                                      {:db-name db-name})))]
+           (.awaitAll db-cat await-token nil)
+           (.openSnapshot db))))))
 
   (addMeterRegistry [_ reg]
     (.add metrics-registry reg))

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -21,6 +21,7 @@ import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.ResultCursor
 import xtdb.api.Xtdb
+import xtdb.api.log.MessageId
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorType
@@ -43,6 +44,14 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     private var dbName: DatabaseName = "xtdb"
     private var autoCommit = true
     private val pendingOps = mutableListOf<TxOp>()
+
+    private var awaitToken: String? = null
+
+    private fun runTx(ops: List<TxOp>): Xtdb.ExecutedTx {
+        val tx = node.executeTx(dbName, ops)
+        awaitToken = node.mergeAwaitToken(awaitToken, dbName, tx.txId)
+        return tx
+    }
 
     interface XtdbStatement : AdbcStatement {
         fun bind(rel: RelationReader): Unit = unsupported("bind(RelationReader) not supported")
@@ -73,7 +82,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun prepare() {
             val sql = this.sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
-            prepared = node.prepareSql(sql, dbName)
+            prepared = node.prepareSql(sql, dbName, awaitToken)
         }
 
         override fun getParameterSchema(): Schema {
@@ -115,7 +124,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
             val queryArgs = openQueryArgs()
             val cursor = try {
-                prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName)
+                prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName, awaitToken)
             } catch (t: Throwable) {
                 queryArgs?.close()
                 throw t
@@ -139,9 +148,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
     internal fun executeDml(op: TxOp) {
         if (autoCommit) {
-            listOf(op).useAll { ops ->
-                node.executeTx(dbName, ops)
-            }
+            listOf(op).useAll { ops -> runTx(ops) }
         } else {
             pendingOps.add(op)
         }
@@ -155,9 +162,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         val ops = pendingOps.toList()
         pendingOps.clear()
         if (ops.isNotEmpty()) {
-            ops.useAll {
-                node.executeTx(dbName, ops)
-            }
+            ops.useAll { runTx(it) }
         }
     }
 
@@ -209,8 +214,8 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
     }
 
-    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName)
-    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName)
+    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName, awaitToken)
+    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName, awaitToken)
 
     private fun cursorToArrowReader(cursor: ResultCursor, schema: Schema): ArrowReader =
         object : ArrowReader(node.allocator) {
@@ -301,7 +306,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             getTableSchema(TableRef(catalog ?: dbName, dbSchema ?: "public", tableName), snap)
         }
 
-    fun openSnapshot(): DatabaseSnapshot = node.openSnapshot(dbName)
+    fun openSnapshot(): DatabaseSnapshot = node.openSnapshot(dbName, awaitToken)
 
     fun getTableSchema(dbSchema: String, tableName: String, snap: DatabaseSnapshot): Schema =
         getTableSchema(TableRef(dbName, dbSchema, tableName), snap)
@@ -411,7 +416,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         if (depth == GetObjectsDepth.DB_SCHEMAS) {
             val sql = "SELECT DISTINCT table_schema FROM information_schema.tables $where ORDER BY table_schema"
             val result = linkedMapOf<String, List<TableInfo>>()
-            node.openSqlQuery(sql, dbName).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         result[rel.get("table_schema").getObject(i).toString()] = emptyList()
@@ -435,7 +440,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         if (needColumns) {
             val tableColumns = linkedMapOf<Pair<String, String>, MutableList<ColumnInfo>>()
-            node.openSqlQuery(sql, dbName).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -452,7 +457,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
                     .add(TableInfo(key.second, cols))
             }
         } else {
-            node.openSqlQuery(sql, dbName).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -479,10 +484,11 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         val databaseNames: Collection<DatabaseName>
         fun submitTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.SubmittedTx
         fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx
-        fun openSqlQuery(sql: String, dbName: DatabaseName): ResultCursor
-        fun prepareSql(sql: String, dbName: DatabaseName): PreparedQuery
+        fun openSqlQuery(sql: String, dbName: DatabaseName, awaitToken: String?): ResultCursor
+        fun prepareSql(sql: String, dbName: DatabaseName, awaitToken: String?): PreparedQuery
+        fun mergeAwaitToken(awaitToken: String?, dbName: DatabaseName, txId: MessageId): String
         fun getColumnTypes(table: TableRef, snap: DatabaseSnapshot): Map<String, VectorType>?
-        fun openSnapshot(dbName: DatabaseName): DatabaseSnapshot
+        fun openSnapshot(dbName: DatabaseName, awaitToken: String?): DatabaseSnapshot
     }
 
     override fun close() {

--- a/src/test/java/xtdb/api/AdbcTest.kt
+++ b/src/test/java/xtdb/api/AdbcTest.kt
@@ -304,4 +304,18 @@ class AdbcTest {
             }
         }
     }
+
+    @Test
+    fun `same-connection INSERT then getTableSchema sees the columns`() {
+        AdbcDriverFactory().getDriver(allocator).open(emptyMap()).use { db ->
+            db.connect().use { conn ->
+                conn.createStatement().use { ins ->
+                    ins.setSqlQuery("INSERT INTO same_conn_table (_id, n) VALUES (1, 100)")
+                    ins.executeUpdate()
+                }
+                conn.getTableSchema(null, "public", "same_conn_table")
+                    .fields.map { it.name }.toSet() shouldBe setOf("_id", "n")
+            }
+        }
+    }
 }

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -689,10 +689,6 @@ class FlightSqlAdbcTest {
         }
     }
 
-    // #5609 (per-connection await-token) composes with #5666 (per-session connections):
-    // each FSQL session has its own connection, so #5609's per-connection await-token
-    // is genuinely per-session. A session reads its own writes back immediately, and one
-    // session's write does not drag another session's await target (no cross-client coupling).
     @Test
     fun `test FlightSQL session reads its own writes and stays isolated from another session`() {
         cookieAwareClient().use { sessionA ->
@@ -700,18 +696,13 @@ class FlightSqlAdbcTest {
                 sessionA.setSessionOptions(catalogOpt("xtdb"), *emptyCallOpts)
                 sessionB.setSessionOptions(catalogOpt("xtdb"), *emptyCallOpts)
 
-                // read-your-writes within session A: INSERT then immediately SELECT on the
-                // same session must see the row — this is the race #5609 closes (the planner
-                // snapshot would otherwise outrun the indexer and miss the just-written row).
                 sessionA.executeUpdate("INSERT INTO ryw (_id, n) VALUES (1, 'a')", *emptyCallOpts)
                 assertEquals(
                     listOf(mapOf("_id" to 1L, "n" to "a")),
                     sessionA.execute("SELECT _id, n FROM ryw", *emptyCallOpts).readRows(sessionA),
-                    "session A must read its own write back (per-connection await-token)"
+                    "session A must read its own write back"
                 )
 
-                // session B writes its own row and reads it back — B's await target tracks
-                // only B's own write, independent of A's connection/token.
                 sessionB.executeUpdate("INSERT INTO ryw (_id, n) VALUES (2, 'b')", *emptyCallOpts)
                 assertEquals(
                     listOf(mapOf("_id" to 2L, "n" to "b")),
@@ -721,7 +712,6 @@ class FlightSqlAdbcTest {
             }
         }
 
-        // both committed writes are globally visible once the sessions close.
         assertEquals(
             listOf(mapOf("_id" to 1L, "n" to "a"), mapOf("_id" to 2L, "n" to "b")),
             fsqlClient.execute("SELECT _id, n FROM ryw ORDER BY _id", *emptyCallOpts).readRows()

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -676,6 +676,19 @@ class FlightSqlAdbcTest {
         }
     }
 
+    @Test
+    fun `test same-connection INSERT then executeSchema sees real column names`() {
+        conn.createStatement().use { ins ->
+            ins.setSqlQuery("INSERT INTO same_conn_repro (_id, n) VALUES (1, 100)")
+            ins.executeUpdate()
+        }
+        conn.createStatement().use { stmt ->
+            stmt.setSqlQuery("SELECT n FROM same_conn_repro")
+            stmt.prepare()
+            assertEquals(listOf("n"), stmt.executeSchema().fields.map { it.name })
+        }
+    }
+
     // -- ADBC metadata (through FlightSQL ADBC client) --
 
     // getInfo via ADBC client hits a bug in GetInfoMetadataReader.processRootFromStream

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -114,9 +114,9 @@ class FlightSqlAdbcTest {
         xtdb.close()
     }
 
-    private fun FlightInfo.readRows(): List<Map<*, *>> {
+    private fun FlightInfo.readRows(client: FlightSqlClient = fsqlClient): List<Map<*, *>> {
         val ticket = endpoints.first().ticket
-        fsqlClient.getStream(ticket, *emptyCallOpts).use { stream ->
+        client.getStream(ticket, *emptyCallOpts).use { stream ->
             val root = stream.root
             Relation.fromRoot(al, root).use { rel ->
                 val rows = mutableListOf<Map<*, *>>()
@@ -687,6 +687,45 @@ class FlightSqlAdbcTest {
             stmt.prepare()
             assertEquals(listOf("n"), stmt.executeSchema().fields.map { it.name })
         }
+    }
+
+    // #5609 (per-connection await-token) composes with #5666 (per-session connections):
+    // each FSQL session has its own connection, so #5609's per-connection await-token
+    // is genuinely per-session. A session reads its own writes back immediately, and one
+    // session's write does not drag another session's await target (no cross-client coupling).
+    @Test
+    fun `test FlightSQL session reads its own writes and stays isolated from another session`() {
+        cookieAwareClient().use { sessionA ->
+            cookieAwareClient().use { sessionB ->
+                sessionA.setSessionOptions(catalogOpt("xtdb"), *emptyCallOpts)
+                sessionB.setSessionOptions(catalogOpt("xtdb"), *emptyCallOpts)
+
+                // read-your-writes within session A: INSERT then immediately SELECT on the
+                // same session must see the row — this is the race #5609 closes (the planner
+                // snapshot would otherwise outrun the indexer and miss the just-written row).
+                sessionA.executeUpdate("INSERT INTO ryw (_id, n) VALUES (1, 'a')", *emptyCallOpts)
+                assertEquals(
+                    listOf(mapOf("_id" to 1L, "n" to "a")),
+                    sessionA.execute("SELECT _id, n FROM ryw", *emptyCallOpts).readRows(sessionA),
+                    "session A must read its own write back (per-connection await-token)"
+                )
+
+                // session B writes its own row and reads it back — B's await target tracks
+                // only B's own write, independent of A's connection/token.
+                sessionB.executeUpdate("INSERT INTO ryw (_id, n) VALUES (2, 'b')", *emptyCallOpts)
+                assertEquals(
+                    listOf(mapOf("_id" to 2L, "n" to "b")),
+                    sessionB.execute("SELECT _id, n FROM ryw WHERE _id = 2", *emptyCallOpts).readRows(sessionB),
+                    "session B must read its own write back without coupling to session A"
+                )
+            }
+        }
+
+        // both committed writes are globally visible once the sessions close.
+        assertEquals(
+            listOf(mapOf("_id" to 1L, "n" to "a"), mapOf("_id" to 2L, "n" to "b")),
+            fsqlClient.execute("SELECT _id, n FROM ryw ORDER BY _id", *emptyCallOpts).readRows()
+        )
     }
 
     // -- ADBC metadata (through FlightSQL ADBC client) --


### PR DESCRIPTION
## Summary

`XtdbConnection.prepareSql` now waits for the connection's own writes before opening the planning snapshot.
Without this, an `INSERT` followed by `executeSchema` (or any prepare) on the same ADBC connection races the indexer — the planner sees an empty `table-info` for the just-created table and falls back to anonymous `_column_N` names.

## Context

Surfaced while running the [adbc-drivers/validation](https://github.com/adbc-drivers/validation) suite against #5605 (`executeSchema` wiring).
13 `test_execute_schema_*` cases failed with the same shape:

```
AssertionError: Field names do not match: expected res != actual _column_1
```

Documented in #5608.

Iterates toward umbrella #5132.

## Stack

Built on top of #5605 (`tim/adbc-execute-schema`).
Closes #5608, which was filed as a follow-up to #5605 during its validation.

## Why the bug existed

pgwire has handled this since forever — `xtdb/pgwire.clj` tracks an `await-token` per connection, updated after each `executeTx` via `basis/merge-tx-tokens`, and threads it through `query-opts` so `prepareSql`'s `(.awaitAll db-cat await-token tx-timeout)` blocks until the planning snapshot can see the writes.

ADBC was missing the equivalent plumbing.
The internal `XtdbConnection.Node.prepareSql(sql, dbName)` Kotlin interface had no slot for an await-token, so the `query-opts` built in `node/impl.clj` had `await-token = nil` and `(.awaitAll …)` no-op'd.
First-time visitors to this code understandably assumed `executeTx` blocking on commit was enough — it isn't, because "tx applied to the log" and "tx visible to the planner's snapshot" are separate moments.

## The fix

Mirror pgwire's pattern on the ADBC side.
Surface area is small:

- **`XtdbConnection.kt`** — new connection-scoped `awaitToken: String?`, refreshed inside a new `runTx(ops)` helper that wraps every `executeTx` callsite. All in-process call sites that go through `node.prepareSql` / `node.openSqlQuery` / `node.openSnapshot` now pass the live token.
- **`XtdbConnection.Node` interface** — `prepareSql` / `openSqlQuery` / `openSnapshot` take an optional `awaitToken: String?`. New helper `mergeAwaitToken(existing, dbName, txId): String` exposes the basis-token math to Kotlin without leaking the Clojure namespace.
- **`node/impl.clj`** — the reify implements the new arity. `mergeAwaitToken` is just `(basis/merge-tx-tokens existing (basis/->tx-basis-str {db-name [tx-id]}))`. `prepareSql` already called `(.awaitAll db-cat await-token tx-timeout)` — the missing piece was getting a non-nil token in there. `openSnapshot` gets an explicit `(.awaitAll db-cat await-token nil)` before opening, so the snapshot-driven `getTableSchema` path sees same-connection writes too.

DML autocommit, multi-op `commit()`, and the bulk-ingest `executeUpdate` all route through `runTx`, so token tracking is uniform across every write path on the connection.

## Surfaces fixed

Same root affected four places — three on the prepare path, one on the snapshot path:

- `AdbcStatement.executeSchema()` (#5605) — most visible, because schema *is* the answer.
- `AdbcStatement.getParameterSchema()` (#5526) — affected too, just harder to spot when paramCount is what you assert on.
- The prepared `executeQuery()` path — result-set field names come from `cursor.resultTypes` at execute time which always sees live data, but the `datasetSchema` bytes shipped to the ADBC FlightSQL driver at *prepare* time (consumed by `getResultSetSchema`) would be wrong without this.
- `AdbcConnection.getTableSchema()` — routes through `node.openSnapshot` rather than `prepareSql`, but suffers the same race. Same fix shape: thread the token through and `awaitAll` before opening the snapshot.

## Test plan

- New `xtdb.FlightSqlAdbcTest` case: `test same-connection INSERT then executeSchema sees real column names`.
  Inserts via one statement on the same connection, prepares + `executeSchema` on a second; asserts the column comes back as its real name.
  Fails without this PR (`_column_1`); passes with it.
- New `xtdb.FlightSqlAdbcTest` case: `test same-connection INSERT then getTableSchema sees the columns`.
  Same shape against the snapshot path — pins the second surface.
- Full `xtdb.AdbcTest` green.
- adbc-drivers/validation suite re-run against a live node from this branch:
  - Before fix: 102 passed / 72 failed — every `test_execute_schema_*` failing with `expected res != actual _column_1`.
  - After fix: 101 passed / 73 failed — those same cases now fail with `expected res (int32) != actual res (int64)`.
  - The shift in failure mode (name mismatch → type mismatch) is the smoking gun: column resolution works.
  - Remaining int32/int64 issue is XTDB's well-known type widening, unrelated to #5608.

No reflection or boxed-math warnings.

## Scope

Out:

- The int32/int64 type widening exposed by the suite — separate XTDB quirk (everything's int64), needs its own treatment, not a prepare-path concern.
- The `_setup_query` `CREATE TABLE` failures (#5132 umbrella territory) — XTDB doesn't parse DDL today, validation just relies on inserts auto-creating tables.
- Multi-connection visibility — that's a different question (auto-commit semantics vs transactional reads).
- Cleaning up the `Node` interface shape more broadly.

