### PR TITLE
fix(database): hand DETACH close off to a closer scope (resolves #5613)

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -47,6 +47,7 @@ import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import java.time.Duration
 import java.util.*
+import kotlin.concurrent.Volatile
 
 private val LOG = Database::class.logger
 
@@ -82,6 +83,10 @@ class Database(
 
     val latestProcessedMsgId: MessageId get() = watchers.latestSourceMsgId
     val ingestionError: IngestionStoppedException? get() = watchers.exception
+
+    @Volatile
+    var isClosing: Boolean = false
+        internal set
 
     fun awaitTxBlocking(txId: Long, timeout: Duration? = null): TransactionResult? =
         runBlocking {

--- a/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
@@ -1,5 +1,11 @@
 package xtdb.database
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import xtdb.NodeBase
 import xtdb.compactor.Compactor
 import xtdb.database.proto.DatabaseConfig
@@ -11,24 +17,32 @@ import xtdb.table.DatabaseName
 import xtdb.util.closeAll
 import xtdb.util.closeOnCatch
 import xtdb.util.debug
+import xtdb.util.error
 import xtdb.util.logger
 import xtdb.util.warn
 import java.util.concurrent.ConcurrentHashMap
 
 private val LOG = DatabaseCatalog::class.logger
 
-class DatabaseCatalog(
+class DatabaseCatalog @JvmOverloads constructor(
     private val base: NodeBase,
     private val indexer: Indexer,
     private val compactor: Compactor,
+    closerDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : Database.Catalog, AutoCloseable {
 
     private val databases = ConcurrentHashMap<DatabaseName, Database>()
     private val dormantDatabases = ConcurrentHashMap<DatabaseName, DatabaseConfig>()
 
-    override val databaseNames: Collection<DatabaseName> get() = databases.keys.toSet()
+    // Closing databases stay in `databases` until their close completes — see #5613.
+    private val closerJob = SupervisorJob()
+    private val closerScope = CoroutineScope(closerJob + closerDispatcher)
 
-    override fun databaseOrNull(dbName: DatabaseName): Database? = databases[dbName]
+    override val databaseNames: Collection<DatabaseName>
+        get() = databases.entries.asSequence().filter { !it.value.isClosing }.map { it.key }.toSet()
+
+    override fun databaseOrNull(dbName: DatabaseName): Database? =
+        databases[dbName]?.takeUnless { it.isClosing }
 
     override val serialisedSecondaryDatabases: Map<DatabaseName, DatabaseConfig>
         get() {
@@ -40,7 +54,16 @@ class DatabaseCatalog(
     private val skipDbs: Set<String> get() = base.config.skipDbs
 
     override fun attach(dbName: DatabaseName, config: Database.Config?) {
-        if (databases.containsKey(dbName) || dormantDatabases.containsKey(dbName))
+        databases[dbName]?.let { existing ->
+            if (existing.isClosing)
+                throw Conflict(
+                    "Database is still being detached — retry once the previous detach has completed",
+                    "xtdb/db-being-detached",
+                    mapOf("db-name" to dbName)
+                )
+            throw Conflict("Database already exists", "xtdb/db-exists", mapOf("db-name" to dbName))
+        }
+        if (dormantDatabases.containsKey(dbName))
             throw Conflict("Database already exists", "xtdb/db-exists", mapOf("db-name" to dbName))
 
         val dbConfig = config ?: Database.Config()
@@ -73,24 +96,42 @@ class DatabaseCatalog(
 
         if (dormantDatabases.remove(dbName) != null) return
 
-        val db = databases.remove(dbName)
+        val db = databases[dbName]
             ?: throw NotFound("Database does not exist", "xtdb/no-such-db", mapOf("db-name" to dbName))
 
-        db.close()
+        if (db.isClosing)
+            throw NotFound("Database does not exist", "xtdb/no-such-db", mapOf("db-name" to dbName))
+
+        // Close off the persister's stack — see #5613.
+        db.isClosing = true
+        closerScope.launch {
+            try {
+                db.close()
+            } catch (t: Throwable) {
+                LOG.error(t) { "Failed to close detaching database '$dbName'" }
+            } finally {
+                databases.remove(dbName, db)
+            }
+        }
     }
 
     override fun close() {
+        // Join without cancelling — cancelling would interrupt each db.close() mid-teardown.
+        runBlocking { closerJob.children.toList().forEach { it.join() } }
+        closerJob.cancel()
         databases.values.closeAll()
         indexer.close()
     }
 
     companion object {
         @JvmStatic
+        @JvmOverloads
         fun open(
             base: NodeBase,
+            closerDispatcher: CoroutineDispatcher = Dispatchers.IO,
         ): DatabaseCatalog {
             val indexer = base.indexerFactory.create(base)
-            val catalog = DatabaseCatalog(base, indexer, base.compactor)
+            val catalog = DatabaseCatalog(base, indexer, base.compactor, closerDispatcher)
 
             catalog.closeOnCatch {
                 val conf = base.config

--- a/core/src/test/kotlin/xtdb/database/DatabaseCatalogTest.kt
+++ b/core/src/test/kotlin/xtdb/database/DatabaseCatalogTest.kt
@@ -1,0 +1,40 @@
+package xtdb.database
+
+import clojure.lang.Keyword
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import xtdb.NodeBase
+import xtdb.error.Conflict
+
+class DatabaseCatalogTest {
+
+    private val ERROR_CODE = Keyword.intern("xtdb.error", "code")
+
+    private fun Conflict.errCode(): String? = (data.valAt(ERROR_CODE) as? Keyword)?.toString()?.removePrefix(":")
+
+    @Test
+    fun `reattach during detach returns transient conflict (#5613)`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+
+        NodeBase.openBase(openMeterRegistry = false).use { base ->
+            DatabaseCatalog.open(base, dispatcher).use { catalog ->
+                catalog.attach("test_db", Database.Config())
+                // close is enqueued on the paused dispatcher
+                catalog.detach("test_db")
+
+                val ex = assertThrows<Conflict> {
+                    catalog.attach("test_db", Database.Config())
+                }
+                assertEquals("xtdb/db-being-detached", ex.errCode())
+
+                // drain the closer, then re-attach succeeds
+                scheduler.advanceUntilIdle()
+                catalog.attach("test_db", Database.Config())
+            }
+        }
+    }
+}

--- a/docs/src/content/docs/about/dbs-in-xtdb.md
+++ b/docs/src/content/docs/about/dbs-in-xtdb.md
@@ -5,6 +5,14 @@ title: Databases in XTDB
 <details>
   <summary>Changelog (last updated v2.2)</summary>
 
+v2.2: DETACH DATABASE is asynchronous
+
+: `DETACH` returns once the database is hidden from queries; resource teardown continues in the background — see ['Attaching/Detaching secondary databases'](#attachingdetaching-secondary-databases-v21) below.
+
+  Previously `DETACH` blocked until all resources were released, which could deadlock when detaching a Kafka-backed secondary.
+
+  No upgrade steps needed; if you script rapid `DETACH X; ATTACH X` flows, handle the new `xtdb/db-being-detached` error by retrying.
+
 v2.2: single-writer indexing
 
 : Indexing within a database is now single-writer — see ['Database architecture'](#database-architecture) above for how it works today.
@@ -267,6 +275,9 @@ $$
 ```
 
 - To detach a database, send `DETACH DATABASE my_secondary`.
+
+  (v2.2+) `DETACH` returns once the database is no longer queryable; resource cleanup (closing the log subscription, flushing buffers) continues in the background.
+  Re-attaching the same name before cleanup completes returns a transient `xtdb/db-being-detached` conflict — clients should retry.
 - **Read-only mode (v2.2+)**: specify `mode: 'read-only'` in the configuration to attach a database read-only.
   A read-only cluster still indexes transactions locally so it can serve queries, but it won't write blocks to the object store or compact — it pauses at block boundaries and picks up blocks written by another (read-write) cluster on the same database instead.
 

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -491,4 +491,31 @@ class KafkaClusterTest {
                 job2.cancelAndJoin()
             }
         }
+
+    @Test
+    @Timeout(value = 30, unit = java.util.concurrent.TimeUnit.SECONDS)
+    fun `DETACH on Kafka-backed secondary completes promptly (#5613)`() {
+        val primaryTopic = "kafka-detach-primary-${UUID.randomUUID()}"
+        val secondaryTopic = "kafka-detach-secondary-${UUID.randomUUID()}"
+
+        Xtdb.openNode {
+            server { port = 0 }; flightSql = null
+            logCluster("kafka", KafkaCluster.ClusterFactory(container.bootstrapServers))
+            log(KafkaCluster.LogFactory("kafka", primaryTopic))
+        }.use { node ->
+            node.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute(
+                        """
+                        ATTACH DATABASE secondary WITH ${'$'}${'$'}
+                            log: !Kafka
+                              cluster: kafka
+                              topic: $secondaryTopic
+                        ${'$'}${'$'}""".trimIndent()
+                    )
+                    stmt.execute("DETACH DATABASE secondary")
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
DETACH on a Kafka-backed secondary used to deadlock.
The primary's persister processed the DETACH record, called dbCatalog.detach which called db.close, which ran runBlocking { cancelAndJoin } on the secondary's scope.
That transitively waited for openGroupSubscription's finally to call unregister on the shared Kafka consumer, which posted to commandCh and parked on the polling actor.
The actor was already parked on task.onComplete.await for the same persister.
Three-way cycle.

The fix is structural: get db.close off the persister's call stack.
DatabaseCatalog now owns a closerScope; detach marks the database closing, launches db.close on that scope, and removes the entry from the databases map in the launch's finally.
The persister returns immediately and completes its task; the actor's await unblocks; the actor services the eventually-posted Unregister at its leisure.

A new Database.isClosing flag lets the catalog hide the database from queries (databaseOrNull, databaseNames) the moment DETACH returns, even though resources are still being reclaimed in the background.
The entry stays in the databases map until the closer's job completes, which keeps same-name reattach blocked on the existing name-conflict check — surfaced via a distinct error code (xtdb/db-being-detached) with a retry-able message.

The trade we're accepting: DETACH no longer waits for resources to be released.
Rapid same-name reattach (DETACH X; ATTACH X back-to-back) gets a transient Conflict during the close window with the new error code, and the client retries.

Refs #5613
Related #5622
