### PR TITLE
fix(indexer): make leader-processor close await its persister (resolves #5626)

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -61,7 +61,7 @@ class Database(
     private val meterRegistry: MeterRegistry?,
     val compactorOrNull: Compactor.ForDatabase? = null,
     private val job: Job? = null,
-    private val processor: AutoCloseable? = null,
+    private val processor: LogProcessor? = null,
     private val registeredGauges: List<Gauge> = emptyList(),
 ) : IQuerySource.QueryDatabase, AutoCloseable {
     val name: DatabaseName get() = queryState.name
@@ -113,8 +113,11 @@ class Database(
 
     override fun close() {
         meterRegistry?.let { reg -> registeredGauges.forEach { reg.remove(it) } }
-        job?.let { runBlocking { it.cancelAndJoin() } }
-        listOf(processor, compactorOrNull, queryState, storage, allocator).closeAll()
+        runBlocking {
+            job?.cancelAndJoin()
+            processor?.close()
+        }
+        listOf(compactorOrNull, queryState, storage, allocator).closeAll()
     }
 
     fun submitTxBlocking(ops: List<TxOp>, opts: TxOpts): Xtdb.SubmittedTx {
@@ -156,7 +159,7 @@ class Database(
      * Intended for tests and manual admin pokes; bypasses the `enabled` flag.
      */
     fun gcAll() {
-        (processor as? LogProcessor)?.gcAll()
+        processor?.gcAll()
     }
 
     companion object {
@@ -198,7 +201,7 @@ class Database(
                 else compactor.openForDatabase(allocator, storage, state, watchers)
             }
 
-            var processor: AutoCloseable? = null
+            var processor: LogProcessor? = null
             val job = Job()
             val scope = CoroutineScope(job + CoroutineExceptionHandler { _, e ->
                 watchers.notifyError(e)
@@ -242,7 +245,7 @@ class Database(
 
                         return object : LogProcessor.LeaderSystem {
                             override val proc get() = leaderProc
-                            override fun close() { leaderProc.close(); replicaProducer.close() }
+                            override suspend fun close() { leaderProc.close(); replicaProducer.close() }
                         }
                     }
 

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -267,7 +267,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
         replicaState.value = ReplicaState.Failed(latestReplicaMsgId, e)
     }
 
-    override fun close() {
+    override suspend fun close() {
         allocator.close()
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -500,18 +500,15 @@ class LeaderLogProcessor(
         }
     }
 
-    override fun close() {
-        // HACK: we cancel without joining because a blocking join deadlocks under runTest's virtual time.
-        extJob?.cancel()
+    override suspend fun close() {
+        extJob?.cancelAndJoin()
         extSource?.close()
         blockGc.close()
         trieGc.close()
-        // `persisterJob.cancel()` only — `CoroutineScope(ctx)` may share ctx's Job (e.g. under
-        // runTest), so `scope.cancel()` would tear down the surrounding scope.
-        persisterJob.cancel()
         sourceLogCh.close()
         extSourceCh.close()
         gcCh.close()
+        persisterJob.join()
         indexer.close()
         allocator.close()
     }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.database.DatabaseState
@@ -26,10 +27,11 @@ class LogProcessor(
     private val blockUploader: BlockUploader,
     private val scope: CoroutineScope,
     meterRegistry: MeterRegistry? = null,
-) : Log.SubscriptionListener<SourceMessage>, AutoCloseable {
+) : Log.SubscriptionListener<SourceMessage> {
 
-    interface Processor<M> : Log.RecordProcessor<M>, AutoCloseable {
+    interface Processor<M> : Log.RecordProcessor<M> {
         val latestReplicaMsgId: MessageId
+        suspend fun close()
     }
 
     interface LeaderProcessor : Processor<SourceMessage> {
@@ -64,14 +66,16 @@ class LogProcessor(
         ): FollowerProcessor
     }
 
-    sealed interface SubSystem : AutoCloseable
+    sealed interface SubSystem {
+        suspend fun close()
+    }
 
     interface LeaderSystem : SubSystem {
         val proc: LeaderProcessor
     }
 
     private class FollowerSystem(val proc: FollowerProcessor, private val job: Job) : SubSystem {
-        override fun close() {
+        override suspend fun close() {
             job.cancel()
             proc.close()
         }
@@ -80,8 +84,9 @@ class LogProcessor(
     private fun openFollowerSystem(
         latestReplicaMsgId: MessageId,
         pendingBlock: PendingBlock? = null,
-    ): FollowerSystem =
-        procFactory.openFollower(pendingBlock, latestReplicaMsgId).closeOnCatch { proc ->
+    ): FollowerSystem {
+        val proc = procFactory.openFollower(pendingBlock, latestReplicaMsgId)
+        return try {
             LOG.info {
                 buildString {
                     append("[$dbName] starting follower: ")
@@ -98,7 +103,11 @@ class LogProcessor(
                     proc.notifyError(e); throw e
                 }
             })
+        } catch (t: Throwable) {
+            runBlocking { proc.close() }
+            throw t
         }
+    }
 
     @Volatile
     private var sys: SubSystem =
@@ -140,26 +149,28 @@ class LogProcessor(
 
                         val pendingBlock = followerProc.pendingBlock
 
-                        procFactory.openTransition(replicaProducer, followerProc.latestReplicaMsgId)
-                            .use { transition ->
-                                if (pendingBlock != null) {
-                                    LOG.debug("[$dbName] transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
-                                    blockUploader.uploadBlock(
-                                        replicaProducer, pendingBlock.boundaryMsgId, pendingBlock.boundaryMessage,
-                                    )
-                                    LOG.debug("[$dbName] transition: replaying ${pendingBlock.bufferedRecords.size} buffered records through transition processor")
-                                    transition.processRecords(pendingBlock.bufferedRecords)
-                                }
-
-                                LOG.debug("[$dbName] transition: opening leader processor")
-
-                                val sys = procFactory.openLeaderSystem(replicaProducer, replayTarget)
-                                this.sys = sys
-
-                                val resumeMsgId = watchers.latestSourceMsgId
-                                LOG.info("[$dbName] leader startup complete, resuming after $resumeMsgId")
-                                Log.TailSpec(resumeMsgId, sys.proc)
+                        val transition = procFactory.openTransition(replicaProducer, followerProc.latestReplicaMsgId)
+                        try {
+                            if (pendingBlock != null) {
+                                LOG.debug("[$dbName] transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
+                                blockUploader.uploadBlock(
+                                    replicaProducer, pendingBlock.boundaryMsgId, pendingBlock.boundaryMessage,
+                                )
+                                LOG.debug("[$dbName] transition: replaying ${pendingBlock.bufferedRecords.size} buffered records through transition processor")
+                                transition.processRecords(pendingBlock.bufferedRecords)
                             }
+
+                            LOG.debug("[$dbName] transition: opening leader processor")
+
+                            val sys = procFactory.openLeaderSystem(replicaProducer, replayTarget)
+                            this.sys = sys
+
+                            val resumeMsgId = watchers.latestSourceMsgId
+                            LOG.info("[$dbName] leader startup complete, resuming after $resumeMsgId")
+                            Log.TailSpec(resumeMsgId, sys.proc)
+                        } finally {
+                            transition.close()
+                        }
                     }
                 } catch (e: InterruptedException) {
                     throw e
@@ -193,7 +204,7 @@ class LogProcessor(
         }
     }
 
-    override fun close() {
+    suspend fun close() {
         sys.close()
     }
 

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -147,7 +147,7 @@ class TransitionLogProcessor(
         }
     }
 
-    override fun close() {
+    override suspend fun close() {
         allocator.close()
     }
 }

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -121,7 +121,8 @@ class ExternalSourceTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val extSource = InMemoryExternalSource()
 
-        leaderProc(replicaLog = replicaLog, extSource = extSource, ctx = coroutineContext).use {
+        val lp = leaderProc(replicaLog = replicaLog, extSource = extSource, ctx = coroutineContext)
+        try {
             extSource.channel.send(null)
             delay(500.milliseconds)
 
@@ -141,6 +142,8 @@ class ExternalSourceTest {
             assertEquals(true, resolved.committed)
             assertEquals(0L, resolved.txId)
             assertNull(resolved.srcMsgId, "ext-source ResolvedTx should not carry a source-log msgId")
+        } finally {
+            lp.close()
         }
     }
 
@@ -230,9 +233,12 @@ class ExternalSourceTest {
             override fun close() {}
         }
 
-        leaderProc(watchers = watchers, extSource = failingSource, ctx = coroutineContext).use {
+        val lp = leaderProc(watchers = watchers, extSource = failingSource, ctx = coroutineContext)
+        try {
             delay(500.milliseconds)
             assertNotNull(watchers.exception, "watchers should be in failed state")
+        } finally {
+            lp.close()
         }
     }
 

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -201,7 +201,7 @@ class LogProcessorSimTest : SimulationTestBase() {
             )
             return object : LogProcessor.LeaderSystem {
                 override val proc get() = proc
-                override fun close() = proc.close()
+                override suspend fun close() = proc.close()
             }
         }
 
@@ -353,7 +353,8 @@ class LogProcessorSimTest : SimulationTestBase() {
             MemoryStorage(allocator, epoch = 0).use { bp ->
                 SimNode("test-db", bp, IndexerConfig(rowsPerBlock = rowsPerBlock), simExtSource).use { node ->
                     val logProcScope = CoroutineScope(dispatcher + Job(coroutineContext.job))
-                    node.openLogProcessor(logProcScope).use { logProc ->
+                    val logProc = node.openLogProcessor(logProcScope)
+                    try {
                         val groupJob = launch(dispatcher) { srcLog.openGroupSubscription(logProc) }
 
                         launch(dispatcher) {
@@ -401,6 +402,8 @@ class LogProcessorSimTest : SimulationTestBase() {
 
                         assertBlockFilesExist(bp, "test-db", replicaMessages)
                         assertSnapshotHasNoAbortedRows(node)
+                    } finally {
+                        logProc.close()
                     }
                 }
             }
@@ -432,9 +435,10 @@ class LogProcessorSimTest : SimulationTestBase() {
                             val followerScopeA = CoroutineScope(dispatcher + Job(coroutineContext.job))
                             val followerScopeB = CoroutineScope(dispatcher + Job(coroutineContext.job))
 
-                            leader.openLogProcessor(leaderScope).use { leaderProc ->
-                                followerA.openLogProcessor(followerScopeA).use { followerProcA ->
-                                    followerB.openLogProcessor(followerScopeB).use { followerProcB ->
+                            val leaderProc = leader.openLogProcessor(leaderScope)
+                            val followerProcA = followerA.openLogProcessor(followerScopeA)
+                            val followerProcB = followerB.openLogProcessor(followerScopeB)
+                            try {
                                         val groupJobLeader =
                                             launch(dispatcher) { srcLog.openGroupSubscription(leaderProc) }
                                         val groupJobA =
@@ -514,8 +518,10 @@ class LogProcessorSimTest : SimulationTestBase() {
                                         assertSnapshotHasNoAbortedRows(leader)
                                         assertSnapshotHasNoAbortedRows(followerA)
                                         assertSnapshotHasNoAbortedRows(followerB)
-                                    }
-                                }
+                            } finally {
+                                leaderProc.close()
+                                followerProcA.close()
+                                followerProcB.close()
                             }
                         }
                     }
@@ -547,8 +553,9 @@ class LogProcessorSimTest : SimulationTestBase() {
                         val scopeA = CoroutineScope(dispatcher + Job(coroutineContext.job))
                         val scopeB = CoroutineScope(dispatcher + Job(coroutineContext.job))
 
-                        nodeA.openLogProcessor(scopeA).use { logProcA ->
-                            nodeB.openLogProcessor(scopeB).use { logProcB ->
+                        val logProcA = nodeA.openLogProcessor(scopeA)
+                        val logProcB = nodeB.openLogProcessor(scopeB)
+                        try {
                                 val groupJobA = launch(dispatcher) { srcLog.openGroupSubscription(logProcA) }
                                 val groupJobB = launch(dispatcher) { srcLog.openGroupSubscription(logProcB) }
 
@@ -621,7 +628,9 @@ class LogProcessorSimTest : SimulationTestBase() {
 
                                 assertSnapshotHasNoAbortedRows(nodeA)
                                 assertSnapshotHasNoAbortedRows(nodeB)
-                            }
+                        } finally {
+                            logProcA.close()
+                            logProcB.close()
                         }
                     }
                 }

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -77,7 +77,7 @@ class LogProcessorTest {
                 )
                 return object : LogProcessor.LeaderSystem {
                     override val proc get() = leaderProc
-                    override fun close() = leaderProc.close()
+                    override suspend fun close() = leaderProc.close()
                 }
             }
 


### PR DESCRIPTION
Resolves #5626.

DETACH of an external-source database leaked live-index allocator memory whenever the leader's persister was mid-`importTx` when the close ran. `LeaderLogProcessor.close()` was non-suspending and fire-and-forget on the persister cancel (`persisterJob.cancel()` with no `join`), so the persister could continue mutating `LiveIndex` after close returned. `Database.close()`'s closeAll then ran `queryState.close()` → `LiveIndex.close()` while those mutations were still in flight; the race surfaced as the "Memory was leaked by query" stack trace and aborted the rest of closeAll — leaving the database's Kafka clients, buffer pool, and own allocator pinned for the rest of the node's life.

Before #5613, the close path deadlocked silently before reaching `LiveIndex.close()`, so the leak never surfaced.

`LeaderLogProcessor.close()` becomes a suspending function that awaits the persister before tearing down `indexer` and `allocator`. This cascades through `Processor<M>`, `SubSystem`, `LeaderSystem`, `FollowerSystem` and `LogProcessor` — all drop `AutoCloseable` in favour of `suspend fun close()`. `Database.close()`'s existing `runBlocking { job.cancelAndJoin() }` is extended to drive `processor.close()` in the same block; the indexer-close path now has a single sync/suspending bridge, at the `Database.close()` `AutoCloseable` boundary.

The previous shape carried an invisible contract: "the thread closing me must not share a scheduler with my persister, or `runBlocking { join }` deadlocks." That's what the persister-actor refactor's HACK comment encoded — and it's the same contract that kotlinx-coroutines-test's standard pattern (dispatcher injection with a shared `TestScheduler`) violates by design. Suspending close drops the contract entirely: `Job.join()` is a coroutine yield, not a thread park, so it composes with `runTest`'s scheduler, `withTimeout`, and structured cancellation without further surgery.

The Allium spec already stated that `close()` waits for any in-progress commit/import — the spec was aspirational; this brings the code in line.

Refs #5613