### PR TITLE
feat(durable-streams): proto, atomic producer, integration test

### DIFF
--- a/modules/durable-streams/build.gradle.kts
+++ b/modules/durable-streams/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    `java-library`
+    alias(libs.plugins.clojurephant)
+    `maven-publish`
+    signing
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.dokka)
+}
+
+publishing {
+    publications.create("maven", MavenPublication::class) {
+        pom {
+            name.set("XTDB Durable Streams")
+            description.set("XTDB Durable Streams log module")
+        }
+    }
+}
+
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+dependencies {
+    api(project(":xtdb-api"))
+    api(project(":xtdb-core"))
+
+    // protobuf-kotlin is required for the Log.Registration interface signature
+    // (fromProto takes com.google.protobuf.Any).
+    api(libs.protobuf.kotlin)
+
+    api(kotlin("stdlib"))
+
+    implementation(libs.kotlinx.coroutines)
+    testImplementation(libs.kotlinx.coroutines.test)
+
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+}

--- a/modules/durable-streams/build.gradle.kts
+++ b/modules/durable-streams/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.dokka)
+
+    alias(libs.plugins.protobuf)
 }
 
 publishing {
@@ -30,8 +32,21 @@ dependencies {
     api(kotlin("stdlib"))
 
     implementation(libs.kotlinx.coroutines)
-    testImplementation(libs.kotlinx.coroutines.test)
 
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.asProvider().get()}"
+    }
+
+    generateProtoTasks {
+        all().forEach {
+            it.builtins {
+                create("kotlin")
+            }
+        }
+    }
 }

--- a/modules/durable-streams/src/main/clojure/xtdb/durable_streams.clj
+++ b/modules/durable-streams/src/main/clojure/xtdb/durable_streams.clj
@@ -1,0 +1,19 @@
+(ns xtdb.durable-streams
+  (:require [xtdb.log :as log]
+            [xtdb.time :as time])
+  (:import [xtdb.api.log DurableStreamsLog$ClusterFactory DurableStreamsLog$LogFactory]))
+
+(defmethod log/->log-cluster-factory ::cluster
+  [_ {:keys [base-url connect-timeout long-poll-timeout]}]
+  (cond-> (DurableStreamsLog$ClusterFactory. base-url)
+    connect-timeout    (.connectTimeout (time/->duration connect-timeout))
+    long-poll-timeout  (.longPollTimeout (time/->duration long-poll-timeout))))
+
+(defmethod log/->log-factory ::durable-streams
+  [_ {:keys [cluster topic replica-topic epoch tenant create-stream?] :as opts}]
+  (let [cluster-str (str (symbol cluster))]
+    (cond-> (DurableStreamsLog$LogFactory. cluster-str topic)
+      replica-topic (.replicaTopic replica-topic)
+      epoch         (.epoch epoch)
+      tenant        (.tenant tenant)
+      (contains? opts :create-stream?) (.createStream (boolean create-stream?)))))

--- a/modules/durable-streams/src/main/kotlin/xtdb/api/log/DurableStreamsLog.kt
+++ b/modules/durable-streams/src/main/kotlin/xtdb/api/log/DurableStreamsLog.kt
@@ -1,0 +1,386 @@
+@file:UseSerializers(DurationSerde::class)
+
+package xtdb.api.log
+
+import kotlinx.coroutines.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.subclass
+import xtdb.DurationSerde
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
+import xtdb.database.proto.DatabaseConfig
+import xtdb.util.MsgIdUtil.afterMsgIdToOffset
+import xtdb.util.MsgIdUtil.msgIdToEpoch
+import xtdb.util.MsgIdUtil.msgIdToOffset
+import xtdb.util.logger
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpRequest.BodyPublishers
+import java.net.http.HttpResponse.BodyHandlers
+import java.time.Duration
+import java.time.Instant
+import java.util.Base64
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.coroutines.CoroutineContext
+import com.google.protobuf.Any as ProtoAny
+
+private val LOG = DurableStreamsLog::class.logger
+
+// DS uses application/json so each POST is a one-element array and GET returns
+// a positionally-stable array — no custom binary framing needed.
+private const val DS_CONTENT_TYPE = "application/json"
+private const val HDR_NEXT_OFFSET = "Stream-Next-Offset"
+
+private val B64_ENC = Base64.getEncoder()
+private val B64_DEC = Base64.getDecoder()
+
+// Encodes one XTDB byte-array message as a one-element JSON array for DS POST.
+// e.g.  ["SGVsbG8="]
+private fun encodeOne(bytes: ByteArray): ByteArray =
+    "[\"${B64_ENC.encodeToString(bytes)}\"]".toByteArray(Charsets.UTF_8)
+
+// Parses a GET response body (JSON array of base64 strings) into byte arrays.
+// Base64 chars are ASCII-safe so no escape sequences appear inside the strings;
+// a simple scan is correct and avoids a full JSON library dependency.
+internal fun parseMessages(body: String): List<ByteArray> {
+    val trimmed = body.trim()
+    if (trimmed == "[]" || trimmed.isEmpty()) return emptyList()
+    val inner = trimmed.removePrefix("[").removeSuffix("]")
+    val result = mutableListOf<ByteArray>()
+    var i = 0
+    while (i < inner.length) {
+        while (i < inner.length && inner[i] != '"') i++   // skip to open quote
+        if (i >= inner.length) break
+        val start = i + 1
+        val end = inner.indexOf('"', start)
+        if (end < 0) break
+        result += B64_DEC.decode(inner.substring(start, end))
+        i = end + 1
+    }
+    return result
+}
+
+/**
+ * XTDB log backed by a Durable Streams HTTP server (DS protocol §5).
+ *
+ * Messages are base64-encoded inside one-element JSON arrays so that
+ * each POST is exactly one addressable DS message and GET responses are
+ * split cleanly, without custom binary framing.
+ *
+ * YAML config:
+ * ```yaml
+ * remotes:
+ *   my-ds:
+ *     !DurableStreams
+ *     baseUrl: https://my-worker.workers.dev
+ *
+ * log:
+ *   !DurableStreams
+ *   cluster: my-ds
+ *   topic:   xtdb-log
+ * ```
+ */
+class DurableStreamsLog(
+    val baseUrl: String,
+    private val connectTimeout: Duration = Duration.ofSeconds(10),
+    // Kept slightly above the server's 25 s hold so the client never times out first.
+    private val longPollTimeout: Duration = Duration.ofSeconds(30),
+    coroutineContext: CoroutineContext = Dispatchers.IO,
+) : Remote {
+
+    private val http: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(connectTimeout)
+        .build()
+
+    val scope: CoroutineScope = CoroutineScope(SupervisorJob() + coroutineContext)
+
+    // ---- HTTP helpers -------------------------------------------------------
+
+    /** Idempotently creates the DS stream (PUT §5.1). */
+    internal fun ensureStream(url: String) {
+        val req = HttpRequest.newBuilder(URI.create(url))
+            .PUT(BodyPublishers.noBody())
+            .header("Content-Type", DS_CONTENT_TYPE)
+            .build()
+        val resp = http.send(req, BodyHandlers.discarding())
+        check(resp.statusCode() in 200..201) {
+            "PUT $url returned ${resp.statusCode()} — stream creation failed"
+        }
+    }
+
+    /** Returns the offset of the latest message, or -1 if the stream is empty / not found. */
+    private fun fetchLatestOffset(url: String): Long {
+        val req = HttpRequest.newBuilder(URI.create(url))
+            .method("HEAD", BodyPublishers.noBody())
+            .build()
+        val resp = http.send(req, BodyHandlers.discarding())
+        if (resp.statusCode() == 404) return -1L
+        check(resp.statusCode() == 200) { "HEAD $url returned ${resp.statusCode()}" }
+        // Stream-Next-Offset is the next vacant slot; latest written = nextOffset - 1.
+        return resp.headers().firstValue(HDR_NEXT_OFFSET)
+            .map { it.toLong() - 1L }
+            .orElse(-1L)
+    }
+
+    // ---- Inner log ----------------------------------------------------------
+
+    inner class DsLog<M>(
+        private val codec: MessageCodec<M>,
+        private val streamUrl: String,
+        override val epoch: Int,
+    ) : Log<M> {
+
+        private val latestOffset0 = AtomicLong(fetchLatestOffset(streamUrl))
+
+        override val latestSubmittedOffset: Long
+            get() = latestOffset0.get()
+
+        // §5.2 Append
+        override suspend fun appendMessage(message: M): Log.MessageMetadata {
+            val body = encodeOne(codec.encode(message))
+            val req = HttpRequest.newBuilder(URI.create(streamUrl))
+                .POST(BodyPublishers.ofByteArray(body))
+                .header("Content-Type", DS_CONTENT_TYPE)
+                .build()
+
+            val resp = runInterruptible(Dispatchers.IO) {
+                http.send(req, BodyHandlers.discarding())
+            }
+            check(resp.statusCode() in 200..204) {
+                "POST $streamUrl returned ${resp.statusCode()}"
+            }
+
+            // Stream-Next-Offset is the offset after the message we just wrote.
+            val nextOffset = resp.headers().firstValue(HDR_NEXT_OFFSET)
+                .orElseThrow { IllegalStateException("Missing $HDR_NEXT_OFFSET in POST response from $streamUrl") }
+                .toLong()
+
+            val logOffset = nextOffset - 1L
+            latestOffset0.updateAndGet { it.coerceAtLeast(logOffset) }
+            return Log.MessageMetadata(epoch, logOffset, Instant.now())
+        }
+
+        // §5.6 + §5.5: read the last message in the stream
+        override fun readLastMessage(): M? {
+            val latest = fetchLatestOffset(streamUrl)
+            if (latest < 0L) return null
+            val url = "$streamUrl?offset=$latest"
+            val resp = http.send(HttpRequest.newBuilder(URI.create(url)).GET().build(), BodyHandlers.ofString())
+            if (resp.statusCode() == 404) return null
+            check(resp.statusCode() == 200) { "GET $url returned ${resp.statusCode()}" }
+            return parseMessages(resp.body()).lastOrNull()?.let { codec.decode(it) }
+        }
+
+        // §5.6 Catch-up read across a [fromMsgId, toMsgId) range
+        override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId): Sequence<Log.Record<M>> {
+            // Silently skip cross-epoch reads — matches Kafka behaviour.
+            if (msgIdToEpoch(fromMsgId) != epoch || msgIdToEpoch(toMsgId) != epoch) return emptySequence()
+            val fromOffset = msgIdToOffset(fromMsgId)
+            val toOffset = msgIdToOffset(toMsgId)
+            if (fromOffset >= toOffset) return emptySequence()
+
+            return sequence {
+                val url = "$streamUrl?offset=$fromOffset"
+                val resp = http.send(
+                    HttpRequest.newBuilder(URI.create(url)).GET().build(),
+                    BodyHandlers.ofString()
+                )
+                if (resp.statusCode() == 404) return@sequence
+                check(resp.statusCode() == 200) { "GET $url returned ${resp.statusCode()}" }
+
+                // DS returns all messages from fromOffset to current tail in one response.
+                // Slice to the requested window.
+                val approxTimestamp = Instant.now()
+                for ((i, bytes) in parseMessages(resp.body()).withIndex()) {
+                    val offset = fromOffset + i
+                    if (offset >= toOffset) break
+                    val msg = codec.decode(bytes) ?: continue
+                    yield(Log.Record(epoch, offset, approxTimestamp, msg))
+                }
+            }
+        }
+
+        // §SCR-246 long-poll: tail the stream indefinitely, delivering records to processor.
+        // Each iteration issues one long-poll GET; 200 = data arrived, 204 = timeout (loop again).
+        override suspend fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) =
+            coroutineScope {
+                // Compute starting offset from afterMsgId.
+                val prevOffset = afterMsgIdToOffset(epoch, afterMsgId)
+                var offset = if (prevOffset < 0L) 0L else prevOffset + 1L
+
+                while (isActive) {
+                    val url = "$streamUrl?offset=$offset&live=long-poll"
+                    val req = HttpRequest.newBuilder(URI.create(url))
+                        .GET()
+                        .timeout(longPollTimeout)
+                        .build()
+
+                    val resp = runInterruptible(Dispatchers.IO) {
+                        http.send(req, BodyHandlers.ofString())
+                    }
+
+                    when (resp.statusCode()) {
+                        200 -> {
+                            val body = resp.body()
+                            val messages = parseMessages(body)
+                            if (messages.isNotEmpty()) {
+                                val batchTime = Instant.now()
+                                val records = messages.mapIndexedNotNull { i, bytes ->
+                                    codec.decode(bytes)?.let { msg ->
+                                        Log.Record(epoch, offset + i, batchTime, msg)
+                                    }
+                                }
+                                if (records.isNotEmpty()) {
+                                    processor.processRecords(records)
+                                    offset += messages.size.toLong()
+                                    latestOffset0.updateAndGet { it.coerceAtLeast(offset - 1) }
+                                }
+                            }
+                            // Advance offset from header when up-to-date (empty batch from long-poll).
+                            resp.headers().firstValue(HDR_NEXT_OFFSET).ifPresent { hdr ->
+                                val nextOff = hdr.toLong()
+                                if (nextOff > offset) offset = nextOff
+                            }
+                        }
+
+                        204 -> {
+                            // Long-poll timeout or stream closed at tail — nothing new, loop.
+                            resp.headers().firstValue(HDR_NEXT_OFFSET).ifPresent { hdr ->
+                                val nextOff = hdr.toLong()
+                                if (nextOff > offset) offset = nextOff
+                            }
+                        }
+
+                        else -> {
+                            LOG.warn { "Unexpected ${resp.statusCode()} from long-poll $url — backing off 1 s" }
+                            delay(1_000)
+                        }
+                    }
+                }
+            }
+
+        // Group subscription: DS has no consumer-group protocol, so we model the stream
+        // as a single-partition group.  The listener assigns itself to partition 0 and
+        // we run tailAll for as long as the coroutine lives.
+        override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>) {
+            val tailSpec = listener.onPartitionsAssigned(listOf(0)) ?: return
+            try {
+                tailAll(tailSpec.afterMsgId, tailSpec.processor)
+            } finally {
+                withContext(NonCancellable) {
+                    listener.onPartitionsRevokedSync(listOf(0))
+                }
+            }
+        }
+
+        override fun close() = Unit
+    }
+
+    // ---- Lifecycle ----------------------------------------------------------
+
+    override fun close() {
+        runBlocking { withTimeout(5_000) { scope.coroutineContext.job.cancelAndJoin() } }
+    }
+
+    // ---- Serializable factories ---------------------------------------------
+
+    @Serializable
+    @SerialName("!DurableStreams")
+    data class ClusterFactory @JvmOverloads constructor(
+        val baseUrl: String,
+        var connectTimeout: Duration = Duration.ofSeconds(10),
+        var longPollTimeout: Duration = Duration.ofSeconds(30),
+    ) : Remote.Factory<DurableStreamsLog> {
+
+        fun connectTimeout(d: Duration) = apply { connectTimeout = d }
+        fun longPollTimeout(d: Duration) = apply { longPollTimeout = d }
+
+        override fun open() = DurableStreamsLog(baseUrl, connectTimeout, longPollTimeout)
+    }
+
+    @Serializable
+    @SerialName("!DurableStreams")
+    data class LogFactory @JvmOverloads constructor(
+        val cluster: RemoteAlias,
+        val topic: String,
+        var replicaTopic: String = "$topic-replica",
+        var epoch: Int = 0,
+        var tenant: String = "xtdb",
+        var createStream: Boolean = true,
+    ) : Log.Factory {
+
+        fun replicaTopic(t: String) = apply { replicaTopic = t }
+        fun epoch(e: Int) = apply { epoch = e }
+        fun tenant(t: String) = apply { tenant = t }
+        fun createStream(c: Boolean) = apply { createStream = c }
+
+        private fun resolve(remotes: Map<RemoteAlias, Remote>): DurableStreamsLog {
+            val alias = cluster
+            return requireNotNull(remotes[alias] as? DurableStreamsLog) {
+                "Missing DurableStreams remote: '$alias'"
+            }
+        }
+
+        private fun <M> openLog(
+            ds: DurableStreamsLog,
+            codec: MessageCodec<M>,
+            streamName: String,
+        ): Log<M> {
+            val url = "${ds.baseUrl}/streams/$tenant/$streamName"
+            if (createStream) ds.ensureStream(url)
+            return ds.DsLog(codec, url, epoch)
+        }
+
+        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>): Log<SourceMessage> =
+            openLog(resolve(remotes), SourceMessage.Codec, topic)
+
+        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>) =
+            ReadOnlyLog(openSourceLog(remotes))
+
+        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>): Log<ReplicaMessage> =
+            openLog(resolve(remotes), ReplicaMessage.Codec, replicaTopic)
+
+        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>) =
+            ReadOnlyLog(openReplicaLog(remotes))
+
+        // writeTo serialises the log config to protobuf for multi-node followers to
+        // reconstruct their log handle.  Single-node DS deployments don't need this;
+        // a proto definition can be added when multi-node support is required.
+        override fun writeTo(dbConfig: DatabaseConfig.Builder) {
+            throw UnsupportedOperationException(
+                "DurableStreams log does not yet support multi-node log config persistence via writeTo; " +
+                "add a proto definition when follower nodes are needed."
+            )
+        }
+    }
+
+    // ---- SPI registrations --------------------------------------------------
+
+    /**
+     * @suppress
+     */
+    class Registration : Log.Registration {
+        override val protoTag: String
+            get() = throw UnsupportedOperationException("DurableStreams log has no proto tag")
+
+        override fun fromProto(msg: ProtoAny): Log.Factory =
+            throw UnsupportedOperationException("DurableStreams log cannot be reconstructed from proto")
+
+        override fun registerSerde(builder: PolymorphicModuleBuilder<Log.Factory>) {
+            builder.subclass(LogFactory::class)
+        }
+    }
+
+    /**
+     * @suppress
+     */
+    class ClusterRegistration : Remote.Registration {
+        override fun registerSerde(builder: PolymorphicModuleBuilder<Remote.Factory<*>>) {
+            builder.subclass(ClusterFactory::class)
+        }
+    }
+}

--- a/modules/durable-streams/src/main/kotlin/xtdb/api/log/DurableStreamsLog.kt
+++ b/modules/durable-streams/src/main/kotlin/xtdb/api/log/DurableStreamsLog.kt
@@ -8,14 +8,18 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.subclass
+import java.util.UUID
 import xtdb.DurationSerde
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
 import xtdb.database.proto.DatabaseConfig
+import xtdb.durable_streams.proto.DurableStreamsLogConfig
+import xtdb.durable_streams.proto.durableStreamsLogConfig
 import xtdb.util.MsgIdUtil.afterMsgIdToOffset
 import xtdb.util.MsgIdUtil.msgIdToEpoch
 import xtdb.util.MsgIdUtil.msgIdToOffset
 import xtdb.util.logger
+import xtdb.util.warn
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -256,12 +260,89 @@ class DurableStreamsLog(
                         }
 
                         else -> {
-                            LOG.warn { "Unexpected ${resp.statusCode()} from long-poll $url — backing off 1 s" }
+                            LOG.warn("Unexpected ${resp.statusCode()} from long-poll $url — backing off 1 s")
                             delay(1_000)
                         }
                     }
                 }
             }
+
+        // DS has no transaction protocol, so we follow InMemoryLog's buffered model:
+        // appendMessage queues into the tx; commit() flushes synchronously with
+        // monotonic Producer-Seq headers so transport retries dedupe (§5.2.1).
+        // abort() drops the buffer without ever hitting the network.
+        override fun openAtomicProducer(transactionalId: String): Log.AtomicProducer<M> {
+            // Append a UUID so each producer instance has a unique Producer-Id —
+            // we don't persist an epoch across restarts, so this avoids 403 "stale
+            // producer epoch" against prior incarnations of the same transactionalId.
+            val producerId = "$transactionalId-${UUID.randomUUID()}"
+            val seqGen = AtomicLong(0L)
+            val producerEpoch = 0
+
+            return object : Log.AtomicProducer<M> {
+                @Volatile
+                private var producerClosed = false
+
+                override fun openTx(): Log.AtomicProducer.Tx<M> {
+                    check(!producerClosed) { "Atomic producer is closed" }
+                    val buffer = mutableListOf<Pair<M, CompletableDeferred<Log.MessageMetadata>>>()
+                    var isOpen = true
+
+                    return object : Log.AtomicProducer.Tx<M> {
+                        override fun appendMessage(message: M): CompletableDeferred<Log.MessageMetadata> {
+                            check(isOpen) { "Transaction already closed" }
+                            return CompletableDeferred<Log.MessageMetadata>()
+                                .also { buffer.add(message to it) }
+                        }
+
+                        override fun commit() {
+                            check(isOpen) { "Transaction already closed" }
+                            isOpen = false
+                            for ((msg, deferred) in buffer) {
+                                try {
+                                    val body = encodeOne(codec.encode(msg))
+                                    val seq = seqGen.getAndIncrement()
+                                    val req = HttpRequest.newBuilder(URI.create(streamUrl))
+                                        .POST(BodyPublishers.ofByteArray(body))
+                                        .header("Content-Type", DS_CONTENT_TYPE)
+                                        .header("Producer-Id", producerId)
+                                        .header("Producer-Epoch", producerEpoch.toString())
+                                        .header("Producer-Seq", seq.toString())
+                                        .build()
+                                    val resp = http.send(req, BodyHandlers.discarding())
+                                    check(resp.statusCode() in 200..204) {
+                                        "POST $streamUrl returned ${resp.statusCode()}"
+                                    }
+                                    val nextOffset = resp.headers().firstValue(HDR_NEXT_OFFSET)
+                                        .orElseThrow { IllegalStateException("Missing $HDR_NEXT_OFFSET in POST response from $streamUrl") }
+                                        .toLong()
+                                    val logOffset = nextOffset - 1L
+                                    latestOffset0.updateAndGet { it.coerceAtLeast(logOffset) }
+                                    deferred.complete(Log.MessageMetadata(epoch, logOffset, Instant.now()))
+                                } catch (e: Throwable) {
+                                    deferred.completeExceptionally(e)
+                                    throw e
+                                }
+                            }
+                        }
+
+                        override fun abort() {
+                            check(isOpen) { "Transaction already closed" }
+                            isOpen = false
+                            buffer.clear()
+                        }
+
+                        override fun close() {
+                            if (isOpen) abort()
+                        }
+                    }
+                }
+
+                override fun close() {
+                    producerClosed = true
+                }
+            }
+        }
 
         // Group subscription: DS has no consumer-group protocol, so we model the stream
         // as a single-partition group.  The listener assigns itself to partition 0 and
@@ -347,14 +428,14 @@ class DurableStreamsLog(
         override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>) =
             ReadOnlyLog(openReplicaLog(remotes))
 
-        // writeTo serialises the log config to protobuf for multi-node followers to
-        // reconstruct their log handle.  Single-node DS deployments don't need this;
-        // a proto definition can be added when multi-node support is required.
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
-            throw UnsupportedOperationException(
-                "DurableStreams log does not yet support multi-node log config persistence via writeTo; " +
-                "add a proto definition when follower nodes are needed."
-            )
+            dbConfig.setOtherLog(ProtoAny.pack(durableStreamsLogConfig {
+                this.clusterAlias = this@LogFactory.cluster
+                this.topic = this@LogFactory.topic
+                this.epoch = this@LogFactory.epoch
+                this.replicaTopic = this@LogFactory.replicaTopic
+                this.tenant = this@LogFactory.tenant
+            }, "proto.xtdb.com"))
         }
     }
 
@@ -365,10 +446,17 @@ class DurableStreamsLog(
      */
     class Registration : Log.Registration {
         override val protoTag: String
-            get() = throw UnsupportedOperationException("DurableStreams log has no proto tag")
+            get() = "proto.xtdb.com/xtdb.durable_streams.proto.DurableStreamsLogConfig"
 
         override fun fromProto(msg: ProtoAny): Log.Factory =
-            throw UnsupportedOperationException("DurableStreams log cannot be reconstructed from proto")
+            msg.unpack(DurableStreamsLogConfig::class.java).let {
+                LogFactory(it.clusterAlias, it.topic).apply {
+                    if (it.epoch != 0) epoch = it.epoch
+                    if (it.hasReplicaTopic()) replicaTopic = it.replicaTopic
+                    if (it.hasTenant()) tenant = it.tenant
+                    createStream = false
+                }
+            }
 
         override fun registerSerde(builder: PolymorphicModuleBuilder<Log.Factory>) {
             builder.subclass(LogFactory::class)

--- a/modules/durable-streams/src/main/proto/durable_streams.proto
+++ b/modules/durable-streams/src/main/proto/durable_streams.proto
@@ -1,0 +1,13 @@
+edition = "2023";
+
+package xtdb.durable_streams.proto;
+
+option java_multiple_files = true;
+
+message DurableStreamsLogConfig {
+    string cluster_alias = 1;
+    string topic = 2;
+    int32 epoch = 3;
+    string replica_topic = 4;
+    string tenant = 5;
+}

--- a/modules/durable-streams/src/main/resources/META-INF/services/xtdb.api.Remote$Registration
+++ b/modules/durable-streams/src/main/resources/META-INF/services/xtdb.api.Remote$Registration
@@ -1,0 +1,1 @@
+xtdb.api.log.DurableStreamsLog$ClusterRegistration

--- a/modules/durable-streams/src/main/resources/META-INF/services/xtdb.api.log.Log$Registration
+++ b/modules/durable-streams/src/main/resources/META-INF/services/xtdb.api.log.Log$Registration
@@ -1,0 +1,1 @@
+xtdb.api.log.DurableStreamsLog$Registration

--- a/modules/durable-streams/src/test/kotlin/xtdb/api/log/DurableStreamsLogIntegrationTest.kt
+++ b/modules/durable-streams/src/test/kotlin/xtdb/api/log/DurableStreamsLogIntegrationTest.kt
@@ -1,0 +1,330 @@
+package xtdb.api.log
+
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import xtdb.util.MsgIdUtil.offsetToMsgId
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStreamReader
+import java.net.ServerSocket
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * End-to-end tests against the real WorkerDO Durable Streams implementation
+ * via the Node HTTP shim at `scratchpad/slice-1/worker/ds_node_shim.mjs`.
+ *
+ * Skipped automatically when `node` is not on PATH or the shim file is not
+ * present — keeps CI green on developer machines that don't have the spike
+ * checkout sitting next to this one.
+ *
+ * Override the shim location with the `XTDB_DS_NODE_SHIM` env var.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DurableStreamsLogIntegrationTest {
+
+    private object StringCodec : MessageCodec<String> {
+        override fun encode(message: String): ByteArray = message.toByteArray(Charsets.UTF_8)
+        override fun decode(bytes: ByteArray): String = String(bytes, Charsets.UTF_8)
+    }
+
+    // One shim process for the whole class — each test uses a unique stream
+    // path so the WorkerDO instances don't share state.
+    private var shim: ShimProcess? = null
+    private lateinit var log: DurableStreamsLog
+    private lateinit var streamPath: String
+
+    @BeforeAll
+    fun startShim() {
+        shim = ShimProcess.startIfAvailable()
+    }
+
+    @AfterAll
+    fun stopShim() {
+        shim?.stop()
+    }
+
+    @BeforeEach
+    fun setUp() {
+        assumeTrue(shim != null, "Node DS shim not available — set XTDB_DS_NODE_SHIM or install node")
+        log = DurableStreamsLog(shim!!.baseUrl)
+        streamPath = "/streams/xtdb/test-${System.nanoTime()}"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        runCatching { log.close() }
+    }
+
+    private fun openLog(epoch: Int = 0): DurableStreamsLog.DsLog<String> {
+        val url = "${shim!!.baseUrl}$streamPath"
+        log.ensureStream(url)
+        return log.DsLog(StringCodec, url, epoch)
+    }
+
+    @Test
+    fun `appendMessage returns metadata with monotonic offsets`() = runBlocking {
+        openLog().use { dsLog ->
+            val m0 = dsLog.appendMessage("hello")
+            val m1 = dsLog.appendMessage("world")
+            val m2 = dsLog.appendMessage("xtdb")
+
+            assertEquals(0L, m0.logOffset)
+            assertEquals(1L, m1.logOffset)
+            assertEquals(2L, m2.logOffset)
+            assertEquals(2L, dsLog.latestSubmittedOffset)
+        }
+    }
+
+    @Test
+    fun `readLastMessage returns the most recent message`() = runBlocking {
+        openLog().use { dsLog ->
+            assertNull(dsLog.readLastMessage())
+            dsLog.appendMessage("first")
+            dsLog.appendMessage("second")
+            assertEquals("second", dsLog.readLastMessage())
+        }
+    }
+
+    @Test
+    fun `readRecords returns messages in the half-open offset range`() = runBlocking {
+        openLog().use { dsLog ->
+            listOf("a", "b", "c", "d").forEach { dsLog.appendMessage(it) }
+
+            val all = dsLog.readRecords(offsetToMsgId(0, 0), offsetToMsgId(0, 4)).toList()
+            assertEquals(listOf("a", "b", "c", "d"), all.map { it.message })
+            assertEquals(listOf(0L, 1L, 2L, 3L), all.map { it.logOffset })
+
+            val slice = dsLog.readRecords(offsetToMsgId(0, 1), offsetToMsgId(0, 3)).toList()
+            assertEquals(listOf("b", "c"), slice.map { it.message })
+        }
+    }
+
+    @Test
+    fun `readRecords returns empty when ranges are empty or cross-epoch`() = runBlocking {
+        openLog(epoch = 2).use { dsLog ->
+            dsLog.appendMessage("x")
+            assertEquals(emptyList<Log.Record<String>>(),
+                dsLog.readRecords(offsetToMsgId(0, 0), offsetToMsgId(0, 1)).toList())
+            assertEquals(emptyList<Log.Record<String>>(),
+                dsLog.readRecords(offsetToMsgId(2, 5), offsetToMsgId(2, 5)).toList())
+        }
+    }
+
+    @Test
+    fun `tailAll delivers records as they are appended`() = runBlocking {
+        openLog().use { dsLog ->
+            dsLog.appendMessage("warm-up")
+
+            val received = CopyOnWriteArrayList<String>()
+            val tail = launch(Dispatchers.IO) {
+                dsLog.tailAll(offsetToMsgId(0, -1)) { records ->
+                    records.forEach { received += it.message }
+                }
+            }
+            try {
+                withTimeout(10.seconds) {
+                    while (received.size < 1) delay(20)
+                }
+                assertEquals(listOf("warm-up"), received.toList())
+
+                dsLog.appendMessage("live-1")
+                dsLog.appendMessage("live-2")
+                withTimeout(10.seconds) {
+                    while (received.size < 3) delay(20)
+                }
+                assertEquals(listOf("warm-up", "live-1", "live-2"), received.toList())
+            } finally {
+                tail.cancel()
+                tail.join()
+            }
+        }
+    }
+
+    @Test
+    fun `openAtomicProducer commits a buffered transaction`() = runBlocking {
+        openLog().use { dsLog ->
+            dsLog.openAtomicProducer("test-tx").use { producer ->
+                val tx = producer.openTx()
+                val d0 = tx.appendMessage("tx-a")
+                val d1 = tx.appendMessage("tx-b")
+                assertFalse(d0.isCompleted)
+                assertFalse(d1.isCompleted)
+                tx.commit()
+                assertEquals(0L, d0.await().logOffset)
+                assertEquals(1L, d1.await().logOffset)
+            }
+            assertEquals(listOf("tx-a", "tx-b"),
+                dsLog.readRecords(offsetToMsgId(0, 0), offsetToMsgId(0, 2)).map { it.message }.toList())
+        }
+    }
+
+    @Test
+    fun `openAtomicProducer abort discards buffered messages`() = runBlocking {
+        openLog().use { dsLog ->
+            dsLog.openAtomicProducer("test-tx").use { producer ->
+                val tx = producer.openTx()
+                tx.appendMessage("dropped-1")
+                tx.appendMessage("dropped-2")
+                tx.abort()
+            }
+            assertNull(dsLog.readLastMessage())
+            assertEquals(-1L, dsLog.latestSubmittedOffset)
+        }
+    }
+
+    @Test
+    fun `openAtomicProducer supports multiple sequential transactions`() = runBlocking {
+        openLog().use { dsLog ->
+            dsLog.openAtomicProducer("multi-tx").use { producer ->
+                producer.openTx().also { tx ->
+                    tx.appendMessage("one")
+                    tx.appendMessage("two")
+                    tx.commit()
+                }
+                producer.openTx().also { tx ->
+                    tx.appendMessage("three")
+                    tx.commit()
+                }
+            }
+            assertEquals(2L, dsLog.latestSubmittedOffset)
+            assertEquals(listOf("one", "two", "three"),
+                dsLog.readRecords(offsetToMsgId(0, 0), offsetToMsgId(0, 3)).map { it.message }.toList())
+        }
+    }
+
+    @Test
+    fun `latestSubmittedOffset reflects existing stream state on open`() = runBlocking {
+        openLog().use { dsLog ->
+            dsLog.appendMessage("seed-0")
+            dsLog.appendMessage("seed-1")
+        }
+        openLog().use { dsLog ->
+            assertEquals(1L, dsLog.latestSubmittedOffset)
+        }
+    }
+
+    @Test
+    fun `openGroupSubscription tails the stream as partition 0`() = runBlocking {
+        openLog().use { dsLog ->
+            dsLog.appendMessage("g0")
+            dsLog.appendMessage("g1")
+            val received = CopyOnWriteArrayList<String>()
+            val sub = launch(Dispatchers.IO) {
+                dsLog.openGroupSubscription(object : Log.SubscriptionListener<String> {
+                    override suspend fun onPartitionsAssigned(partitions: Collection<Int>): Log.TailSpec<String> {
+                        assertEquals(listOf(0), partitions.toList())
+                        return Log.TailSpec(offsetToMsgId(0, -1)) { records ->
+                            records.forEach { received += it.message }
+                        }
+                    }
+                    override suspend fun onPartitionsRevoked(partitions: Collection<Int>) = Unit
+                })
+            }
+            try {
+                withTimeout(10.seconds) { while (received.size < 2) delay(20) }
+                assertEquals(listOf("g0", "g1"), received.toList())
+            } finally {
+                sub.cancel()
+                sub.join()
+            }
+        }
+    }
+}
+
+/**
+ * Launches the scratchpad DS Node shim on a free port. The shim re-uses the
+ * production WorkerDO implementation via in-process mock state, so tests run
+ * against the same logic CF deploys — minus the DO storage layer.
+ */
+private class ShimProcess private constructor(
+    val process: Process,
+    val port: Int,
+) {
+    val baseUrl: String get() = "http://127.0.0.1:$port"
+
+    fun stop() {
+        if (!process.isAlive) return
+        process.destroy()
+        if (!process.waitFor(5, TimeUnit.SECONDS)) process.destroyForcibly()
+    }
+
+    companion object {
+        private val SHIM_CANDIDATES = listOf(
+            System.getenv("XTDB_DS_NODE_SHIM"),
+            "/home/sprite/repos/scratchpad/slice-1/worker/ds_node_shim.mjs",
+            "/home/hogan/scratchpad/slice-1/worker/ds_node_shim.mjs",
+            System.getProperty("user.home") + "/repos/scratchpad/slice-1/worker/ds_node_shim.mjs",
+        )
+
+        fun startIfAvailable(): ShimProcess? {
+            val nodeBin = locateNode() ?: return null
+            val shimFile = SHIM_CANDIDATES
+                .filterNotNull()
+                .map(::File)
+                .firstOrNull { it.isFile } ?: return null
+
+            val port = freePort()
+            val pb = ProcessBuilder(nodeBin, shimFile.absolutePath)
+                .directory(shimFile.parentFile)
+                .redirectErrorStream(true)
+            pb.environment()["PORT"] = port.toString()
+            pb.environment()["HOST"] = "127.0.0.1"
+            val process = pb.start()
+
+            return try {
+                if (waitForReady(process, port)) ShimProcess(process, port)
+                else {
+                    process.destroyForcibly(); null
+                }
+            } catch (e: Throwable) {
+                process.destroyForcibly(); throw e
+            }
+        }
+
+        private fun locateNode(): String? {
+            // Honour explicit override first.
+            System.getenv("XTDB_NODE_BIN")?.takeIf { File(it).canExecute() }?.let { return it }
+            // Fall back to walking PATH.
+            val pathEnv = System.getenv("PATH") ?: return null
+            return pathEnv.split(File.pathSeparator)
+                .asSequence()
+                .map { File(it, "node") }
+                .firstOrNull { it.canExecute() }
+                ?.absolutePath
+        }
+
+        private fun freePort(): Int = ServerSocket(0).use { it.localPort }
+
+        private fun waitForReady(process: Process, port: Int): Boolean {
+            // Drain output on a background thread so the shim doesn't block
+            // on a full pipe — and so we can spot the "listening at" line.
+            val reader = BufferedReader(InputStreamReader(process.inputStream))
+            val readyMarker = "listening at"
+            val deadline = System.nanoTime() + 10_000_000_000L
+            val ready = java.util.concurrent.CountDownLatch(1)
+
+            Thread {
+                try {
+                    reader.forEachLine { line ->
+                        if (line.contains(readyMarker)) ready.countDown()
+                    }
+                } catch (_: Throwable) {
+                    // Pipe closed when process dies; nothing to do.
+                }
+            }.apply { isDaemon = true }.start()
+
+            val timeoutMs = ((deadline - System.nanoTime()) / 1_000_000L).coerceAtLeast(1)
+            if (!ready.await(timeoutMs, TimeUnit.MILLISECONDS)) return false
+            return process.isAlive
+        }
+    }
+}

--- a/modules/durable-streams/src/test/kotlin/xtdb/api/log/DurableStreamsLogTest.kt
+++ b/modules/durable-streams/src/test/kotlin/xtdb/api/log/DurableStreamsLogTest.kt
@@ -1,0 +1,101 @@
+package xtdb.api.log
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.Base64
+
+class DurableStreamsLogTest {
+
+    // ---- parseMessages unit tests -------------------------------------------
+
+    @Test
+    fun `parseMessages - empty array`() {
+        assertEquals(emptyList<ByteArray>(), parseMessages("[]"))
+    }
+
+    @Test
+    fun `parseMessages - blank string`() {
+        assertEquals(emptyList<ByteArray>(), parseMessages("  "))
+    }
+
+    @Test
+    fun `parseMessages - single element`() {
+        val bytes = "hello".toByteArray()
+        val b64 = Base64.getEncoder().encodeToString(bytes)
+        val result = parseMessages("[\"$b64\"]")
+        assertEquals(1, result.size)
+        assertArrayEquals(bytes, result[0])
+    }
+
+    @Test
+    fun `parseMessages - multiple elements`() {
+        val msgs = listOf("hello", "world", "xtdb").map { it.toByteArray() }
+        val json = "[" + msgs.joinToString(",") { "\"${Base64.getEncoder().encodeToString(it)}\"" } + "]"
+        val result = parseMessages(json)
+        assertEquals(3, result.size)
+        msgs.forEachIndexed { i, expected ->
+            assertArrayEquals(expected, result[i])
+        }
+    }
+
+    @Test
+    fun `parseMessages - handles whitespace around array`() {
+        val bytes = "test".toByteArray()
+        val b64 = Base64.getEncoder().encodeToString(bytes)
+        val result = parseMessages("  [ \"$b64\" ]  ")
+        assertEquals(1, result.size)
+        assertArrayEquals(bytes, result[0])
+    }
+
+    @Test
+    fun `parseMessages - binary data round-trips`() {
+        val bytes = ByteArray(256) { it.toByte() }
+        val b64 = Base64.getEncoder().encodeToString(bytes)
+        val result = parseMessages("[\"$b64\"]")
+        assertEquals(1, result.size)
+        assertArrayEquals(bytes, result[0])
+    }
+
+    // ---- ClusterFactory builder tests ---------------------------------------
+
+    @Test
+    fun `ClusterFactory sets baseUrl`() {
+        val f = DurableStreamsLog.ClusterFactory("https://example.workers.dev")
+        assertEquals("https://example.workers.dev", f.baseUrl)
+    }
+
+    @Test
+    fun `ClusterFactory builder methods return same instance`() {
+        val f = DurableStreamsLog.ClusterFactory("https://x.example")
+            .connectTimeout(java.time.Duration.ofSeconds(5))
+            .longPollTimeout(java.time.Duration.ofSeconds(20))
+        assertEquals(java.time.Duration.ofSeconds(5), f.connectTimeout)
+        assertEquals(java.time.Duration.ofSeconds(20), f.longPollTimeout)
+    }
+
+    // ---- LogFactory builder tests -------------------------------------------
+
+    @Test
+    fun `LogFactory defaults`() {
+        val f = DurableStreamsLog.LogFactory("my-cluster", "xtdb-log")
+        assertEquals("my-cluster", f.cluster)
+        assertEquals("xtdb-log", f.topic)
+        assertEquals("xtdb-log-replica", f.replicaTopic)
+        assertEquals(0, f.epoch)
+        assertEquals("xtdb", f.tenant)
+        assertTrue(f.createStream)
+    }
+
+    @Test
+    fun `LogFactory builder methods`() {
+        val f = DurableStreamsLog.LogFactory("cluster", "topic")
+            .replicaTopic("replica-custom")
+            .epoch(3)
+            .tenant("acme")
+            .createStream(false)
+        assertEquals("replica-custom", f.replicaTopic)
+        assertEquals(3, f.epoch)
+        assertEquals("acme", f.tenant)
+        assertFalse(f.createStream)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,8 +14,9 @@ if (file("lang/test-harness").isDirectory) {
 
 include("docker:standalone", "docker:aws", "docker:azure", "docker:google-cloud")
 
-include("modules:kafka", "modules:kafka-connect", "modules:postgres-source", "modules:aws", "modules:azure", "modules:google-cloud")
+include("modules:kafka", "modules:kafka-connect", "modules:postgres-source", "modules:aws", "modules:azure", "modules:google-cloud", "modules:durable-streams")
 project(":modules:kafka").name = "xtdb-kafka"
+project(":modules:durable-streams").name = "xtdb-durable-streams"
 project(":modules:kafka-connect").name = "xtdb-kafka-connect"
 project(":modules:postgres-source").name = "xtdb-postgres-source"
 project(":modules:aws").name = "xtdb-aws"


### PR DESCRIPTION
## Summary

Fills in the deferred pieces from the initial `xtdb-durable-streams` module so it covers the same surface as Kafka for multi-node deployments and atomic submission.

- **`writeTo` / `fromProto`** — wired through a new `DurableStreamsLogConfig` proto (`cluster_alias`, `topic`, `epoch`, `replica_topic`, `tenant`).
  Follower nodes can reconstruct the log from the database catalog without recreating the underlying DS stream.

- **`openAtomicProducer`** — follows `InMemoryLog`'s buffered-tx model: `appendMessage` queues into the tx; `commit()` flushes synchronously with monotonic `Producer-Seq` headers so transport retries dedupe per DS §5.2.1; `abort()` drops the buffer without hitting the network.
  `Producer-Id` is suffixed with a UUID per instance to avoid stale-epoch fencing across restarts (DS treats `Producer-Epoch` monotonically per `Producer-Id`).

- **`DurableStreamsLogIntegrationTest`** — exercises the real WorkerDO via the scratchpad Node shim (`slice-1/worker/ds_node_shim.mjs`) as a subprocess.
  The shim re-uses the production DO implementation against in-memory state, so this exercises the same logic CF deploys minus the DO storage layer.
  Tests auto-skip via `assumeTrue` when `node` or the shim are not present, so this stays green on developer machines without the spike checkout.

## Test plan

- [x] `./gradlew :modules:xtdb-durable-streams:test` — 20 passed / 0 failed / 0 skipped (10 unit, 10 integration).
- [ ] `./gradlew :xtdb-core:test :xtdb-api:test` — adjacent module check (running).
- [ ] No reflection or boxed-math warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)