### PR TITLE
feat: Add replica log processing metrics to monitoring dashboard.

### DIFF
--- a/monitoring/dev-dashboards/xtdb-monitoring.json
+++ b/monitoring/dev-dashboards/xtdb-monitoring.json
@@ -2225,7 +2225,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 110
+            "y": 40
           },
           "id": 39,
           "options": {
@@ -2265,6 +2265,543 @@
           ],
           "title": "Follower / Leader ($database)",
           "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "description": "Cluster-average (quantile(0.5, …) across the published percentile series) of handleRecord time, broken out per ReplicaMessage variant. The \"what does steady state look like\" view — ResolvedTx carries the per-tx baseline, TriesAdded / TriesDeleted should sit close to zero, and BlockBoundary / BlockUploaded show how long routine block-transition work takes when nothing is contended. Pair with the p99 panel: if p50 stays flat while p99 climbs, the followers are seeing occasional stalls rather than a uniform slowdown.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 46
+          },
+          "id": 48,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "quantile(0.5, xtdb_replica_process_timer_seconds{db=\"$database\"}) by (msg_type)",
+              "legendFormat": "{{msg_type}} p50",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Replica record processing — p50 by message type",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "description": "p99 of handleRecord time, broken out per ReplicaMessage variant. The follower's primary \"where is time going under load\" view — a healthy replica's ResolvedTx line dominates everything else; TriesAdded / TriesDeleted should stay flat and cheap; BlockUploaded spikes are expected once per block but shouldn't trend up over time. If BlockBoundary rises noticeably, suspect contention on the pending-block setup path. Compare with the p50 panel to disambiguate \"everything's slower\" from \"tail-only stalls\".",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 46
+          },
+          "id": 50,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "quantile(0.99, xtdb_replica_process_timer_seconds{db=\"$database\"}) by (msg_type)",
+              "legendFormat": "{{msg_type}} p99",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Replica record processing — p99 by message type",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "description": "Records-per-second handled by the follower, split by message type. Together with Panel 1 this tells the \"busy vs slow\" story: a flat p99 with rising throughput is healthy; rising p99 with flat throughput is the case that warrants investigation. Also the simplest \"is the follower receiving anything?\" signal.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 46
+          },
+          "id": 51,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "sum by (msg_type) (rate(xtdb_replica_process_timer_seconds_count{db=\"$database\"}[1m]))",
+              "legendFormat": "{{msg_type}}/s",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Replica record throughput — by message type",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "description": "Time the follower spends with a pendingBlock open — from receiving BlockBoundary to receiving the matching BlockUploaded (i.e. waiting for the leader's BlockUploader to finish writing and announce the block). Pair with the leader's Block Uploaded Timer panel: if the follower's buffer window is large but the leader's upload timer is small, the lag is in propagation (log / message bus); if both are large, the upload itself is the bottleneck.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 55
+          },
+          "id": 52,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.5, xtdb_replica_block_buffer_timer_seconds{db=\"$database\"})",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Average Cluster",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.99, xtdb_replica_block_buffer_timer_seconds{db=\"$database\"})",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "99% Cluster",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.999, xtdb_replica_block_buffer_timer_seconds{db=\"$database\"})",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "99.9% Cluster",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Block buffer window",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "description": "How many replica records get buffered between a BlockBoundary and its matching BlockUploaded. 0 is the happy path — BlockUploaded followed BlockBoundary with no intervening traffic. Sustained non-zero values mean the follower is receiving txs faster than the leader is finishing block uploads, so each block window catches more in-flight records; if max approaches maxBufferedRecords (default 1024) the processor will start applying back-pressure on the log.\n\nThe underlying meter is a DistributionSummary with no published percentiles, so we plot the peak (_max) and the per-block mean (_sum / _count over a window). For a true distribution view, add .publishPercentiles(...) to the meter and switch to a quantile(…) aggregation.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 55
+          },
+          "id": 53,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "max(xtdb_replica_block_buffered_records_max{db=\"$database\"})",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "peak",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(xtdb_replica_block_buffered_records_sum{db=\"$database\"}[1m])) / sum(rate(xtdb_replica_block_buffered_records_count{db=\"$database\"}[1m]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "mean per block (1m)",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Records buffered per block",
+          "type": "timeseries"
         }
       ],
       "repeat": "database",
@@ -2272,7 +2809,7 @@
       "type": "row"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2280,547 +2817,548 @@
         "y": 32
       },
       "id": 42,
-      "panels": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "description": "Whether a replication stream is currently open to Postgres for this source. Should be 1 in steady state; 0 while the source is supposed to be running indicates we've lost the stream — check wal_lag_bytes and the node logs for cause. Distinct from \"are events flowing\" (use last_event_time and events/s for that) — this answers specifically \"is the partition processor alive and streaming\".",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-RdYlGr"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "inactive"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "active"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": 0
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 3,
+            "x": 0,
+            "y": 65
+          },
+          "id": 47,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "xtdb_postgres_source_connection_state{source=\"$postgres_source\", source_type=\"postgres\"}",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "connection",
+              "range": true,
+              "refId": "C",
+              "useBackend": false
+            }
+          ],
+          "title": "Connection",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "description": "Wall-clock time of the most recently applied source commit, surfaced as an absolute timestamp so an operator can read it at a glance. Reads `N/A` before any event has landed (the underlying gauge sits at 0). The complementary \"is anything still flowing\" signal is the gap between this value and `time()` — use it alongside `wal_lag_bytes` to disambiguate a silent slot from a busy one.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "index": 0,
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "dateTimeAsIsoNoDateIfToday"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 3,
+            "x": 3,
+            "y": 65
+          },
+          "id": 45,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "xtdb_postgres_source_last_event_time_seconds{source=\"$postgres_source\", source_type=\"postgres\"} * 1000",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "last event",
+              "range": true,
+              "refId": "C",
+              "useBackend": false
+            }
+          ],
+          "title": "Last event time",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "description": "Bytes between pg_current_wal_lsn() and the slot's confirmed_flush_lsn on the source database, read lazily on every Prometheus scrape (so cadence matches your scrape interval). The most accurate freshness signal — it doesn't depend on us receiving events, so a stalled slot will show growing lag here even if commit_lag_seconds looks fine. A small steady value (a few hundred KB at most) is normal; a sustained climb means we're falling behind the source's write rate.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 6,
+            "y": 65
+          },
+          "id": 43,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "xtdb_postgres_source_wal_lag_bytes{source=\"$postgres_source\", source_type=\"postgres\"}",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "lag bytes",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "WAL Lag",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "description": "Events and commits per second over a 1m window. Useful as a \"is anything happening?\" baseline; tail latency panels above tell you about quality, this tells you about quantity.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 12,
+            "y": 65
+          },
+          "id": 46,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "rate(xtdb_postgres_source_events_total{source=\"$postgres_source\", source_type=\"postgres\"}[1m])",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "events/s",
+              "range": true,
+              "refId": "C",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "rate(xtdb_postgres_source_commits_total{source=\"$postgres_source\", source_type=\"postgres\"}[1m])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "commits/s",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Throughput",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "description": "Distribution of now − sourceCommitTime at the point we apply each tx. Measures the end-to-end latency from a write committing on Postgres to it being indexed in XT, but only when traffic is flowing — a silent slot keeps this gauge frozen on its last value. Compare with WAL lag to disambiguate \"no events\" from \"slow events\".",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 18,
+            "y": 65
+          },
+          "id": 44,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "quantile(0.5, xtdb_postgres_source_commit_lag_seconds{source=\"$postgres_source\", source_type=\"postgres\"})",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "Average Cluster",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "quantile(0.99, xtdb_postgres_source_commit_lag_seconds{source=\"$postgres_source\", source_type=\"postgres\"})",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "99% Cluster",
+              "range": true,
+              "refId": "B",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "DS_PROMETHEUS"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "quantile(0.999, xtdb_postgres_source_commit_lag_seconds{source=\"$postgres_source\", source_type=\"postgres\"})",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "99.9% Cluster",
+              "range": true,
+              "refId": "C",
+              "useBackend": false
+            }
+          ],
+          "title": "Commit lag (apply-time)",
+          "type": "timeseries"
+        }
+      ],
       "repeat": "postgres_source",
       "title": "Postgres source - $postgres_source",
       "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "DS_PROMETHEUS"
-      },
-      "description": "Whether a replication stream is currently open to Postgres for this source. Should be 1 in steady state; 0 while the source is supposed to be running indicates we've lost the stream — check wal_lag_bytes and the node logs for cause. Distinct from \"are events flowing\" (use last_event_time and events/s for that) — this answers specifically \"is the partition processor alive and streaming\".",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-RdYlGr"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "index": 1,
-                  "text": "inactive"
-                },
-                "1": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "active"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 3,
-        "x": 0,
-        "y": 33
-      },
-      "id": 47,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "DS_PROMETHEUS"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "xtdb_postgres_source_connection_state{source=\"$postgres_source\", source_type=\"postgres\"}",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "connection",
-          "range": true,
-          "refId": "C",
-          "useBackend": false
-        }
-      ],
-      "title": "Connection",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "DS_PROMETHEUS"
-      },
-      "description": "Wall-clock time of the most recently applied source commit, surfaced as an absolute timestamp so an operator can read it at a glance. Reads `N/A` before any event has landed (the underlying gauge sits at 0). The complementary \"is anything still flowing\" signal is the gap between this value and `time()` — use it alongside `wal_lag_bytes` to disambiguate a silent slot from a busy one.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "index": 0,
-                  "text": "N/A"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "dateTimeAsIsoNoDateIfToday"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 3,
-        "x": 3,
-        "y": 33
-      },
-      "id": 45,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "DS_PROMETHEUS"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "xtdb_postgres_source_last_event_time_seconds{source=\"$postgres_source\", source_type=\"postgres\"} * 1000",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "last event",
-          "range": true,
-          "refId": "C",
-          "useBackend": false
-        }
-      ],
-      "title": "Last event time",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "DS_PROMETHEUS"
-      },
-      "description": "Bytes between pg_current_wal_lsn() and the slot's confirmed_flush_lsn on the source database, read lazily on every Prometheus scrape (so cadence matches your scrape interval). The most accurate freshness signal — it doesn't depend on us receiving events, so a stalled slot will show growing lag here even if commit_lag_seconds looks fine. A small steady value (a few hundred KB at most) is normal; a sustained climb means we're falling behind the source's write rate.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 33
-      },
-      "id": 43,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "DS_PROMETHEUS"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "xtdb_postgres_source_wal_lag_bytes{source=\"$postgres_source\", source_type=\"postgres\"}",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "lag bytes",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "WAL Lag",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "DS_PROMETHEUS"
-      },
-      "description": "Events and commits per second over a 1m window. Useful as a \"is anything happening?\" baseline; tail latency panels above tell you about quality, this tells you about quantity.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 33
-      },
-      "id": 46,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "DS_PROMETHEUS"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "rate(xtdb_postgres_source_events_total{source=\"$postgres_source\", source_type=\"postgres\"}[1m])",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "events/s",
-          "range": true,
-          "refId": "C",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "DS_PROMETHEUS"
-          },
-          "editorMode": "code",
-          "expr": "rate(xtdb_postgres_source_commits_total{source=\"$postgres_source\", source_type=\"postgres\"}[1m])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "commits/s",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Throughput",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "DS_PROMETHEUS"
-      },
-      "description": "Distribution of now − sourceCommitTime at the point we apply each tx. Measures the end-to-end latency from a write committing on Postgres to it being indexed in XT, but only when traffic is flowing — a silent slot keeps this gauge frozen on its last value. Compare with WAL lag to disambiguate \"no events\" from \"slow events\".",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 33
-      },
-      "id": 44,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "DS_PROMETHEUS"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "quantile(0.5, xtdb_postgres_source_commit_lag_seconds{source=\"$postgres_source\", source_type=\"postgres\"})",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "Average Cluster",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "DS_PROMETHEUS"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "quantile(0.99, xtdb_postgres_source_commit_lag_seconds{source=\"$postgres_source\", source_type=\"postgres\"})",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "99% Cluster",
-          "range": true,
-          "refId": "B",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "DS_PROMETHEUS"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "quantile(0.999, xtdb_postgres_source_commit_lag_seconds{source=\"$postgres_source\", source_type=\"postgres\"})",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "99.9% Cluster",
-          "range": true,
-          "refId": "C",
-          "useBackend": false
-        }
-      ],
-      "title": "Commit lag (apply-time)",
-      "type": "timeseries"
     },
     {
       "collapsed": true,
@@ -2828,7 +3366,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 33
       },
       "id": 14,
       "panels": [
@@ -2899,7 +3437,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 464
+            "y": 66
           },
           "id": 15,
           "options": {
@@ -3004,7 +3542,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 464
+            "y": 66
           },
           "id": 16,
           "options": {
@@ -3126,7 +3664,7 @@
             "h": 7,
             "w": 6,
             "x": 12,
-            "y": 464
+            "y": 66
           },
           "id": 21,
           "options": {
@@ -3231,7 +3769,7 @@
             "h": 7,
             "w": 6,
             "x": 18,
-            "y": 464
+            "y": 66
           },
           "id": 17,
           "options": {
@@ -3336,7 +3874,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 471
+            "y": 73
           },
           "id": 18,
           "options": {
@@ -3458,7 +3996,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 471
+            "y": 73
           },
           "id": 19,
           "options": {
@@ -3563,7 +4101,7 @@
             "h": 7,
             "w": 6,
             "x": 12,
-            "y": 471
+            "y": 73
           },
           "id": 25,
           "options": {
@@ -3668,7 +4206,7 @@
             "h": 7,
             "w": 6,
             "x": 18,
-            "y": 471
+            "y": 73
           },
           "id": 26,
           "options": {
@@ -3773,7 +4311,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 478
+            "y": 80
           },
           "id": 29,
           "options": {
@@ -3878,7 +4416,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 478
+            "y": 80
           },
           "id": 30,
           "options": {
@@ -3951,7 +4489,7 @@
             "h": 7,
             "w": 6,
             "x": 12,
-            "y": 478
+            "y": 80
           },
           "id": 12,
           "options": {
@@ -4061,7 +4599,7 @@
             "h": 7,
             "w": 6,
             "x": 18,
-            "y": 478
+            "y": 80
           },
           "id": 11,
           "options": {
@@ -4189,7 +4727,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 485
+            "y": 87
           },
           "id": 13,
           "options": {
@@ -4350,7 +4888,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 485
+            "y": 87
           },
           "id": 40,
           "options": {
@@ -4468,5 +5006,5 @@
   "timezone": "browser",
   "title": "XTDB: Monitoring Dashboard",
   "uid": "aeews5bgs0zk0b",
-  "version": 20
+  "version": 23
 }

--- a/monitoring/public-dashboards/xtdb-monitoring.json
+++ b/monitoring/public-dashboards/xtdb-monitoring.json
@@ -2290,7 +2290,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 110
+            "y": 40
           },
           "id": 39,
           "options": {
@@ -2330,6 +2330,555 @@
           ],
           "title": "Follower / Leader ($database)",
           "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Cluster-average (quantile(0.5, …) across the published percentile series) of handleRecord time, broken out per ReplicaMessage variant. The \"what does steady state look like\" view — ResolvedTx carries the per-tx baseline, TriesAdded / TriesDeleted should sit close to zero, and BlockBoundary / BlockUploaded show how long routine block-transition work takes when nothing is contended. Pair with the p99 panel: if p50 stays flat while p99 climbs, the followers are seeing occasional stalls rather than a uniform slowdown.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 46
+          },
+          "id": 48,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "quantile(0.5, xtdb_replica_process_timer_seconds{db=\"$database\"}) by (msg_type)",
+              "legendFormat": "{{msg_type}} p50",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              }
+            }
+          ],
+          "title": "Replica record processing — p50 by message type",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "p99 of handleRecord time, broken out per ReplicaMessage variant. The follower's primary \"where is time going under load\" view — a healthy replica's ResolvedTx line dominates everything else; TriesAdded / TriesDeleted should stay flat and cheap; BlockUploaded spikes are expected once per block but shouldn't trend up over time. If BlockBoundary rises noticeably, suspect contention on the pending-block setup path. Compare with the p50 panel to disambiguate \"everything's slower\" from \"tail-only stalls\".",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 46
+          },
+          "id": 50,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "quantile(0.99, xtdb_replica_process_timer_seconds{db=\"$database\"}) by (msg_type)",
+              "legendFormat": "{{msg_type}} p99",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              }
+            }
+          ],
+          "title": "Replica record processing — p99 by message type",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Records-per-second handled by the follower, split by message type. Together with Panel 1 this tells the \"busy vs slow\" story: a flat p99 with rising throughput is healthy; rising p99 with flat throughput is the case that warrants investigation. Also the simplest \"is the follower receiving anything?\" signal.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 46
+          },
+          "id": 51,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "sum by (msg_type) (rate(xtdb_replica_process_timer_seconds_count{db=\"$database\"}[1m]))",
+              "legendFormat": "{{msg_type}}/s",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              }
+            }
+          ],
+          "title": "Replica record throughput — by message type",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Time the follower spends with a pendingBlock open — from receiving BlockBoundary to receiving the matching BlockUploaded (i.e. waiting for the leader's BlockUploader to finish writing and announce the block). Pair with the leader's Block Uploaded Timer panel: if the follower's buffer window is large but the leader's upload timer is small, the lag is in propagation (log / message bus); if both are large, the upload itself is the bottleneck.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 55
+          },
+          "id": 52,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.5, xtdb_replica_block_buffer_timer_seconds{db=\"$database\"})",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Average Cluster",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.99, xtdb_replica_block_buffer_timer_seconds{db=\"$database\"})",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "99% Cluster",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.999, xtdb_replica_block_buffer_timer_seconds{db=\"$database\"})",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "99.9% Cluster",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Block buffer window",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "How many replica records get buffered between a BlockBoundary and its matching BlockUploaded. 0 is the happy path — BlockUploaded followed BlockBoundary with no intervening traffic. Sustained non-zero values mean the follower is receiving txs faster than the leader is finishing block uploads, so each block window catches more in-flight records; if max approaches maxBufferedRecords (default 1024) the processor will start applying back-pressure on the log.\n\nThe underlying meter is a DistributionSummary with no published percentiles, so we plot the peak (_max) and the per-block mean (_sum / _count over a window). For a true distribution view, add .publishPercentiles(...) to the meter and switch to a quantile(…) aggregation.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 55
+          },
+          "id": 53,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "max(xtdb_replica_block_buffered_records_max{db=\"$database\"})",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "peak",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(xtdb_replica_block_buffered_records_sum{db=\"$database\"}[1m])) / sum(rate(xtdb_replica_block_buffered_records_count{db=\"$database\"}[1m]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "mean per block (1m)",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Records buffered per block",
+          "type": "timeseries"
         }
       ],
       "repeat": "database",
@@ -2395,7 +2944,7 @@
             "h": 7,
             "w": 3,
             "x": 0,
-            "y": 117
+            "y": 129
           },
           "id": 47,
           "options": {
@@ -2477,7 +3026,7 @@
             "h": 7,
             "w": 3,
             "x": 3,
-            "y": 117
+            "y": 129
           },
           "id": 45,
           "options": {
@@ -2587,7 +3136,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 117
+            "y": 129
           },
           "id": 43,
           "options": {
@@ -2692,7 +3241,7 @@
             "h": 7,
             "w": 6,
             "x": 12,
-            "y": 117
+            "y": 129
           },
           "id": 46,
           "options": {
@@ -2811,7 +3360,7 @@
             "h": 7,
             "w": 6,
             "x": 18,
-            "y": 117
+            "y": 129
           },
           "id": 44,
           "options": {
@@ -2965,7 +3514,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 548
+            "y": 169
           },
           "id": 15,
           "options": {
@@ -3070,7 +3619,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 548
+            "y": 169
           },
           "id": 16,
           "options": {
@@ -3192,7 +3741,7 @@
             "h": 7,
             "w": 6,
             "x": 12,
-            "y": 548
+            "y": 169
           },
           "id": 21,
           "options": {
@@ -3297,7 +3846,7 @@
             "h": 7,
             "w": 6,
             "x": 18,
-            "y": 548
+            "y": 169
           },
           "id": 17,
           "options": {
@@ -3402,7 +3951,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 555
+            "y": 176
           },
           "id": 18,
           "options": {
@@ -3524,7 +4073,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 555
+            "y": 176
           },
           "id": 19,
           "options": {
@@ -3629,7 +4178,7 @@
             "h": 7,
             "w": 6,
             "x": 12,
-            "y": 555
+            "y": 176
           },
           "id": 25,
           "options": {
@@ -3734,7 +4283,7 @@
             "h": 7,
             "w": 6,
             "x": 18,
-            "y": 555
+            "y": 176
           },
           "id": 26,
           "options": {
@@ -3839,7 +4388,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 562
+            "y": 183
           },
           "id": 29,
           "options": {
@@ -3944,7 +4493,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 562
+            "y": 183
           },
           "id": 30,
           "options": {
@@ -4017,7 +4566,7 @@
             "h": 7,
             "w": 6,
             "x": 12,
-            "y": 562
+            "y": 183
           },
           "id": 12,
           "options": {
@@ -4127,7 +4676,7 @@
             "h": 7,
             "w": 6,
             "x": 18,
-            "y": 562
+            "y": 183
           },
           "id": 11,
           "options": {
@@ -4255,7 +4804,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 569
+            "y": 190
           },
           "id": 13,
           "options": {
@@ -4416,7 +4965,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 569
+            "y": 190
           },
           "id": 40,
           "options": {
@@ -4517,13 +5066,13 @@
     ]
   },
   "time": {
-    "from": "2026-05-12T12:16:59.668Z",
-    "to": "2026-05-12T12:50:22.521Z"
+    "from": "now-5m",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "XTDB: Monitoring Dashboard",
   "uid": "aeews5bgs0zk0b",
-  "version": 21,
+  "version": 24,
   "weekStart": ""
 }


### PR DESCRIPTION
Added some visualizations against the metrics introduced in #5607 to the monitoring dashboard - the following are added under the $database repeating row (ie, we graph these per database):
<img width="3701" height="1075" alt="image" src="https://github.com/user-attachments/assets/36a503b0-b447-4f3b-ba3c-f3ec50b89d7f" />

 