### PR TITLE
fix(kafka): isolate rebalance-listener failure to the failing topic

### DIFF
--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.InterruptException
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
@@ -152,6 +153,14 @@ class KafkaCluster(
         class Unregister(val topic: String, val cont: CancellableContinuation<Unit>) : GroupCommand
     }
 
+    private class ListenerAssignmentFailures(val byTopic: Map<String, Throwable>) :
+        RuntimeException(
+            byTopic.entries.joinToString(", ") { (topic, e) ->
+                "$topic (${e.javaClass.simpleName}: ${e.message})"
+            },
+            byTopic.values.firstOrNull(),
+        )
+
     @Suppress("UNCHECKED_CAST")
     private inner class SharedGroupConsumer : AutoCloseable {
         private val subscriptions = mutableMapOf<String, TopicSubscription<*>>()
@@ -207,17 +216,19 @@ class KafkaCluster(
             else consumer.subscribe(topics, object : ConsumerRebalanceListener {
                 override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) =
                     launderInterruptedException {
-                        try {
-                            runBlocking {
-                                for ((topic, tps) in partitions.groupBy { it.topic() }) {
+                        val failures = mutableMapOf<String, Throwable>()
+                        runBlocking {
+                            for ((topic, tps) in partitions.groupBy { it.topic() }) {
+                                try {
                                     val sub = subscriptions[topic] as? TopicSubscription<Any?> ?: continue
                                     sub.onPartitionAssigned(tps.single())
+                                } catch (e: Throwable) {
+                                    failures[topic] = e
+                                    LOG.error(e) { "rebalance listener onPartitionsAssigned failed for partitions $tps" }
                                 }
                             }
-                        } catch (e: Throwable) {
-                            LOG.error(e) { "rebalance listener onPartitionsAssigned failed for partitions $partitions" }
-                            throw e
                         }
+                        if (failures.isNotEmpty()) throw ListenerAssignmentFailures(failures)
                     }
 
                 override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) =
@@ -327,6 +338,14 @@ class KafkaCluster(
                                 } catch (e: OffsetOutOfRangeException) {
                                     LOG.error(e) { "evicting subscriptions for OffsetOutOfRange partitions: ${e.partitions()}" }
                                     evictSubscriptions(e.partitions().map { it.topic() }.toSet(), e)
+                                } catch (e: KafkaException) {
+                                    val failures = generateSequence<Throwable>(e) { it.cause }
+                                        .filterIsInstance<ListenerAssignmentFailures>()
+                                        .firstOrNull() ?: throw e
+                                    failures.byTopic.forEach { (topic, cause) ->
+                                        LOG.error(cause) { "evicting topic '$topic' after listener failure on assignment" }
+                                    }
+                                    evictSubscriptions(failures.byTopic)
                                 }
                             }
                         }

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -257,14 +257,17 @@ class KafkaCluster(
 
         // Deliberately no `onPartitionsRevokedSync` — would trigger LogProcessor's
         // leader→follower transition during a Failed-state cleanup.
-        private fun evictSubscriptions(topics: Collection<String>, cause: Throwable) {
-            for (topic in topics) {
+        private fun evictSubscriptions(byTopic: Map<String, Throwable>) {
+            for ((topic, cause) in byTopic) {
                 subscriptions.remove(topic)?.completion?.let { completion ->
                     if (completion.isActive) completion.completeExceptionally(cause)
                 }
             }
             applySubscriptions()
         }
+
+        private fun evictSubscriptions(topics: Collection<String>, cause: Throwable) =
+            evictSubscriptions(topics.associateWith { cause })
 
         // Order matters: close before drain (no new commands can land mid-drain),
         // drain before evict (queued unregister continuations need resuming before

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -480,38 +480,45 @@ class KafkaClusterTest {
         override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
     }
 
+    private class ThrowingOnRecordsListener(private val toThrow: Throwable) : SubscriptionListener<SourceMessage> {
+        override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> =
+            TailSpec(afterMsgId = -1L, processor = RecordProcessor { throw toThrow })
+
+        override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+    }
+
     @Test
-    fun `poll loop failure evicts all subscriptions with cause and unblocks shutdown`() = runTest(timeout = 30.seconds) {
-        val topic1 = "test-poll-fail-${UUID.randomUUID()}"
-        val topic2 = "test-poll-fail-${UUID.randomUUID()}"
+    fun `processRecords failure tears down poll loop and evicts all subscriptions`() = runTest(timeout = 30.seconds) {
+        val throwingTopic = "test-records-fail-throwing-${UUID.randomUUID()}"
+        val healthyTopic = "test-records-fail-healthy-${UUID.randomUUID()}"
 
-        val boom = RuntimeException("listener boom")
+        val boom = RuntimeException("processRecords boom")
+        val throwing = ThrowingOnRecordsListener(boom)
         val healthy = TrackingListener()
-        val throwing = ThrowingOnAssignListener(boom)
 
-        val caughtHealthy = AtomicReference<Throwable?>(null)
         val caughtThrowing = AtomicReference<Throwable?>(null)
+        val caughtHealthy = AtomicReference<Throwable?>(null)
 
-        withClusterAndLogs(listOf(topic1, topic2)) { _, logs ->
-            val (logHealthy, logThrowing) = logs
+        withClusterAndLogs(listOf(throwingTopic, healthyTopic)) { _, logs ->
+            val (logThrowing, logHealthy) = logs
 
-            // register the healthy subscriber first and wait for it to be assigned —
-            // guarantees it's in the subscriptions map when the throwing one tanks the poll loop
+            val jobThrowing = launch(SupervisorJob()) {
+                try { logThrowing.openGroupSubscription(throwing) }
+                catch (e: Throwable) { caughtThrowing.set(e) }
+            }
             val jobHealthy = launch(SupervisorJob()) {
                 try { logHealthy.openGroupSubscription(healthy) }
                 catch (e: Throwable) { caughtHealthy.set(e) }
             }
             while (!healthy.isAssigned) delay(100.milliseconds)
 
-            val jobThrowing = launch(SupervisorJob()) {
-                try { logThrowing.openGroupSubscription(throwing) }
-                catch (e: Throwable) { caughtThrowing.set(e) }
-            }
+            // both subscribers have completed onPartitionsAssigned. Send a record to the
+            // throwing topic — its processor throws inside the records-loop, propagating
+            // out of the for-loop, past the OOR catch, into pollingJob's outer catch.
+            logThrowing.appendMessage(txMessage(1))
 
-            // both subscribers should surface a failure (no hang) — the outer runTest timeout
-            // is the regression canary for the pre-fix shutdown-hang behaviour
-            jobHealthy.join()
             jobThrowing.join()
+            jobHealthy.join()
         }
 
         val exThrowing = caughtThrowing.get()
@@ -520,9 +527,51 @@ class KafkaClusterTest {
             ?: error("healthy subscriber must surface a failure when the poll loop dies, not hang")
 
         assertTrue(generateSequence<Throwable>(exThrowing) { it.cause }.any { it === boom },
-            "throwing subscriber must see the listener exception in its cause chain, got: $exThrowing")
+            "throwing subscriber must see the processRecords exception in its cause chain, got: $exThrowing")
         assertTrue(generateSequence<Throwable>(exHealthy) { it.cause }.any { it === boom },
-            "healthy subscriber must see the listener exception in its cause chain, got: $exHealthy")
+            "healthy subscriber must see the processRecords exception in its cause chain, got: $exHealthy")
+    }
+
+    @Test
+    fun `listener failure on assignment evicts only that topic, healthy subscribers keep working`() = runTest(timeout = 60.seconds) {
+        val healthyTopic = "test-isolated-fail-healthy-${UUID.randomUUID()}"
+        val throwingTopic = "test-isolated-fail-throwing-${UUID.randomUUID()}"
+
+        val boom = RuntimeException("listener boom")
+        val healthy = TrackingListener()
+        val throwing = ThrowingOnAssignListener(boom)
+        val caughtThrowing = AtomicReference<Throwable?>(null)
+
+        withClusterAndLogs(listOf(healthyTopic, throwingTopic)) { _, logs ->
+            val (logHealthy, logThrowing) = logs
+
+            // healthy subscriber first, wait until it's assigned and processing
+            val jobHealthy = launch { logHealthy.openGroupSubscription(healthy) }
+            while (!healthy.isAssigned) delay(100.milliseconds)
+
+            // throwing subscriber registers; its onPartitionsAssigned tanks
+            val jobThrowing = launch(SupervisorJob()) {
+                try { logThrowing.openGroupSubscription(throwing) }
+                catch (e: Throwable) { caughtThrowing.set(e) }
+            }
+
+            jobThrowing.join()
+            val exThrowing = caughtThrowing.get()
+                ?: error("throwing subscriber must surface its own failure")
+            assertTrue(generateSequence<Throwable>(exThrowing) { it.cause }.any { it === boom },
+                "throwing subscriber must see the listener exception in its cause chain, got: $exThrowing")
+
+            // the healthy subscriber must still be alive — receive a fresh record after the failure
+            logHealthy.appendMessage(txMessage(42))
+            while (healthy.records.isEmpty()) delay(100.milliseconds)
+            assertEquals(1, healthy.records.size,
+                "healthy subscriber must keep processing after an unrelated topic's listener failed")
+            val msg = healthy.records[0].message
+            check(msg is SourceMessage.LegacyTx)
+            assertArrayEquals(byteArrayOf(-1, 42), msg.payload)
+
+            jobHealthy.cancelAndJoin()
+        }
     }
 
     @Test


### PR DESCRIPTION
Follows on from #5650 (which made `SharedGroupConsumer` evict every subscription on poll-loop failure to unblock shutdown). That fix was right for "the whole poll loop died" but used the wrong granularity for the most common trigger: a single `SubscriptionListener.onPartitionsAssigned` failure (e.g. `LogProcessor`'s leader transition throwing) would propagate through Kafka's `ConsumerRebalanceListenerInvoker` as `KafkaException: User rebalance callback throws an error`, land in `pollingJob`'s outer catch, and tear down *every* subscriber sharing the consumer — taking down Kafka ingestion for every database on the node because one database's leader transition failed.

This PR moves listener failures from "tank everything" to "evict only this topic".

## Approach

The rebalance wrapper now runs the per-topic loop to completion (so healthy topics in the same rebalance still get set up — relevant on startup when several databases register before the first poll), collects failures into a `Map<String, Throwable>`, and throws a private `ListenerAssignmentFailures` carrier. The poll-loop's new `catch (KafkaException)` branch unwraps the carrier and evicts the named topics with their own per-topic causes via the existing `evictSubscriptions`. A `KafkaException` *without* the carrier (some other rebalance failure) is rethrown to preserve the existing `cleanupOnFailure` path.

## Decisions worth flagging

**Exception-as-carrier rather than a flag or a queued `Evict` command.**
The constraint forcing the choice is that `consumer.subscribe` (inside `applySubscriptions`) is unsafe from within Kafka's rebalance callback — Kafka's docs say so, and nesting `subscribe` inside an in-flight rebalance deadlocks the join state machine. *Something* has to communicate "evict these topics" out of the callback to a safe point. A flag-plus-pending-evictions list works but needs mutable state in both the callback and the poll loop, and is the shape an earlier draft had that we explicitly moved away from. A queued `Evict` command would leave a race window between the callback returning and the command being processed, during which `processor` would be null and records could NPE in the records-loop. The exception approach is synchronous — by the time we're back in the poll-loop catch, the rebalance has finished, no records have flowed, and we can call `evictSubscriptions` freely.

**Walking the cause chain to find the carrier.**

```kotlin
val failures = generateSequence<Throwable>(e) { it.cause }
    .filterIsInstance<ListenerAssignmentFailures>()
    .firstOrNull() ?: throw e
```

kotlinx coroutines' stacktrace-recovery copies exceptions as they cross suspend boundaries (`runInterruptible`, `Deferred.await`), with the original as the *copy's* cause — so our carrier ends up at depth two, not one. This is [documented kotlinx behaviour](https://github.com/Kotlin/kotlinx.coroutines/blob/master/docs/topics/debugging.md) and matches the pattern Spring Kafka's [`ErrorHandlingUtils.findRootCause`](https://docs.spring.io/spring-kafka/api/org/springframework/kafka/listener/ErrorHandlingUtils.html) uses for the same shape of problem. A single-level `e.cause` check landed amber in TDD before the chain walk turned it green.

## Tidy first

The first commit adds a `Map<String, Throwable>`-shaped overload to `evictSubscriptions` and makes the existing `Collection<String>, Throwable` form delegate to it via `topics.associateWith { cause }`. No behaviour change; lets the new caller hand its `Map` straight in instead of looping the existing form N times (N `applySubscriptions` round-trips per rebalance failure).

## Test plan

- [x] `./gradlew :modules:xtdb-kafka:integration-test --rerun-tasks` — all kafka integration tests pass on a fresh run.
- [x] Replaced `poll loop failure evicts all subscriptions with cause and unblocks shutdown` (premise no longer holds — listener throw doesn't tank loop) with `processRecords failure tears down poll loop and evicts all subscriptions`, an equivalent that exercises the same `cleanupOnFailure` path via a different trigger (a `RecordProcessor` that throws on first record). Catch-and-cleanup coverage preserved.
- [x] Added `listener failure on assignment evicts only that topic, healthy subscribers keep working` as the green test for the new behaviour — verifies the throwing subscriber surfaces its own failure (with the listener exception in its cause chain) while a sibling healthy subscriber on a different topic keeps processing fresh records.

## Out of scope

- Listener failures during `onPartitionsRevoked` (symmetric per-topic treatment would apply, but the revoked path doesn't tank the loop the same way today, and we don't have a failure mode in production driving it).
- Surfacing `CancellationException` stack provenance via `-Dkotlinx.coroutines.debug` — operational change, not code; same note as #5650.

---

Generated with Claude Code