### PR TITLE
fix: name the database in out-of-sync log error

### DIFF
--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -154,18 +154,18 @@
 
 
 (def out-of-sync-log-message
-  "Node failed to start due to an invalid transaction log state (%s) that does not correspond with the latest indexed transaction (epoch=%s and offset=%s).
+  "Database '%s' failed to start due to an invalid transaction log state (%s) that does not correspond with the latest indexed transaction (epoch=%s and offset=%s).
 
   Please see https://docs.xtdb.com/ops/backup-and-restore/out-of-sync-log.html for more information and next steps.")
 
-(defn ->out-of-sync-exception [latest-completed-offset ^long latest-submitted-offset ^long epoch]
+(defn ->out-of-sync-exception [db-name latest-completed-offset ^long latest-submitted-offset ^long epoch]
   (let [log-state-str (if (= -1 latest-submitted-offset)
                         "the log is empty"
                         (format "epoch=%s, offset=%s" epoch latest-submitted-offset))]
     (IllegalStateException.
-      (format out-of-sync-log-message log-state-str epoch latest-completed-offset))))
+      (format out-of-sync-log-message db-name log-state-str epoch latest-completed-offset))))
 
-(defn validate-offsets [^Log log ^TransactionKey latest-completed-tx]
+(defn validate-offsets [db-name ^Log log ^TransactionKey latest-completed-tx]
   (when latest-completed-tx
     (let [latest-completed-tx-id (.getTxId latest-completed-tx)
           latest-completed-offset (MsgIdUtil/msgIdToOffset latest-completed-tx-id)
@@ -175,7 +175,7 @@
       (if (= latest-completed-epoch epoch)
         (cond
           (< latest-submitted-offset latest-completed-offset)
-          (throw (->out-of-sync-exception latest-completed-offset latest-submitted-offset epoch)))
+          (throw (->out-of-sync-exception db-name latest-completed-offset latest-submitted-offset epoch)))
         (log/info "Starting node with a log that has a different epoch than the latest completed tx (This is expected if you are starting a new epoch) - Skipping offset validation.")))))
 
 (defn- ->TxOps [tx-ops]

--- a/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
@@ -49,6 +49,7 @@ class DatabaseStorage(
         }
 
         private fun throwIllegalLogState(
+            dbName: DatabaseName,
             latestSubmittedOffset: LogOffset, logEpoch: Int, completedEpoch: Int, completedOffset: MessageId
         ): Nothing {
             val logState =
@@ -57,7 +58,7 @@ class DatabaseStorage(
 
             error(
                 buildString {
-                    appendLine("Node failed to start due to an invalid transaction log state ($logState) " +
+                    appendLine("Database '$dbName' failed to start due to an invalid transaction log state ($logState) " +
                             "that does not correspond with the latest indexed transaction " +
                             "(epoch=$completedEpoch and offset=$completedOffset).")
                     appendLine()
@@ -67,7 +68,7 @@ class DatabaseStorage(
             )
         }
 
-        private fun validateOffsets(log: Log<SourceMessage>, latestCompletedTx: TransactionKey?) {
+        private fun validateOffsets(dbName: DatabaseName, log: Log<SourceMessage>, latestCompletedTx: TransactionKey?) {
             if (latestCompletedTx == null) return
 
             val completedTxId = latestCompletedTx.txId
@@ -80,7 +81,7 @@ class DatabaseStorage(
                 completedEpoch != logEpoch -> logNewEpoch()
 
                 latestSubmittedOffset < completedOffset ->
-                    throwIllegalLogState(latestSubmittedOffset, logEpoch, completedEpoch, completedOffset)
+                    throwIllegalLogState(dbName, latestSubmittedOffset, logEpoch, completedEpoch, completedOffset)
             }
         }
 
@@ -114,7 +115,7 @@ class DatabaseStorage(
                 val log = if (readOnly) dbConfig.log.openReadOnlySourceLog(remotes)
                 else dbConfig.log.openSourceLog(remotes)
 
-                validateOffsets(log, latestCompletedTx)
+                validateOffsets(dbName, log, latestCompletedTx)
                 log
             }
 

--- a/docs/src/content/docs/ops/backup-and-restore/out-of-sync-log.md
+++ b/docs/src/content/docs/ops/backup-and-restore/out-of-sync-log.md
@@ -7,15 +7,15 @@ This is a safety mechanism designed to prevent divergence between the transactio
 
 You may encounter an error such as:
 
-> "**Node failed to start due to an invalid transaction log state
-> (epoch=0, offset=200) that does not correspond with the latest indexed
-> transaction (epoch=0 and offset=289).**"
+> "**Database 'xtdb' failed to start due to an invalid transaction log
+> state (epoch=0, offset=200) that does not correspond with the latest
+> indexed transaction (epoch=0 and offset=289).**"
 
 or:
 
-> "**Node failed to start due to an invalid transaction log state (the
-> log is empty) that does not correspond with the latest indexed
-> transaction (epoch=0 and offset=289).**"
+> "**Database 'xtdb' failed to start due to an invalid transaction log
+> state (the log is empty) that does not correspond with the latest
+> indexed transaction (epoch=0 and offset=289).**"
 
 ## What Is Preserved
 

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -143,7 +143,7 @@
       (t/is
        (thrown-with-msg?
         IllegalStateException
-        #"Node failed to start due to an invalid transaction log state \(the log is empty\)"
+        #"Database 'xtdb' failed to start due to an invalid transaction log state \(the log is empty\)"
         (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
                                                            :poll-duration "PT2S"
                                                            :properties-map {}
@@ -245,7 +245,7 @@
       (t/is
        (thrown-with-msg?
         IllegalStateException
-        #"Node failed to start due to an invalid transaction log state \(epoch=0, offset=1\) that does not correspond with the latest indexed transaction \(epoch=0 and offset=2\)"
+        #"Database 'xtdb' failed to start due to an invalid transaction log state \(epoch=0, offset=1\) that does not correspond with the latest indexed transaction \(epoch=0 and offset=2\)"
         (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
                                                            :poll-duration "PT2S"}]}
                          :log [:kafka {:cluster :my-kafka

--- a/src/test/clojure/xtdb/log_test.clj
+++ b/src/test/clojure/xtdb/log_test.clj
@@ -155,31 +155,31 @@
             (serde/->TxKey (MsgIdUtil/offsetToMsgId epoch offset) (Instant/now)))]
 
     (t/testing "no error when latestSubmittedOffset >= latestCompletedOffset and same epoch"
-      (t/is (nil? (log/validate-offsets (->simulated-log 0 5) (->latest-completed-tx 0 5))))
-      (t/is (nil? (log/validate-offsets (->simulated-log 0 10) (->latest-completed-tx 0 5))))
-      (t/is (nil? (log/validate-offsets (->simulated-log 1 5) (->latest-completed-tx 1 5)))))
+      (t/is (nil? (log/validate-offsets "xtdb" (->simulated-log 0 5) (->latest-completed-tx 0 5))))
+      (t/is (nil? (log/validate-offsets "xtdb" (->simulated-log 0 10) (->latest-completed-tx 0 5))))
+      (t/is (nil? (log/validate-offsets "xtdb" (->simulated-log 1 5) (->latest-completed-tx 1 5)))))
 
     (t/testing "throws when latestSubmittedOffset < latestCompletedOffset and same epoch - stale log"
       (t/is (thrown-with-msg? IllegalStateException
-                              #"Node failed to start due to an invalid transaction log state \(epoch=0, offset=1\)"
-                              (log/validate-offsets (->simulated-log 0 1) (->latest-completed-tx 0 2))))
+                              #"Database 'xtdb' failed to start due to an invalid transaction log state \(epoch=0, offset=1\)"
+                              (log/validate-offsets "xtdb" (->simulated-log 0 1) (->latest-completed-tx 0 2))))
       (t/is (thrown-with-msg? IllegalStateException
-                              #"Node failed to start due to an invalid transaction log state \(epoch=1, offset=1\)"
-                              (log/validate-offsets (->simulated-log 1 1) (->latest-completed-tx 1 2)))))
+                              #"Database 'xtdb' failed to start due to an invalid transaction log state \(epoch=1, offset=1\)"
+                              (log/validate-offsets "xtdb" (->simulated-log 1 1) (->latest-completed-tx 1 2)))))
 
     (t/testing "throws when latestSubmittedOffset is -1 and latestCompletedOffset is not for the same epoch - empty log"
       (t/is (thrown-with-msg? IllegalStateException
-                              #"Node failed to start due to an invalid transaction log state \(the log is empty\)"
-                              (log/validate-offsets (->simulated-log 0 -1) (->latest-completed-tx 0 2))))
+                              #"Database 'xtdb' failed to start due to an invalid transaction log state \(the log is empty\)"
+                              (log/validate-offsets "xtdb" (->simulated-log 0 -1) (->latest-completed-tx 0 2))))
       (t/is (thrown-with-msg? IllegalStateException
-                              #"Node failed to start due to an invalid transaction log state \(the log is empty\)"
-                              (log/validate-offsets (->simulated-log 1 -1) (->latest-completed-tx 1 2)))))
+                              #"Database 'xtdb' failed to start due to an invalid transaction log state \(the log is empty\)"
+                              (log/validate-offsets "xtdb" (->simulated-log 1 -1) (->latest-completed-tx 1 2)))))
 
     (t/testing "no error for empty log when epochs differ - validation skipped"
-      (t/is (nil? (log/validate-offsets (->simulated-log 1 -1) (->latest-completed-tx 0 2)))))
+      (t/is (nil? (log/validate-offsets "xtdb" (->simulated-log 1 -1) (->latest-completed-tx 0 2)))))
 
     (t/testing "no error when latestCompletedTx is nil"
-      (t/is (nil? (log/validate-offsets (->simulated-log 0 5) nil))))))
+      (t/is (nil? (log/validate-offsets "xtdb" (->simulated-log 0 5) nil))))))
 
 (t/deftest test-memory-log-epochs
   (util/with-tmp-dirs #{local-disk-path}
@@ -207,7 +207,7 @@
     (t/is
       (thrown-with-msg?
         IllegalStateException
-        #"Node failed to start due to an invalid transaction log state \(the log is empty\)"
+        #"Database 'xtdb' failed to start due to an invalid transaction log state \(the log is empty\)"
         (xtn/start-node {:log [:in-memory {}]
                          :storage [:local {:path local-disk-path}]})))
 
@@ -256,7 +256,7 @@
     (t/is
       (thrown-with-msg?
         IllegalStateException
-        #"Node failed to start due to an invalid transaction log state \(the log is empty\)"
+        #"Database 'xtdb' failed to start due to an invalid transaction log state \(the log is empty\)"
         (xtn/start-node {:log [:local {:path (.resolve node-dir "new-log")}]
                          :storage [:local {:path (.resolve node-dir "objects")}]})))
 


### PR DESCRIPTION
## Summary

In multi-db setups, the existing "Node failed to start due to an invalid transaction log state…" error from `DatabaseStorage.throwIllegalLogState` was misleading on two counts:

- it implied the *node* had failed to start, when in practice it's a single database's log that's out of sync — non-essential databases shouldn't necessarily prevent the node from coming up;
- it gave no indication of *which* database tripped the check, leaving operators to figure out the culprit themselves.

This threads the database name through `validateOffsets` / `throwIllegalLogState` and reframes the message as `Database '<name>' failed to start due to an invalid transaction log state …`.

The quoted error examples in `docs/src/content/docs/ops/backup-and-restore/out-of-sync-log.md` are updated to match.

Resolves #5642