### PR TITLE
refactor(postgres-source)!: drop schemaIncludeList

### DIFF
--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
@@ -52,7 +52,6 @@ class PgWireDriver(
     private val password: String,
     private val slotName: String,
     private val publicationName: String,
-    private val schemaIncludeList: List<String>,
 ) : PostgresDriver {
 
     private data class ColumnInfo(val name: String, val typeOid: Int)
@@ -170,11 +169,10 @@ class PgWireDriver(
         createQuery(
             """
             SELECT schemaname, tablename FROM pg_publication_tables
-            WHERE pubname = :pubName AND schemaname IN (<schemas>)
+            WHERE pubname = :pubName
             ORDER BY schemaname, tablename""".trimIndent()
         )
             .bind("pubName", publicationName)
-            .bindList("schemas", schemaIncludeList)
             .map { rs, _ -> rs.getString("schemaname") to rs.getString("tablename") }
             .list()
 

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -121,7 +121,6 @@ class PostgresSource(
         val remote: RemoteAlias,
         val slotName: String,
         val publicationName: String,
-        val schemaIncludeList: List<String> = listOf("public"),
     ) : ExternalSource.Factory {
 
         override fun open(
@@ -147,7 +146,7 @@ class PostgresSource(
 
             val driver = PgWireDriver(
                 dbName, pg.hostname, pg.port, pg.database, pg.username, pg.password,
-                slotName, publicationName, schemaIncludeList,
+                slotName, publicationName,
             )
 
             return PostgresSource(dbName, driver, slotName, meterRegistry)
@@ -158,7 +157,6 @@ class PostgresSource(
                 remote = this@Factory.remote
                 slotName = this@Factory.slotName
                 publicationName = this@Factory.publicationName
-                schemaIncludeList += this@Factory.schemaIncludeList
             }, PROTO_TAG_PREFIX)
         }
 
@@ -171,7 +169,6 @@ class PostgresSource(
                     remote = config.remote,
                     slotName = config.slotName,
                     publicationName = config.publicationName,
-                    schemaIncludeList = config.schemaIncludeListList,
                 )
             }
 

--- a/modules/postgres-source/src/main/proto/postgres_source.proto
+++ b/modules/postgres-source/src/main/proto/postgres_source.proto
@@ -8,7 +8,6 @@ message PostgresSourceConfig {
     string remote = 1;
     string slot_name = 2;
     string publication_name = 3;
-    repeated string schema_include_list = 4;
 }
 
 message PostgresSourceToken {

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
@@ -19,7 +19,6 @@ class PostgresSourceFactoryTest {
             remote = "pg",
             slotName = "my_slot",
             publicationName = "my_pub",
-            schemaIncludeList = listOf("public", "analytics"),
         )
 
         val restored = protoRoundTrip(original)
@@ -27,7 +26,6 @@ class PostgresSourceFactoryTest {
         assertEquals("pg", restored.remote)
         assertEquals("my_slot", restored.slotName)
         assertEquals("my_pub", restored.publicationName)
-        assertEquals(listOf("public", "analytics"), restored.schemaIncludeList)
     }
 
     @Test
@@ -37,7 +35,6 @@ class PostgresSourceFactoryTest {
               remote: pg
               slotName: my_slot
               publicationName: my_pub
-              schemaIncludeList: [public]
         """.trimIndent()
 
         val config = Database.Config.fromYaml(yaml)
@@ -46,7 +43,6 @@ class PostgresSourceFactoryTest {
         assertEquals("pg", factory.remote)
         assertEquals("my_slot", factory.slotName)
         assertEquals("my_pub", factory.publicationName)
-        assertEquals(listOf("public"), factory.schemaIncludeList)
     }
 
     @Test

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -100,7 +100,6 @@ class PostgresSourceIntegrationTest {
                           remote: pg
                           slotName: $slotName
                           publicationName: $publicationName
-                          schemaIncludeList: [public]
                     $$""".trimIndent()
                 )
             }
@@ -316,6 +315,54 @@ class PostgresSourceIntegrationTest {
                 xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_mt_users WHERE _id = 3").isNotEmpty() &&
                     xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_mt_orders WHERE _id = 2").isNotEmpty()
             }
+        }
+    }
+
+    @Test
+    fun `tables outside the publication are not replicated`() = runTest(timeout = 120.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+        val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS pg_pub_in (_id INT PRIMARY KEY, name TEXT)",
+            "CREATE TABLE IF NOT EXISTS pg_pub_out (_id INT PRIMARY KEY, name TEXT)",
+            "INSERT INTO pg_pub_in (_id, name) VALUES (1, 'in-snap')",
+            "INSERT INTO pg_pub_out (_id, name) VALUES (1, 'out-snap')",
+            "CREATE PUBLICATION $pubName FOR TABLE pg_pub_in",
+        )
+
+        openNode(sourceTopic).use { node ->
+            attachPostgresSource(node, slotName = slotName, publicationName = pubName)
+
+            awaitCondition("included table snapshotted", timeout = 30.seconds) {
+                runCatching {
+                    xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_pub_in WHERE _id = 1").isNotEmpty()
+                }.getOrDefault(false)
+            }
+
+            // Stream a change to both tables; only the included one should land.
+            pgExecute(
+                "INSERT INTO pg_pub_in (_id, name) VALUES (2, 'in-stream')",
+                "INSERT INTO pg_pub_out (_id, name) VALUES (2, 'out-stream')",
+            )
+
+            awaitCondition("streaming change to included table", timeout = 30.seconds) {
+                xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_pub_in WHERE _id = 2").isNotEmpty()
+            }
+
+            // pg_pub_out is not in the publication — neither its snapshot row
+            // nor its streamed insert should ever appear, so the table is never
+            // materialised in XTDB at all.
+            val publicTables = xtQueryDb(
+                node, "cdc",
+                """
+                SELECT table_name FROM information_schema.tables
+                WHERE table_schema = 'public'
+                """.trimIndent(),
+            ).map { it["table_name"] as String }
+            assertTrue(publicTables.contains("pg_pub_in"), "expected pg_pub_in in $publicTables")
+            assertTrue(!publicTables.contains("pg_pub_out"), "pg_pub_out should not be replicated, got $publicTables")
         }
     }
 


### PR DESCRIPTION
The Postgres publication already says which tables get replicated.
`schemaIncludeList` only narrowed the snapshot discovery query against
`pg_publication_tables` — the replication stream itself was driven entirely by
`publication_names` and ignored the list.

That made the option a footgun: a `schemaIncludeList` narrower than the
publication would silently skip tables at snapshot time but still receive CDC
events for them at stream time, so discovery and stream disagreed. The
`["public"]` default also quietly assumed publications live in `public` — a
publication on any other schema would discover zero tables until the user
spotted it.

The publication is now the sole source of truth. Callers who want a subset of
tables shape the publication directly (`CREATE PUBLICATION … FOR TABLE …` or
`FOR TABLES IN SCHEMA …`) rather than layering a second filter on top.

### Breaking change scope

- YAML config: `schemaIncludeList:` under `externalSource: !Postgres` is gone.
- Kotlin: `PostgresSource.Factory(…, schemaIncludeList = …)` parameter removed.
- Proto: field 4 (`schema_include_list`) is removed from `PostgresSourceConfig`
  without a `reserved` marker. The field only ever shipped in v2.2.0-beta1; no
  upgrade path reads a stored config carrying it, so the tag is safe to reuse
  for an unrelated field in future.

### Tests

The existing integration tests already cover "tables in the publication land in
XTDB". Added one that creates two tables, publishes only one, writes to both
(snapshot + streaming), and asserts via `information_schema.tables` that the
unpublished table is never materialised — pinning the new contract directly.