### PR TITLE
fix(kafka)!: seek to topic beginning when there's no prior anchor

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -263,6 +263,10 @@ class FollowerLogProcessor @JvmOverloads constructor(
         LOG.debug("[$dbName] transition: replica watchers caught up to $target")
     }
 
+    override fun notifyError(e: Throwable) {
+        replicaState.value = ReplicaState.Failed(latestReplicaMsgId, e)
+    }
+
     override fun close() {
         allocator.close()
     }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -41,6 +41,7 @@ class LogProcessor(
     interface FollowerProcessor : Processor<ReplicaMessage> {
         val pendingBlock: PendingBlock?
         suspend fun awaitReplicaMsgId(target: MessageId)
+        fun notifyError(e: Throwable)
     }
 
     private val dbName = dbState.name
@@ -90,7 +91,13 @@ class LogProcessor(
                 }
             }
 
-            FollowerSystem(proc, scope.launch { replicaLog.tailAll(latestReplicaMsgId, proc) })
+            FollowerSystem(proc, scope.launch {
+                try {
+                    replicaLog.tailAll(latestReplicaMsgId, proc)
+                } catch (e: Throwable) {
+                    proc.notifyError(e); throw e
+                }
+            })
         }
 
     @Volatile

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -159,6 +159,7 @@ class KafkaCluster(
             val epoch: Int,
             val listener: Log.SubscriptionListener<M>,
             var processor: Log.RecordProcessor<M>?,
+            val completion: CompletableDeferred<Unit> = CompletableDeferred(),
         ) {
             // expecting a load of change here for multi-part.
 
@@ -228,7 +229,10 @@ class KafkaCluster(
                 }
 
                 is GroupCommand.Unregister -> {
-                    subscriptions.remove(cmd.topic)?.listener?.onPartitionsRevokedSync(listOf(0))
+                    subscriptions.remove(cmd.topic)?.let { sub ->
+                        sub.listener.onPartitionsRevokedSync(listOf(0))
+                        sub.completion.complete(Unit)
+                    }
                     applySubscriptions()
                     cmd.cont.resume(Unit)
                 }
@@ -284,10 +288,12 @@ class KafkaCluster(
             topic: String,
             codec: MessageCodec<M>,
             epoch: Int,
-            listener: Log.SubscriptionListener<M>
-        ) {
-            commandCh.send(GroupCommand.Register(topic, TopicSubscription(codec, epoch, listener, null)))
+            listener: Log.SubscriptionListener<M>,
+        ): TopicSubscription<M> {
+            val sub = TopicSubscription(codec, epoch, listener, null)
+            commandCh.send(GroupCommand.Register(topic, sub))
             consumer.wakeup()
+            return sub
         }
 
         suspend fun unregister(topic: String) {
@@ -575,10 +581,10 @@ class KafkaCluster(
         }
 
         override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>) {
-            sharedGroupConsumer.register(topic, codec, epoch, listener)
+            val sub = sharedGroupConsumer.register(topic, codec, epoch, listener)
             LOG.info { "registered group subscription for topic '$topic'" }
             try {
-                suspendCancellableCoroutine<Unit> { } // wait until cancelled
+                sub.completion.await()
             } finally {
                 withContext(NonCancellable) { sharedGroupConsumer.unregister(topic) }
             }

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -88,6 +88,12 @@ private fun KafkaConfigMap.openProducer() =
         ByteArraySerializer()
     )
 
+private fun KafkaConsumer<*, *>.resolveSeekOffset(tp: TopicPartition, epoch: Int, afterMsgId: MessageId): LogOffset {
+    val previousOffset = afterMsgIdToOffset(epoch, afterMsgId)
+    val seekFromBeginning = previousOffset < 0L
+    return if (seekFromBeginning) beginningOffsets(listOf(tp))[tp] ?: 0L else previousOffset + 1
+}
+
 private fun KafkaConfigMap.openConsumer() =
     KafkaConsumer(
         mapOf(
@@ -169,7 +175,7 @@ class KafkaCluster(
                 listener.onPartitionsAssigned(listOf(tp.partition()))
                     ?.let { tailSpec ->
                         processor = tailSpec.processor
-                        consumer.seek(tp, afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1)
+                        consumer.seek(tp, consumer.resolveSeekOffset(tp, epoch, tailSpec.afterMsgId))
                     }
             }
 
@@ -588,7 +594,7 @@ class KafkaCluster(
             kafkaConfigMap.openConsumer().use { c ->
                 val tp = TopicPartition(topic, 0)
                 c.assign(listOf(tp))
-                c.seek(tp, afterMsgIdToOffset(epoch, afterMsgId) + 1)
+                c.seek(tp, c.resolveSeekOffset(tp, epoch, afterMsgId))
 
                 while (isActive) {
                     val records = runInterruptible(Dispatchers.IO) { c.pollRecords() }

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
@@ -92,7 +93,7 @@ private fun KafkaConfigMap.openConsumer() =
         mapOf(
             "enable.auto.commit" to "false",
             "isolation.level" to "read_committed",
-            "auto.offset.reset" to "latest",
+            "auto.offset.reset" to "none",
             "partition.assignment.strategy" to "org.apache.kafka.clients.consumer.CooperativeStickyAssignor",
         ) + this,
         UnitDeserializer,
@@ -144,6 +145,7 @@ class KafkaCluster(
     private sealed interface GroupCommand {
         class Register(val topic: String, val subscription: SharedGroupConsumer.TopicSubscription<*>) : GroupCommand
         class Unregister(val topic: String, val cont: CancellableContinuation<Unit>) : GroupCommand
+        class UnregisterOnFailure(val topics: Collection<String>, val cause: Throwable) : GroupCommand
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -236,6 +238,16 @@ class KafkaCluster(
                     applySubscriptions()
                     cmd.cont.resume(Unit)
                 }
+
+                // No `onPartitionsRevokedSync` — the subscriber learns about the failure via
+                // `completion.completeExceptionally`; firing the revoke would also trigger
+                // LogProcessor's leader→follower transition during a Failed-state cleanup.
+                is GroupCommand.UnregisterOnFailure -> {
+                    for (topic in cmd.topics) {
+                        subscriptions.remove(topic)?.completion?.completeExceptionally(cmd.cause)
+                    }
+                    applySubscriptions()
+                }
             }
         }
 
@@ -264,13 +276,18 @@ class KafkaCluster(
                         if (subscriptions.isNotEmpty()) {
                             @OptIn(ExperimentalCoroutinesApi::class)
                             onTimeout(0.milliseconds) {
-                                consumer.pollRecords()?.let { consumerRecords ->
-                                    for ((topic, recs) in consumerRecords.groupBy { it.topic() }) {
-                                        val sub = subscriptions[topic]
-                                            ?: error("Received records for unsubscribed topic $topic")
+                                try {
+                                    consumer.pollRecords()?.let { consumerRecords ->
+                                        for ((topic, recs) in consumerRecords.groupBy { it.topic() }) {
+                                            val sub = subscriptions[topic]
+                                                ?: error("Received records for unsubscribed topic $topic")
 
-                                        sub.processRecords(recs)
+                                            sub.processRecords(recs)
+                                        }
                                     }
+                                } catch (e: OffsetOutOfRangeException) {
+                                    LOG.error(e) { "evicting subscriptions for OffsetOutOfRange partitions: ${e.partitions()}" }
+                                    processCommand(GroupCommand.UnregisterOnFailure(e.partitions().map { it.topic() }.toSet(), e))
                                 }
                             }
                         }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -756,4 +756,174 @@ class KafkaClusterTest {
                 "primary must remain healthy after detaching the failed secondary")
         }
     }
+
+    @Test
+    @Timeout(value = 30, unit = java.util.concurrent.TimeUnit.SECONDS)
+    fun `tailAll picks up records appended past a truncated prefix when starting fresh`() = runBlocking {
+        val topic = "trunc-fresh-${UUID.randomUUID()}"
+        val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
+        val subscriber = mockk<RecordProcessor<SourceMessage>> {
+            coEvery { processRecords(capture(msgs)) } returns Unit
+        }
+
+        KafkaCluster.ClusterFactory(container.bootstrapServers)
+            .pollDuration(Duration.ofMillis(100))
+            .open().use { cluster ->
+                KafkaCluster.LogFactory("my-cluster", topic)
+                    .openSourceLog(mapOf("my-cluster" to cluster))
+                    .use { log ->
+                        log.seedAndTruncate(topic, count = 20, truncateBefore = 20L)
+                        log.appendMessage(txMessage(1))
+                        log.appendMessage(txMessage(2))
+                        log.appendMessage(txMessage(3))
+
+                        val job = launch { log.tailAll(-1L, subscriber) }
+                        try {
+                            withTimeoutOrNull(5.seconds) {
+                                while (synchronized(msgs) { msgs.flatten().size } < 3) delay(100.milliseconds)
+                            }
+                        } finally {
+                            job.cancelAndJoin()
+                        }
+                    }
+            }
+
+        assertEquals(3, synchronized(msgs) { msgs.flatten().size })
+    }
+
+    @Test
+    @Timeout(value = 30, unit = java.util.concurrent.TimeUnit.SECONDS)
+    fun `openGroupSubscription picks up records appended past a truncated prefix when starting fresh`() = runBlocking {
+        val topic = "trunc-fresh-grp-${UUID.randomUUID()}"
+        val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
+        val processor = RecordProcessor<SourceMessage> { records -> msgs.add(records) }
+        val listener = object : SubscriptionListener<SourceMessage> {
+            override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> =
+                TailSpec(afterMsgId = -1L, processor = processor)
+            override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+        }
+
+        KafkaCluster.ClusterFactory(container.bootstrapServers)
+            .pollDuration(Duration.ofMillis(100))
+            .open().use { cluster ->
+                KafkaCluster.LogFactory("my-cluster", topic)
+                    .openSourceLog(mapOf("my-cluster" to cluster))
+                    .use { log ->
+                        log.seedAndTruncate(topic, count = 20, truncateBefore = 20L)
+                        log.appendMessage(txMessage(1))
+                        log.appendMessage(txMessage(2))
+                        log.appendMessage(txMessage(3))
+
+                        val job = launch { log.openGroupSubscription(listener) }
+                        try {
+                            withTimeoutOrNull(5.seconds) {
+                                while (synchronized(msgs) { msgs.flatten().size } < 3) delay(100.milliseconds)
+                            }
+                        } finally {
+                            job.cancelAndJoin()
+                        }
+                    }
+            }
+
+        assertEquals(3, synchronized(msgs) { msgs.flatten().size })
+    }
+
+    @Test
+    @Timeout(value = 90, unit = java.util.concurrent.TimeUnit.SECONDS)
+    fun `node re-indexes from the truncated prefix on restart without a persisted block`(
+        @TempDir storage: Path,
+        @TempDir cacheDir1: Path,
+        @TempDir cacheDir2: Path,
+    ) {
+        val sourceTopic = "trunc-restart-${UUID.randomUUID()}"
+
+        val props = mapOf<String, Any>("bootstrap.servers" to container.bootstrapServers, "acks" to "all")
+        KafkaProducer(props, ByteArraySerializer(), ByteArraySerializer()).use { producer ->
+            repeat(20) { producer.send(ProducerRecord(sourceTopic, ByteArray(8) { 0 })) }
+            producer.flush()
+        }
+        AdminClient.create(props).use { admin ->
+            admin.deleteRecords(
+                mapOf(TopicPartition(sourceTopic, 0) to RecordsToDelete.beforeOffset(20L))
+            ).all().get()
+        }
+
+        Xtdb.openNode {
+            server { port = 0 }; flightSql = null
+            diskCache(DiskCache.factory(cacheDir1))
+            logCluster("kafka", KafkaCluster.ClusterFactory(container.bootstrapServers))
+            log(KafkaCluster.LogFactory("kafka", sourceTopic))
+            storage(Storage.local(storage))
+        }.use { node ->
+            node.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("INSERT INTO foo (_id, x) VALUES ('a', 1)")
+                    stmt.execute("INSERT INTO foo (_id, x) VALUES ('b', 2)")
+                }
+            }
+        }
+
+        Xtdb.openNode {
+            server { port = 0 }; flightSql = null
+            diskCache(DiskCache.factory(cacheDir2))
+            logCluster("kafka", KafkaCluster.ClusterFactory(container.bootstrapServers))
+            log(KafkaCluster.LogFactory("kafka", sourceTopic))
+            storage(Storage.local(storage))
+        }.use { node ->
+            // An INSERT blocks on awaitTx for its own tx, which is processed strictly after
+            // session 1's records on the source log — so by the time this returns, the prior
+            // session's txs have been re-indexed.
+            node.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("INSERT INTO foo (_id, x) VALUES ('c', 3)")
+                    stmt.executeQuery("SELECT _id, x FROM foo ORDER BY _id").use { rs ->
+                        assertTrue(rs.next()); assertEquals("a", rs.getString("_id")); assertEquals(1, rs.getInt("x"))
+                        assertTrue(rs.next()); assertEquals("b", rs.getString("_id")); assertEquals(2, rs.getInt("x"))
+                        assertTrue(rs.next()); assertEquals("c", rs.getString("_id")); assertEquals(3, rs.getInt("x"))
+                        assertTrue(!rs.next())
+                    }
+                }
+            }
+            val primary = (node as Xtdb.XtdbInternal).dbCatalog.primary
+            assertEquals(null, primary.ingestionError, "node must replay cleanly from the truncated prefix")
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = java.util.concurrent.TimeUnit.SECONDS)
+    fun `node starts cleanly against a pre-truncated topic prefix`(@TempDir cacheDir: Path) {
+        val sourceTopic = "trunc-fresh-node-${UUID.randomUUID()}"
+
+        val props = mapOf<String, Any>("bootstrap.servers" to container.bootstrapServers, "acks" to "all")
+        KafkaProducer(props, ByteArraySerializer(), ByteArraySerializer()).use { producer ->
+            repeat(20) { producer.send(ProducerRecord(sourceTopic, ByteArray(8) { 0 })) }
+            producer.flush()
+        }
+        AdminClient.create(props).use { admin ->
+            admin.deleteRecords(
+                mapOf(TopicPartition(sourceTopic, 0) to RecordsToDelete.beforeOffset(20L))
+            ).all().get()
+        }
+
+        Xtdb.openNode {
+            server { port = 0 }; flightSql = null
+            diskCache(DiskCache.factory(cacheDir))
+            logCluster("kafka", KafkaCluster.ClusterFactory(container.bootstrapServers))
+            log(KafkaCluster.LogFactory("kafka", sourceTopic))
+        }.use { node ->
+            node.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("INSERT INTO foo (_id, x) VALUES ('a', 1)")
+                    stmt.executeQuery("SELECT _id, x FROM foo").use { rs ->
+                        assertTrue(rs.next())
+                        assertEquals("a", rs.getString("_id"))
+                        assertEquals(1, rs.getInt("x"))
+                    }
+                }
+            }
+            val primary = (node as Xtdb.XtdbInternal).dbCatalog.primary
+            assertEquals(null, primary.ingestionError,
+                "a fresh node must not error when the topic's earliest offset is past 0")
+        }
+    }
 }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -3,31 +3,45 @@ package xtdb.api.log
 import com.google.protobuf.ByteString
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.clients.admin.RecordsToDelete
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RecordTooLargeException
+import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.io.TempDir
 import org.testcontainers.kafka.ConfluentKafkaContainer
 import xtdb.api.Xtdb
 import xtdb.api.log.Log.*
 import xtdb.api.storage.Storage
+import xtdb.cache.DiskCache
 import xtdb.database.Database
 import xtdb.log.proto.TrieDetails
 import xtdb.log.proto.trieMetadata
+import xtdb.util.MsgIdUtil
 import xtdb.util.asPath
 import xtdb.util.closeAll
 import java.nio.ByteBuffer
+import java.nio.file.Path
 import java.time.Duration
 import java.util.*
 import java.util.Collections.synchronizedList
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -516,6 +530,230 @@ class KafkaClusterTest {
                     stmt.execute("DETACH DATABASE secondary")
                 }
             }
+        }
+    }
+
+    private suspend fun Log<SourceMessage>.seedAndTruncate(topic: String, count: Int, truncateBefore: Long) {
+        repeat(count) { i -> appendMessage(txMessage((i + 1).toByte())) }
+        AdminClient.create(mapOf<String, Any>("bootstrap.servers" to container.bootstrapServers)).use { admin ->
+            admin.deleteRecords(
+                mapOf(TopicPartition(topic, 0) to RecordsToDelete.beforeOffset(truncateBefore))
+            ).all().get()
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, unit = java.util.concurrent.TimeUnit.SECONDS)
+    fun `tailAll fails when its anchor offset has been truncated`() = runBlocking {
+        val topic = "trunc-anchored-${UUID.randomUUID()}"
+        val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
+        val subscriber = mockk<RecordProcessor<SourceMessage>> {
+            coEvery { processRecords(capture(msgs)) } returns Unit
+        }
+        val caught = AtomicReference<Throwable?>(null)
+
+        KafkaCluster.ClusterFactory(container.bootstrapServers)
+            .pollDuration(Duration.ofMillis(100))
+            .open().use { cluster ->
+                KafkaCluster.LogFactory("my-cluster", topic)
+                    .openSourceLog(mapOf("my-cluster" to cluster))
+                    .use { log ->
+                        log.seedAndTruncate(topic, count = 5, truncateBefore = 3L)
+
+                        // Anchor inside the now-truncated prefix — seek lands below the earliest available offset.
+                        val anchorInTruncatedPrefix = MsgIdUtil.offsetToMsgId(0, 1L)
+                        val job = launch(SupervisorJob()) {
+                            try { log.tailAll(anchorInTruncatedPrefix, subscriber) }
+                            catch (e: Throwable) { caught.set(e) }
+                        }
+                        val completed = withTimeoutOrNull(3.seconds) { job.join() } != null
+                        job.cancelAndJoin()
+
+                        assertTrue(completed, "tailAll silently polled past the truncation — should have thrown")
+                    }
+            }
+
+        assertEquals(0, synchronized(msgs) { msgs.flatten().size },
+            "received records past a truncated anchor — silent skip is data loss")
+        assertNotNull(caught.get(), "tailAll must throw, not silently auto-reset")
+    }
+
+    @Test
+    @Timeout(value = 30, unit = java.util.concurrent.TimeUnit.SECONDS)
+    fun `openGroupSubscription surfaces error when anchor truncated`() = runBlocking {
+        val topic = "trunc-grp-${UUID.randomUUID()}"
+        val anchorInTruncatedPrefix = MsgIdUtil.offsetToMsgId(0, 1L)
+        val caught = AtomicReference<Throwable?>(null)
+        val listener = object : SubscriptionListener<SourceMessage> {
+            override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> =
+                TailSpec(afterMsgId = anchorInTruncatedPrefix, processor = RecordProcessor { _ -> })
+            override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+        }
+
+        KafkaCluster.ClusterFactory(container.bootstrapServers)
+            .pollDuration(Duration.ofMillis(100))
+            .open().use { cluster ->
+                KafkaCluster.LogFactory("my-cluster", topic)
+                    .openSourceLog(mapOf("my-cluster" to cluster))
+                    .use { log ->
+                        log.seedAndTruncate(topic, count = 5, truncateBefore = 3L)
+
+                        val job = launch(SupervisorJob()) {
+                            try { log.openGroupSubscription(listener) }
+                            catch (e: Throwable) { caught.set(e) }
+                        }
+                        val completed = withTimeoutOrNull(5.seconds) { job.join() } != null
+                        job.cancelAndJoin()
+
+                        assertTrue(completed, "openGroupSubscription silently polled past the truncation — should have thrown")
+                    }
+            }
+
+        assertNotNull(caught.get(), "openGroupSubscription must surface OffsetOutOfRange to its subscriber")
+    }
+
+    @Test
+    @Timeout(value = 60, unit = java.util.concurrent.TimeUnit.SECONDS)
+    fun `node surfaces error on restart when replica log truncated past stored boundary`(
+        @TempDir storageDir: Path, @TempDir cacheDir1: Path, @TempDir cacheDir2: Path,
+    ) {
+        val sourceTopic = "trunc-node-${UUID.randomUUID()}"
+        val replicaTopic = "$sourceTopic-replica"
+
+        Xtdb.openNode {
+            server { port = 0 }; flightSql = null
+            diskCache(DiskCache.factory(cacheDir1))
+            logCluster("kafka", KafkaCluster.ClusterFactory(container.bootstrapServers))
+            log(KafkaCluster.LogFactory("kafka", sourceTopic))
+            storage(Storage.local(storageDir))
+            compactor { threads(0) }
+        }.use { node ->
+            node.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("INSERT INTO foo (_id, x) VALUES ('a', 1)")
+                }
+            }
+            val cat = (node as Xtdb.XtdbInternal).dbCatalog
+            cat.primary.sendFlushBlockMessage()
+            cat.syncAll(Duration.ofSeconds(10))
+            node.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("INSERT INTO foo (_id, x) VALUES ('b', 2)")
+                }
+            }
+        }
+
+        // Truncate the entire replica log — the earliest available offset is now past the persisted boundary.
+        AdminClient.create(mapOf<String, Any>("bootstrap.servers" to container.bootstrapServers)).use { admin ->
+            val tp = TopicPartition(replicaTopic, 0)
+            val endOffset = admin.listOffsets(mapOf(tp to org.apache.kafka.clients.admin.OffsetSpec.latest()))
+                .all().get()[tp]!!.offset()
+            admin.deleteRecords(mapOf(tp to RecordsToDelete.beforeOffset(endOffset))).all().get()
+        }
+
+        Xtdb.openNode {
+            server { port = 0 }; flightSql = null
+            diskCache(DiskCache.factory(cacheDir2))
+            logCluster("kafka", KafkaCluster.ClusterFactory(container.bootstrapServers))
+            log(KafkaCluster.LogFactory("kafka", sourceTopic))
+            storage(Storage.local(storageDir))
+            compactor { threads(0) }
+        }.use { node ->
+            val primary = (node as Xtdb.XtdbInternal).dbCatalog.primary
+            val deadline = System.currentTimeMillis() + 30_000
+            while (primary.ingestionError == null && System.currentTimeMillis() < deadline) {
+                Thread.sleep(100)
+            }
+            assertNotNull(primary.ingestionError,
+                "node must surface IngestionStoppedException when replica log truncated past stored boundary")
+        }
+    }
+
+    @Test
+    @Timeout(value = 90, unit = java.util.concurrent.TimeUnit.SECONDS)
+    fun `secondary failure does not affect primary and can still be detached`(
+        @TempDir primaryStorage: Path,
+        @TempDir secondaryStorage: Path,
+        @TempDir cacheDir1: Path,
+        @TempDir cacheDir2: Path,
+    ) {
+        val primaryTopic = "trunc-secondary-primary-${UUID.randomUUID()}"
+        val secondaryTopic = "trunc-secondary-${UUID.randomUUID()}"
+        val secondaryReplicaTopic = "$secondaryTopic-replica"
+
+        Xtdb.openNode {
+            server { port = 0 }; flightSql = null
+            diskCache(DiskCache.factory(cacheDir1))
+            logCluster("kafka", KafkaCluster.ClusterFactory(container.bootstrapServers))
+            log(KafkaCluster.LogFactory("kafka", primaryTopic))
+            storage(Storage.local(primaryStorage))
+            compactor { threads(0) }
+        }.use { node ->
+            node.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute(
+                        """
+                        ATTACH DATABASE secondary WITH ${'$'}${'$'}
+                            log: !Kafka
+                              cluster: kafka
+                              topic: $secondaryTopic
+                            storage: !Local
+                              path: "${secondaryStorage.toString().replace("\\", "/")}"
+                        ${'$'}${'$'}""".trimIndent()
+                    )
+                }
+            }
+
+            val cat = (node as Xtdb.XtdbInternal).dbCatalog
+            node.createConnectionBuilder().database("secondary").build().use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("INSERT INTO foo (_id, x) VALUES ('a', 1)")
+                }
+            }
+            cat["secondary"]!!.sendFlushBlockMessage()
+            cat.syncAll(Duration.ofSeconds(10))
+            node.createConnectionBuilder().database("secondary").build().use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("INSERT INTO foo (_id, x) VALUES ('b', 2)")
+                }
+            }
+        }
+
+        AdminClient.create(mapOf<String, Any>("bootstrap.servers" to container.bootstrapServers)).use { admin ->
+            val tp = TopicPartition(secondaryReplicaTopic, 0)
+            val endOffset = admin.listOffsets(mapOf(tp to org.apache.kafka.clients.admin.OffsetSpec.latest()))
+                .all().get()[tp]!!.offset()
+            admin.deleteRecords(mapOf(tp to RecordsToDelete.beforeOffset(endOffset))).all().get()
+        }
+
+        Xtdb.openNode {
+            server { port = 0 }; flightSql = null
+            diskCache(DiskCache.factory(cacheDir2))
+            logCluster("kafka", KafkaCluster.ClusterFactory(container.bootstrapServers))
+            log(KafkaCluster.LogFactory("kafka", primaryTopic))
+            storage(Storage.local(primaryStorage))
+            compactor { threads(0) }
+        }.use { node ->
+            val cat = (node as Xtdb.XtdbInternal).dbCatalog
+            val primary = cat.primary
+            val deadline = System.currentTimeMillis() + 30_000
+            while (cat["secondary"]?.ingestionError == null && System.currentTimeMillis() < deadline) {
+                Thread.sleep(100)
+            }
+            assertNotNull(cat["secondary"]?.ingestionError,
+                "secondary must surface IngestionStoppedException when its replica log is truncated past the stored boundary")
+            assertEquals(null, primary.ingestionError,
+                "primary must remain healthy when an unrelated secondary fails")
+
+            node.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("DETACH DATABASE secondary")
+                }
+            }
+            assertEquals(null, cat["secondary"],
+                "DETACH on a failed secondary must complete and remove it from the catalog")
+            assertEquals(null, primary.ingestionError,
+                "primary must remain healthy after detaching the failed secondary")
         }
     }
 }


### PR DESCRIPTION
Part of #5618.

Follow-up to the [first PR](#5627) — that one made truncated Kafka logs surface an `OffsetOutOfRangeException` instead of silently auto-resetting.
This one handles the case the first PR exposed: a fresh indexer (no persisted block, anchor msgId = `-1`) starting against a topic whose earliest offset has moved past `0` under retention.

Before the first PR's `auto.offset.reset = none` change, this scenario was masked.
After it, a fresh node could no longer start against any topic with retention that had eaten records past offset 0 — the consumer would seek to literal offset 0 and immediately throw.

## Approach

`MsgIdUtil.afterMsgIdToOffset` returns `-1` to mean "start from the beginning" — either because the caller has no prior anchor or the anchor is from a different epoch.
The seek path was naively `+1`-ing that to literal `0`.
Under Kafka retention with an advanced low-watermark, that's below the partition's earliest available offset and throws.

The fix is to consult `KafkaConsumer.beginningOffsets` when the resolved offset is `< 0`, so a `-1` anchor means "wherever the partition currently starts" rather than "literal `0`":

```kotlin
private fun KafkaConsumer<*, *>.resolveSeekOffset(tp: TopicPartition, epoch: Int, afterMsgId: MessageId): LogOffset {
    val previousOffset = afterMsgIdToOffset(epoch, afterMsgId)
    val seekFromBeginning = previousOffset < 0L
    return if (seekFromBeginning) beginningOffsets(listOf(tp))[tp] ?: 0L else previousOffset + 1
}
```

Applied at both seek call sites — `TopicSubscription.onPartitionAssigned` (group subscription) and direct `KafkaLog.tailAll`.

## Tests

Four regression tests:

- `tailAll picks up records appended past a truncated prefix when starting fresh` — cluster-level, direct-consumer path.
- `openGroupSubscription picks up records appended past a truncated prefix when starting fresh` — cluster-level, shared-consumer path.
- `node starts cleanly against a pre-truncated topic prefix` — node-level: fresh node opens against a topic whose prefix has aged out, ingests new records cleanly.
- `node re-indexes from the truncated prefix on restart without a persisted block` — node-level restart: a node inserts a couple of txs without flushing a block, restarts, and the second session re-reads those txs from the source log via beginning-offset seek.
  The second session does its own INSERT to drive the leader through the prior session's records before asserting — relies on pgwire's normal `awaitTx` rather than a sleep or `syncAll`.

## Breaking change

Deployments where the indexer might restart against a topic with retention shorter than the restart gap (no flushed block in between) now seek to the partition's earliest available offset instead of literal `0`.
Previously (after the first PR) this would have surfaced `IngestionStoppedException` to clients — now it starts cleanly.
Strictly more lenient, but it changes observable behaviour, hence the `!`.