### PR TITLE
fix(kafka): lazy seek inside rebalance callback (resolves #5633)

### DIFF
--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -88,10 +88,9 @@ private fun KafkaConfigMap.openProducer() =
         ByteArraySerializer()
     )
 
-private fun KafkaConsumer<*, *>.resolveSeekOffset(tp: TopicPartition, epoch: Int, afterMsgId: MessageId): LogOffset {
+private fun KafkaConsumer<*, *>.seekToAfterMsgId(tp: TopicPartition, epoch: Int, afterMsgId: MessageId) {
     val previousOffset = afterMsgIdToOffset(epoch, afterMsgId)
-    val seekFromBeginning = previousOffset < 0L
-    return if (seekFromBeginning) beginningOffsets(listOf(tp))[tp] ?: 0L else previousOffset + 1
+    if (previousOffset < 0L) seekToBeginning(listOf(tp)) else seek(tp, previousOffset + 1)
 }
 
 private fun KafkaConfigMap.openConsumer() =
@@ -175,7 +174,7 @@ class KafkaCluster(
                 listener.onPartitionsAssigned(listOf(tp.partition()))
                     ?.let { tailSpec ->
                         processor = tailSpec.processor
-                        consumer.seek(tp, consumer.resolveSeekOffset(tp, epoch, tailSpec.afterMsgId))
+                        consumer.seekToAfterMsgId(tp, epoch, tailSpec.afterMsgId)
                     }
             }
 
@@ -594,7 +593,7 @@ class KafkaCluster(
             kafkaConfigMap.openConsumer().use { c ->
                 val tp = TopicPartition(topic, 0)
                 c.assign(listOf(tp))
-                c.seek(tp, c.resolveSeekOffset(tp, epoch, afterMsgId))
+                c.seekToAfterMsgId(tp, epoch, afterMsgId)
 
                 while (isActive) {
                     val records = runInterruptible(Dispatchers.IO) { c.pollRecords() }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -3,6 +3,7 @@ package xtdb.api.log
 import com.google.protobuf.ByteString
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -10,6 +11,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.yield
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.admin.RecordsToDelete
@@ -418,6 +420,54 @@ class KafkaClusterTest {
             check(msg is SourceMessage.LegacyTx)
             assertArrayEquals(byteArrayOf(-1, 3), msg.payload)
 
+            job2.cancelAndJoin()
+        }
+    }
+
+    private class RacingListener : SubscriptionListener<SourceMessage> {
+        val entered = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        val records = CopyOnWriteArrayList<Record<SourceMessage>>()
+
+        override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> {
+            entered.complete(Unit)
+            release.await()
+            return TailSpec(-1L, RecordProcessor { recs -> records.addAll(recs) })
+        }
+
+        override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+    }
+
+    @Test
+    fun `wakeup during seek does not skip seek (regression for #5633)`() = runTest(timeout = 10.seconds) {
+        val topic1 = "test-seek-race-${UUID.randomUUID()}"
+        val topic2 = "test-seek-race-${UUID.randomUUID()}"
+
+        withClusterAndLogs(listOf(topic1, topic2)) { _, logs ->
+            val (log1, log2) = logs
+            val listener1 = RacingListener()
+            val listener2 = RacingListener()
+
+            val job1 = launch { log1.openGroupSubscription(listener1) }
+            listener1.entered.await()
+
+            // second register() arms consumer.wakeup() while topic1's callback is parked.
+            val job2 = launch { log2.openGroupSubscription(listener2) }
+            yield()
+
+            listener1.release.complete(Unit)
+
+            listener2.entered.await()
+            listener2.release.complete(Unit)
+
+            log1.appendMessage(txMessage(1))
+            log2.appendMessage(txMessage(2))
+
+            // an inner withTimeout would use the TestScope's virtual clock and trip before
+            // records flow; rely on the outer real-time runTest timeout instead.
+            while (listener1.records.isEmpty() || listener2.records.isEmpty()) delay(50.milliseconds)
+
+            job1.cancelAndJoin()
             job2.cancelAndJoin()
         }
     }


### PR DESCRIPTION
Resolves #5633.

## Approach

The wakeup race is in the seek path that #5618 / 891858567 introduced.
`resolveSeekOffset` made a blocking `KafkaConsumer.beginningOffsets` call from inside the rebalance callback.
That call is wakeup-sensitive — any concurrent `register()` or `unregister()` from another database fires `consumer.wakeup()`, interrupts `beginningOffsets` with `WakeupException` partway through, and aborts the seek.
Kafka has already applied the partition assignment internally by the time the listener fires, so the partition ends up assigned-without-position; the next `poll()` throws `NoOffsetForPartitionException` and the poll loop dies.

`KafkaConsumer.seekToBeginning(listOf(tp))` is the right API for the "wherever this partition currently begins" semantic that 891858567 was implementing manually: lazy, no synchronous broker call, no wakeup exposure.
The four truncated-prefix regression tests added in that commit still pass — `seekToBeginning` resolves to the earliest offset at fetch time, same outcome as the previous code.

Considered alternatives:

- **Catching `InvalidOffsetException` in the poll loop and evicting subscriptions.** Symptomatic — masks the underlying race and would tear down healthy subscriptions on any future sibling exception for the wrong reason.
- **Pre-resolving offsets at `Register` time and only calling `seek` from the callback.** Architecturally cleaner — keeps the rebalance callback free of consumer ops — but changes the contract of `SubscriptionListener.onPartitionsAssigned` (which `LogProcessor` relies on for its leader/follower transition). Bigger surface area than the bug warrants; deferred.

## Test

Regression test parks topic1's rebalance callback via a `RacingListener`, queues a second register (arming `consumer.wakeup()`), releases the first listener, and asserts records flow on both topics.
The dual-listener shape gives explicit handshakes on both sides instead of a `delay()`-based timing guess.
Without the fix it dies on `NoOffsetForPartitionException`; with it, it passes in ~1.2s.

## Test plan

- [x] `./gradlew :modules:xtdb-kafka:integration-test --tests 'xtdb.api.log.KafkaClusterTest'` — 21/21 green locally, including the new regression test and the four truncated-prefix tests from #5618.