### PR TITLE
ai: initialise Rosetta workspace docs under dev/

### DIFF
--- a/dev/ARCHITECTURE.md
+++ b/dev/ARCHITECTURE.md
@@ -1,0 +1,87 @@
+# ARCHITECTURE
+
+Technical architecture of XTDB 2.x: the layering, the transaction/indexing model, and the query path.
+Status: current.
+This file is the grep-friendly orientation map; the authoritative narrative is `dev/doc/high-level-tour.adoc` and the `dev/doc/*.allium` specs — follow those for the full story and the exact behaviour.
+
+## Layering: Storage / State / Services
+
+XTDB is "functional core, imperative shell" expressed with OO vocabulary.
+Dependencies flow inward: Services depend on State and Storage; State has no runtime I/O (it only hydrates from Storage at startup).
+
+- **Storage** (I/O): the log and the object store.
+- **State** (in-memory): catalogs and the live index — yield data, do no I/O.
+- **Services** (orchestration): processors, compactor, garbage collector — do the I/O.
+
+## Storage layer
+
+- **Log** (Kafka or local), per database, two streams:
+  - **source log** — clients submit transactions (many writers); also carries flush signals and compaction results.
+  - **replica log** — the leader's resolved output (single writer); the source of truth that all nodes converge on.
+- **Object store** (S3 / Azure Blob / GCS / local):
+  - **L0 blocks** — batches of transaction events in Arrow format.
+  - **L1+ tries** — compaction output, an LSM tree split into current (infinite-recency) and historical (finite-recency) sides.
+  - **table blocks** — per-block, per-table metadata and row summaries.
+
+## State layer (in-memory)
+
+- **LiveIndex** (`indexer/LiveIndex.kt`) — in-flight transactions not yet persisted to a block; snapshotted per-tx for concurrent reads; rebuilt from the latest block + replica log on restart.
+- **TrieCatalog** (`trie_catalog.clj`, `trie/`) — per-table inventory of immutable trie snapshots (nascent → live → garbage); current/historical split.
+- **BlockCatalog** (`block_catalog.clj`) — latest persisted block per database.
+- **TableCatalog** (`table_catalog.clj`) — per-table metadata.
+- **Watchers** (`api/log/Watchers.kt`) — latest tx-id / source-msg-id, enabling read-your-writes; also carries the external-source resume token.
+
+## Services layer: single-writer-per-database indexing
+
+`LogProcessor` is a state machine driven by Kafka consumer-group rebalancing — Kafka does the leader election, XTDB does not.
+Exactly one leader per database; a node may lead database A while following database B.
+
+- **Leader** (`LeaderLogProcessor.kt`) — consumes the source log, resolves transactions (puts/deletes/erases, constraints), writes `ResolvedTx` to the replica log via a **fenced transactional producer**, feeds LiveIndex, and triggers block flush when LiveIndex fills or on a timeout (thresholds in `IndexerConfig`).
+- **ExternalSourceLeader** (`ExternalSourceProcessor.kt`) — CDC-driven; ingests from an external system (e.g. Postgres logical replication), assigns its own tx-ids, rejects client `submitTx`, and carries a resume token.
+- **Follower** (`FollowerLogProcessor.kt`) — consumes the replica log, applies `ResolvedTx` to LiveIndex; buffers across a block boundary until the block is uploaded.
+- **Transition** (`TransitionLogProcessor.kt`) — ephemeral startup/handoff state that replays the dead leader's pending block and catches up the replica log before becoming leader.
+
+Supporting services:
+- **BlockUploader** (`BlockUploader.kt`) — freezes LiveIndex, registers L0 tries, writes table blocks and the block file to the object store, writes `BlockUploaded` to the replica log (fenced), advances LiveIndex, signals the compactor.
+- **Compactor** (`compactor.clj`, `compaction.allium`) — runs on every node, coordination-free (deterministic job selection + idempotent output); merges small tries into larger LSM levels.
+- **GarbageCollector** (`garbage_collector.clj`, `gc.allium`) — deletes superseded tries from the object store and the TrieCatalog.
+- **BufferPool** (`storage/BufferPool.kt`, `RemoteBufferPool.kt`) — memory-mapped, locally-cached access to object-store files.
+
+## Transaction lifecycle
+
+```
+client submitTx → source log → Leader resolves → replica log (fenced)
+   → LiveIndex (snapshots for reads) → BlockUploader (on full/timeout)
+   → L0 block + tries in object store → Compactor merges L0→L1→L2+
+   → query scan merges LiveIndex + tries for the requested VT/ST
+```
+
+## Query path
+
+1. **Parse** — SQL via ANTLR (`core/src/main/antlr/`, `sql/parse.clj`); XTQL via hand-rolled parser (`xtql/`).
+   Both lower to one relational form.
+2. **Plan & optimise** — `logical_plan.clj`: relational algebra (`:scan`, `:select`, `:project`, `:join`, `:group-by`, `:order-by`, …) with equivalence rewrites (filter push-down, subquery decorrelation) applied to fixpoint.
+3. **Execute** — pull-based operator pipeline (`operator/`); expressions compiled to vectorised kernels (`expression.clj`).
+   The **scan** operator (`operator/scan/ScanCursor.kt`) is the heart: it selects LSM files via TrieCatalog metadata (Bloom filters on IID, temporal bounds), merge-sorts pages from LiveIndex + tries, and performs **bitemporal resolution** so downstream operators see a materialised valid-time snapshot.
+
+## Surfaces
+
+- **pgwire** (`pgwire/`) — primary entry point; Postgres-wire compatible; multi-database via connection params.
+- **Flight SQL** (`flight_sql/FlightSql.kt`).
+- **In-process API** (`api/`) and a JDBC path.
+
+## Multi-database
+
+One node hosts multiple independent databases; each has its own source + replica log topics and its own elected leader.
+
+## Testing architecture
+
+Test tasks, tags, locations and namespace-filter conventions are documented authoritatively in `AGENTS.md` ("Running tests") and `dev/README.adoc` ("Testing") — not repeated here.
+Architecturally relevant points: property-based testing uses `clojure.test.check`; integration uses Testcontainers; and the `*.allium` specs encode domain behaviour and are kept in sync with code as part of the Definition of Done.
+
+## Cross-cutting
+
+- **Arrow** is the in-memory and on-disk columnar format throughout (off-heap via Netty allocator).
+- **Errors**: `xtdb.error` / `Anomaly` sealed hierarchy — see `AGENTS.md` ("Errors") and `api/.../xtdb/error.clj` for the categories.
+- **Serialization**: Protobuf for block/log wire formats; Transit for Clojure data.
+- **Observability**: Micrometer + OpenTelemetry; Prometheus/CloudWatch/Azure Monitor registries.

--- a/dev/ASSUMPTIONS.md
+++ b/dev/ASSUMPTIONS.md
@@ -1,0 +1,24 @@
+# ASSUMPTIONS
+
+Assumptions and unknowns recorded during Rosetta initialisation, for the user to confirm or correct.
+Status: open.
+
+## Assumptions made during init
+
+- **Docs relocated to `dev/`** — because `docs/` is the live Astro documentation site, all Rosetta-managed docs were written under `dev/` (and working files under `dev/agents/`), recorded in `gain.json`.
+  Assumed acceptable per the user's instruction "use /dev folder for Rosetta docs".
+- **Mode = install** — no prior `bootstrap_rosetta_files` existed.
+- **composite = false** — single git repository with one documentation root; submodules are vendored externals.
+- **Phase 4 (copy rules) skipped** — optional and not recommended; Rosetta serves rules on demand via MCP.
+- Content of `dev/CONTEXT.md`, `ARCHITECTURE.md`, `TECHSTACK.md`, `DEPENDENCIES.md` was distilled from existing authoritative docs (`AGENTS.md`, `dev/README.adoc`, `dev/doc/*`) and a read-only code-discovery pass; library versions are a snapshot of `gradle/libs.versions.toml` at init time.
+
+## Open questions (for Phase 7 HITL)
+
+1. Commit the `dev/`-rooted Rosetta files to SCM, or keep them local / git-ignored?
+2. Wire Rosetta integration shells into `.claude/` (Phase 2), or leave Rosetta MCP-only?
+3. Are `dev/CONTEXT.md` / `dev/ARCHITECTURE.md` welcome alongside the existing `dev/README.adoc` + `dev/doc/*.adoc`, or should they instead point to / be merged with those?
+
+## Unknowns / not verified
+
+- GC algorithm details (not deep-read).
+- Full logical-plan optimiser rule set.

--- a/dev/CODEMAP.md
+++ b/dev/CODEMAP.md
@@ -1,0 +1,67 @@
+# CODEMAP
+
+Map of the XTDB 2.x workspace: modules, where each concern lives, and how the source tree is laid out.
+Status: current.
+
+## Build topology
+
+Gradle multi-module build (JDK 21, version catalog at `gradle/libs.versions.toml`).
+`build-logic/jlink` is an included build that produces the minimal custom JRE used by all `Test`/`JavaExec`/`clojureRepl` tasks.
+`buildSrc` holds custom plugins (Shadow-jar config, `DataReaderTransformer`).
+The authoritative list of modules and their `xtdb-*` artifact names is `settings.gradle.kts`; the table below adds each module's purpose.
+
+## Modules
+
+| Module | Dir | Artifact | Languages | Purpose |
+| --- | --- | --- | --- | --- |
+| api | `api/` | xtdb-api | Clojure, Kotlin, proto | Public API, error types, transit serde, Arrow integration |
+| core | `core/` | xtdb-core | Kotlin, Clojure, Java, ANTLR, proto | Query engine, storage, indexing, compaction, log coordination, pgwire, SQL grammar, monitoring |
+| main | `main/` | xtdb-main | Clojure | CLI entrypoint, playground, logging config |
+| kafka | `modules/kafka/` | xtdb-kafka | Clojure, Kotlin, proto | Kafka source/replica log backend |
+| kafka-connect | `modules/kafka-connect/` | xtdb-kafka-connect (labs) | Clojure, Kotlin | Kafka Connect sink connector (shadow-jar) |
+| postgres-source | `modules/postgres-source/` | xtdb-postgres-source | Kotlin, proto | Postgres CDC external source |
+| aws | `modules/aws/` | xtdb-aws | Clojure, Kotlin, proto | S3 object store + CloudWatch metrics |
+| azure | `modules/azure/` | xtdb-azure | Clojure, Kotlin, proto | Azure Blob store + Azure Monitor |
+| google-cloud | `modules/google-cloud/` | xtdb-google-cloud | Clojure, Kotlin, proto | GCS object store |
+| datasets | `modules/datasets/` | xtdb-datasets | Clojure | TPC-H / benchmark data generation |
+| bench | `modules/bench/` | (unpublished) | Clojure | Benchmarks (TPC-H, auctionmark, scan-perf, tsbs, …) |
+| docker:standalone | `docker/standalone/` | xtdb-standalone | Java | Single-jar distribution image |
+| docker:{aws,azure,google-cloud} | `docker/*/` | (unpublished) | config | Cloud-variant Docker images |
+| monitoring(:docker-image) | `monitoring/` | — | config | Local Prometheus/Grafana/Tempo stack (conditional) |
+| lang:test-harness | `lang/test-harness/` | test-harness | — | Non-JVM language test harness (conditional include) |
+
+## Concern → code-area map
+
+- Public API & config: `api/src/main/kotlin/xtdb/api/`, `api/src/main/clojure/xtdb/`
+- Error handling: `api/src/main/clojure/xtdb/error.clj`, `api/src/main/kotlin/xtdb/error/Anomaly.kt`
+- Indexing & log coordination: `core/src/main/kotlin/xtdb/indexer/` (LiveIndex, LogProcessor + Leader/Follower/ExternalSource/Transition variants, BlockUploader)
+- Catalogs (State): `core/src/main/kotlin/xtdb/catalog/`, Clojure `xtdb/{block_catalog,table_catalog,trie_catalog}.clj`
+- Storage: `core/src/main/kotlin/xtdb/storage/` (BufferPool, RemoteBufferPool), `core/src/main/kotlin/xtdb/block/`
+- Compaction / GC: `core/src/main/clojure/xtdb/compactor.clj`, `xtdb/garbage_collector.clj` (+ `dev/doc/compaction.allium`, `gc.allium`, `block-gc.allium`)
+- Query engine: `core/src/main/clojure/xtdb/logical_plan.clj`, `core/src/main/kotlin/xtdb/operator/`, expression engine `xtdb/expression.clj` + `core/src/main/kotlin/xtdb/expression/`
+- SQL: ANTLR grammar in `core/src/main/antlr/`, parse in `core/src/main/clojure/xtdb/sql/`
+- XTQL: `core/src/main/clojure/xtdb/xtql/`
+- pgwire / Flight SQL: `core/src/main/kotlin/xtdb/pgwire/`, `flight_sql/`
+- Bitemporal resolution: `core/src/main/kotlin/xtdb/bitemporal/`, scan in `core/src/main/kotlin/xtdb/operator/scan/`
+
+## Source & test layout
+
+- Main source per module: `src/main/{clojure,kotlin,java,resources}` (core adds `src/main/{antlr,proto}`).
+- Most Clojure tests live in the **root** module under `src/test/clojure` (run via root `:test`).
+- Kotlin tests live per-module under `src/test/kotlin` (e.g. `:xtdb-core:test`).
+- Shared test fixtures: `src/testFixtures/clojure`, with `src/testFixtures/resources/log4j2-test.xml`.
+
+## Submodules
+
+External, vendored — not project doc roots (source of truth: `.gitmodules`):
+- `docs/shared` — shared website assets.
+- `docs/lib/railroad` — railroad-diagram generator.
+- `modules/datasets/lib/tsbs` — Time Series Benchmark Suite.
+
+## Existing developer docs (pre-Rosetta, authoritative)
+
+- `AGENTS.md` — agent/dev conventions (root).
+- `dev/README.adoc`, `dev/GIT.adoc` — developer workflow & git practices.
+- `dev/doc/*.adoc` — architecture (`high-level-tour.adoc`, `query_and_access_patterns.adoc`, `evaluating-index-strategies.adoc`).
+- `dev/doc/*.allium` — executable domain specs (`db`, `compaction`, `gc`, `block-gc`, `trie-cat`).
+- `docs/` — end-user Astro documentation site.

--- a/dev/CONTEXT.md
+++ b/dev/CONTEXT.md
@@ -1,0 +1,32 @@
+# CONTEXT
+
+Business and product context for XTDB 2.x — what it is and who it serves.
+Target state only; no technical detail, no change log.
+Status: current.
+The full product story lives in the root `README.adoc` and the end-user docs site (`docs/`); this is a short orientation.
+
+## What XTDB is
+
+XTDB is an immutable, bitemporal SQL database.
+It records data on two independent time axes and never overwrites history, so any past state can be queried as-of any point in time.
+It is built by JUXT and is open source.
+
+## Core value
+
+- **Bitemporal by default**: every row is versioned on **system time** (when XTDB recorded it) and **valid time** (when it is true in the domain).
+  This gives time-travel queries, retroactive and scheduled corrections, and full audit history without bolt-on snapshots or backups.
+- **Immutable / append-only**: data accumulates; the full history is always available.
+- **SQL-first, Postgres-compatible**: speaks a SQL dialect with SQL:2011 temporal semantics over the PostgreSQL wire protocol, so existing Postgres clients, drivers and tools connect directly.
+  XTQL is offered as an alternative, composable query language.
+- **Separation of storage and compute**: durable state lives in an object store and a log; nodes are largely stateless and scale independently.
+- **Cloud-native storage**: object-store backed (S3, Azure Blob, Google Cloud Storage, or local), with a Kafka (or local) transaction log.
+
+## Who it's for
+
+Applications where history and temporal correctness matter: compliance and regulatory retention, audit trails, finance, insurance, healthcare, and any domain that must answer "what did we know, and when did we know it?".
+Teams that want those guarantees while keeping a familiar SQL / Postgres surface.
+
+## Shape of a deployment
+
+A node connects to a log and an object store, exposes a Postgres-wire endpoint, and can host multiple independent databases.
+A standalone Docker image runs everything in-process for local or single-node use; cloud images pair the engine with Kafka and the relevant object store.

--- a/dev/DEPENDENCIES.md
+++ b/dev/DEPENDENCIES.md
@@ -1,0 +1,41 @@
+# DEPENDENCIES
+
+How the modules depend on each other and which external system each integrates with.
+Status: current.
+Exact dependency declarations live in each module's `build.gradle.kts`; versions in `gradle/libs.versions.toml`.
+This file holds only the wiring that isn't obvious from a single build file.
+
+## Inter-module dependencies
+
+- `xtdb-core` depends on `xtdb-api`.
+- `xtdb-main` depends on `xtdb-core` (+ logging).
+- Each backend module (`kafka`, `aws`, `azure`, `google-cloud`, `postgres-source`) depends on `xtdb-core`/`xtdb-api` and plugs in a log or object-store implementation.
+- Docker image projects aggregate `xtdb-main` + the relevant backend modules via shadow-jar.
+- `bench` / `datasets` depend on core + cloud SDKs for workload generation.
+
+## Module → external system
+
+What each module talks to at runtime (the part not visible in a single `build.gradle.kts`).
+For the actual libraries, read that module's `build.gradle.kts`.
+
+| Module | Integrates with |
+| --- | --- |
+| xtdb-api | SQL clients, columnar (Arrow) serde |
+| xtdb-core | pgwire, healthz HTTP, metrics/tracing export, SQL parsing |
+| xtdb-main | CLI / process entrypoint |
+| xtdb-kafka | Apache Kafka (source + replica log) |
+| xtdb-postgres-source | PostgreSQL logical replication (CDC external source) |
+| xtdb-aws | AWS S3 (object store), CloudWatch (metrics) |
+| xtdb-azure | Azure Blob Storage, Azure Monitor (metrics) |
+| xtdb-google-cloud | Google Cloud Storage |
+| xtdb-kafka-connect | Kafka Connect |
+| modules:bench | benchmarking; all cloud backends |
+| modules:datasets | benchmark dataset generation (TPC-H, cloud-sourced) |
+
+## Vendored submodules
+
+See `.gitmodules` (also mapped in `dev/CODEMAP.md`) — fetched via git submodule + git-lfs where applicable.
+
+## Maintenance
+
+`./gradlew dependencyUpdates` reports available upgrades against the version catalog — see the "Tooling" section of `dev/README.adoc`.

--- a/dev/PATTERNS/CHANGES.md
+++ b/dev/PATTERNS/CHANGES.md
@@ -1,0 +1,6 @@
+# PATTERNS — CHANGES
+
+Change log for the patterns index.
+Status: current.
+
+- init — patterns extracted from `AGENTS.md` and `dev/README.adoc` and confirmed against code during Rosetta workspace initialisation.

--- a/dev/PATTERNS/INDEX.md
+++ b/dev/PATTERNS/INDEX.md
@@ -1,0 +1,33 @@
+# PATTERNS — INDEX
+
+Navigational index of the coding/architectural patterns this codebase follows.
+Status: current.
+The patterns are stated authoritatively in `AGENTS.md` and `dev/README.adoc` (and `dev/GIT.adoc` for git); this file is a one-line-each pointer so an agent knows what exists and where to read it — it does not restate the rationale or cite code sites (those drift).
+
+## Architectural
+
+- **Make illegal states unrepresentable** (+ corollary: no hack values) → `dev/README.adoc`, "General Coding Principles".
+- **Storage / State / Services layering** (functional core, imperative shell) → `dev/README.adoc`; modelled in `dev/ARCHITECTURE.md` and `dev/doc/db.allium`.
+- **Tidy-first** (separate equivalence changes from behaviour changes) → `AGENTS.md`, `dev/README.adoc`.
+- **Intentional defaults** (defaults only where they're the overwhelming norm) → `dev/README.adoc`.
+- **Coordination-free services** (deterministic + idempotent, e.g. compaction) → `dev/doc/compaction.allium`.
+
+## Coding conventions
+
+- **Errors via `xtdb.error` / `Anomaly`** (no raw exceptions; `incorrect`/`unsupported`/`fault`/…) → `AGENTS.md` ("Errors"), `dev/README.adoc`.
+- **Comments explain why, not what** → `dev/README.adoc` ("Comments").
+- **Sentence-per-line** in docs and commit bodies → `AGENTS.md`.
+- **Clojure↔Kotlin interop** (`.getX` for Kotlin `val`s; type-hint at the destructuring site) → `AGENTS.md`.
+- **Conventional commits with scopes** (`!` only for user-facing breaks) → `AGENTS.md`.
+
+## Testing
+
+- Test locations, tasks, tags, property testing, allium specs → `AGENTS.md` ("Running tests"), `dev/README.adoc` ("Testing").
+- Observe real phenomena, not mock calls; reserve mocks for injecting failures → team convention (see test suites).
+
+## Workflow
+
+- **Ship / Show / Ask** → `dev/README.adoc` ("Git"), `dev/GIT.adoc`.
+- Commit/PR/issue prose via the chalk skills.
+
+See `dev/PATTERNS/CHANGES.md` for the change log.

--- a/dev/README.adoc
+++ b/dev/README.adoc
@@ -29,6 +29,30 @@ bbin install https://github.com/bhauman/clojure-mcp-light.git --tag v0.2.1
 
 See link:../skills/clojure-eval/SKILL.md[skills/clojure-eval/SKILL.md] for usage details.
 
+=== Optional: Rosetta
+
+https://griddynamics.github.io/rosetta/[Rosetta] is a centralised, versioned instruction set for AI coding agents, distributed as a Claude Code plugin.
+Once installed, its workflows and skills (`rosetta:*`) are available natively.
+Using it is opt-in and per-developer: it is *not* a mandatory project process, and not installing it changes nothing about the build, the tests, or anyone else's workflow — the `dev/` docs are then just additional Markdown.
+This repo's `gain.json` and the Rosetta-managed docs under `dev/` (`CONTEXT.md`, `ARCHITECTURE.md`, `CODEMAP.md`, etc.) come with the checkout, so there's no per-developer doc setup — only the plugin install below.
+
+Install it (into Claude Code only — see the notes):
+
+```bash
+claude plugin marketplace add griddynamics/rosetta
+claude plugin install rosetta@rosetta
+```
+
+No restart is required; Claude Code loads plugins dynamically.
+
+Notes:
+
+* Requires manager/company approval, and a capable model (Sonnet 4.6, GPT-5.4-medium, gemini-3.1-pro, or better) — avoid Auto model selection.
+* Install to Claude Code only: Cursor picks up all Claude Code plugins, so installing it elsewhere duplicates it in Cursor's context.
+* The plugin is the supported integration. If you previously wired Rosetta in as an MCP server, that's now redundant and can be removed.
+
+See the https://griddynamics.github.io/rosetta/docs/plugins/[plugin installation guide] and the https://griddynamics.github.io/rosetta/[Rosetta documentation] for details.
+
 == Getting started
 
 XT2 uses https://gradle.org/[Gradle] - a JVM build tool that supports multi-module, polyglot projects.

--- a/dev/TECHSTACK.md
+++ b/dev/TECHSTACK.md
@@ -1,0 +1,43 @@
+# TECHSTACK
+
+The technologies, languages, and libraries XTDB 2.x is built on, grouped by purpose.
+Status: current.
+This file is the by-purpose map; it deliberately holds no version numbers — exact versions live in `gradle/libs.versions.toml` (and the Gradle version in `gradle/wrapper/gradle-wrapper.properties`).
+
+## Languages & roles
+
+- **Kotlin** — the bulk of `core`: storage, indexing, operators, pgwire, low-level/high-performance runtime.
+- **Clojure** — query planner, expression engine, SQL/XTQL, CLI, much of the public API surface.
+- **Java** — minimal; ANTLR-generated parser and protobuf code.
+
+## Build & tooling
+
+- **Gradle** multi-module build with a version catalog; `org.gradle.parallel=true` (`gradle.properties`).
+- **Clojurephant** (Gradle Clojure), **Kotlin JVM + serialization**, **protobuf**, **Shadow** (uber-jars) plugins.
+- **jlink** custom minimal JRE (`build-logic/jlink`) used by all Test/JavaExec/REPL tasks; `-PfullJdk` escape hatch.
+- **Dokka** (Kotlin/Java API docs), **Codox** (Clojure API docs), **JReleaser** (Maven Central), **ben-manes versions** (`dependencyUpdates`).
+- REPL/AI dev: `clj-nrepl-eval` / clojure-mcp-light (optional), CIDER nREPL, Integrant REPL.
+
+Plugin and tool versions: `gradle/libs.versions.toml` (`[plugins]` and `[versions]`).
+
+## Core libraries by area
+
+Each module's exact dependency set is in its `build.gradle.kts`; versions in `gradle/libs.versions.toml`.
+The grouping below is what each area is *for*.
+
+- **Columnar / data**: Apache Arrow (vector, algorithm, compression, memory-netty, flight-sql) + Arrow ADBC; RoaringBitmap, HPPC, Caffeine.
+- **Log / messaging**: Kafka clients & connect-api; Protobuf; Transit (clj/java); kotlinx-coroutines.
+- **SQL / parsing**: ANTLR; pgjdbc; next.jdbc, HoneySQL, JDBI, Exposed; pg2 (pgwire client, testing).
+- **HTTP**: Ring + ring-jetty9-adapter, Reitit, Muuntaja, Jsonista, Hato (healthz / HTTP surfaces).
+- **Object stores**: AWS SDK (S3, CloudWatch, STS), Azure (storage-blob, identity, management), Google Cloud Storage + Guava.
+- **Clojure core**: spec, data.json, data.csv, tools.cli, clj-yaml, Integrant.
+- **Kotlin serialization**: kotlinx-serialization-json, kaml.
+- **Logging**: SLF4J facade over Log4j2 (jul/jcl/jpl/slf4j bridges, JSON layout); clojure.tools.logging.
+- **Observability**: Micrometer (+ Prometheus / CloudWatch / Azure Monitor registries), Micrometer Tracing, OpenTelemetry SDK (OTLP exporter).
+- **Testing**: JUnit Jupiter, clojure.test.check, Testcontainers (kafka/postgres/minio/keycloak), Kotest, MockK.
+
+## Runtime requirements
+
+- JDK 21+ (enforced by the Gradle toolchain).
+- Off-heap direct memory for Arrow (Netty allocator); the JVM runs with `--enable-native-access`, `--add-opens java.base/java.nio`, and a configured `MaxDirectMemorySize` (see root `build.gradle.kts` for the exact flags).
+- A log (Kafka or local) and an object store (S3/Azure/GCS/local).

--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -1,0 +1,17 @@
+# TODO
+
+Improvements and larger suggestions surfaced during Rosetta initialisation.
+Status: open.
+This is a seed list from the init pass, not an authoritative backlog — issues are tracked on the xtdb org "2.x" project board (see `AGENTS.md`).
+
+## Documentation / init follow-ups
+
+- Decide whether the Rosetta docs under `dev/` are committed to SCM or kept local (see `dev/ASSUMPTIONS.md`).
+- Decide whether to wire Rosetta integration shells into `.claude/` (Phase 2 — deferred, pending user confirmation).
+- Cross-link the existing `dev/doc/*.adoc` deep-dives from `dev/ARCHITECTURE.md` once stable.
+
+## Areas flagged for deeper documentation (from discovery)
+
+- Garbage-collection algorithm: `gc.allium` / `block-gc.allium` exist but were not deep-read during init.
+- Logical-plan optimiser: full rule set and interactions not exhaustively captured.
+- Expression-compilation kernels: optimisation paths in `expression.clj` warrant a focused write-up.

--- a/dev/agents/IMPLEMENTATION.md
+++ b/dev/agents/IMPLEMENTATION.md
@@ -1,0 +1,14 @@
+# IMPLEMENTATION
+
+Current state of implementation, very concise.
+The only change log for Rosetta-managed work.
+Structured to minimise git conflicts: append entries, newest at top.
+Status: current.
+
+## Log
+
+- init — Rosetta workspace initialisation (init-workspace-flow).
+  Created `gain.json` (docs remapped to `dev/`, mode `plugin`), `dev/{CONTEXT,ARCHITECTURE,TECHSTACK,DEPENDENCIES,CODEMAP,TODO,ASSUMPTIONS}.md`, `dev/PATTERNS/{INDEX,CHANGES}.md`, `dev/agents/{IMPLEMENTATION,MEMORY,init-workspace-flow-state}.md`.
+  Phase 4 (rules) skipped (not recommended); Phase 2 (shells) skipped (Rosetta installed as plugin → shells unnecessary).
+  All 8 phases resolved.
+  Docs trimmed to hold synthesis only and point volatile facts at their golden sources (versions → `gradle/libs.versions.toml`, etc.); per-developer plugin setup documented in `dev/README.adoc`.

--- a/dev/agents/MEMORY.md
+++ b/dev/agents/MEMORY.md
@@ -1,0 +1,13 @@
+# MEMORY
+
+Brief root causes of errors/mistakes and what worked or didn't, for future agents.
+Status: current.
+
+## Init-time learnings
+
+- **`docs/` is the live Astro documentation site**, not a generic docs folder — never write Rosetta `docs/*` files there.
+  Rosetta docs live under `dev/` in this repo (see `gain.json`).
+- **Rosetta MCP retrieval is keyword-matched**: `query_instructions` returns full content only for narrow queries; broad ones return a listing only.
+  Prefer tight, distinctive queries.
+- **Authoritative existing docs** to lean on rather than re-derive: `AGENTS.md`, `dev/README.adoc`, `dev/GIT.adoc`, `dev/doc/*.adoc`, `dev/doc/*.allium`.
+- **Do not run tests directly** — delegate to the `gradle-tests` agent; Clojure namespaces use underscores in `--tests` filters.

--- a/dev/agents/init-workspace-flow-state.md
+++ b/dev/agents/init-workspace-flow-state.md
@@ -1,0 +1,64 @@
+# init-workspace-flow state
+
+Rosetta init-workspace-flow tracking state for the XTDB 2.x repo.
+Single writer: the orchestrator.
+
+## Phase 1 — Context [COMPLETED]
+
+- **mode**: `install` — no `bootstrap_rosetta_files` existed before this run (`gain.json`, `dev/CONTEXT.md`, etc. were all absent).
+- **plugin_active**: `false` — Rosetta is running in MCP mode (no `RUNNING AS A PLUGIN` marker; `get_context_instructions` tool present).
+- **composite**: `false` — single git repository.
+  It is a multi-module Gradle build, but there is one documentation root; the git submodules (`docs/shared`, `docs/lib/railroad`, `modules/datasets/lib/tsbs`) are vendored external libraries, not independent project doc roots.
+- **path override**: docs root remapped to `dev/` (per `gain.json`) because `docs/` is the live Astro documentation site.
+
+### Existing-file inventory (against bootstrap_rosetta_files, remapped to dev/)
+
+| Rosetta file | Mapped location | Status |
+| --- | --- | --- |
+| gain.json | `gain.json` | CREATED (phase 1) |
+| CONTEXT.md | `dev/CONTEXT.md` | pending (phase 6) |
+| ARCHITECTURE.md | `dev/ARCHITECTURE.md` | pending (phase 6) |
+| TODO.md | `dev/TODO.md` | pending (phase 6) |
+| ASSUMPTIONS.md | `dev/ASSUMPTIONS.md` | pending (phase 6/7) |
+| TECHSTACK.md | `dev/TECHSTACK.md` | pending (phase 6) |
+| DEPENDENCIES.md | `dev/DEPENDENCIES.md` | pending (phase 6) |
+| CODEMAP.md | `dev/CODEMAP.md` | pending (phase 3) |
+| REQUIREMENTS/* | `dev/REQUIREMENTS/` | not created (no source requirements) |
+| PATTERNS/* | `dev/PATTERNS/` | pending (phase 5) |
+| IMPLEMENTATION.md | `dev/agents/IMPLEMENTATION.md` | pending (phase 6) |
+| MEMORY.md | `dev/agents/MEMORY.md` | pending (phase 6) |
+
+## Phase 3 — Discovery [COMPLETED]
+
+4 parallel read-only subagents (build/topology, tech-stack/deps, architecture/domain, patterns/conventions) returned evidence-backed findings → `dev/CODEMAP.md`.
+
+## Phase 4 — Rules [SKIPPED]
+
+Copying Rosetta rules locally is optional and not recommended; MCP serves them on demand.
+
+## Phase 5 — Patterns [COMPLETED]
+
+`dev/PATTERNS/INDEX.md` + `CHANGES.md` written from `AGENTS.md` / `dev/README.adoc`, confirmed in code.
+
+## Phase 6 — Documentation [COMPLETED]
+
+`dev/{CONTEXT,ARCHITECTURE,TECHSTACK,DEPENDENCIES,TODO,ASSUMPTIONS}.md` and `dev/agents/{IMPLEMENTATION,MEMORY}.md` written.
+
+## Phase 8 — Verification [COMPLETED]
+
+All 13 bootstrap files present under `dev/`/root; none leaked into the Astro `docs/` site; git shows only new untracked files (non-destructive).
+
+## Phase 2 — Shells [SKIPPED — plugin mode]
+
+Rosetta is now installed as a Claude Code plugin (`rosetta:*` skills/workflows are native).
+Per the `init-workspace-flow-shells` skill ("Skipped in plugin mode"), no proxy shells are written.
+`gain.json` mode set to `plugin`.
+
+## Phase 7 — Questions (HITL) [IN PROGRESS]
+
+Open decisions surfaced to user: (1) commit dev/ Rosetta files to SCM? (2) wire `.claude/` integration shells? (3) relationship to existing dev/README + dev/doc.
+
+## Gaps logged for Phase 7
+
+- Confirm whether Phase 2 integration shells are wanted (writes into `.claude/`).
+- Confirm whether Rosetta docs under `dev/` should be committed to SCM or stay local.

--- a/gain.json
+++ b/gain.json
@@ -1,0 +1,30 @@
+{
+  "$comment": "Rosetta SDLC config. Overrides default Rosetta file locations; wins in conflicts. In this repo the live Astro documentation site occupies docs/, so all Rosetta-managed docs are relocated under dev/ to avoid collision.",
+  "rosetta": {
+    "release": "R2.0",
+    "mode": "plugin"
+  },
+  "paths": {
+    "docsRoot": "dev",
+    "agentsRoot": "dev/agents",
+    "plansRoot": "dev/plans",
+    "refsrcRoot": "dev/refsrc"
+  },
+  "files": {
+    "context": "dev/CONTEXT.md",
+    "architecture": "dev/ARCHITECTURE.md",
+    "todo": "dev/TODO.md",
+    "assumptions": "dev/ASSUMPTIONS.md",
+    "techstack": "dev/TECHSTACK.md",
+    "dependencies": "dev/DEPENDENCIES.md",
+    "codemap": "dev/CODEMAP.md",
+    "requirements": "dev/REQUIREMENTS",
+    "patterns": "dev/PATTERNS",
+    "implementation": "dev/agents/IMPLEMENTATION.md",
+    "memory": "dev/agents/MEMORY.md"
+  },
+  "scm": {
+    "exclude": ["dev/agents/TEMP", "dev/refsrc"],
+    "excludeException": ["dev/refsrc/INDEX.md"]
+  }
+}


### PR DESCRIPTION
We've adopted Rosetta — a centralised, updatable instruction set for AI coding agents — and this initialises the workspace it expects. Rosetta's init-workspace-flow wants a standard set of orientation docs (context, architecture, tech stack, dependencies, a code map, distilled patterns) plus its own agent working files, none of which existed here.

The decision worth a reviewer's attention is *where these live*. Rosetta defaults to writing them under `docs/`, but `docs/` in this repo is the live Astro documentation site — writing there would pollute the published docs. `gain.json` (Rosetta's location-override file, which wins in conflicts) relocates the entire Rosetta footprint under `dev/`, with working files under `dev/agents/`. Verified post-init that nothing leaked into the published site.

The docs hold synthesis that lives nowhere else — the concern→code map, the Storage/State/Services layering, module→external-system wiring — and delegate every volatile, look-up-able fact to its golden source via a precise coordinate: versions → `gradle/libs.versions.toml`, per-module deps → each `build.gradle.kts`, submodules → `.gitmodules`, test/commit conventions → `AGENTS.md`/`dev/README.adoc`. That's deliberate: a hand-copied version number silently rots the next time someone bumps a dependency, so these files map and point rather than duplicate.

To be clear about intent: **this is opt-in.** I've deliberately *not* made Rosetta a mandatory process for the project — it's there for individual developers to use the skills as they see fit. Nothing here changes the build, the tests, or anyone's workflow; if you don't install the plugin, the `dev/` docs are just additional Markdown.

**Getting set up (if you want it).** Rosetta is a Claude Code plugin; `dev/README.adoc` now documents it next to the other AI-tooling prerequisites. The short version:

```
claude plugin marketplace add griddynamics/rosetta
claude plugin install rosetta@rosetta
```

No restart needed. Use a capable model (not Auto), and install to Claude Code only — Cursor picks up all Claude Code plugins. `gain.json` and the `dev/` docs come with the checkout, so there's no doc setup, just the plugin. Full instructions: https://griddynamics.github.io/rosetta/docs/plugins/ and https://griddynamics.github.io/rosetta/.

Scope: the plugin makes Rosetta's "shells" phase (host command proxies) unnecessary — the `rosetta:*` skills are native — and the optional "copy rules locally" phase is skipped. If you previously had Rosetta wired in as an MCP server, it's now redundant. Open questions deliberately left for a human — whether to keep these committed long-term, and how they relate to the existing `dev/` docs — are recorded in `dev/ASSUMPTIONS.md`.

Additive only: 13 new files plus a `dev/README.adoc` addition, no existing behaviour touched — the review is whether the `dev/` layout, the doc content, and the setup steps are right.