### PR TITLE
fix(kafka): evict subscriptions on poll-loop failure

### DIFF
--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -150,7 +150,6 @@ class KafkaCluster(
     private sealed interface GroupCommand {
         class Register(val topic: String, val subscription: SharedGroupConsumer.TopicSubscription<*>) : GroupCommand
         class Unregister(val topic: String, val cont: CancellableContinuation<Unit>) : GroupCommand
-        class UnregisterOnFailure(val topics: Collection<String>, val cause: Throwable) : GroupCommand
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -253,17 +252,18 @@ class KafkaCluster(
                     applySubscriptions()
                     cmd.cont.resume(Unit)
                 }
+            }
+        }
 
-                // No `onPartitionsRevokedSync` — the subscriber learns about the failure via
-                // `completion.completeExceptionally`; firing the revoke would also trigger
-                // LogProcessor's leader→follower transition during a Failed-state cleanup.
-                is GroupCommand.UnregisterOnFailure -> {
-                    for (topic in cmd.topics) {
-                        subscriptions.remove(topic)?.completion?.completeExceptionally(cmd.cause)
-                    }
-                    applySubscriptions()
+        // Deliberately no `onPartitionsRevokedSync` — would trigger LogProcessor's
+        // leader→follower transition during a Failed-state cleanup.
+        private fun evictSubscriptions(topics: Collection<String>, cause: Throwable) {
+            for (topic in topics) {
+                subscriptions.remove(topic)?.completion?.let { completion ->
+                    if (completion.isActive) completion.completeExceptionally(cause)
                 }
             }
+            applySubscriptions()
         }
 
         private suspend fun KafkaConsumer<*, ByteArray>.pollRecords() =
@@ -302,7 +302,7 @@ class KafkaCluster(
                                     }
                                 } catch (e: OffsetOutOfRangeException) {
                                     LOG.error(e) { "evicting subscriptions for OffsetOutOfRange partitions: ${e.partitions()}" }
-                                    processCommand(GroupCommand.UnregisterOnFailure(e.partitions().map { it.topic() }.toSet(), e))
+                                    evictSubscriptions(e.partitions().map { it.topic() }.toSet(), e)
                                 }
                             }
                         }

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.onClosed
 import kotlinx.coroutines.channels.onSuccess
-import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
@@ -52,6 +51,7 @@ import xtdb.util.close
 import xtdb.util.error
 import xtdb.util.info
 import xtdb.util.logger
+import xtdb.util.warn
 import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant.ofEpochMilli
@@ -266,6 +266,27 @@ class KafkaCluster(
             applySubscriptions()
         }
 
+        // Order matters: close before drain (no new commands can land mid-drain),
+        // drain before evict (queued unregister continuations need resuming before
+        // subscribers wake into their finally and find the channel closed).
+        private fun cleanupOnFailure(cause: Throwable) {
+            commandCh.close()
+            while (true) {
+                val cmd = commandCh.tryReceive().getOrNull() ?: break
+                when (cmd) {
+                    is GroupCommand.Register -> cmd.subscription.completion.let { completion ->
+                        if (completion.isActive) completion.completeExceptionally(cause)
+                    }
+                    is GroupCommand.Unregister -> cmd.cont.resume(Unit)
+                }
+            }
+            try {
+                evictSubscriptions(subscriptions.keys.toList(), cause)
+            } catch (cleanup: Throwable) {
+                LOG.warn(cleanup, "error during subscription cleanup after poll loop failure")
+            }
+        }
+
         private suspend fun KafkaConsumer<*, ByteArray>.pollRecords() =
             runInterruptible(Dispatchers.IO) {
                 try {
@@ -309,10 +330,12 @@ class KafkaCluster(
                     }
                 }
             } catch (e: CancellationException) {
+                cleanupOnFailure(e)
                 throw e
             } catch (e: Throwable) {
                 LOG.error(e) { "SharedGroupConsumer poll loop failed" }
-                throw e
+                cleanupOnFailure(e)
+                // Don't rethrow — already handled; the scope has no handler, so it'd just double-log.
             }
         }
 
@@ -330,8 +353,13 @@ class KafkaCluster(
 
         suspend fun unregister(topic: String) {
             suspendCancellableCoroutine { cont ->
-                commandCh.trySendBlocking(GroupCommand.Unregister(topic, cont)).getOrThrow()
-                consumer.wakeup()
+                val result = commandCh.trySend(GroupCommand.Unregister(topic, cont))
+                when {
+                    // consumer shut down; subscription already evicted via cleanupOnFailure
+                    result.isClosed -> cont.resume(Unit)
+                    result.isSuccess -> consumer.wakeup()
+                    else -> error("commandCh trySend failed: $result")
+                }
             }
         }
 

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -472,6 +472,59 @@ class KafkaClusterTest {
         }
     }
 
+    private class ThrowingOnAssignListener(private val toThrow: Throwable) : SubscriptionListener<SourceMessage> {
+        override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> {
+            throw toThrow
+        }
+
+        override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+    }
+
+    @Test
+    fun `poll loop failure evicts all subscriptions with cause and unblocks shutdown`() = runTest(timeout = 30.seconds) {
+        val topic1 = "test-poll-fail-${UUID.randomUUID()}"
+        val topic2 = "test-poll-fail-${UUID.randomUUID()}"
+
+        val boom = RuntimeException("listener boom")
+        val healthy = TrackingListener()
+        val throwing = ThrowingOnAssignListener(boom)
+
+        val caughtHealthy = AtomicReference<Throwable?>(null)
+        val caughtThrowing = AtomicReference<Throwable?>(null)
+
+        withClusterAndLogs(listOf(topic1, topic2)) { _, logs ->
+            val (logHealthy, logThrowing) = logs
+
+            // register the healthy subscriber first and wait for it to be assigned —
+            // guarantees it's in the subscriptions map when the throwing one tanks the poll loop
+            val jobHealthy = launch(SupervisorJob()) {
+                try { logHealthy.openGroupSubscription(healthy) }
+                catch (e: Throwable) { caughtHealthy.set(e) }
+            }
+            while (!healthy.isAssigned) delay(100.milliseconds)
+
+            val jobThrowing = launch(SupervisorJob()) {
+                try { logThrowing.openGroupSubscription(throwing) }
+                catch (e: Throwable) { caughtThrowing.set(e) }
+            }
+
+            // both subscribers should surface a failure (no hang) — the outer runTest timeout
+            // is the regression canary for the pre-fix shutdown-hang behaviour
+            jobHealthy.join()
+            jobThrowing.join()
+        }
+
+        val exThrowing = caughtThrowing.get()
+            ?: error("throwing subscriber must surface a failure, not hang")
+        val exHealthy = caughtHealthy.get()
+            ?: error("healthy subscriber must surface a failure when the poll loop dies, not hang")
+
+        assertTrue(generateSequence<Throwable>(exThrowing) { it.cause }.any { it === boom },
+            "throwing subscriber must see the listener exception in its cause chain, got: $exThrowing")
+        assertTrue(generateSequence<Throwable>(exHealthy) { it.cause }.any { it === boom },
+            "healthy subscriber must see the listener exception in its cause chain, got: $exHealthy")
+    }
+
     @Test
     fun `database can resubscribe after unsubscribing`() = runTest(timeout = 60.seconds) {
         val topic1 = "test-shared-resub-${UUID.randomUUID()}"


### PR DESCRIPTION
## Background

The Kafka-backed `SharedGroupConsumer` shares a single poll loop and Kafka consumer across every database's source-log subscription on a node. When that poll loop's body threw — most realistically when a `SubscriptionListener.onPartitionsAssigned` callback (e.g. `LogProcessor`'s leader transition) threw, surfacing back through Kafka as `KafkaException: User rebalance callback throws an error` — the catch logged "SharedGroupConsumer poll loop failed" and rethrew, but nothing failed the subscribers' `completion` deferreds.

Each subscriber parked forever on `sub.completion.await()` in `openGroupSubscription`, then its `withContext(NonCancellable) { unregister(topic) }` finally-block parked on a `CancellableContinuation` that nobody would resume. The owning `Database`'s scope had perpetual children, `DatabaseCatalog.close()` couldn't join, and node shutdown didn't complete.

Symptom-side this manifested as nodes that wouldn't exit graceful shutdown, and as subscribers seeing `JobCancellationException("Job was cancelled")` in their logs with no provenance for the actual cause.

## Shape of the fix

A new private `cleanupOnFailure(cause)` runs inside the polling coroutine before either catch returns. The ordering is load-bearing:

1. `commandCh.close()` — block new `register`/`unregister` from landing mid-cleanup.
2. Drain remaining queued commands — fail any pending `Register`'s `completion`, resume any pending `Unregister`'s continuation; otherwise they'd leak.
3. `evictSubscriptions(subscriptions.keys, cause)` — complete every live subscription's deferred exceptionally with the real cause.

`unregister` swapped `trySendBlocking().getOrThrow()` for `trySend` + an explicit `when` on the `ChannelResult`. The race: subscribers wake from the exceptional `completion.await()` and head into their `withContext(NonCancellable)` cleanup, but the channel may already be closed. The `ChannelResult` form handles the closed-channel case atomically — a `Closed` result resumes the continuation as if the unregister succeeded (the subscription has already been evicted via `cleanupOnFailure`). Throwing out of the finally would have suppressed the original cause; the `ChannelResult` shape avoids that without exception flow.

The `Throwable` catch deliberately does not rethrow now. The catch logs and runs cleanup; rethrowing would propagate as an uncaught exception in `KafkaCluster.scope` (a `SupervisorJob` with no handler), getting logged a second time by the JVM uncaught-exception handler in production. `CancellationException` still rethrows — coroutines convention.

## Tidy first

The first commit pulls `evictSubscriptions(topics, cause)` out as a named private function and drops the `UnregisterOnFailure` entry from the `GroupCommand` sealed hierarchy. It was never sent through `commandCh` — only invoked inline from the poll loop's `OffsetOutOfRange` catch — so grouping it with the queued commands implied a channel-drain semantics that didn't apply. Behaviour-preserving; no functional change.

## Test plan

- [x] `./gradlew :modules:xtdb-kafka:integration-test` — full kafka integration suite passes.
- [x] New `poll loop failure evicts all subscriptions with cause and unblocks shutdown` exercises the previously-unccovered path: one healthy subscriber and one throwing subscriber, both must surface the listener exception in their cause chain. The `runTest(timeout = 30.seconds)` is the shutdown-hang regression canary — pre-fix the `join()` calls never returned.

## Out of scope

- Per-topic eviction on a single listener's failure — so other healthy subscribers carry on instead of all going down together. Explored in this session, deferred.
- Surfacing `CancellationException` stack provenance via the kotlinx `-Dkotlinx.coroutines.debug` flag — operational change, not code.