### PR TITLE
fix(pgwire)!: simple JSON error detail; encoder handles VectorType

### DIFF
--- a/api/src/main/kotlin/xtdb/JsonLdSerde.kt
+++ b/api/src/main/kotlin/xtdb/JsonLdSerde.kt
@@ -26,9 +26,17 @@ import java.io.OutputStream
 import java.math.BigDecimal
 import java.time.*
 import java.util.*
+import org.apache.arrow.vector.types.pojo.Field
+import xtdb.arrow.VectorType
 import xtdb.table.TableRef
 import xtdb.time.Interval
 import xtdb.time.asInterval
+import xtdb.util.requiringResolve
+
+private val RENDER_TYPE by lazy { requiringResolve("xtdb.serde.types/render-type") }
+private val RENDER_FIELD by lazy { requiringResolve("xtdb.serde.types/render-field") }
+private val PARSE_TYPE by lazy { requiringResolve("xtdb.serde.types/->type") }
+private val PARSE_FIELD by lazy { requiringResolve("xtdb.serde.types/->field") }
 
 /**
  * JSON-LD serializer with @type/@value wrappers for non-native JSON types
@@ -124,6 +132,9 @@ object AnyJsonLdSerde : KSerializer<Any> {
                         )
                     }
 
+                    "xt:type" -> PARSE_TYPE.invoke(value.fromLdValue().toCljColl())
+                    "xt:field" -> PARSE_FIELD.invoke(value.fromLdValue().toCljColl())
+
                     in ANOMALY_TYPES -> toThrowable(
                         type,
                         value as? JsonObject ?: throw jsonIAEwithMessage(
@@ -144,6 +155,13 @@ object AnyJsonLdSerde : KSerializer<Any> {
     }
 
     fun Any?.toJsonLdElement(type: String) = mapOf("@type" to type, "@value" to toString()).toJsonLdElement()
+
+    private fun Any?.toCljColl(): Any? = when (this) {
+        is Map<*, *> -> PersistentHashMap.create(entries.associate { (k, v) -> k to v?.toCljColl() })
+        is Set<*> -> PersistentHashSet.create(map { it?.toCljColl() })
+        is List<*> -> PersistentVector.create(map { it?.toCljColl() })
+        else -> this
+    }
 
     fun Throwable.toJsonLdElement(): JsonElement {
         val type = when (this) {
@@ -202,6 +220,9 @@ object AnyJsonLdSerde : KSerializer<Any> {
             "@type" to "xt:table",
             "@value" to mapOf("db" to dbName, "schema" to schemaName, "table" to tableName)
         ).toJsonLdElement()
+
+        is VectorType -> mapOf("@type" to "xt:type", "@value" to RENDER_TYPE.invoke(this)).toJsonLdElement()
+        is Field -> mapOf("@type" to "xt:field", "@value" to RENDER_FIELD.invoke(this)).toJsonLdElement()
 
         is Throwable -> toJsonLdElement()
         else -> throw Incorrect("unknown type: ${this.javaClass.name}")

--- a/api/src/main/kotlin/xtdb/JsonSerde.kt
+++ b/api/src/main/kotlin/xtdb/JsonSerde.kt
@@ -12,7 +12,16 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
 import xtdb.AnyJsonLdSerde.fromLdValue
 import xtdb.AnyJsonLdSerde.toJsonLdElement
+import xtdb.error.Anomaly.Companion.CATEGORY
+import xtdb.error.Busy
+import xtdb.error.Conflict
+import xtdb.error.Fault
+import xtdb.error.Forbidden
 import xtdb.error.Incorrect
+import xtdb.error.Interrupted
+import xtdb.error.NotFound
+import xtdb.error.Unavailable
+import xtdb.error.Unsupported
 import java.io.InputStream
 import java.io.OutputStream
 import java.math.BigDecimal
@@ -21,6 +30,10 @@ import java.time.temporal.Temporal
 import java.util.*
 import xtdb.table.TableRef
 import xtdb.time.Interval
+import xtdb.util.requiringResolve
+
+private val PR_STR by lazy { requiringResolve("clojure.core/pr-str") }
+private val ERROR_CODE_KW = Keyword.intern("xtdb.error", "code")
 
 /**
  * Simple JSON serializer - non-native types become strings
@@ -57,8 +70,57 @@ object AnySerde : KSerializer<Any> {
         is Duration -> JsonPrimitive(toString())
         is Interval -> JsonPrimitive(toString())
         is TableRef -> toJsonLdElement()
-        is Throwable -> toJsonLdElement()
+        is Throwable -> toSimpleJsonElement()
         else -> throw Incorrect("unknown type: ${this.javaClass.name}")
+    }
+
+    fun Throwable.toSimpleJsonElement(): JsonElement {
+        val category = when (this) {
+            is Incorrect -> "incorrect"
+            is Unsupported -> "unsupported"
+            is Conflict -> "conflict"
+            is Fault -> "fault"
+            is Interrupted -> "interrupted"
+            is NotFound -> "not-found"
+            is Forbidden -> "forbidden"
+            is Busy -> "busy"
+            is Unavailable -> "unavailable"
+            else -> "error"
+        }
+        val rawData = (this as? IExceptionInfo)?.data as? Map<*, *> ?: emptyMap<Any, Any>()
+        val code = (rawData[ERROR_CODE_KW] as? Keyword)?.sym?.toString()
+        val displayData = rawData
+            .filterKeys { it != CATEGORY && it != ERROR_CODE_KW }
+            .mapKeys { (k, _) -> (k as? Keyword)?.sym?.toString() ?: k.toString() }
+
+        return buildJsonObject {
+            put("category", category)
+            code?.let { put("code", it) }
+            message?.let { put("message", it) }
+            if (displayData.isNotEmpty()) {
+                putJsonObject("data") {
+                    for ((k, v) in displayData) {
+                        put(k, v.toSimpleJsonValue())
+                    }
+                }
+            }
+        }
+    }
+
+    private fun Any?.toSimpleJsonValue(): JsonElement = when (this) {
+        null -> JsonNull
+        is String -> JsonPrimitive(this)
+        is Number -> JsonPrimitive(this)
+        is Boolean -> JsonPrimitive(this)
+        is Keyword -> JsonPrimitive(sym.toString())
+        is Symbol -> JsonPrimitive(toString())
+        is Map<*, *> -> JsonObject(entries.associate { (k, v) ->
+            val keyStr = (k as? Keyword)?.sym?.toString() ?: k?.toString() ?: "null"
+            keyStr to v.toSimpleJsonValue()
+        })
+        is Set<*> -> JsonArray(map { it.toSimpleJsonValue() })
+        is Collection<*> -> JsonArray(map { it.toSimpleJsonValue() })
+        else -> JsonPrimitive(PR_STR.invoke(this) as String)
     }
 
     override fun deserialize(decoder: Decoder) =

--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -176,7 +176,8 @@
                              to-col-type-head)
                   (contains? var-width-comparable-types to-col-type-head))
       (throw (err/unsupported :xtdb.group-by/unsupported-min-max-type
-                              "Unsupported type in min/max aggregate"
+                              (format "Unsupported type in min/max aggregate: %s"
+                                      (pr-str to-col-type))
                               {:unsupported-type to-col-type})))))
 
 (defn- min-max-factory
@@ -186,7 +187,8 @@
   (let [to-arrow-type (LeastUpperBound/of [from-type])
         to-type (or (some-> to-arrow-type types/->type)
                     (throw (err/incorrect :xtdb.group-by/incomparable-min-max-types
-                                          "Incomparable types in min/max aggregate"
+                                          (format "Incomparable types in min/max aggregate: %s"
+                                                  (pr-str from-type))
                                           {:from-type from-type})))]
     (assert-supported-min-max-type to-type)
 

--- a/src/test/clojure/xtdb/pgwire/authn_test.clj
+++ b/src/test/clojure/xtdb/pgwire/authn_test.clj
@@ -77,9 +77,13 @@
                    :localized-severity "ERROR",
                    :sql-state "28P01",
                    :message "Password authentication failed for user: test-user"
-                   :detail #xt/error [:incorrect :xtdb/authn-failed
-                                      "Password authentication failed for user: test-user"
-                                      {:status 401, :body {"access-token" nil, "refresh-token" nil, "expires-at" nil}}]}}]]
+                   :detail {"category" "incorrect"
+                            "code" "xtdb/authn-failed"
+                            "message" "Password authentication failed for user: test-user"
+                            "data" {"status" 401
+                                    "body" {"access-token" nil
+                                            "refresh-token" nil
+                                            "expires-at" nil}}}}}]]
                @!in-msgs)))))
 
 (deftest ^:integration test-oidc-client-credentials-auth-success
@@ -111,7 +115,7 @@
                    :localized-severity "ERROR",
                    :sql-state "28P01",
                    :message "Client credentials must be provided in the format 'client-id:client-secret'",
-                   :detail #xt/error [:incorrect :xtdb/invalid-client-credentials
-                                      "Client credentials must be provided in the format 'client-id:client-secret'"
-                                      {}]}}]]
+                   :detail {"category" "incorrect"
+                            "code" "xtdb/invalid-client-credentials"
+                            "message" "Client credentials must be provided in the format 'client-id:client-secret'"}}}]]
                @!in-msgs)))))

--- a/src/test/clojure/xtdb/pgwire_protocol_test.clj
+++ b/src/test/clojure/xtdb/pgwire_protocol_test.clj
@@ -220,9 +220,10 @@
                    :localized-severity "ERROR",
                    :sql-state "22P02",
                    :message "Text 'alan' could not be parsed at index 0"
-                   :detail #xt/error [:incorrect :xtdb.pgwire/invalid-arg-representation 
-                                      "Text 'alan' could not be parsed at index 0"
-                                      {:arg-idx 0, :arg-format :text}]}}]
+                   :detail {"category" "incorrect"
+                            "code" "xtdb.pgwire/invalid-arg-representation"
+                            "message" "Text 'alan' could not be parsed at index 0"
+                            "data" {"arg-idx" 0, "arg-format" "text"}}}}]
                 [:msg-ready {:status :idle}]]
                @!in-msgs)))))
 
@@ -293,9 +294,10 @@
                 [:msg-error-response {:error-fields
                                       {:severity "ERROR", :localized-severity "ERROR", :sql-state "08P01",
                                        :message "DML is not allowed in a READ ONLY transaction"
-                                       :detail #xt/error [:incorrect :xtdb/dml-in-read-only-tx 
-                                                          "DML is not allowed in a READ ONLY transaction"
-                                                          {:query "INSERT INTO foo RECORDS {_id: 1}"}]}}]
+                                       :detail {"category" "incorrect"
+                                                "code" "xtdb/dml-in-read-only-tx"
+                                                "message" "DML is not allowed in a READ ONLY transaction"
+                                                "data" {"query" "INSERT INTO foo RECORDS {_id: 1}"}}}}]
                 [:msg-ready {:status :idle}]]
 
                (test "SELECT 1 one; INSERT INTO foo RECORDS {_id: 1}"))))
@@ -306,9 +308,10 @@
                 [:msg-error-response {:error-fields
                                       {:severity "ERROR", :localized-severity "ERROR", :sql-state "08P01",
                                        :message "Queries are unsupported in a DML transaction"
-                                       :detail #xt/error [:incorrect :xtdb/queries-in-read-write-tx
-                                                          "Queries are unsupported in a DML transaction"
-                                                          {:query "SELECT 1 one"}]}}]
+                                       :detail {"category" "incorrect"
+                                                "code" "xtdb/queries-in-read-write-tx"
+                                                "message" "Queries are unsupported in a DML transaction"
+                                                "data" {"query" "SELECT 1 one"}}}}]
                 [:msg-ready {:status :idle}]]
 
                (test "INSERT INTO foo RECORDS {_id: 1}; SELECT 1 one"))))
@@ -327,7 +330,9 @@
                 [:msg-error-response {:error-fields
                                       {:severity "ERROR", :localized-severity "ERROR", :sql-state "08P01"
                                        :message "data exception - division by zero"
-                                       :detail #xt/error [:incorrect :xtdb.expression/division-by-zero "data exception - division by zero" {}]}}]
+                                       :detail {"category" "incorrect"
+                                                "code" "xtdb.expression/division-by-zero"
+                                                "message" "data exception - division by zero"}}}]
                 [:msg-ready {:status :failed-transaction}]]
                (test "BEGIN; SELECT 1/0 boom;"))))
 

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2470,6 +2470,28 @@ ORDER BY t.oid DESC LIMIT 1"
     (t/is (thrown-with-msg? PSQLException #"ERROR: Negative substring length"
                             (jdbc/execute! conn ["SELECT SUBSTRING('asf' FROM 0 FOR -1);"])))))
 
+(t/deftest test-anomaly-with-vector-type-encodes-on-json-pgwire
+  (xt/submit-tx tu/*node*
+                [[:put-docs :docs {:xt/id 1, :v 12}]
+                 [:put-docs :docs {:xt/id 2, :v #xt/zoned-date-time "2022-08-01T13:34+01:00[Europe/London]"}]])
+
+  (with-open [conn (pgjdbc-conn)]
+    (let [ex (try
+               (jdbc/execute! conn ["SELECT MAX(v) AS m FROM docs"])
+               (catch PSQLException e e))]
+      (t/is (instance? PSQLException ex))
+      (t/is (re-find #"Incomparable types in min/max aggregate" (.getMessage ex)))
+
+      (let [detail (some-> ^PSQLException ex .getServerErrorMessage .getDetail)
+            decoded (some-> detail JsonLdSerde/decodeJsonLd)
+            from-type (some-> decoded ex-data :from-type)]
+        (t/is (some? detail) "server sent a JSON-encoded error detail")
+        (t/is (instance? xtdb.error.Incorrect decoded)
+              "detail decodes back to the original anomaly type")
+        (t/is (re-find #"Incomparable types in min/max aggregate" (ex-message decoded)))
+        (t/is (instance? xtdb.arrow.VectorType from-type)
+              ":from-type round-tripped to a VectorType — encoder shipped canonical form")))))
+
 (def display-tables-query
   "
 SELECT n.nspname as \"Schema\",

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -720,13 +720,13 @@
        (testing "error during query execution"
          (send "select (1 / 0) from (values (42)) a (a);\n")
          (is (= ["ERROR:  data exception - division by zero"
-                 "DETAIL:  {\"@type\":\"xt:incorrect\",\"@value\":{\"xtdb.error/message\":\"data exception - division by zero\",\"xtdb.error/data\":{\"xtdb.error/code\":{\"@type\":\"xt:keyword\",\"@value\":\"xtdb.expression/division-by-zero\"}}}}"]
+                 "DETAIL:  {\"category\":\"incorrect\",\"code\":\"xtdb.expression/division-by-zero\",\"message\":\"data exception - division by zero\"}"]
                 (read :stderr)))
 
          (with-redefs [pgw/cmd-exec-query (fn [& _]  (throw (Exception. "unexpected")))]
            (send "select 1;\n")
            (is (= ["ERROR:  unexpected"
-                   "DETAIL:  {\"@type\":\"xt:fault\",\"@value\":{\"xtdb.error/message\":\"unexpected\",\"xtdb.error/data\":{\"xtdb.error/code\":{\"@type\":\"xt:keyword\",\"@value\":\"xtdb.error/unknown\"}}}}"]
+                   "DETAIL:  {\"category\":\"fault\",\"code\":\"xtdb.error/unknown\",\"message\":\"unexpected\"}"]
                   (read :stderr))))
 
          (with-redefs [pgw/cmd-exec-query (fn [& _]  (throw (ex-info "with pg code" {::pgw/severity :error, ::pgw/error-code "XXXXX"})))]
@@ -744,7 +744,7 @@
        (testing "error query"
          (send "INSERT INTO foo (id, a) VALUES (1, 2);\n")
          (is (= ["ERROR:  missing '_id'"
-                 "DETAIL:  {\"@type\":\"xt:incorrect\",\"@value\":{\"xtdb.error/message\":\"missing '_id'\",\"xtdb.error/data\":{\"doc\":{\"id\":1,\"a\":2},\"xtdb.error/code\":{\"@type\":\"xt:keyword\",\"@value\":\"missing-id\"}}}}"]
+                 "DETAIL:  {\"category\":\"incorrect\",\"code\":\"missing-id\",\"message\":\"missing '_id'\",\"data\":{\"doc\":{\"id\":1,\"a\":2}}}"]
                 (read :stderr)))
          ;; to drain the standard stream
          (read))
@@ -2470,7 +2470,7 @@ ORDER BY t.oid DESC LIMIT 1"
     (t/is (thrown-with-msg? PSQLException #"ERROR: Negative substring length"
                             (jdbc/execute! conn ["SELECT SUBSTRING('asf' FROM 0 FOR -1);"])))))
 
-(t/deftest test-anomaly-with-vector-type-encodes-on-json-pgwire
+(t/deftest test-min-max-incomparable-default-json-pgwire
   (xt/submit-tx tu/*node*
                 [[:put-docs :docs {:xt/id 1, :v 12}]
                  [:put-docs :docs {:xt/id 2, :v #xt/zoned-date-time "2022-08-01T13:34+01:00[Europe/London]"}]])
@@ -2481,16 +2481,39 @@ ORDER BY t.oid DESC LIMIT 1"
                (catch PSQLException e e))]
       (t/is (instance? PSQLException ex))
       (t/is (re-find #"Incomparable types in min/max aggregate" (.getMessage ex)))
+      (t/is (re-find #"#xt/type" (.getMessage ex))
+            "message includes the rendered VectorType (call-site enrichment)")
+
+      (let [detail (some-> ^PSQLException ex .getServerErrorMessage .getDetail)
+            decoded (some-> detail JsonSerde/decode)]
+        (t/is (some? detail) "server sent a JSON-encoded error detail")
+        (t/is (= "incorrect" (get decoded "category")))
+        (t/is (= "xtdb.group-by/incomparable-min-max-types" (get decoded "code")))
+        (t/is (re-find #"Incomparable types in min/max aggregate" (get decoded "message")))
+        (t/is (re-find #"#xt/type" (get-in decoded ["data" "from-type"]))
+              "data.from-type is the pr-str'd VectorType form")))))
+
+(t/deftest test-min-max-incomparable-json-ld-pgwire
+  (xt/submit-tx tu/*node*
+                [[:put-docs :docs {:xt/id 1, :v 12}]
+                 [:put-docs :docs {:xt/id 2, :v #xt/zoned-date-time "2022-08-01T13:34+01:00[Europe/London]"}]])
+
+  (with-open [conn (pgjdbc-conn)]
+    (jdbc/execute! conn ["SET fallback_output_format = 'json-ld'"])
+    (let [ex (try
+               (jdbc/execute! conn ["SELECT MAX(v) AS m FROM docs"])
+               (catch PSQLException e e))]
+      (t/is (instance? PSQLException ex))
+      (t/is (re-find #"Incomparable types in min/max aggregate" (.getMessage ex)))
 
       (let [detail (some-> ^PSQLException ex .getServerErrorMessage .getDetail)
             decoded (some-> detail JsonLdSerde/decodeJsonLd)
             from-type (some-> decoded ex-data :from-type)]
-        (t/is (some? detail) "server sent a JSON-encoded error detail")
+        (t/is (some? detail))
         (t/is (instance? xtdb.error.Incorrect decoded)
               "detail decodes back to the original anomaly type")
-        (t/is (re-find #"Incomparable types in min/max aggregate" (ex-message decoded)))
         (t/is (instance? xtdb.arrow.VectorType from-type)
-              ":from-type round-tripped to a VectorType — encoder shipped canonical form")))))
+              ":from-type round-tripped to a VectorType via the json-ld opt-in")))))
 
 (def display-tables-query
   "

--- a/src/test/kotlin/xtdb/JsonLdSerdeTest.kt
+++ b/src/test/kotlin/xtdb/JsonLdSerdeTest.kt
@@ -2,8 +2,11 @@ package xtdb
 
 import clojure.lang.Keyword
 import clojure.lang.Symbol
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import xtdb.arrow.VectorType
 import xtdb.error.Incorrect
 import xtdb.error.Unsupported
 import java.math.BigDecimal
@@ -159,5 +162,22 @@ class JsonLdSerdeTest {
               }
             }""".trimJson()
         )
+    }
+
+    @Test
+    fun `round-trips vector types`() {
+        VectorType.I64.assertRoundTrip(
+            """{"@type":"xt:type","@value":{"@type":"xt:keyword","@value":"i64"}}"""
+        )
+
+        VectorType.maybe(VectorType.I64).assertRoundTrip(
+            """{"@type":"xt:type","@value":[{"@type":"xt:keyword","@value":"?"},{"@type":"xt:keyword","@value":"i64"}]}"""
+        )
+    }
+
+    @Test
+    fun `round-trips fields`() {
+        Field("foo", FieldType.notNullable(VectorType.I64.arrowType), emptyList())
+            .assertRoundTrip("""{"@type":"xt:field","@value":{"foo":{"@type":"xt:keyword","@value":"i64"}}}""")
     }
 }

--- a/src/test/kotlin/xtdb/JsonSerdeTest.kt
+++ b/src/test/kotlin/xtdb/JsonSerdeTest.kt
@@ -115,7 +115,7 @@ class JsonSerdeTest {
             data = mapOf("a" to 1L),
         ))
         assertEquals(
-            """{"@type":"xt:incorrect","@value":{"xtdb.error/message":"sort your request out!","xtdb.error/data":{"xtdb.error/code":{"@type":"xt:keyword","@value":"xtdb/malformed-req"},"a":1}}}""",
+            """{"category":"incorrect","code":"xtdb/malformed-req","message":"sort your request out!","data":{"a":1}}""",
             json
         )
     }
@@ -128,7 +128,7 @@ class JsonSerdeTest {
             mapOf("a" to 1L)
         ))
         assertEquals(
-            """{"@type":"xt:unsupported","@value":{"xtdb.error/message":"ruh roh.","xtdb.error/data":{"xtdb.error/code":{"@type":"xt:keyword","@value":"xtdb/boom"},"a":1}}}""",
+            """{"category":"unsupported","code":"xtdb/boom","message":"ruh roh.","data":{"a":1}}""",
             json
         )
     }


### PR DESCRIPTION
Refs #4472

## Context

A `MAX` over a column with mixed `i64` and `timestamptz` values dropped the pgwire connection with `EOFException` client-side and no server-side log line.
The aggregator was correctly throwing `Incorrect` with `:from-type from-type` (a `VectorType`) in ex-data, but `JsonSerde.encodeToBytes(ex)` on the default `:json` fallback delegates Throwables to `JsonLdSerde`'s encoder, which had no case for `VectorType` and threw on `"unknown type"`.
The thrown `Incorrect` escaped `send-ex` (it's inside `handle-msg`'s `catch Throwable`), unwound through `conn-loop`, and fell through `connect`'s outer try — whose catches cover `SocketException`/`EOFException`/`IOException`/`Interrupted` but not `Incorrect`.
The `finally` closed the socket cleanly (FIN), no `ErrorResponse` was written, and the server logged nothing because every pgwire error path is at debug.

So any anomaly carrying an encoder-unknown type in ex-data silently takes down the pgwire connection on the default `:json` path.
`:from-type` in `group_by.clj`'s min/max factory is one trigger; `:field` (an Arrow `Field`) in `indexer.clj:39` has the same shape.

## Two commits, separable

**Commit 1 (non-breaking): encoder cases for `VectorType`/`Field`.**
Adds the missing cases to `JsonLdSerde` using Clojure's existing `xtdb.serde.types/render-type`/`render-field` via `requiringResolve` — the same canonical wire form already used by REPL `print-method`, transit handlers, and `information_schema.columns.data_type`.
Also: `group_by.clj`'s min/max error messages now `pr-str` the offending type into the message itself, so the user-visible string carries the diagnostic info without needing to decode the structured detail.

**Commit 2 (breaking): `JsonSerde` no longer delegates Throwables to JSON-LD.**
The default `:json` path now emits plain JSON for error details — `{"category":"...","code":"...","message":"...","data":{...}}` — with recursive JSON encoding of ex-data values (Maps → JSON objects, Sets/Collections → JSON arrays, Keywords/Symbols → strings, unknowns → `pr-str`).
Continues the JSON-LD surface-area reduction begun by 9eb556328 (which moved result rows to simple JSON by default but kept the Throwable carve-out delegating to JsonLdSerde).
The `:json-ld` opt-in path is unchanged.

## Breaking change

The pgwire `Detail` field shape on the default `:json` `fallback_output_format` changes from JSON-LD (`{"@type":"xt:incorrect","@value":{...}}`) to plain JSON.
Clients that were parsing the JSON-LD form on the default path need to update their parser.
`fallback_output_format = 'json-ld'` preserves the previous error-detail shape but also flips result-row encoding to JSON-LD.

## Scope

- The encoder fix covers `VectorType` and `Field`. Other types in ex-data that aren't natively JSON-encodable still fall through to `pr-str` (rendering as a Clojure-printer string).
- The min/max message enrichment via `pr-str` is applied only to `group_by.clj`'s two call sites. The wider err/* surface (~245 sites) audit isn't in scope here.
- JSON-LD support isn't removed — see #4472 for that history.

## Test plan

- [x] `test-min-max-incomparable-default-json-pgwire` — vanilla pgjdbc, asserts no EOF, message carries rendered type, detail parses as plain JSON with the expected fields.
- [x] `test-min-max-incomparable-json-ld-pgwire` — same trigger with `SET fallback_output_format = 'json-ld'`, asserts the detail round-trips back to a typed `Incorrect` with a `VectorType` `:from-type`.
- [x] `JsonLdSerdeTest`: round-trip tests for `VectorType` and `Field`.
- [x] `JsonSerdeTest`: updated `shouldSerializeIncorrect`/`shouldSerializeUnsupported` for the new simple-JSON shape.
- [x] Existing wire-protocol tests updated where they previously asserted JSON-LD detail.
- [x] Full `:test` green (1475 tests). The two updated integration tests in `pgwire/authn_test.clj` verified locally.

Generated with Claude Code