### PR TITLE
feat: extract per-connection await-token into shared Session layer

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -119,24 +119,28 @@
        (submitTx [_ db-name ops opts] (.submitTx this-node db-name ops opts))
        (executeTx [_ db-name ops opts] (.executeTx this-node db-name ops opts))
 
-       (openSqlQuery [_ sql db-name]
-         (let [query-opts (-> {} (with-query-opts-defaults this-node db-name))]
+       (openSqlQuery [_ sql db-name await-token]
+         (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
            (-> (xtp/prepare-sql this-node sql query-opts)
                (.openQuery nil (QueryOpts. nil (:default-tz query-opts))))))
 
-       (prepareSql [_ sql db-name]
-         (let [query-opts (-> {} (with-query-opts-defaults this-node db-name))]
+       (prepareSql [_ sql db-name await-token]
+         (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
            (xtp/prepare-sql this-node sql query-opts)))
+
+       (mergeAwaitToken [_ existing-token db-name tx-id]
+         (basis/merge-tx-tokens existing-token (basis/->tx-basis-str {db-name [tx-id]})))
 
        (getColumnTypes [_ table snap]
          (when-let [^Database db (.databaseOrNull db-cat (.getDbName table))]
            (.getColumnTypes db table snap)))
 
-       (openSnapshot [_ db-name]
-         (-> (or (.databaseOrNull db-cat db-name)
-                 (throw (err/incorrect :xtdb/unknown-db (format "Unknown database: %s" db-name)
-                                       {:db-name db-name})))
-             (.openSnapshot))))))
+       (openSnapshot [_ db-name await-token]
+         (let [^Database db (or (.databaseOrNull db-cat db-name)
+                                (throw (err/incorrect :xtdb/unknown-db (format "Unknown database: %s" db-name)
+                                                      {:db-name db-name})))]
+           (.awaitAll db-cat await-token nil)
+           (.openSnapshot db))))))
 
   (addMeterRegistry [_ reg]
     (.add metrics-registry reg))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -83,6 +83,27 @@
            :committed? committed?
            :error error}))))
 
+(defn- ->session-node ^Session$Node [this-node ^Database$Catalog db-cat]
+  (reify Session$Node
+    (submitTx [_ db-name ops opts] (.submitTx this-node db-name ops opts))
+    (executeTx [_ db-name ops opts] (.executeTx this-node db-name ops opts))
+
+    (openSqlQuery [_ sql db-name await-token]
+      (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
+        (-> (xtp/prepare-sql this-node sql query-opts)
+            (.openQuery nil (QueryOpts. nil (:default-tz query-opts))))))
+
+    (prepareSql [_ sql db-name await-token]
+      (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
+        (xtp/prepare-sql this-node sql query-opts)))
+
+    (openSnapshot [_ db-name await-token]
+      (let [^Database db (or (.databaseOrNull db-cat db-name)
+                             (throw (err/incorrect :xtdb/unknown-db (format "Unknown database: %s" db-name)
+                                                   {:db-name db-name})))]
+        (.awaitAll db-cat await-token nil)
+        (.openSnapshot db)))))
+
 (defrecord Node [^BufferAllocator allocator, ^Database$Catalog db-cat
                  ^IQuerySource q-src
                  ^CompositeMeterRegistry metrics-registry
@@ -112,35 +133,20 @@
       (.createConnectionBuilder data-source)))
 
   (connect [this-node]
-    (XtdbConnection.
-     (reify XtdbConnection$Node
-       (getAllocator [_] allocator)
-       (getDatabaseNames [_] (.getDatabaseNames db-cat))
-       (submitTx [_ db-name ops opts] (.submitTx this-node db-name ops opts))
-       (executeTx [_ db-name ops opts] (.executeTx this-node db-name ops opts))
+    (let [session-node (->session-node this-node db-cat)]
+      (XtdbConnection.
+       (reify XtdbConnection$Node
+         (getAllocator [_] allocator)
+         (getDatabaseNames [_] (.getDatabaseNames db-cat))
+         (submitTx [_ db-name ops opts] (.submitTx session-node db-name ops opts))
+         (executeTx [_ db-name ops opts] (.executeTx session-node db-name ops opts))
+         (openSqlQuery [_ sql db-name await-token] (.openSqlQuery session-node sql db-name await-token))
+         (prepareSql [_ sql db-name await-token] (.prepareSql session-node sql db-name await-token))
+         (openSnapshot [_ db-name await-token] (.openSnapshot session-node db-name await-token))
 
-       (openSqlQuery [_ sql db-name await-token]
-         (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
-           (-> (xtp/prepare-sql this-node sql query-opts)
-               (.openQuery nil (QueryOpts. nil (:default-tz query-opts))))))
-
-       (prepareSql [_ sql db-name await-token]
-         (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
-           (xtp/prepare-sql this-node sql query-opts)))
-
-       (mergeAwaitToken [_ existing-token db-name tx-id]
-         (basis/merge-tx-tokens existing-token (basis/->tx-basis-str {db-name [tx-id]})))
-
-       (getColumnTypes [_ table snap]
-         (when-let [^Database db (.databaseOrNull db-cat (.getDbName table))]
-           (.getColumnTypes db table snap)))
-
-       (openSnapshot [_ db-name await-token]
-         (let [^Database db (or (.databaseOrNull db-cat db-name)
-                                (throw (err/incorrect :xtdb/unknown-db (format "Unknown database: %s" db-name)
-                                                      {:db-name db-name})))]
-           (.awaitAll db-cat await-token nil)
-           (.openSnapshot db))))))
+         (getColumnTypes [_ table snap]
+           (when-let [^Database db (.databaseOrNull db-cat (.getDbName table))]
+             (.getColumnTypes db table snap)))))))
 
   (addMeterRegistry [_ reg]
     (.add metrics-registry reg))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -22,6 +22,7 @@
            [java.util.concurrent.atomic AtomicReference]
            (org.apache.arrow.memory BufferAllocator)
            xtdb.NodeBase
+           (xtdb Session Session$Node)
            (xtdb.adbc XtdbConnection XtdbConnection$Node)
            (xtdb.antlr Sql$DirectlyExecutableStatementContext)
            (xtdb.api DataSource TransactionKey TransactionResult TransactionResult$Committed TransactionResult$Aborted Xtdb Xtdb$CompactorNode Xtdb$Config Xtdb$ExecutedTx Xtdb$SubmittedTx Xtdb$XtdbInternal)
@@ -193,6 +194,9 @@
 
   Xtdb$XtdbInternal
   (getDbCatalog [_] db-cat)
+
+  (openSession [this-node db-name]
+    (Session. (->session-node this-node db-cat) db-name))
 
   xtp/PNode
   (submit-tx [this tx-ops opts]

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -8,7 +8,6 @@
             [xtdb.antlr :as antlr]
             [xtdb.api :as xt]
             [xtdb.authn :as authn]
-            [xtdb.basis :as basis]
             [xtdb.db-catalog :as db]
             [xtdb.error :as err]
             [xtdb.expression :as expr]
@@ -42,7 +41,8 @@
            (org.apache.arrow.memory BufferAllocator)
            org.apache.arrow.vector.types.pojo.Field
            (xtdb.antlr Sql$DirectlyExecutableStatementContext SqlVisitor)
-           (xtdb.api Authenticator DataSource DataSource$ConnectionBuilder OAuthResult ServerConfig Xtdb Xtdb$Config)
+           xtdb.Session
+           (xtdb.api Authenticator DataSource DataSource$ConnectionBuilder OAuthResult ServerConfig Xtdb Xtdb$Config Xtdb$XtdbInternal)
            xtdb.api.module.XtdbModule
            (xtdb.arrow Relation Relation$ILoader VectorType)
            xtdb.arrow.RelationReader
@@ -369,7 +369,9 @@
                  (.databaseOrNull db-cat db-name))
                (throw (err-invalid-catalog db-name)))
         user (get startup-opts "user")
-        conn (assoc conn :node node, :authn authn, :default-db db-name, :db db)]
+        xt-session (.openSession ^Xtdb$XtdbInternal node db-name)
+        conn (assoc conn :node node, :authn authn, :default-db db-name, :db db)
+        _ (swap! (:conn-state conn) assoc :xt-session xt-session)]
     (if authn
       (condp = (.methodFor authn user (pgio/host-address frontend))
         #xt.authn/method :trust
@@ -508,8 +510,9 @@
 
   (pgio/cmd-write-msg conn pgio/msg-close-complete))
 
-(defmethod handle-msg* :msg-terminate [{:keys [!closing?] :as conn} _]
+(defmethod handle-msg* :msg-terminate [{:keys [conn-state !closing?] :as conn} _]
   (close-all-portals conn)
+  (util/close (:xt-session @conn-state))
   (reset! !closing? true))
 
 ;;; server impl
@@ -536,10 +539,10 @@
 
 (defn cmd-begin [{:keys [node conn-state]} tx-opts {:keys [args]}]
   (swap! conn-state
-         (fn [{:keys [session await-token] :as st}]
+         (fn [{:keys [session ^Session xt-session] :as st}]
            (let [await-token (if-let [[_ tok] (find tx-opts :await-token)]
                                (apply-args tok args)
-                               await-token)
+                               (.getAwaitToken xt-session))
                  {:keys [^Clock clock]} session]
 
              (when-not (= :read-write (:access-mode tx-opts))
@@ -571,7 +574,7 @@
   (close-all-portals conn))
 
 (defn cmd-commit [{:keys [^Xtdb node conn-state default-db ^BufferAllocator allocator, tx-error-counter, tx-latency-timer, tx-submit-timer, tx-execute-timer] :as conn}]
-  (let [{:keys [transaction session]} @conn-state
+  (let [{:keys [transaction session ^Session xt-session]} @conn-state
         {:keys [failed dml-buf system-time access-mode default-tz async? user-metadata]} transaction
         {:keys [parameters]} session]
     (if failed
@@ -592,26 +595,19 @@
                                                                                  [op])))
                                                                    (util/safe-mapv #(xt-log/open-tx-op % allocator {:default-tz default-tz})))]
                                         (if async?
-                                          (let [tx-id (with-auth-check conn
-                                                        (metrics/record-callable! tx-submit-timer
-                                                                                  (.submitTx node default-db tx-ops tx-opts)))
-                                                msg-id (.getTxId tx-id)]
-                                            (swap! conn-state (fn [cs]
-                                                                (-> cs
-                                                                    (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {default-db [msg-id]}))
-                                                                    (assoc :latest-submitted-tx {:tx-id msg-id})))))
+                                          (let [submitted-tx (with-auth-check conn
+                                                               (metrics/record-callable! tx-submit-timer
+                                                                                         (.submitTx xt-session tx-ops tx-opts)))
+                                                msg-id (.getTxId submitted-tx)]
+                                            (swap! conn-state assoc :latest-submitted-tx {:tx-id msg-id}))
 
                                           (let [tx (with-auth-check conn
                                                      (metrics/record-callable! tx-execute-timer
-                                                                               (.executeTx node default-db tx-ops tx-opts)))
-                                                msg-id (.getTxId tx)]
-                                            (swap! conn-state (fn [cs]
-                                                                (-> cs
-                                                                    (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {default-db [msg-id]}))
-                                                                    (assoc :latest-submitted-tx {:tx-id msg-id
-                                                                                                 :system-time (.getSystemTime tx)
-                                                                                                 :committed? (.getCommitted tx)
-                                                                                                 :error (.getError tx)}))))
+                                                                               (.executeTx xt-session tx-ops tx-opts)))]
+                                            (swap! conn-state assoc :latest-submitted-tx {:tx-id (.getTxId tx)
+                                                                                          :system-time (.getSystemTime tx)
+                                                                                          :committed? (.getCommitted tx)
+                                                                                          :error (.getError tx)})
 
                                             (when-let [error (.getError tx)]
                                               (throw error))))))))
@@ -981,10 +977,10 @@
     (try
       (let [{:keys [^Sql$DirectlyExecutableStatementContext parsed-query explain? explain-analyze?]} stmt
 
-            {:keys [session await-token]} @conn-state
+            {:keys [session ^Session xt-session]} @conn-state
             {:keys [^Clock clock]} session
 
-            query-opts {:await-token await-token
+            query-opts {:await-token (.getAwaitToken xt-session)
                         :tx-timeout (Duration/ofMinutes 1)
                         :default-tz (.getZone clock)
                         :explain? explain?
@@ -1110,9 +1106,9 @@
           result-formats)))
 
 (defn bind-stmt [{:keys [node conn-state ^BufferAllocator allocator query-tracer] :as conn} {:keys [statement-type ^PreparedQuery prepared-query args result-format] :as stmt}]
-  (let [{:keys [session transaction await-token]} @conn-state
+  (let [{:keys [session transaction ^Session xt-session]} @conn-state
         {:keys [^Clock clock], session-params :parameters} session
-        await-token (:await-token transaction await-token)
+        await-token (:await-token transaction (.getAwaitToken xt-session))
 
         query-opts (QueryOpts. (or (some-> (or (:current-time stmt) (:current-time transaction))
                                             (time/->instant))
@@ -1291,7 +1287,7 @@
 
 (defn cmd-set-await-token [{:keys [conn-state] :as conn} {:keys [await-token args]}]
   (let [await-token (-> await-token (apply-args args))]
-    (swap! conn-state assoc :await-token await-token)
+    (.setAwaitToken ^Session (:xt-session @conn-state) await-token)
     (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET AWAIT_TOKEN"})))
 
 (defn cmd-set-session-characteristics [{:keys [conn-state] :as conn} session-characteristics]
@@ -1458,10 +1454,8 @@
 
   (with-auth-check conn
     (let [{:keys [tx-id error] :as tx} (xtp/attach-db node db-name db-config)]
-      (swap! conn-state (fn [cs]
-                          (-> cs
-                              (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {"xtdb" [tx-id]}))
-                              (assoc :latest-submitted-tx tx))))
+      (.recordTx ^Session (:xt-session @conn-state) "xtdb" tx-id)
+      (swap! conn-state assoc :latest-submitted-tx tx)
 
       (when error
         (throw error)))))
@@ -1477,10 +1471,8 @@
 
   (with-auth-check conn
     (let [{:keys [tx-id error] :as tx} (xtp/detach-db node db-name)]
-      (swap! conn-state (fn [cs]
-                          (-> cs
-                              (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {"xtdb" [tx-id]}))
-                              (assoc :latest-submitted-tx tx))))
+      (.recordTx ^Session (:xt-session @conn-state) "xtdb" tx-id)
+      (swap! conn-state assoc :latest-submitted-tx tx)
 
       (when error
         (throw error)))))

--- a/core/src/main/kotlin/xtdb/Session.kt
+++ b/core/src/main/kotlin/xtdb/Session.kt
@@ -1,0 +1,40 @@
+package xtdb
+
+import xtdb.api.Xtdb
+import xtdb.api.log.MessageId
+import xtdb.database.DatabaseName
+import xtdb.database.encodeTxBasisToken
+import xtdb.database.mergeTxBasisTokens
+import xtdb.indexer.Snapshot
+import xtdb.query.PreparedQuery
+import xtdb.tx.TxOp
+import xtdb.tx.TxOpts
+
+class Session(private val node: Node, var dbName: DatabaseName) : AutoCloseable {
+
+    interface Node {
+        fun submitTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.SubmittedTx
+        fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx
+        fun openSqlQuery(sql: String, dbName: DatabaseName, awaitToken: String?): ResultCursor
+        fun prepareSql(sql: String, dbName: DatabaseName, awaitToken: String?): PreparedQuery
+        fun openSnapshot(dbName: DatabaseName, awaitToken: String?): Snapshot
+    }
+
+    var awaitToken: String? = null
+
+    fun recordTx(dbName: DatabaseName, txId: MessageId) {
+        awaitToken = mergeTxBasisTokens(awaitToken, mapOf(dbName to listOf(txId)).encodeTxBasisToken())
+    }
+
+    fun submitTx(ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.SubmittedTx =
+        node.submitTx(dbName, ops, opts).also { recordTx(dbName, it.txId) }
+
+    fun executeTx(ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx =
+        node.executeTx(dbName, ops, opts).also { recordTx(dbName, it.txId) }
+
+    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName, awaitToken)
+    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName, awaitToken)
+    fun openSnapshot(): Snapshot = node.openSnapshot(dbName, awaitToken)
+
+    override fun close() {}
+}

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -21,6 +21,7 @@ import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.ResultCursor
 import xtdb.api.Xtdb
+import xtdb.api.log.MessageId
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorType
@@ -43,6 +44,14 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     private var dbName: DatabaseName = "xtdb"
     private var autoCommit = true
     private val pendingOps = mutableListOf<TxOp>()
+
+    private var awaitToken: String? = null
+
+    private fun runTx(ops: List<TxOp>): Xtdb.ExecutedTx {
+        val tx = node.executeTx(dbName, ops)
+        awaitToken = node.mergeAwaitToken(awaitToken, dbName, tx.txId)
+        return tx
+    }
 
     interface XtdbStatement : AdbcStatement {
         fun bind(rel: RelationReader): Unit = unsupported("bind(RelationReader) not supported")
@@ -73,7 +82,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun prepare() {
             val sql = this.sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
-            prepared = node.prepareSql(sql, dbName)
+            prepared = node.prepareSql(sql, dbName, awaitToken)
         }
 
         override fun getParameterSchema(): Schema {
@@ -115,7 +124,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
             val queryArgs = openQueryArgs()
             val cursor = try {
-                prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName)
+                prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName, awaitToken)
             } catch (t: Throwable) {
                 queryArgs?.close()
                 throw t
@@ -139,9 +148,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
     internal fun executeDml(op: TxOp) {
         if (autoCommit) {
-            listOf(op).useAll { ops ->
-                node.executeTx(dbName, ops)
-            }
+            listOf(op).useAll { ops -> runTx(ops) }
         } else {
             pendingOps.add(op)
         }
@@ -155,9 +162,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         val ops = pendingOps.toList()
         pendingOps.clear()
         if (ops.isNotEmpty()) {
-            ops.useAll {
-                node.executeTx(dbName, ops)
-            }
+            ops.useAll { runTx(it) }
         }
     }
 
@@ -209,8 +214,8 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
     }
 
-    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName)
-    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName)
+    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName, awaitToken)
+    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName, awaitToken)
 
     private fun cursorToArrowReader(cursor: ResultCursor, schema: Schema): ArrowReader =
         object : ArrowReader(node.allocator) {
@@ -301,7 +306,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             getTableSchema(TableRef(catalog ?: dbName, dbSchema ?: "public", tableName), snap)
         }
 
-    fun openSnapshot(): Snapshot = node.openSnapshot(dbName)
+    fun openSnapshot(): Snapshot = node.openSnapshot(dbName, awaitToken)
 
     fun getTableSchema(dbSchema: String, tableName: String, snap: Snapshot): Schema =
         getTableSchema(TableRef(dbName, dbSchema, tableName), snap)
@@ -411,7 +416,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         if (depth == GetObjectsDepth.DB_SCHEMAS) {
             val sql = "SELECT DISTINCT table_schema FROM information_schema.tables $where ORDER BY table_schema"
             val result = linkedMapOf<String, List<TableInfo>>()
-            node.openSqlQuery(sql, dbName).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         result[rel.get("table_schema").getObject(i).toString()] = emptyList()
@@ -435,7 +440,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         if (needColumns) {
             val tableColumns = linkedMapOf<Pair<String, String>, MutableList<ColumnInfo>>()
-            node.openSqlQuery(sql, dbName).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -452,7 +457,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
                     .add(TableInfo(key.second, cols))
             }
         } else {
-            node.openSqlQuery(sql, dbName).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -479,10 +484,11 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         val databaseNames: Collection<DatabaseName>
         fun submitTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.SubmittedTx
         fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx
-        fun openSqlQuery(sql: String, dbName: DatabaseName): ResultCursor
-        fun prepareSql(sql: String, dbName: DatabaseName): PreparedQuery
+        fun openSqlQuery(sql: String, dbName: DatabaseName, awaitToken: String?): ResultCursor
+        fun prepareSql(sql: String, dbName: DatabaseName, awaitToken: String?): PreparedQuery
+        fun mergeAwaitToken(awaitToken: String?, dbName: DatabaseName, txId: MessageId): String
         fun getColumnTypes(table: TableRef, snap: Snapshot): Map<String, VectorType>?
-        fun openSnapshot(dbName: DatabaseName): Snapshot
+        fun openSnapshot(dbName: DatabaseName, awaitToken: String?): Snapshot
     }
 
     override fun close() {

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -20,8 +20,8 @@ import org.apache.arrow.vector.complex.writer.VarCharWriter
 import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.ResultCursor
+import xtdb.Session
 import xtdb.api.Xtdb
-import xtdb.api.log.MessageId
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorType
@@ -41,17 +41,10 @@ import xtdb.util.useAll
 
 class XtdbConnection(private val node: Node) : AdbcConnection {
 
-    private var dbName: DatabaseName = "xtdb"
+    private val session = Session(node, "xtdb")
+    private val dbName get() = session.dbName
     private var autoCommit = true
     private val pendingOps = mutableListOf<TxOp>()
-
-    private var awaitToken: String? = null
-
-    private fun runTx(ops: List<TxOp>): Xtdb.ExecutedTx {
-        val tx = node.executeTx(dbName, ops)
-        awaitToken = node.mergeAwaitToken(awaitToken, dbName, tx.txId)
-        return tx
-    }
 
     interface XtdbStatement : AdbcStatement {
         fun bind(rel: RelationReader): Unit = unsupported("bind(RelationReader) not supported")
@@ -82,7 +75,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun prepare() {
             val sql = this.sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
-            prepared = node.prepareSql(sql, dbName, awaitToken)
+            prepared = session.prepareSql(sql)
         }
 
         override fun getParameterSchema(): Schema {
@@ -124,7 +117,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
             val queryArgs = openQueryArgs()
             val cursor = try {
-                prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName, awaitToken)
+                prepared?.openQuery(queryArgs, QueryOpts()) ?: session.openSqlQuery(sql)
             } catch (t: Throwable) {
                 queryArgs?.close()
                 throw t
@@ -148,7 +141,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
     internal fun executeDml(op: TxOp) {
         if (autoCommit) {
-            listOf(op).useAll { ops -> runTx(ops) }
+            listOf(op).useAll { ops -> session.executeTx(ops) }
         } else {
             pendingOps.add(op)
         }
@@ -162,7 +155,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         val ops = pendingOps.toList()
         pendingOps.clear()
         if (ops.isNotEmpty()) {
-            ops.useAll { runTx(it) }
+            ops.useAll { session.executeTx(it) }
         }
     }
 
@@ -214,8 +207,8 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
     }
 
-    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName, awaitToken)
-    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName, awaitToken)
+    fun prepareSql(sql: String): PreparedQuery = session.prepareSql(sql)
+    fun openSqlQuery(sql: String): ResultCursor = session.openSqlQuery(sql)
 
     private fun cursorToArrowReader(cursor: ResultCursor, schema: Schema): ArrowReader =
         object : ArrowReader(node.allocator) {
@@ -306,7 +299,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             getTableSchema(TableRef(catalog ?: dbName, dbSchema ?: "public", tableName), snap)
         }
 
-    fun openSnapshot(): Snapshot = node.openSnapshot(dbName, awaitToken)
+    fun openSnapshot(): Snapshot = session.openSnapshot()
 
     fun getTableSchema(dbSchema: String, tableName: String, snap: Snapshot): Schema =
         getTableSchema(TableRef(dbName, dbSchema, tableName), snap)
@@ -416,7 +409,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         if (depth == GetObjectsDepth.DB_SCHEMAS) {
             val sql = "SELECT DISTINCT table_schema FROM information_schema.tables $where ORDER BY table_schema"
             val result = linkedMapOf<String, List<TableInfo>>()
-            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
+            session.openSqlQuery(sql).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         result[rel.get("table_schema").getObject(i).toString()] = emptyList()
@@ -440,7 +433,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         if (needColumns) {
             val tableColumns = linkedMapOf<Pair<String, String>, MutableList<ColumnInfo>>()
-            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
+            session.openSqlQuery(sql).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -457,7 +450,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
                     .add(TableInfo(key.second, cols))
             }
         } else {
-            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
+            session.openSqlQuery(sql).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -475,24 +468,19 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     override fun getCurrentCatalog(): String = dbName
 
     override fun setCurrentCatalog(catalog: String) {
-        dbName = catalog
+        session.dbName = catalog
     }
     override fun getCurrentDbSchema(): String = "public"
 
-    interface Node {
+    interface Node : Session.Node {
         val allocator: BufferAllocator
         val databaseNames: Collection<DatabaseName>
-        fun submitTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.SubmittedTx
-        fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx
-        fun openSqlQuery(sql: String, dbName: DatabaseName, awaitToken: String?): ResultCursor
-        fun prepareSql(sql: String, dbName: DatabaseName, awaitToken: String?): PreparedQuery
-        fun mergeAwaitToken(awaitToken: String?, dbName: DatabaseName, txId: MessageId): String
         fun getColumnTypes(table: TableRef, snap: Snapshot): Map<String, VectorType>?
-        fun openSnapshot(dbName: DatabaseName, awaitToken: String?): Snapshot
     }
 
     override fun close() {
         rollback()
+        session.close()
     }
 
     companion object {

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -47,6 +47,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
     interface XtdbInternal : Xtdb {
         val dbCatalog: Database.Catalog
+        fun openSession(dbName: DatabaseName): xtdb.Session
     }
 
     fun <T : XtdbModule> module(type: Class<T>): T?

--- a/src/test/java/xtdb/api/AdbcTest.kt
+++ b/src/test/java/xtdb/api/AdbcTest.kt
@@ -304,4 +304,18 @@ class AdbcTest {
             }
         }
     }
+
+    @Test
+    fun `same-connection INSERT then getTableSchema sees the columns`() {
+        AdbcDriverFactory().getDriver(allocator).open(emptyMap()).use { db ->
+            db.connect().use { conn ->
+                conn.createStatement().use { ins ->
+                    ins.setSqlQuery("INSERT INTO same_conn_table (_id, n) VALUES (1, 100)")
+                    ins.executeUpdate()
+                }
+                conn.getTableSchema(null, "public", "same_conn_table")
+                    .fields.map { it.name }.toSet() shouldBe setOf("_id", "n")
+            }
+        }
+    }
 }

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -244,6 +244,19 @@ class FlightSqlAdbcTest {
         }
     }
 
+    @Test
+    fun `test same-connection INSERT then executeSchema sees real column names`() {
+        conn.createStatement().use { ins ->
+            ins.setSqlQuery("INSERT INTO same_conn_repro (_id, n) VALUES (1, 100)")
+            ins.executeUpdate()
+        }
+        conn.createStatement().use { stmt ->
+            stmt.setSqlQuery("SELECT n FROM same_conn_repro")
+            stmt.prepare()
+            assertEquals(listOf("n"), stmt.executeSchema().fields.map { it.name })
+        }
+    }
+
     // -- ADBC metadata (through FlightSQL ADBC client) --
 
     // getInfo via ADBC client hits a bug in GetInfoMetadataReader.processRootFromStream

--- a/src/test/kotlin/xtdb/SessionTest.kt
+++ b/src/test/kotlin/xtdb/SessionTest.kt
@@ -1,0 +1,105 @@
+package xtdb
+
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import xtdb.api.Xtdb
+import xtdb.api.log.MessageId
+import xtdb.database.DatabaseName
+import xtdb.database.decodeTxBasisToken
+import xtdb.indexer.Snapshot
+import xtdb.query.PreparedQuery
+import xtdb.tx.TxOp
+import xtdb.tx.TxOpts
+import java.time.Instant
+
+class SessionTest {
+
+    private class FakeNode : Session.Node {
+        var nextTxId: MessageId = 0
+        val submittedDbs = mutableListOf<DatabaseName>()
+        val queryTokens = mutableListOf<Pair<DatabaseName, String?>>()
+        val snapshotTokens = mutableListOf<Pair<DatabaseName, String?>>()
+
+        override fun submitTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts) =
+            Xtdb.SubmittedTx(nextTxId).also { submittedDbs += dbName }
+
+        override fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts) =
+            Xtdb.ExecutedTx(nextTxId, Instant.EPOCH, true, null).also { submittedDbs += dbName }
+
+        override fun openSqlQuery(sql: String, dbName: DatabaseName, awaitToken: String?): ResultCursor {
+            queryTokens += (dbName to awaitToken); return mockk()
+        }
+
+        override fun prepareSql(sql: String, dbName: DatabaseName, awaitToken: String?): PreparedQuery {
+            queryTokens += (dbName to awaitToken); return mockk()
+        }
+
+        override fun openSnapshot(dbName: DatabaseName, awaitToken: String?): Snapshot {
+            snapshotTokens += (dbName to awaitToken); return mockk()
+        }
+    }
+
+    private fun tokenOf(awaitToken: String?) = awaitToken?.decodeTxBasisToken()
+
+    @Test
+    fun `a submitted write is awaited by the next read`() {
+        val node = FakeNode().apply { nextTxId = 7 }
+        val session = Session(node, "mydb")
+
+        session.submitTx(emptyList())
+        session.openSqlQuery("SELECT 1")
+        session.openSnapshot()
+
+        val expectedToken = mapOf("mydb" to listOf(7L))
+        assertEquals(expectedToken, tokenOf(node.queryTokens.single().second))
+        assertEquals(expectedToken, tokenOf(node.snapshotTokens.single().second))
+    }
+
+    @Test
+    fun `executeTx folds its tx into the token the same way as submitTx`() {
+        val node = FakeNode().apply { nextTxId = 11 }
+        val session = Session(node, "mydb")
+
+        session.executeTx(emptyList())
+
+        assertEquals(mapOf("mydb" to listOf(11L)), tokenOf(session.awaitToken))
+    }
+
+    @Test
+    fun `successive writes accumulate monotonically`() {
+        val node = FakeNode()
+        val session = Session(node, "mydb")
+
+        node.nextTxId = 4; session.submitTx(emptyList())
+        node.nextTxId = 9; session.submitTx(emptyList())
+
+        assertEquals(mapOf("mydb" to listOf(9L)), tokenOf(session.awaitToken))
+    }
+
+    @Test
+    fun `retargeting dbName moves both writes and token onto the new db`() {
+        val node = FakeNode().apply { nextTxId = 3 }
+        val session = Session(node, "xtdb")
+
+        session.dbName = "other"
+        session.submitTx(emptyList())
+        session.openSqlQuery("SELECT 1")
+
+        assertEquals(listOf("other"), node.submittedDbs)
+        assertEquals("other", node.queryTokens.single().first)
+        assertEquals(mapOf("other" to listOf(3L)), tokenOf(session.awaitToken))
+    }
+
+    @Test
+    fun `recordTx merges a foreign db without disturbing the session db`() {
+        val node = FakeNode().apply { nextTxId = 2 }
+        val session = Session(node, "secondary")
+
+        session.submitTx(emptyList())
+        session.recordTx("xtdb", 5)
+
+        assertEquals(mapOf("secondary" to listOf(2L), "xtdb" to listOf(5L)), tokenOf(session.awaitToken))
+    }
+
+}


### PR DESCRIPTION
## Summary

Extracts per-connection await-token tracking from `XtdbConnection` and `pgwire` into a shared `xtdb.Session` primitive.
One implementation, two consumers.

Addresses @jarohen's review on #5609:
> if pgwire and ADBC both require the same behaviour (and a hypothetical third protocol might too) then it's worth instead moving this functionality down a layer.

## Stack

Stacked on #5609 (base shows 4 commits until that lands; the last two are this PR).
Merges cleanly once #5609 lands.

## Shape

`xtdb.Session` owns a connection-scoped `awaitToken: String?`, refreshes it after every `submitTx` / `executeTx`, and threads it through `openSqlQuery` / `prepareSql` / `openSnapshot`.

`Session.Node` is a pure executor SPI — `submitTx`, `executeTx`, `openSqlQuery`, `prepareSql`, `openSnapshot`.
The await-token bookkeeping lives on `Session` itself (`recordTx`), implemented natively in Kotlin over `Basis.mergeTxBasisTokens` / `encodeTxBasisToken` — no Clojure round-trip, and implementors of `Node` never see token mechanics.
`XtdbConnection.Node` extends `Session.Node`.

New `Xtdb.XtdbInternal.openSession(dbName)` factory; `impl.clj` grows a shared `->session-node` helper used by both `connect` and `openSession`, so the ADBC and pgwire bridges can't drift.

Two commits:

1. **`feat(adbc): extract per-connection await-token into shared Session layer`** — `Session` class + `SessionTest`, `XtdbConnection` delegates, `->session-node` helper + `connect` rewrite.
2. **`feat(pgwire): migrate per-connection await-token to shared Session layer`** — `openSession` factory, 13 `:await-token` references in pgwire migrated to a `:xt-session` in conn-state, `xtdb.basis` require dropped (merge math now lives behind `Session`).

## Review actions applied

Pre-empting the review patterns from #5605/#5609:

- **`mergeAwaitToken` removed from the `Session.Node` SPI** — it was a token-string helper masquerading as an executor method.
  Merge is now a `Session` state-transition (`recordTx(dbName, txId)`), so every `Node` implementor stays ignorant of token format.
- **Reify duplication collapsed** — `connect` and `openSession` shared a near-identical `Session.Node` reify; extracted `->session-node`.
- **`AutoCloseable` honoured at the ownership sites** — ADBC `XtdbConnection.close()` and pgwire `:msg-terminate` now close the session, rather than the type advertising a close contract nobody called.
- **`cmd-commit` local `tx-id` → `submitted-tx`** — it binds a `SubmittedTx`, not an id.

## Test plan

- `xtdb.SessionTest` (new): 5/5 — pins the read-your-writes token contract, monotonic accumulation, cross-db merge (the attach/detach primitive), and dbName retargeting.
- `xtdb.pgwire-test` + `xtdb.pgwire-protocol-test`: 192/192 green.
- `xtdb.api.AdbcTest` + `xtdb.FlightSqlAdbcTest`: 28/28 green.
- No reflection / boxed-math warnings.

## Scope

Out:

- `autoCommit` / `pendingOps` / `currentCatalog` state still lives in each consumer (`XtdbConnection`, pgwire's `:conn-state`).
  This PR scopes to await-token tracking only — that's what @jarohen's comment named, and it's the cleanest narrow win.
  Broader session-state extraction can follow.
- pgwire's `:session` config map (clock, parameters, characteristics) is unrelated and untouched — kept as `:xt-session` alongside to avoid conflating protocol session state with XTDB session state.

## Follow-ups

- Unblocks #5079 (FlightSQL session management): `openSession` is the factory it needs to replace `XtdbProducer.defaultConnections` with a per-FSQL-session `Session` map, fixing the await-token race on shared FSQL connections.
