### PR TITLE
fix(database): mark out-of-sync log unhealthy, don't fail node startup

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -175,39 +175,48 @@ class Database(
             )
         }
 
-        private fun throwIllegalLogState(
-            dbName: DatabaseName,
+        private fun illegalLogState(
+            dbName: DatabaseName, latestProcessedMsgId: MessageId,
             latestSubmittedOffset: LogOffset, logEpoch: Int, processedEpoch: Int, processedOffset: MessageId
-        ): Nothing {
+        ): IngestionStoppedException {
             val logState =
                 if (latestSubmittedOffset == -1L) "the log is empty"
                 else "epoch=$logEpoch, offset=$latestSubmittedOffset"
 
-            error(
-                buildString {
-                    appendLine("Database '$dbName' failed to start due to an invalid transaction log state ($logState) " +
-                            "that does not correspond with the latest processed message " +
-                            "(epoch=$processedEpoch and offset=$processedOffset).")
-                    appendLine()
-                    append("Please see https://docs.xtdb.com/ops/backup-and-restore/out-of-sync-log.html " +
-                            "for more information and next steps.")
-                }
-            )
+            val msg = buildString {
+                appendLine("Database '$dbName' has an invalid transaction log state ($logState) " +
+                        "that does not correspond with the latest processed message " +
+                        "(epoch=$processedEpoch and offset=$processedOffset).")
+                appendLine()
+                append("Please see https://docs.xtdb.com/ops/backup-and-restore/out-of-sync-log.html " +
+                        "for more information and next steps.")
+            }
+
+            return IngestionStoppedException(latestProcessedMsgId, IllegalStateException(msg))
         }
 
-        private fun validateOffsets(dbName: DatabaseName, log: Log<SourceMessage>, latestProcessedMsgId: MessageId?) {
-            if (latestProcessedMsgId == null) return
+        /**
+         * Returns an [IngestionStoppedException] if the log/storage offsets diverge
+         * (rotated/truncated/wrong topic), otherwise null.
+         * A divergent epoch is expected when starting a new epoch and is not an error.
+         */
+        private fun offsetMismatchOrNull(
+            dbName: DatabaseName, log: Log<SourceMessage>, latestProcessedMsgId: MessageId?
+        ): IngestionStoppedException? {
+            if (latestProcessedMsgId == null) return null
 
             val processedOffset = msgIdToOffset(latestProcessedMsgId)
             val processedEpoch = msgIdToEpoch(latestProcessedMsgId)
             val logEpoch = log.epoch
             val latestSubmittedOffset = log.latestSubmittedOffset
 
-            when {
-                processedEpoch != logEpoch -> logNewEpoch()
+            return when {
+                processedEpoch != logEpoch -> { logNewEpoch(); null }
 
                 latestSubmittedOffset < processedOffset ->
-                    throwIllegalLogState(dbName, latestSubmittedOffset, logEpoch, processedEpoch, processedOffset)
+                    illegalLogState(dbName, latestProcessedMsgId, latestSubmittedOffset, logEpoch, processedEpoch, processedOffset)
+
+                else -> null
             }
         }
 
@@ -236,15 +245,18 @@ class Database(
             // block-catalog watermark (or the source-log epoch floor on a fresh epoch).
             val txId = state.liveIndex.latestCompletedTx?.txId ?: -1L
 
-            // Catch log/storage divergence (rotated/truncated/wrong topic) before we wire up
-            // the indexer — see /ops/backup-and-restore/out-of-sync-log.
-            validateOffsets(dbName, storage.sourceLog, blockCatalog.latestProcessedMsgId)
-
             val watchers = Watchers(
                 latestTxId = txId,
                 latestSourceMsgId = sourceMsgId,
                 externalSourceToken = blockCatalog.externalSourceToken,
             )
+
+            // Catch log/storage divergence (rotated/truncated/wrong topic). Rather than failing
+            // node startup, poison this database's watchers — it surfaces as an ingestion error
+            // (healthz red, queries throw) while the node, and any healthy siblings, stay up.
+            // See /ops/backup-and-restore/out-of-sync-log (#5644).
+            val offsetMismatch = offsetMismatchOrNull(dbName, storage.sourceLog, blockCatalog.latestProcessedMsgId)
+            if (offsetMismatch != null) watchers.notifyError(offsetMismatch)
 
             val crashLogger = CrashLogger(allocator, storage.bufferPool, base.config.nodeId)
 
@@ -259,7 +271,7 @@ class Database(
                 watchers.notifyError(e)
             })
 
-            if (indexerConfig.enabled) {
+            if (indexerConfig.enabled && offsetMismatch == null) {
                 val blockUploader = BlockUploader(storage, state, compactorForDb, dbCatalog, base.meterRegistry)
                 val hasExternalSource = dbConfig.externalSource != null
 

--- a/src/test/clojure/xtdb/healthz_test.clj
+++ b/src/test/clojure/xtdb/healthz_test.clj
@@ -1,13 +1,15 @@
 (ns xtdb.healthz-test
   (:require [clj-http.client :as clj-http]
             [clojure.test :as t]
+            [next.jdbc :as jdbc]
             [xtdb.api :as xt]
             [xtdb.db-catalog :as db]
             [xtdb.healthz :as healthz]
             [xtdb.node :as xtn]
             [xtdb.test-util :as tu]
             [xtdb.util :as util])
-  (:import [xtdb.database Database Database$Catalog Database$Config]
+  (:import [xtdb.api.log IngestionStoppedException]
+           [xtdb.database Database Database$Catalog Database$Config]
            xtdb.storage.BufferPoolKt))
 
 (defn ->healthz-url [port endpoint]
@@ -232,3 +234,57 @@
             (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
               (t/is (= 503 (:status resp)))
               (t/is (re-find #"xtdb.*Primary error" (:body resp))))))))))
+
+;; --- end-to-end: a genuinely out-of-sync database is poisoned (not a node failure) and
+;;     drives healthz the same way a runtime ingestion error does (#5644) ---
+
+(t/deftest test-out-of-sync-noncritical-secondary-stays-alive-5644
+  (util/with-tmp-dirs #{node-dir sec-dir}
+    (let [port (tu/free-port)
+          sec-log (.resolve sec-dir "log")
+          sec-storage (.resolve sec-dir "storage")]
+      ;; set up: attach a (non-critical) secondary with its own log + storage, write a tx, flush a block
+      (with-open [node (tu/->local-node {:node-dir node-dir, :compactor-threads 0})]
+        (jdbc/execute! node [(format "ATTACH DATABASE secondary WITH $$
+  log: !Local
+    path: '%s'
+  storage: !Local
+    path: '%s'
+$$" sec-log sec-storage)])
+        (with-open [conn (-> (.createConnectionBuilder node) (.database "secondary") (.build))]
+          (jdbc/execute! conn ["INSERT INTO foo RECORDS {_id: 1}"]))
+        (tu/flush-block! node))
+
+      ;; clear the secondary's log but keep its storage -> out of sync on restart
+      (util/delete-dir sec-log)
+
+      (with-open [node (tu/->local-node {:node-dir node-dir, :compactor-threads 0, :healthz-port port})]
+        (t/testing "the secondary is poisoned"
+          (t/is (instance? IngestionStoppedException
+                           (.getIngestionError (.databaseOrNull (db/<-node node) "secondary")))))
+
+        (t/testing "node stays alive - a non-critical out-of-sync secondary doesn't fail liveness"
+          (let [{:keys [status headers]} (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
+            (t/is (= 200 status))
+            (t/is (= "1" (get headers "X-XTDB-Databases-Unhealthy")))))))))
+
+(t/deftest test-out-of-sync-primary-unhealthy-5644
+  (util/with-tmp-dirs #{storage-path}
+    (let [port (tu/free-port)
+          node-cfg {:log [:in-memory {}]
+                    :storage [:local {:path storage-path}]}]
+      ;; flush a block, then submit a further tx that lives only in the (volatile) in-memory log
+      (with-open [node (xtn/start-node node-cfg)]
+        (xt/execute-tx node [[:put-docs :foo {:xt/id 1}]])
+        (tu/flush-block! node)
+        (xt/execute-tx node [[:put-docs :foo {:xt/id 2}]]))
+
+      ;; restart with intact storage + a fresh, empty log: storage is ahead of the log
+      (with-open [node (xtn/start-node (assoc node-cfg :healthz {:port port}))]
+        (t/testing "the primary is poisoned"
+          (t/is (instance? IngestionStoppedException (.getIngestionError (db/primary-db node)))))
+
+        (t/testing "the primary is always critical -> node is unhealthy"
+          (let [{:keys [status body]} (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
+            (t/is (= 503 status))
+            (t/is (re-find #"xtdb" body))))))))

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -10,7 +10,7 @@
   (:import org.apache.kafka.common.KafkaException
            org.testcontainers.kafka.ConfluentKafkaContainer
            org.testcontainers.utility.DockerImageName 
-           [xtdb.api.log Log]))
+           [xtdb.api.log IngestionStoppedException Log]))
 
 (def ^:private ^:dynamic *bootstrap-servers* nil)
 
@@ -139,19 +139,19 @@
                        {:xt/id :lost}])
                  (set (xt/q node "SELECT _id FROM xt_docs")))))
 
-      ;; Node with intact storage and (now) empty topic
-      (t/is
-       (thrown-with-msg?
-        IllegalStateException
-        #"Database 'xtdb' failed to start due to an invalid transaction log state \(the log is empty\)"
-        (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                           :poll-duration "PT2S"
-                                                           :properties-map {}
-                                                           :properties-file nil}]}
-                         :log [:kafka {:cluster :my-kafka
-                                       :topic empty-topic
-                                       :create-topic? true}]
-                         :storage [:local {:path local-disk-path}]})))
+      ;; Node with intact storage and (now) empty topic: starts but poisoned, not a node failure
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                         :poll-duration "PT2S"
+                                                                         :properties-map {}
+                                                                         :properties-file nil}]}
+                                        :log [:kafka {:cluster :my-kafka
+                                                      :topic empty-topic
+                                                      :create-topic? true}]
+                                        :storage [:local {:path local-disk-path}]})]
+        (let [err (.getIngestionError (db/primary-db node))]
+          (t/is (instance? IngestionStoppedException err))
+          (t/is (re-find #"Database 'xtdb' has an invalid transaction log state \(the log is empty\)"
+                         (.getMessage err)))))
 
       ;; Node with intact storage and topic 2 (ie, empty topic) along with setting log offset
       (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
@@ -241,17 +241,18 @@
         (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
         (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]]))
 
-      ;; Attempt to restart the node with intact storage and the stale topic + original epoch
-      (t/is
-       (thrown-with-msg?
-        IllegalStateException
-        #"Database 'xtdb' failed to start due to an invalid transaction log state \(epoch=0, offset=1\) that does not correspond with the latest processed message \(epoch=0 and offset=\d+\)"
-        (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                           :poll-duration "PT2S"}]}
-                         :log [:kafka {:cluster :my-kafka
-                                       :topic stale-topic
-                                       :create-topic? false}]
-                         :storage [:local {:path local-disk-path}]})))
+      ;; Attempt to restart the node with intact storage and the stale topic + original epoch:
+      ;; starts but poisoned, not a node failure
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
+                                                                         :poll-duration "PT2S"}]}
+                                        :log [:kafka {:cluster :my-kafka
+                                                      :topic stale-topic
+                                                      :create-topic? false}]
+                                        :storage [:local {:path local-disk-path}]})]
+        (let [err (.getIngestionError (db/primary-db node))]
+          (t/is (instance? IngestionStoppedException err))
+          (t/is (re-find #"invalid transaction log state \(epoch=0, offset=1\) that does not correspond with the latest processed message \(epoch=0 and offset=\d+\)"
+                         (.getMessage err)))))
 
       ;; Attempt to restart the node with intact storage, a new topic + new epoch
       (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*

--- a/src/test/clojure/xtdb/log_test.clj
+++ b/src/test/clojure/xtdb/log_test.clj
@@ -11,7 +11,7 @@
             [xtdb.util :as util])
   (:import [java.time Duration Instant InstantSource]
            xtdb.api.Xtdb$Config
-           [xtdb.api.log InMemoryLog Log$Factory ReadOnlyLog
+           [xtdb.api.log InMemoryLog IngestionStoppedException Log$Factory ReadOnlyLog
             ReplicaMessage$ResolvedTx SourceMessage$DetachDatabase]
            xtdb.arrow.Relation))
 
@@ -142,6 +142,29 @@
                                                                                        {:xt/id 3, :x "hello"}]]}]]}])
                (util/->clj (.getAsMaps rel)))))))
 
+(t/deftest test-out-of-sync-log-poisons-db-not-fails-node-5644
+  (util/with-tmp-dirs #{local-disk-path}
+    (let [node-cfg {:log [:in-memory {}]
+                    :storage [:local {:path local-disk-path}]}]
+      ;; flush a block, then submit a further tx that lives only in the (volatile) in-memory log
+      (with-open [node (xtn/start-node node-cfg)]
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
+        (t/is (nil? (tu/flush-block! node)))
+        (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :bar}]]))
+
+      ;; restart with intact storage + a fresh, empty log: storage is ahead of the log
+      (with-open [node (xtn/start-node node-cfg)]
+        (t/testing "node starts rather than throwing"
+          (t/is (some? node)))
+
+        (t/testing "the out-of-sync database is poisoned with an ingestion error"
+          (let [err (.getIngestionError (db/primary-db node))]
+            (t/is (instance? IngestionStoppedException err))
+            (t/is (re-find #"Database 'xtdb' has an invalid transaction log state \(the log is empty\)"
+                           (.getMessage err)))
+            (t/is (re-find #"out-of-sync-log" (.getMessage err))
+                  "keeps the link to the recovery docs")))))))
+
 (t/deftest test-memory-log-epochs
   (util/with-tmp-dirs #{local-disk-path}
     ;; Node with local storage and memory log 
@@ -164,13 +187,13 @@
                      {:xt/id :lost}])
                (set (xt/q node "SELECT _id FROM xt_docs")))))
 
-    ;; Node with intact storage and (now) empty memory log 
-    (t/is
-      (thrown-with-msg?
-        IllegalStateException
-        #"Database 'xtdb' failed to start due to an invalid transaction log state \(the log is empty\)"
-        (xtn/start-node {:log [:in-memory {}]
-                         :storage [:local {:path local-disk-path}]})))
+    ;; Node with intact storage and (now) empty memory log: starts but poisoned, not a node failure
+    (with-open [node (xtn/start-node {:log [:in-memory {}]
+                                      :storage [:local {:path local-disk-path}]})]
+      (let [err (.getIngestionError (db/primary-db node))]
+        (t/is (instance? IngestionStoppedException err))
+        (t/is (re-find #"Database 'xtdb' has an invalid transaction log state \(the log is empty\)"
+                       (.getMessage err)))))
 
     ;; Node with intact storage and empty memory log with epoch set to 1
     (with-open [node (xtn/start-node {:log [:in-memory {:epoch 1}]
@@ -213,13 +236,13 @@
                      {:xt/id :lost}])
                (set (xt/q node "SELECT _id FROM xt_docs")))))
 
-    ;; Node with intact storage and empty directory-log
-    (t/is
-      (thrown-with-msg?
-        IllegalStateException
-        #"Database 'xtdb' failed to start due to an invalid transaction log state \(the log is empty\)"
-        (xtn/start-node {:log [:local {:path (.resolve node-dir "new-log")}]
-                         :storage [:local {:path (.resolve node-dir "objects")}]})))
+    ;; Node with intact storage and empty directory-log: starts but poisoned, not a node failure
+    (with-open [node (xtn/start-node {:log [:local {:path (.resolve node-dir "new-log")}]
+                                      :storage [:local {:path (.resolve node-dir "objects")}]})]
+      (let [err (.getIngestionError (db/primary-db node))]
+        (t/is (instance? IngestionStoppedException err))
+        (t/is (re-find #"Database 'xtdb' has an invalid transaction log state \(the log is empty\)"
+                       (.getMessage err)))))
 
     ;; Node with intact storage and empty directory-log with epoch set to 1
     (with-open [node (xtn/start-node {:log [:local {:path (.resolve node-dir "new-log")


### PR DESCRIPTION
Closes #5644.

## What

Currently, when a database's source log is considered 'out of sync' (ie, latest processed message id from the current block is past the end of the log/larger than latest submitted message id), `validateOffsets` throws an `IllegalStateException` from `Database.open`, killing node startup. This is the case for ALL databases - ie, both critical and noncritical databases kill the node in this scenario.

Instead, we now poison that database's `Watchers` (the same path runtime ingestion errors already use) and let `open` return normally:

- the node stays up;
- the database surfaces an `IngestionStoppedException` (queries against it throw rather than silently lying);
- a single out-of-sync secondary no longer blocks the primary from coming up.
- we surface errors via `healthz/alive`, following the usual semantics (ie, errors on critical databases cause this to return a 503).

This unifies the startup and runtime "this database is unrecoverable" failure models behind one operator signal. `Watchers` is now constructed before the offset check so it can be poisoned, and ingestion wiring is skipped for a poisoned database. The diagnostic message (log state, processed offset, recovery-doc link) is preserved — only reworded from "failed to start", since startup no longer fails.

## Worth discussing

### What the check actually captures

Storage records a watermark — `latestProcessedMsgId`, the `(epoch, offset)` of the last message indexed into the object store. The log records `latestSubmittedOffset` for the current epoch. In a healthy system the log always extends at or beyond what storage has already processed.

`validateOffsets` fires when that inverts *within the same epoch*: `latestSubmittedOffset < processedOffset` (the empty-log case being the extreme). i.e. storage "remembers" transactions the log can no longer return — the log was rotated/deleted (Kafka topic recreated, local log dir replaced, wrong/empty topic) while storage stayed intact. A *differing* epoch is deliberately not an error — that's the sanctioned recovery path.

The danger it prevents: silently re-indexing from a divergent log and corrupting the object store with a different transaction history than the one already committed. Storage up to the last processed tx is preserved; submitted-but-unindexed txs in the missing tail are lost. Recovery is an `epoch` bump (fresh empty log under `epoch+1`), which is what the [out-of-sync-log docs](https://docs.xtdb.com/ops/backup-and-restore/out-of-sync-log.html) walk through.

### Is the eager startup check still pulling its weight?

This `validateOffsets` check is fairly old — it landed when we first added epochs. Recent work on `main` (e.g. 5e52b6098 `fix(kafka)!: surface OffsetOutOfRange instead of silently auto-resetting`, plus 891858567 / 69c7baaa0) means we now throw as soon as we seek to an offset that isn't available on the log — which is the same "the log can't produce an offset storage expects" divergence, just detected at seek time rather than eagerly at startup.

So:

- a chunk of this validation may now be redundant with the seek-time behaviour, and the startup check could potentially shrink or go away;
- but the recovery story (epoch bump + these docs) stays valuable regardless of *where* we detect divergence — if anything we should point at the out-of-sync docs *more*, including from the seek-time path, not just here.

Opening as a draft to have that conversation before committing to the approach.
