### PR TITLE
refactor: scope-managed lifecycle for Database services

### DIFF
--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -26,7 +26,6 @@ import xtdb.trie.*
 import xtdb.util.*
 import java.nio.channels.ClosedByInterruptException
 import java.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import kotlin.use
 
 typealias JobKey = Pair<TableRef, TrieKey>
@@ -52,6 +51,9 @@ interface Compactor : AutoCloseable {
     }
 
     interface ForDatabase : AutoCloseable {
+        /** Launches the compaction loop into [scope]; the caller owns its lifetime — cancelling [scope] stops it. */
+        fun runOn(scope: CoroutineScope)
+
         fun signalBlock()
         suspend fun compactAll()
 
@@ -167,9 +169,6 @@ interface Compactor : AutoCloseable {
 
         override fun openForDatabase(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
 
-            private val dbJob = Job()
-            private val scope = CoroutineScope(dbJob + dispatcher)
-
             private val trieCatalog = dbState.trieCatalog
             private val liveIndex = dbState.liveIndexOrNull
 
@@ -197,10 +196,12 @@ interface Compactor : AutoCloseable {
                 }
             }
 
-            init {
-                val jobsScope = CoroutineScope(SupervisorJob(dbJob) + jobsDispatcher)
+            // Pinned to the compactor's own [dispatcher] (the owner scope supplies only the lifetime),
+            // so the seeded `DeterministicDispatcher` injected in the simulation tests drives the loop.
+            override fun runOn(scope: CoroutineScope) {
+                val jobsScope = CoroutineScope(SupervisorJob(scope.coroutineContext.job) + jobsDispatcher)
 
-                scope.launch(CoroutineName("outer loop")) {
+                scope.launch(dispatcher + CoroutineName("outer loop")) {
                     while (true) {
                         availableJobs =
                             jobCalculator.availableJobs(trieCatalog)
@@ -273,15 +274,10 @@ interface Compactor : AutoCloseable {
                 liveIndex?.refreshSnap()
             }
 
+            // State teardown only: the loop is a Service, stopped by the owner cancelling its scope
+            // before this runs (so no buffer is live when the driver's child allocator closes).
             override fun close() {
-
-                runBlocking {
-                    withTimeoutOrNull(10.seconds) { dbJob.cancelAndJoin() }
-                        ?: LOGGER.warn("failed to close compactor cleanly in 10s")
-                }
-
                 driver.close()
-
                 LOGGER.debug("compactor closed")
             }
         }
@@ -293,6 +289,7 @@ interface Compactor : AutoCloseable {
         @JvmField
         val NOOP = object : Compactor {
             override fun openForDatabase(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
+                override fun runOn(scope: CoroutineScope) = Unit
                 override fun signalBlock() = Unit
                 override suspend fun compactAll() = Unit
                 override fun close() = Unit

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -52,6 +52,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import java.time.Duration
 import java.util.*
 import kotlin.concurrent.Volatile
+import kotlin.time.Duration.Companion.seconds
 
 private val LOG = Database::class.logger
 
@@ -62,6 +63,7 @@ class Database(
     val isIndexing: Boolean,
     val partitions: Map<Int, DatabasePartition>,
     private val meterRegistry: MeterRegistry?,
+    private val compactorScope: CoroutineScope? = null,
     private val job: Job? = null,
     private val processor: LogProcessor? = null,
     private val registeredGauges: List<Gauge> = emptyList(),
@@ -133,6 +135,11 @@ class Database(
     override fun close() {
         meterRegistry?.let { reg -> registeredGauges.forEach { reg.remove(it) } }
         runBlocking {
+            // Stop the compaction loop + its jobs before `compactorOrNull.close()` frees the
+            // driver's child allocator below — an outstanding compaction buffer would otherwise
+            // outlive its allocator. Bounded so a stuck job can't hang shutdown.
+            withTimeoutOrNull(10.seconds) { compactorScope?.coroutineContext?.job?.cancelAndJoin() }
+                ?: LOG.warn("compactor did not stop within 10s")
             job?.cancelAndJoin()
             processor?.close()
         }
@@ -267,6 +274,20 @@ class Database(
                 else compactor.openForDatabase(allocator, storage, state, watchers)
             }
 
+            // Independent root owned by this Database: cancelled (bounded) in `close()` before the
+            // compactor's driver allocator is freed. NOOP's `runOn` is a no-op (read-only nodes).
+            // Registered with `safelyOpening` so a failure later in `open` also stops the loop —
+            // it runs against the driver, which `safelyOpening` would otherwise free out from under it.
+            val compactorScope = CoroutineScope(Job())
+            open {
+                AutoCloseable {
+                    runBlocking {
+                        withTimeoutOrNull(10.seconds) { compactorScope.coroutineContext.job.cancelAndJoin() }
+                    }
+                }
+            }
+            compactorForDb.runOn(compactorScope)
+
             var processor: LogProcessor? = null
             val job = Job()
             val scope = CoroutineScope(job + CoroutineExceptionHandler { _, e ->
@@ -372,6 +393,7 @@ class Database(
                 isIndexing = indexerConfig.enabled,
                 partitions = mapOf(0 to partition),
                 meterRegistry = meterRegistry,
+                compactorScope = compactorScope,
                 job = job,
                 processor = processor,
                 registeredGauges = gauges,

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -330,9 +330,23 @@ class Database(
                             flushTimeout = indexerConfig.flushDuration,
                         )
 
+                        // This Database owns the leader's process tree: a SupervisorJob child of
+                        // its scope, so a leader failure is isolated from the rest of the node.
+                        // Step-down cancels it (bounded), then frees the processor's resources —
+                        // cancellation leaves the watermarks consistent-or-behind, so the follower
+                        // the transition opens next replays any gap idempotently.
+                        val leaderScope =
+                            CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext.job))
+                        leaderProc.runOn(leaderScope)
+
                         return object : LogProcessor.LeaderSystem {
                             override val proc get() = leaderProc
-                            override suspend fun close() { leaderProc.close(); replicaProducer.close() }
+                            override suspend fun close() {
+                                withTimeoutOrNull(10.seconds) { leaderScope.coroutineContext.job.cancelAndJoin() }
+                                    ?: LOG.warn("[$dbName] leader did not stop within 10s")
+                                leaderProc.close()
+                                replicaProducer.close()
+                            }
                         }
                     }
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -330,20 +330,14 @@ class Database(
                             flushTimeout = indexerConfig.flushDuration,
                         )
 
-                        // This Database owns the leader's process tree: a SupervisorJob child of
-                        // its scope, so a leader failure is isolated from the rest of the node.
-                        // Step-down cancels it (bounded), then frees the processor's resources —
-                        // cancellation leaves the watermarks consistent-or-behind, so the follower
-                        // the transition opens next replays any gap idempotently.
-                        val leaderScope =
-                            CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext.job))
-                        leaderProc.runOn(leaderScope)
-
+                        // The wrapper drives this system's lifecycle: `runOn(termScope)` starts the
+                        // leader's process tree, the wrapper cancels that scope on step-down / teardown,
+                        // and `close()` then frees the leader's resources (the loops have already stopped,
+                        // so the watermarks are final).
                         return object : LogProcessor.LeaderSystem {
                             override val proc get() = leaderProc
-                            override suspend fun close() {
-                                withTimeoutOrNull(10.seconds) { leaderScope.coroutineContext.job.cancelAndJoin() }
-                                    ?: LOG.warn("[$dbName] leader did not stop within 10s")
+                            override fun runOn(scope: CoroutineScope) = leaderProc.runOn(scope)
+                            override fun close() {
                                 leaderProc.close()
                                 replicaProducer.close()
                             }

--- a/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
@@ -17,7 +17,6 @@ import xtdb.util.debug
 import xtdb.util.logger
 import xtdb.util.warn
 import java.nio.file.Path
-import kotlin.time.Duration.Companion.seconds
 
 private val LOGGER = BlockGarbageCollector::class.logger
 
@@ -29,38 +28,29 @@ private const val DEFAULT_DELETE_PARALLELISM = 64
  *
  * The leader [signal]s at every block boundary; followers never construct one. Block garbage
  * only appears as a side-effect of block uploads, so this is the natural trigger — no timer
- * needed. Fire-and-forget: tx processing never waits for a GC cycle to complete (GC has been
- * disabled for months, so the first cycle's backlog could be huge — see PR #5511).
+ * needed. Fire-and-forget: tx processing never waits for a GC cycle to complete.
  *
- * Parallelism is bounded in two dimensions: [tableParallelism] tables concurrently,
- * [deleteParallelism] DELETEs in flight across the whole cycle (shared pool).
+ * Construction is inert (channels only); [runOn] launches the loop into the caller's scope and
+ * the caller owns its lifetime — cancelling that scope stops the loop. No close.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class BlockGarbageCollector(
     private val bufferPool: BufferPool,
     private val blockCatalog: BlockCatalog,
-    private val blocksToKeep: Int,
-    /** Gates the auto-signal from the leader's block-boundary path; direct `awaitNoGarbage()` is unaffected. */
-    val enabled: Boolean,
-    private val meterRegistry: MeterRegistry? = null,
-    tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
-    deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO,
     dbName: DatabaseName,
-) : AutoCloseable {
-
-    private val dbJob = Job()
-    private val scope = CoroutineScope(dispatcher + dbJob)
+    /** Gates the auto-signal from the leader's block-boundary path; direct [awaitNoGarbage] is unaffected. */
+    private val enabled: Boolean,
+    private val blocksToKeep: Int,
+    private val meterRegistry: MeterRegistry? = null,
+    private val tableDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(DEFAULT_TABLE_PARALLELISM),
+    private val deleteDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(DEFAULT_DELETE_PARALLELISM),
+) {
 
     // [signal] is fire-and-forget; bursts coalesce into one upcoming cycle.
     private val signalCh = Channel<Unit>(CONFLATED)
-
     // [awaitNoGarbage] callers each get a `CompletableDeferred` resumed after the next cycle —
     // every waiter must be preserved.
     private val awaitCh = Channel<CompletableDeferred<Unit>>(UNLIMITED, onUndeliveredElement = { it.cancel() })
-
-    private val tableDispatcher = dispatcher.limitedParallelism(tableParallelism)
-    private val deleteDispatcher = dispatcher.limitedParallelism(deleteParallelism)
 
     private val blockDeleteTimer: Timer? = meterRegistry?.let {
         Timer.builder("xtdb.gc.block_files.delete.timer")
@@ -78,38 +68,6 @@ class BlockGarbageCollector(
 
     init {
         require(blocksToKeep >= 1) { "blocksToKeep must be >= 1, got $blocksToKeep" }
-
-        LOGGER.debug("Starting BlockGarbageCollector (enabled=$enabled, blocksToKeep=$blocksToKeep)")
-
-        scope.launch {
-            while (isActive) {
-                val pending = mutableListOf<CompletableDeferred<Unit>>()
-
-                // Wait for any trigger. Drain both channels each cycle so waiters arriving while
-                // a cycle is running see a cycle that *started* after their suspension — not just
-                // one that finished after it.
-                select {
-                    if (enabled) signalCh.onReceive { }
-                    awaitCh.onReceive { pending += it }
-                }
-
-                try {
-                    do {
-                        signalCh.tryReceive()
-                        while (true) pending.add(awaitCh.tryReceive().getOrNull() ?: break)
-                        garbageCollectBlocks()
-                    } while (drainTriggers(pending))
-
-                    pending.forEach { it.complete(Unit) }
-                } catch (e: CancellationException) {
-                    pending.forEach { it.cancel() }
-                    throw e
-                } catch (e: Exception) {
-                    LOGGER.warn(e, "Block garbage collection cycle failed")
-                    pending.forEach { it.completeExceptionally(e) }
-                }
-            }
-        }
     }
 
     private fun drainTriggers(pending: MutableList<CompletableDeferred<Unit>>): Boolean {
@@ -163,6 +121,38 @@ class BlockGarbageCollector(
         }
     }
 
+    fun runOn(scope: CoroutineScope) = scope.launch {
+        LOGGER.debug("Starting BlockGarbageCollector (enabled=$enabled, blocksToKeep=$blocksToKeep)")
+
+        while (isActive) {
+            val pending = mutableListOf<CompletableDeferred<Unit>>()
+
+            // Wait for any trigger. Drain both channels each cycle so waiters arriving while
+            // a cycle is running see a cycle that *started* after their suspension — not just
+            // one that finished after it.
+            select {
+                if (enabled) signalCh.onReceive { }
+                awaitCh.onReceive { pending += it }
+            }
+
+            try {
+                do {
+                    signalCh.tryReceive()
+                    while (true) pending.add(awaitCh.tryReceive().getOrNull() ?: break)
+                    garbageCollectBlocks()
+                } while (drainTriggers(pending))
+
+                pending.forEach { it.complete(Unit) }
+            } catch (e: CancellationException) {
+                pending.forEach { it.cancel() }
+                throw e
+            } catch (e: Exception) {
+                LOGGER.warn(e, "Block garbage collection cycle failed")
+                pending.forEach { it.completeExceptionally(e) }
+            }
+        }
+    }
+
     /**
      * Schedule a cycle, fire-and-forget. Bursts coalesce into a single upcoming cycle (the
      * underlying signal channel is conflated). Used by the leader's block-boundary path so tx
@@ -191,11 +181,4 @@ class BlockGarbageCollector(
     }
 
     fun awaitNoGarbageBlocking() = runBlocking { awaitNoGarbage() }
-
-    override fun close() {
-        runBlocking {
-            withTimeoutOrNull(5.seconds) { dbJob.cancelAndJoin() }
-                ?: LOGGER.warn("Block GC coroutine did not stop within 5s")
-        }
-    }
 }

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -21,7 +21,6 @@ import xtdb.util.logger
 import xtdb.util.warn
 import java.time.Duration
 import java.time.Instant
-import kotlin.time.Duration.Companion.seconds
 
 private val LOGGER = TrieGarbageCollector::class.logger
 
@@ -36,50 +35,30 @@ private const val TRIES_DELETED_CHUNK_SIZE = 1024
 /**
  * Leader-owned cleanup of stale trie files (meta + data).
  *
- * The leader [signal]s at every block boundary; followers never construct one. Fire-and-forget:
- * tx processing never waits for a GC cycle (GC has been off for months on existing deployments —
- * the first cycle's backlog could stall the indexer for minutes if it were awaited, so the
- * leader's block-boundary path uses non-suspending [signal] instead — see PR #5511).
- *
  * Per-table ordering: obj-store DELETE → atomic ([commitTriesDeleted]) publish-and-commit.
  * A crash mid-cycle leaves orphaned catalog entries that the next cycle re-DELETEs idempotently
  * (S3 returns 404, fine); the reverse order would leave followers thinking deleted files were
  * still live, which is unsafe.
- *
- * Parallelism is bounded in two dimensions: [tableParallelism] tables in flight concurrently,
- * [deleteParallelism] DELETEs in flight across the whole cycle (shared pool).
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class TrieGarbageCollector(
     private val bufferPool: BufferPool,
     dbState: DatabaseState,
-    /**
-     * Publishes a `TriesDeleted` to the replica log AND removes the keys from the local trie catalog — atomically, in a single Persister task on the leader.
-     * The Persister channel is the sole ordering point, so no other replica-log write interleaves between the two.
-     * See the call site for the block-file consistency rationale.
-     */
-    private val commitTriesDeleted: suspend (tableName: TableRef, trieKeys: Set<TrieKey>) -> Unit,
+    val enabled: Boolean,
     private val blocksToKeep: Int,
     private val garbageLifetime: Duration,
-    val enabled: Boolean,
+    private val commitTriesDeleted: suspend (tableName: TableRef, trieKeys: Set<TrieKey>) -> Unit,
     private val meterRegistry: MeterRegistry? = null,
-    tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
-    deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : AutoCloseable {
+    private val tableDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(DEFAULT_TABLE_PARALLELISM),
+    private val deleteDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(DEFAULT_DELETE_PARALLELISM),
+) {
 
     private val blockCatalog = dbState.blockCatalog
     private val trieCatalog = dbState.trieCatalog
 
-    private val dbJob = Job()
-    private val scope = CoroutineScope(dispatcher + dbJob)
-
     // [signal] is fire-and-forget; bursts coalesce into one upcoming cycle.
     private val signalCh = Channel<Unit>(CONFLATED)
     private val awaitCh = Channel<CompletableDeferred<Unit>>(UNLIMITED, onUndeliveredElement = { it.cancel() })
-
-    private val tableDispatcher = dispatcher.limitedParallelism(tableParallelism)
-    private val deleteDispatcher = dispatcher.limitedParallelism(deleteParallelism)
 
     private val deleteTimer: Timer? = meterRegistry?.let {
         Timer.builder("xtdb.gc.tries.delete.timer")
@@ -88,37 +67,6 @@ class TrieGarbageCollector(
             .register(it)
     }
     
-    init {
-        LOGGER.debug("Starting TrieGarbageCollector (enabled=$enabled, blocksToKeep=$blocksToKeep, garbageLifetime=$garbageLifetime)")
-
-        scope.launch {
-            while (isActive) {
-                val pending = mutableListOf<CompletableDeferred<Unit>>()
-
-                select<Unit> {
-                    if (enabled) signalCh.onReceive { }
-                    awaitCh.onReceive { pending += it }
-                }
-
-                try {
-                    do {
-                        signalCh.tryReceive()
-                        while (true) pending.add(awaitCh.tryReceive().getOrNull() ?: break)
-                        garbageCollectTries()
-                    } while (drainTriggers(pending))
-
-                    pending.forEach { it.complete(Unit) }
-                } catch (e: CancellationException) {
-                    pending.forEach { it.cancel() }
-                    throw e
-                } catch (e: Exception) {
-                    LOGGER.warn(e, "Trie garbage collection cycle failed")
-                    pending.forEach { it.completeExceptionally(e) }
-                }
-            }
-        }
-    }
-
     private fun drainTriggers(pending: MutableList<CompletableDeferred<Unit>>): Boolean {
         var any = signalCh.tryReceive().isSuccess
         while (true) {
@@ -132,26 +80,6 @@ class TrieGarbageCollector(
     private fun defaultGarbageAsOf(): Instant? =
         bufferPool.blockFromLatest(blocksToKeep)
             ?.let { it.latestCompletedTx.systemTime.microsAsInstant - garbageLifetime }
-
-    suspend fun garbageCollectTries(garbageAsOf: Instant? = null) {
-        val asOf = garbageAsOf ?: defaultGarbageAsOf() ?: return
-
-        LOGGER.debug("Garbage collecting tries older than $asOf")
-
-        supervisorScope {
-            for (tableName in blockCatalog.allTables) {
-                launch(tableDispatcher) {
-                    try {
-                        garbageCollectTable(tableName, asOf)
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        LOGGER.warn(e, "Trie GC failed for table $tableName")
-                    }
-                }
-            }
-        }
-    }
 
     private suspend fun garbageCollectTable(tableName: TableRef, asOf: Instant) {
         val garbageTries = trieCatalog.garbageTries(tableName, asOf)
@@ -188,10 +116,55 @@ class TrieGarbageCollector(
         }
     }
 
-    /**
-     * Schedule a cycle, fire-and-forget. Bursts coalesce into a single upcoming cycle. Used by
-     * the leader's block-boundary path so tx processing never blocks on GC progress.
-     */
+    suspend fun garbageCollectTries(garbageAsOf: Instant? = null) {
+        val asOf = garbageAsOf ?: defaultGarbageAsOf() ?: return
+
+        LOGGER.debug("Garbage collecting tries older than $asOf")
+
+        supervisorScope {
+            for (tableName in blockCatalog.allTables) {
+                launch(tableDispatcher) {
+                    try {
+                        garbageCollectTable(tableName, asOf)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        LOGGER.warn(e, "Trie GC failed for table $tableName")
+                    }
+                }
+            }
+        }
+    }
+
+    fun runOn(scope: CoroutineScope) = scope.launch {
+        LOGGER.debug("Starting TrieGarbageCollector (enabled=$enabled, blocksToKeep=$blocksToKeep, garbageLifetime=$garbageLifetime)")
+
+        while (isActive) {
+            val pending = mutableListOf<CompletableDeferred<Unit>>()
+
+            select {
+                if (enabled) signalCh.onReceive { }
+                awaitCh.onReceive { pending += it }
+            }
+
+            try {
+                do {
+                    signalCh.tryReceive()
+                    while (true) pending.add(awaitCh.tryReceive().getOrNull() ?: break)
+                    garbageCollectTries()
+                } while (drainTriggers(pending))
+
+                pending.forEach { it.complete(Unit) }
+            } catch (e: CancellationException) {
+                pending.forEach { it.cancel() }
+                throw e
+            } catch (e: Exception) {
+                LOGGER.warn(e, "Trie garbage collection cycle failed")
+                pending.forEach { it.completeExceptionally(e) }
+            }
+        }
+    }
+
     fun signal() {
         signalCh.trySend(Unit)
     }
@@ -199,7 +172,6 @@ class TrieGarbageCollector(
     /**
      * Suspend until a cycle that started at or after this call has completed — every waiter sees
      * a cycle whose start post-dated their arrival, even if another waiter joined mid-cycle.
-     * Intended for tests and admin pokes; production triggers via [signal].
      */
     suspend fun awaitNoGarbage() {
         val deferred = CompletableDeferred<Unit>()
@@ -215,11 +187,4 @@ class TrieGarbageCollector(
     }
 
     fun awaitNoGarbageBlocking() = runBlocking { awaitNoGarbage() }
-
-    override fun close() {
-        runBlocking {
-            withTimeoutOrNull(5.seconds) { dbJob.cancelAndJoin() }
-                ?: LOGGER.warn("Trie GC coroutine did not stop within 5s")
-        }
-    }
 }

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -3,6 +3,7 @@ package xtdb.indexer
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import org.apache.arrow.memory.BufferAllocator
@@ -244,6 +245,8 @@ class FollowerLogProcessor @JvmOverloads constructor(
             } catch (e: InterruptedException) {
                 throw e
             } catch (e: Interrupted) {
+                throw e
+            } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
                 LOG.error(

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -267,7 +267,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
         replicaState.value = ReplicaState.Failed(latestReplicaMsgId, e)
     }
 
-    override suspend fun close() {
+    override fun close() {
         allocator.close()
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -593,7 +593,7 @@ class LeaderLogProcessor(
     // State teardown only: the process tree is stopped by the owner cancelling its scope before
     // this runs, so the loop has stopped and every buffer is freed. All that's left is to free the
     // resources this processor holds — the external source and its child allocator.
-    override suspend fun close() {
+    override fun close() {
         extSource?.close()
         allocator.close()
     }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -38,6 +38,7 @@ import xtdb.util.StringUtil.asLexHex
 import java.nio.ByteBuffer
 import java.time.*
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.seconds
 
 private val SKIPPED_EXN: Throwable = Fault("Transaction was skipped", "xtdb/skipped-tx")
 
@@ -83,15 +84,21 @@ class LeaderLogProcessor(
 
     private val sourceLogTxIndexer = SourceLogTxIndexer(this.allocator, nodeBase, dbState, crashLogger)
 
-    internal val blockGc = nodeBase.config.garbageCollector.let { cfg ->
-        BlockGarbageCollector(
-            bufferPool, blockCatalog,
-            blocksToKeep = cfg.blocksToKeep,
-            enabled = cfg.enabled,
-            meterRegistry = nodeBase.meterRegistry,
-            dbName = dbName
-        )
-    }
+    private val scope = CoroutineScope(ctx)
+    private val gcScope = CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext.job))
+
+    internal val blockGc =
+        nodeBase.config.garbageCollector
+            .let { cfg ->
+                BlockGarbageCollector(
+                    bufferPool, blockCatalog,
+                    dbName = dbName,
+                    enabled = cfg.enabled,
+                    blocksToKeep = cfg.blocksToKeep,
+                    meterRegistry = nodeBase.meterRegistry
+                )
+            }
+            .also { it.runOn(gcScope) }
 
     override var pendingBlock: PendingBlock? = null
         private set
@@ -136,8 +143,6 @@ class LeaderLogProcessor(
         Channel<ExtSourceTask>(RENDEZVOUS, onUndeliveredElement = { it.onComplete.cancel() })
     private val gcCh =
         Channel<GcTask>(RENDEZVOUS, onUndeliveredElement = { it.onComplete.cancel() })
-
-    private val scope = CoroutineScope(ctx)
 
     private suspend fun handleSourceLogRecord(task: SourceLogTask.Record) {
         val record = task.record
@@ -312,11 +317,11 @@ class LeaderLogProcessor(
 
         TrieGarbageCollector(
             bufferPool, dbState,
-            commitTriesDeleted, cfg.blocksToKeep, cfg.garbageLifetime,
-            cfg.enabled,
+            cfg.enabled, cfg.blocksToKeep, cfg.garbageLifetime,
+            commitTriesDeleted,
             nodeBase.meterRegistry
         )
-    }
+    }.also { it.runOn(gcScope) }
 
     private val txErrorCounter: Counter? = nodeBase.meterRegistry?.let { Counter.builder("tx.error").register(it) }
 
@@ -572,8 +577,8 @@ class LeaderLogProcessor(
     override suspend fun close() {
         extJob?.cancelAndJoin()
         extSource?.close()
-        blockGc.close()
-        trieGc.close()
+        withTimeoutOrNull(5.seconds) { gcScope.coroutineContext.job.cancelAndJoin() }
+            ?: LOG.warn("GC coroutines did not stop within 5s")
         sourceLogCh.close()
         extSourceCh.close()
         gcCh.close()

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -37,8 +37,6 @@ import xtdb.util.StringUtil.asLexDec
 import xtdb.util.StringUtil.asLexHex
 import java.nio.ByteBuffer
 import java.time.*
-import kotlin.coroutines.CoroutineContext
-import kotlin.time.Duration.Companion.seconds
 
 private val SKIPPED_EXN: Throwable = Fault("Transaction was skipped", "xtdb/skipped-tx")
 
@@ -56,12 +54,11 @@ class LeaderLogProcessor(
     private val replicaProducer: Log.AtomicProducer<ReplicaMessage>,
     private val skipTxs: Set<MessageId>,
     private val dbCatalog: Database.Catalog?,
-    partition: Int,
+    private val partition: Int,
     afterReplicaMsgId: MessageId,
-    afterToken: ExternalSourceToken?,
+    private val afterToken: ExternalSourceToken?,
     private val instantSource: InstantSource = InstantSource.system(),
     flushTimeout: Duration = Duration.ofMinutes(5),
-    ctx: CoroutineContext = Dispatchers.Default,
 ) : LogProcessor.LeaderProcessor, TxIndexer {
 
     init {
@@ -84,9 +81,8 @@ class LeaderLogProcessor(
 
     private val sourceLogTxIndexer = SourceLogTxIndexer(this.allocator, nodeBase, dbState, crashLogger)
 
-    private val scope = CoroutineScope(ctx)
-    private val gcScope = CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext.job))
-
+    // Constructed inert; both GCs and the persister are launched by [runOn], and torn down by the
+    // owner cancelling the scope it supplies (see `LogProcessor.openLeaderSystem`).
     internal val blockGc =
         nodeBase.config.garbageCollector
             .let { cfg ->
@@ -98,7 +94,6 @@ class LeaderLogProcessor(
                     meterRegistry = nodeBase.meterRegistry
                 )
             }
-            .also { it.runOn(gcScope) }
 
     override var pendingBlock: PendingBlock? = null
         private set
@@ -246,7 +241,12 @@ class LeaderLogProcessor(
     // Unbiased select across the three sources so a slow producer on one channel can't starve
     // the others. The three sources are: source-log records, external-source resolved txs, and
     // GC trie deletions.
-    private val persisterJob: Job = scope.launch {
+    //
+    // Interruptible by cancellation: the only suspension point per task is the replica-log append;
+    // the synchronous in-memory effect that follows it can't be cleaved off by a cancel, and a
+    // cancelled append leaves `latestReplicaMsgId` behind the log (never ahead), so replay closes
+    // any gap. No graceful drain is needed — the owner just cancels the scope.
+    private suspend fun persisterLoop() {
         try {
             while (true) {
                 val task: PersisterTask = selectUnbiased {
@@ -321,19 +321,35 @@ class LeaderLogProcessor(
             commitTriesDeleted,
             nodeBase.meterRegistry
         )
-    }.also { it.runOn(gcScope) }
+    }
 
     private val txErrorCounter: Counter? = nodeBase.meterRegistry?.let { Counter.builder("tx.error").register(it) }
 
-    private val extJob = extSource?.let { source ->
+    /**
+     * Launches the leader's process tree into [scope]: both GCs (on a child [SupervisorJob] so one
+     * GC's failure doesn't take the other down — failure isolation is the owner's concern), the
+     * external-source pump, and the persister. The owner tears the leader down by cancelling
+     * [scope]; nothing here is closed via its own teardown.
+     */
+    fun runOn(scope: CoroutineScope) {
         scope.launch {
-            try {
-                source.onPartitionAssigned(partition, afterToken, this@LeaderLogProcessor)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                watchers.notifyError(e)
+            val gcScope = CoroutineScope(coroutineContext + SupervisorJob(coroutineContext.job))
+            blockGc.runOn(gcScope)
+            trieGc.runOn(gcScope)
+
+            extSource?.let { source ->
+                launch(CoroutineName("$dbName ext-source")) {
+                    try {
+                        source.onPartitionAssigned(partition, afterToken, this@LeaderLogProcessor)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        watchers.notifyError(e)
+                    }
+                }
             }
+
+            launch(CoroutineName("$dbName persister")) { persisterLoop() }
         }
     }
 
@@ -574,15 +590,11 @@ class LeaderLogProcessor(
         }
     }
 
+    // State teardown only: the process tree is stopped by the owner cancelling its scope before
+    // this runs, so the loop has stopped and every buffer is freed. All that's left is to free the
+    // resources this processor holds — the external source and its child allocator.
     override suspend fun close() {
-        extJob?.cancelAndJoin()
         extSource?.close()
-        withTimeoutOrNull(5.seconds) { gcScope.coroutineContext.job.cancelAndJoin() }
-            ?: LOG.warn("GC coroutines did not stop within 5s")
-        sourceLogCh.close()
-        extSourceCh.close()
-        gcCh.close()
-        persisterJob.join()
         allocator.close()
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -2,8 +2,11 @@ package xtdb.indexer
 
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
@@ -64,19 +67,43 @@ class LogProcessor(
         ): FollowerProcessor
     }
 
+    // The same split as the compactor: a SubSystem is constructed inert, started by the owner via
+    // `runOn(scope)`, and torn down by the owner cancelling that scope. `close()` only frees the
+    // State it holds (the proc's allocator, and the leader's replica producer).
     sealed interface SubSystem {
-        suspend fun close()
+        fun runOn(scope: CoroutineScope)
+        fun close()
     }
 
     interface LeaderSystem : SubSystem {
         val proc: LeaderProcessor
     }
 
-    private class FollowerSystem(val proc: FollowerProcessor, private val job: Job) : SubSystem {
-        override suspend fun close() {
-            job.cancel()
-            proc.close()
+    private inner class FollowerSystem(
+        val proc: FollowerProcessor,
+        private val afterReplicaMsgId: MessageId,
+    ) : SubSystem {
+        override fun runOn(scope: CoroutineScope) {
+            scope.launch {
+                LOG.info {
+                    buildString {
+                        append("[$dbName] starting follower: ")
+                        append("pending block: ${proc.pendingBlock != null}, ")
+                        append("src: ${watchers.latestSourceMsgId}, ")
+                        append("replica: $afterReplicaMsgId")
+                    }
+                }
+                try {
+                    replicaLog.tailAll(afterReplicaMsgId, proc)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    proc.notifyError(e); throw e
+                }
+            }
         }
+
+        override fun close() = proc.close()
     }
 
     private fun openFollowerSystem(
@@ -84,32 +111,21 @@ class LogProcessor(
         pendingBlock: PendingBlock? = null,
     ): FollowerSystem {
         val proc = procFactory.openFollower(pendingBlock, latestReplicaMsgId)
-        return try {
-            LOG.info {
-                buildString {
-                    append("[$dbName] starting follower: ")
-                    append("pending block: ${pendingBlock != null}, ")
-                    append("src: ${watchers.latestSourceMsgId}, ")
-                    append("replica: $latestReplicaMsgId")
-                }
-            }
-
-            FollowerSystem(proc, scope.launch {
-                try {
-                    replicaLog.tailAll(latestReplicaMsgId, proc)
-                } catch (e: Throwable) {
-                    proc.notifyError(e); throw e
-                }
-            })
-        } catch (t: Throwable) {
-            proc.close()
-            throw t
-        }
+        return FollowerSystem(proc, latestReplicaMsgId)
     }
+
+    // Each leadership term (follower or leader) runs under its own `termJob` — a SupervisorJob child
+    // of the indexer `scope`, so a term-process failure surfaces as `notifyError` rather than tearing
+    // down the source-log subscription. A transition cancel-and-joins the old `termJob` (in the
+    // rebalance handler) and starts the next role under a fresh one; a Database teardown cancels
+    // `scope`, taking the live term with it.
+    private fun newTermJob() = SupervisorJob(scope.coroutineContext.job)
+    private var termJob = newTermJob()
+    private val termScope get() = CoroutineScope(scope.coroutineContext + termJob)
 
     @Volatile
     private var sys: SubSystem =
-        openFollowerSystem(dbState.blockCatalog.boundaryReplicaMsgId ?: -1)
+        openFollowerSystem(dbState.blockCatalog.boundaryReplicaMsgId ?: -1).also { it.runOn(termScope) }
 
     init {
         meterRegistry?.let { reg ->
@@ -142,8 +158,13 @@ class LogProcessor(
                         val replayTarget = replicaProducer.withTx { it.appendMessage(ReplicaMessage.NoOp) }.await().msgId
 
                         followerProc.awaitReplicaMsgId(replayTarget)
-                        LOG.debug("[$dbName] transition: closing follower system")
+                        LOG.debug("[$dbName] transition: stopping follower system")
+                        // Stop the follower's term scope (its replica tail) and free it before opening
+                        // the leader — both roles share `liveIndex`, so the old term must be fully
+                        // joined first. The leader then runs on a fresh term scope.
+                        termJob.cancelAndJoin()
                         oldSys.close()
+                        termJob = newTermJob()
 
                         val pendingBlock = followerProc.pendingBlock
 
@@ -160,6 +181,7 @@ class LogProcessor(
                             LOG.debug("[$dbName] transition: opening leader processor")
 
                             val sys = procFactory.openLeaderSystem(replicaProducer, replayTarget)
+                            sys.runOn(termScope)
                             this.sys = sys
 
                             val resumeMsgId = watchers.latestSourceMsgId
@@ -186,11 +208,17 @@ class LogProcessor(
         when (val oldSys = sys) {
             is LeaderSystem -> {
                 LOG.info("[$dbName] partitions revoked: $partitions — was leader, transitioning to follower")
-                // Close first: Kafka guarantees no concurrent processing during rebalance,
-                // and close() only releases the allocator — watermark fields remain readable.
-                oldSys.close()
                 val proc = oldSys.proc
+                // Stop the leader's term scope before freeing its resources and opening the follower.
+                // Safe on the Kafka poll thread: this cancelAndJoin already ran here (it was inside the
+                // old `oldSys.close()`); the leader's loops are on Dispatchers.Default with
+                // runInterruptible(IO) Kafka polls, so the join can't wedge the poll thread. `close()`
+                // only frees the allocator, so the watermark fields stay readable after it.
+                termJob.cancelAndJoin()
+                oldSys.close()
+                termJob = newTermJob()
                 this.sys = openFollowerSystem(proc.latestReplicaMsgId, proc.pendingBlock)
+                    .also { it.runOn(termScope) }
             }
 
             is FollowerSystem -> {
@@ -199,7 +227,7 @@ class LogProcessor(
         }
     }
 
-    suspend fun close() {
+    fun close() {
         sys.close()
     }
 

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -5,7 +5,6 @@ import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.database.DatabaseState
@@ -29,9 +28,8 @@ class LogProcessor(
     meterRegistry: MeterRegistry? = null,
 ) : Log.SubscriptionListener<SourceMessage> {
 
-    interface Processor<M> : Log.RecordProcessor<M> {
+    interface Processor<M> : Log.RecordProcessor<M>, AutoCloseable {
         val latestReplicaMsgId: MessageId
-        suspend fun close()
     }
 
     interface LeaderProcessor : Processor<SourceMessage> {
@@ -104,7 +102,7 @@ class LogProcessor(
                 }
             })
         } catch (t: Throwable) {
-            runBlocking { proc.close() }
+            proc.close()
             throw t
         }
     }
@@ -149,8 +147,7 @@ class LogProcessor(
 
                         val pendingBlock = followerProc.pendingBlock
 
-                        val transition = procFactory.openTransition(replicaProducer, followerProc.latestReplicaMsgId)
-                        try {
+                        procFactory.openTransition(replicaProducer, followerProc.latestReplicaMsgId).use { transition ->
                             if (pendingBlock != null) {
                                 LOG.debug("[$dbName] transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
                                 blockUploader.uploadBlock(
@@ -168,8 +165,6 @@ class LogProcessor(
                             val resumeMsgId = watchers.latestSourceMsgId
                             LOG.info("[$dbName] leader startup complete, resuming after $resumeMsgId")
                             Log.TailSpec(resumeMsgId, sys.proc)
-                        } finally {
-                            transition.close()
                         }
                     }
                 } catch (e: InterruptedException) {

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -147,7 +147,7 @@ class TransitionLogProcessor(
         }
     }
 
-    override suspend fun close() {
+    override fun close() {
         allocator.close()
     }
 }

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -1,15 +1,20 @@
 package xtdb
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.test.runTest
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
+import xtdb.SimulationTestUtils.Companion.L0TrieKeys
 import xtdb.SimulationTestUtils.Companion.L1TrieKeys
+import xtdb.SimulationTestUtils.Companion.L3TrieKeys
 import xtdb.SimulationTestUtils.Companion.addTriesToBufferPool
 import xtdb.SimulationTestUtils.Companion.buildTrieDetails
 import xtdb.SimulationTestUtils.Companion.createJobCalculator
@@ -23,11 +28,6 @@ import xtdb.catalog.BlockCatalog.Companion.latestBlock
 import xtdb.compactor.Compactor
 import xtdb.compactor.CompactorDriverConfig
 import xtdb.compactor.CompactorMockDriver
-import org.junit.jupiter.api.extension.BeforeEachCallback
-import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.api.extension.ExtensionContext
-import xtdb.SimulationTestUtils.Companion.L0TrieKeys
-import xtdb.SimulationTestUtils.Companion.L3TrieKeys
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
@@ -38,14 +38,12 @@ import xtdb.storage.MemoryStorage
 import xtdb.table.TableRef
 import xtdb.trie.TrieCatalog
 import xtdb.util.asPath
-import xtdb.util.debug
 import xtdb.util.logger
 import java.nio.ByteBuffer
 import java.time.Duration
 import java.time.Instant
+import java.util.*
 import java.util.concurrent.TimeUnit
-import java.util.UUID
-import kotlin.time.Duration.Companion.microseconds
 
 data class MockDatabase(
     val name: DatabaseName,
@@ -56,9 +54,10 @@ data class MockDatabase(
     val compactor: Compactor,
     val compactorForDb: Compactor.ForDatabase,
     val garbageCollector: TrieGarbageCollector,
+    val gcScope: CoroutineScope,
 ) {
     fun close() {
-        garbageCollector.close()
+        runBlocking { gcScope.coroutineContext.job.cancelAndJoin() }
         compactorForDb.close()
         compactor.close()
     }
@@ -117,19 +116,23 @@ class NodeSimulationTest : SimulationTestBase() {
             val dbStorage = DatabaseStorage(null, null, sharedBufferPool, null)
             val dbState = DatabaseState("xtdb", blockCatalog, null, trieCatalog, null)
             val compactorForDb = compactor.openForDatabase(allocator, dbStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+            val gcScope = CoroutineScope(SupervisorJob() + dispatcher)
+
             val garbageCollector = TrieGarbageCollector(
                 sharedBufferPool, dbState,
+                enabled = false,
+                blocksToKeep = 2,
+                garbageLifetime = garbageLifetime,
                 commitTriesDeleted = { tableName, trieKeys ->
                     // No replica log in the mock — apply the catalog mutation directly so the
                     // simulation's view of the catalog still converges as the test asserts.
                     trieCatalog.deleteTries(tableName, trieKeys)
                 },
-                blocksToKeep = 2,
-                garbageLifetime = garbageLifetime,
-                enabled = false,
-                dispatcher = dispatcher,
-            )
-            MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, garbageCollector)
+                tableDispatcher = dispatcher,
+                deleteDispatcher = dispatcher,
+            ).also { it.runOn(gcScope) }
+
+            MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, garbageCollector, gcScope)
         }
     }
 

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -53,11 +53,16 @@ data class MockDatabase(
     val blockCatalog: BlockCatalog,
     val compactor: Compactor,
     val compactorForDb: Compactor.ForDatabase,
+    val compactorScope: CoroutineScope,
     val garbageCollector: TrieGarbageCollector,
     val gcScope: CoroutineScope,
 ) {
     fun close() {
-        runBlocking { gcScope.coroutineContext.job.cancelAndJoin() }
+        runBlocking {
+            // cancel the compaction loop before `compactorForDb.close()` frees its driver allocator
+            compactorScope.coroutineContext.job.cancelAndJoin()
+            gcScope.coroutineContext.job.cancelAndJoin()
+        }
         compactorForDb.close()
         compactor.close()
     }
@@ -116,6 +121,8 @@ class NodeSimulationTest : SimulationTestBase() {
             val dbStorage = DatabaseStorage(null, null, sharedBufferPool, null)
             val dbState = DatabaseState("xtdb", blockCatalog, null, trieCatalog, null)
             val compactorForDb = compactor.openForDatabase(allocator, dbStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+            val compactorScope = CoroutineScope(SupervisorJob() + dispatcher)
+                .also { compactorForDb.runOn(it) }
             val gcScope = CoroutineScope(SupervisorJob() + dispatcher)
 
             val garbageCollector = TrieGarbageCollector(
@@ -132,7 +139,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 deleteDispatcher = dispatcher,
             ).also { it.runOn(gcScope) }
 
-            MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, garbageCollector, gcScope)
+            MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, compactorScope, garbageCollector, gcScope)
         }
     }
 

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -315,6 +315,33 @@ class CompactorSimulationTest : SimulationTestBase() {
         super.tearDownSimulation()
     }
 
+    // The compaction loop is now a scope-managed Service: open inert, `runOn` a scope, and on
+    // teardown cancel-and-join that scope *before* `close()` frees the driver's child allocator.
+    private inline fun Compactor.ForDatabase.runScoped(block: (Compactor.ForDatabase) -> Unit) {
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        runOn(scope)
+        try {
+            block(this)
+        } finally {
+            runBlocking { scope.coroutineContext.job.cancelAndJoin() }
+            close()
+        }
+    }
+
+    private inline fun List<MockDb>.openCompactorsScoped(block: (List<Compactor.ForDatabase>) -> Unit) {
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        safeMap { db ->
+            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+        }.useAll { compactorsForDb ->
+            compactorsForDb.forEach { it.runOn(scope) }
+            try {
+                block(compactorsForDb)
+            } finally {
+                runBlocking { scope.coroutineContext.job.cancelAndJoin() }
+            }
+        }
+    }
+
     private fun seedTries(tableRef: TableRef, tries: List<TrieDetails>) {
         tries.forEach {
             mockDriver.trieKeyToFileSize[mockDriver.fileSizeKey(tableRef.tableName, it.trieKey.toString())] = it.dataFileSize
@@ -333,7 +360,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         val l0Trie = buildTrieDetails(docsTable.tableName, L0TrieKeys.first())
         val db = dbs[0]
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use {
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).runScoped {
             seedTries(docsTable, listOf(l0Trie))
             it.compactAllSync(null)
         }
@@ -361,7 +388,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         val table = TableRef("xtdb", "public", "docs")
         val db = dbs[0]
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use {
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).runScoped {
             // Round 1: Add 3 L0 tries and compact
             seedTries(
                 table,
@@ -424,7 +451,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         val l0tries = L0TrieKeys.take(100).map { buildTrieDetails(docsTable.tableName, it, 10L * 1024L * 1024L) }
         val db = dbs[0]
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use { c ->
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).runScoped { c ->
             seedTries(docsTable, l0tries.toList())
             c.compactAllSync(null)
             val liveTries = db.trieCatalog.listLiveAndNascentTrieKeys(docsTable)
@@ -447,7 +474,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
         val l1Tries = L1TrieKeys.take(4).map { buildTrieDetails(docsTable.tableName, it, defaultFileTarget) }
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use {
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).runScoped {
             seedTries(docsTable, l1Tries.toList())
 
             it.compactAllSync(null)
@@ -485,7 +512,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
         val missingPartitions = (0..3).filterNot { it in existingPartitions }
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use {
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).runScoped {
             seedTries(docsTable, l1Tries.toList() + existingL2Tries)
 
             it.compactAllSync(null)
@@ -532,7 +559,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         l2tries.add(buildTrieDetails(docsTable.tableName, "l02-rc-p3-b03", defaultFileTarget))
         l2tries.add(buildTrieDetails(docsTable.tableName, "l02-rc-p3-b07", defaultFileTarget))
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use {
+        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).runScoped {
             seedTries(docsTable, l1Tries.toList() + l2tries)
 
             it.compactAllSync(null)
@@ -565,9 +592,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         seedTries(usersTable, usersTries.toList())
         seedTries(ordersTable, ordersTries.toList())
 
-        dbs.safeMap { db ->
-            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
-        }.useAll { compactorsForDb ->
+        dbs.openCompactorsScoped { compactorsForDb ->
             runBlocking {
                 compactorsForDb.shuffled(rand).map { c -> async { c.compactAll() } }.awaitAll()
             }
@@ -614,9 +639,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
         seedTries(docsTable, listOf(l0Trie))
 
-        dbs.safeMap { db ->
-            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
-        }.useAll { compactorsForDb ->
+        dbs.openCompactorsScoped { compactorsForDb ->
             runBlocking {
                 compactorsForDb.shuffled(rand).map { c -> async { c.compactAll() } }.awaitAll()
             }
@@ -648,9 +671,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
         seedTries(docsTable, l0tries.toList())
 
-        dbs.safeMap { db ->
-            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
-        }.useAll { compactorsForDb ->
+        dbs.openCompactorsScoped { compactorsForDb ->
             runBlocking {
                 compactorsForDb.shuffled(rand).map { c -> async { c.compactAll() } }.awaitAll()
             }

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -2,10 +2,14 @@ package xtdb.database
 
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
@@ -31,7 +35,6 @@ import xtdb.tx.TxOpts
 import java.time.Instant
 import java.time.InstantSource
 import java.time.ZoneId
-import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.milliseconds
 
 class ExternalSourceTest {
@@ -93,7 +96,7 @@ class ExternalSourceTest {
         watchers: Watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
         extSource: ExternalSource = InMemoryExternalSource(),
         afterToken: ExternalSourceToken? = null,
-        ctx: CoroutineContext,
+        scope: CoroutineScope,
     ): LeaderLogProcessor {
         val blockCatalog = BlockCatalog("test", null)
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
@@ -110,8 +113,30 @@ class ExternalSourceTest {
             allocator, nodeBase, dbStorage, crashLogger,
             dbState, blockUploader, watchers, extSource, replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterReplicaMsgId = -1, afterToken = afterToken, ctx = ctx
-        )
+            partition = 0, afterReplicaMsgId = -1, afterToken = afterToken,
+        ).also { it.runOn(scope) }
+    }
+
+    // The leader is now a scope-managed Service: `runOn` a scope, and on teardown cancel-and-join
+    // that scope *before* `close()` frees the processor's allocator (cancellation stops the loop;
+    // the synchronous in-memory effects can't be cleaved off, so nothing is left holding a buffer).
+    private suspend fun TestScope.withLeader(
+        sourceLog: InMemoryLog<SourceMessage> = InMemoryLog(InstantSource.system(), 0),
+        replicaLog: InMemoryLog<ReplicaMessage> = InMemoryLog(InstantSource.system(), 0),
+        liveIndex: LiveIndex = this@ExternalSourceTest.liveIndex,
+        watchers: Watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
+        extSource: ExternalSource = InMemoryExternalSource(),
+        afterToken: ExternalSourceToken? = null,
+        block: suspend (LeaderLogProcessor) -> Unit,
+    ) {
+        val scope = CoroutineScope(coroutineContext + Job())
+        val lp = leaderProc(sourceLog, replicaLog, liveIndex, watchers, extSource, afterToken, scope)
+        try {
+            block(lp)
+        } finally {
+            scope.coroutineContext.job.cancelAndJoin()
+            lp.close()
+        }
     }
 
     @Test
@@ -119,8 +144,7 @@ class ExternalSourceTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val extSource = InMemoryExternalSource()
 
-        val lp = leaderProc(replicaLog = replicaLog, extSource = extSource, ctx = coroutineContext)
-        try {
+        withLeader(replicaLog = replicaLog, extSource = extSource) { lp ->
             extSource.channel.send(null)
             delay(500.milliseconds)
 
@@ -140,8 +164,6 @@ class ExternalSourceTest {
             assertEquals(true, resolved.committed)
             assertEquals(0L, resolved.txId)
             assertNull(resolved.srcMsgId, "ext-source ResolvedTx should not carry a source-log msgId")
-        } finally {
-            lp.close()
         }
     }
 
@@ -150,9 +172,7 @@ class ExternalSourceTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val extSource = InMemoryExternalSource()
 
-        val lp = leaderProc(replicaLog = replicaLog, extSource = extSource, ctx = coroutineContext)
-
-        try {
+        withLeader(replicaLog = replicaLog, extSource = extSource) { lp ->
             extSource.channel.send(null)
             extSource.channel.send(null)
             delay(500.milliseconds)
@@ -168,17 +188,14 @@ class ExternalSourceTest {
 
             assertEquals(listOf(0L, 1L), resolvedTxs.map { it.txId })
             assertTrue(resolvedTxs.all { it.committed }, "both txs should be committed")
-        } finally {
-            lp.close()
         }
     }
 
     @Test
     fun `processRecords flows source records through the leader processor`() = runTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
-        val lp = leaderProc(replicaLog = replicaLog, ctx = coroutineContext)
 
-        try {
+        withLeader(replicaLog = replicaLog) { lp ->
             val now = Instant.now()
 
             lp.processRecords(
@@ -190,8 +207,6 @@ class ExternalSourceTest {
             delay(500.milliseconds)
 
             assertTrue(replicaLog.latestSubmittedOffset >= 0, "source records should flow through to the leader")
-        } finally {
-            lp.close()
         }
     }
 
@@ -199,9 +214,8 @@ class ExternalSourceTest {
     fun `indexTx threads resumeToken to watchers`() = runTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
         val extSource = InMemoryExternalSource()
-        val lp = leaderProc(watchers = watchers, extSource = extSource, ctx = coroutineContext)
 
-        try {
+        withLeader(watchers = watchers, extSource = extSource) { lp ->
             val token = "kafka-offset:42".toByteArray()
             extSource.channel.send(token)
 
@@ -210,8 +224,6 @@ class ExternalSourceTest {
             val watcherToken = watchers.externalSourceToken
             assertNotNull(watcherToken)
             assertArrayEquals(token, watcherToken)
-        } finally {
-            lp.close()
         }
     }
 
@@ -231,12 +243,9 @@ class ExternalSourceTest {
             override fun close() {}
         }
 
-        val lp = leaderProc(watchers = watchers, extSource = failingSource, ctx = coroutineContext)
-        try {
+        withLeader(watchers = watchers, extSource = failingSource) { lp ->
             delay(500.milliseconds)
             assertNotNull(watchers.exception, "watchers should be in failed state")
-        } finally {
-            lp.close()
         }
     }
 
@@ -248,14 +257,11 @@ class ExternalSourceTest {
         }
 
         val extSource = InMemoryExternalSource()
-        val lp = leaderProc(watchers = watchers, liveIndex = liveIndex, extSource = extSource, ctx = coroutineContext)
 
-        try {
+        withLeader(watchers = watchers, liveIndex = liveIndex, extSource = extSource) { lp ->
             extSource.channel.send(null)
             delay(500.milliseconds)
             assertNotNull(watchers.exception, "watchers should be in failed state")
-        } finally {
-            lp.close()
         }
     }
 

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -62,10 +62,11 @@ class FollowerLogProcessorTest {
         allocator.close()
     }
 
-    private fun makeProcessor(
+    private suspend inline fun <R> withProcessor(
         maxBufferedRecords: Int = 1024,
         hasExternalSource: Boolean = false,
         meterRegistry: MeterRegistry? = null,
+        block: suspend (FollowerLogProcessor) -> R
     ) =
         FollowerLogProcessor(
             allocator, bufferPool, dbState,
@@ -73,42 +74,39 @@ class FollowerLogProcessorTest {
             hasExternalSource = hasExternalSource,
             meterRegistry = meterRegistry,
             maxBufferedRecords = maxBufferedRecords,
-        )
+        ).use { block(it) }
 
     private fun <M> record(offset: Long, message: M) =
         Log.Record(0, offset, Instant.now(), message)
 
     @Test
     fun `buffer overflow stops ingestion`() = runTest {
-        val proc = makeProcessor(maxBufferedRecords = 2)
+        withProcessor(maxBufferedRecords = 2) { proc ->
+            val records = listOf(
+                record(0, ReplicaMessage.BlockBoundary(0, 0)),
+                record(1, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap())),
+                record(2, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap())),
+                record(3, ReplicaMessage.ResolvedTx(3, Instant.now(), true, null, emptyMap())),
+            )
 
-        val records = listOf(
-            record(0, ReplicaMessage.BlockBoundary(0, 0)),
-            record(1, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap())),
-            record(2, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap())),
-            record(3, ReplicaMessage.ResolvedTx(3, Instant.now(), true, null, emptyMap())),
-        )
-
-        assertThrows<Fault> { proc.processRecords(records) }
-        proc.close()
+            assertThrows<Fault> { proc.processRecords(records) }
+        }
     }
 
     @Test
     fun `ResolvedTx skips already-applied transactions`() = runTest {
         watchers = Watchers(latestTxId = 42, latestSourceMsgId = 42)
-        val proc = makeProcessor()
+        withProcessor { proc ->
+            val tx40 = ReplicaMessage.ResolvedTx(40, Instant.now(), true, null, emptyMap(), srcMsgId = 40)
+            val tx42 = ReplicaMessage.ResolvedTx(42, Instant.now(), true, null, emptyMap(), srcMsgId = 42)
+            val tx43 = ReplicaMessage.ResolvedTx(43, Instant.now(), true, null, emptyMap(), srcMsgId = 43)
 
-        val tx40 = ReplicaMessage.ResolvedTx(40, Instant.now(), true, null, emptyMap(), srcMsgId = 40)
-        val tx42 = ReplicaMessage.ResolvedTx(42, Instant.now(), true, null, emptyMap(), srcMsgId = 42)
-        val tx43 = ReplicaMessage.ResolvedTx(43, Instant.now(), true, null, emptyMap(), srcMsgId = 43)
+            proc.processRecords(listOf(record(0, tx40), record(1, tx42), record(2, tx43)))
 
-        proc.processRecords(listOf(record(0, tx40), record(1, tx42), record(2, tx43)))
-
-        verify(exactly = 0) { liveIndex.importTx(tx40) }
-        verify(exactly = 0) { liveIndex.importTx(tx42) }
-        verify { liveIndex.importTx(tx43) }
-
-        proc.close()
+            verify(exactly = 0) { liveIndex.importTx(tx40) }
+            verify(exactly = 0) { liveIndex.importTx(tx42) }
+            verify { liveIndex.importTx(tx43) }
+        }
     }
 
     @Test
@@ -120,23 +118,21 @@ class FollowerLogProcessorTest {
         blockCatalog = BlockCatalog("test", startBlock)
         dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = 1000, latestSourceMsgId = 1000)
-        val proc = makeProcessor()
+        withProcessor { proc ->
+            val staleRecords = listOf(
+                record(0, ReplicaMessage.ResolvedTx(500, Instant.now(), true, null, emptyMap(), srcMsgId = 500)),
+                record(1, ReplicaMessage.TriesAdded(1, 1, emptyList(), sourceMsgId = 600)),
+                record(2, ReplicaMessage.BlockBoundary(1, 700)),
+                record(3, ReplicaMessage.BlockUploaded(1, 1, 1, 800, emptyList())),
+                // at the boundary — should also be skipped
+                record(4, ReplicaMessage.ResolvedTx(1000, Instant.now(), true, null, emptyMap(), srcMsgId = 1000)),
+            )
 
-        val staleRecords = listOf(
-            record(0, ReplicaMessage.ResolvedTx(500, Instant.now(), true, null, emptyMap(), srcMsgId = 500)),
-            record(1, ReplicaMessage.TriesAdded(1, 1, emptyList(), sourceMsgId = 600)),
-            record(2, ReplicaMessage.BlockBoundary(1, 700)),
-            record(3, ReplicaMessage.BlockUploaded(1, 1, 1, 800, emptyList())),
-            // at the boundary — should also be skipped
-            record(4, ReplicaMessage.ResolvedTx(1000, Instant.now(), true, null, emptyMap(), srcMsgId = 1000)),
-        )
+            proc.processRecords(staleRecords)
 
-        proc.processRecords(staleRecords)
-
-        verify(exactly = 0) { liveIndex.importTx(any()) }
-        assert(watchers.latestSourceMsgId == 1000L) { "latestSourceMsgId should not have changed" }
-
-        proc.close()
+            verify(exactly = 0) { liveIndex.importTx(any()) }
+            assert(watchers.latestSourceMsgId == 1000L) { "latestSourceMsgId should not have changed" }
+        }
     }
 
     @Test
@@ -144,44 +140,46 @@ class FollowerLogProcessorTest {
         // Simulates the replica log sequence when isFull() triggers on the leader:
         // the BlockBoundary's latestProcessedMsgId equals the preceding ResolvedTx's txId.
         // The follower must still process the block transition.
-        val proc = makeProcessor()
+        withProcessor { proc ->
+            val blockProto = block { blockIndex = 0 }.toByteArray()
+            every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
 
-        val blockProto = block { blockIndex = 0 }.toByteArray()
-        every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
+            assertNull(blockCatalog.currentBlockIndex, "no block before processing")
 
-        assertNull(blockCatalog.currentBlockIndex, "no block before processing")
+            val txId = 100L
+            proc.processRecords(
+                listOf(
+                    record(0, ReplicaMessage.ResolvedTx(txId, Instant.now(), true, null, emptyMap())),
+                    record(1, ReplicaMessage.BlockBoundary(0, txId)),
+                    record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, txId, emptyList())),
+                )
+            )
 
-        val txId = 100L
-        proc.processRecords(listOf(
-            record(0, ReplicaMessage.ResolvedTx(txId, Instant.now(), true, null, emptyMap())),
-            record(1, ReplicaMessage.BlockBoundary(0, txId)),
-            record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, txId, emptyList())),
-        ))
-
-        assertEquals(0L, blockCatalog.currentBlockIndex,
-            "block catalog should advance to block 0 even when BlockBoundary.latestProcessedMsgId == last txId")
-
-        proc.close()
+            assertEquals(
+                0L, blockCatalog.currentBlockIndex,
+                "block catalog should advance to block 0 even when BlockBoundary.latestProcessedMsgId == last txId"
+            )
+        }
     }
 
     @Test
     fun `processes messages after skipping stale ones`() = runTest {
         watchers = Watchers(latestTxId = 1000, latestSourceMsgId = 1000)
-        val proc = makeProcessor()
+        withProcessor { proc ->
+            val tx1001 = ReplicaMessage.ResolvedTx(1001, Instant.now(), true, null, emptyMap(), srcMsgId = 1001)
 
-        val tx1001 = ReplicaMessage.ResolvedTx(1001, Instant.now(), true, null, emptyMap(), srcMsgId = 1001)
+            proc.processRecords(
+                listOf(
+                    // stale
+                    record(0, ReplicaMessage.TriesAdded(1, 1, emptyList(), sourceMsgId = 500)),
+                    // current
+                    record(1, tx1001),
+                )
+            )
 
-        proc.processRecords(listOf(
-            // stale
-            record(0, ReplicaMessage.TriesAdded(1, 1, emptyList(), sourceMsgId = 500)),
-            // current
-            record(1, tx1001),
-        ))
-
-        verify { liveIndex.importTx(tx1001) }
-        assert(watchers.latestSourceMsgId == 1001L)
-
-        proc.close()
+            verify { liveIndex.importTx(tx1001) }
+            assert(watchers.latestSourceMsgId == 1001L)
+        }
     }
 
     @Test
@@ -189,102 +187,108 @@ class FollowerLogProcessorTest {
         // Reproduces #5580: an ext-source ResolvedTx (srcMsgId=null) followed by a BlockBoundary
         // whose latestProcessedMsgId reflects the leader's still-default source watermark would
         // previously violate `srcMsgId >= latestSourceMsgId` on the follower.
-        val proc = makeProcessor(hasExternalSource = true)
+        withProcessor(hasExternalSource = true) { proc ->
+            val blockProto = block { blockIndex = 0 }.toByteArray()
+            every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
 
-        val blockProto = block { blockIndex = 0 }.toByteArray()
-        every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
+            val extTx = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
+            proc.processRecords(
+                listOf(
+                    record(0, extTx),
+                    record(1, ReplicaMessage.BlockBoundary(0, -1)),
+                    record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, -1, emptyList())),
+                )
+            )
 
-        val extTx = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
-        proc.processRecords(listOf(
-            record(0, extTx),
-            record(1, ReplicaMessage.BlockBoundary(0, -1)),
-            record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, -1, emptyList())),
-        ))
-
-        verify { liveIndex.importTx(extTx) }
-        assertEquals(-1L, watchers.latestSourceMsgId,
-            "ext-source ResolvedTx must not bump latestSourceMsgId")
-        assertEquals(0L, blockCatalog.currentBlockIndex)
-
-        proc.close()
+            verify { liveIndex.importTx(extTx) }
+            assertEquals(
+                -1L, watchers.latestSourceMsgId,
+                "ext-source ResolvedTx must not bump latestSourceMsgId"
+            )
+            assertEquals(0L, blockCatalog.currentBlockIndex)
+        }
     }
 
     @Test
     fun `mixed ext-source and source-log ResolvedTxs advance the right watermarks`() = runTest {
-        val proc = makeProcessor(hasExternalSource = true)
+        withProcessor(hasExternalSource = true) { proc ->
+            val ext0 = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
+            val src1 = ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap(), srcMsgId = 1)
+            val ext2 = ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap(), srcMsgId = null)
 
-        val ext0 = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
-        val src1 = ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap(), srcMsgId = 1)
-        val ext2 = ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap(), srcMsgId = null)
+            proc.processRecords(listOf(record(0, ext0), record(1, src1), record(2, ext2)))
 
-        proc.processRecords(listOf(record(0, ext0), record(1, src1), record(2, ext2)))
-
-        verify { liveIndex.importTx(ext0) }
-        verify { liveIndex.importTx(src1) }
-        verify { liveIndex.importTx(ext2) }
-        assertEquals(1L, watchers.latestSourceMsgId,
-            "latestSourceMsgId reflects only the source-log tx; ext-source txs leave it alone")
-
-        proc.close()
+            verify { liveIndex.importTx(ext0) }
+            verify { liveIndex.importTx(src1) }
+            verify { liveIndex.importTx(ext2) }
+            assertEquals(
+                1L, watchers.latestSourceMsgId,
+                "latestSourceMsgId reflects only the source-log tx; ext-source txs leave it alone"
+            )
+        }
     }
 
     @Test
     fun `records replica processing metrics`() = runTest {
         val registry = SimpleMeterRegistry()
-        val proc = makeProcessor(meterRegistry = registry)
+        withProcessor(meterRegistry = registry) { proc ->
+            val blockProto = block { blockIndex = 0 }.toByteArray()
+            every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
 
-        val blockProto = block { blockIndex = 0 }.toByteArray()
-        every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
+            proc.processRecords(
+                listOf(
+                    record(0, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap())),
+                    record(1, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap())),
+                    record(2, ReplicaMessage.BlockBoundary(0, 2)),
+                    record(3, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 2, emptyList())),
+                )
+            )
 
-        proc.processRecords(listOf(
-            record(0, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap())),
-            record(1, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap())),
-            record(2, ReplicaMessage.BlockBoundary(0, 2)),
-            record(3, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 2, emptyList())),
-        ))
+            fun timerCount(msgType: String) = registry.find("xtdb.replica.process.timer")
+                .tags("db", "test", "msg.type", msgType)
+                .timer()?.count() ?: 0L
 
-        fun timerCount(msgType: String) = registry.find("xtdb.replica.process.timer")
-            .tags("db", "test", "msg.type", msgType)
-            .timer()?.count() ?: 0L
+            assertEquals(2L, timerCount("ResolvedTx"))
+            assertEquals(1L, timerCount("BlockBoundary"))
+            assertEquals(1L, timerCount("BlockUploaded"))
 
-        assertEquals(2L, timerCount("ResolvedTx"))
-        assertEquals(1L, timerCount("BlockBoundary"))
-        assertEquals(1L, timerCount("BlockUploaded"))
+            val bufferTimer = registry.find("xtdb.replica.block.buffer.timer").tag("db", "test").timer()
+            assertNotNull(bufferTimer, "block buffer timer should be registered")
+            assertEquals(1L, bufferTimer!!.count(), "one block buffer window")
+            assertTrue(bufferTimer.totalTime(java.util.concurrent.TimeUnit.NANOSECONDS) >= 0)
 
-        val bufferTimer = registry.find("xtdb.replica.block.buffer.timer").tag("db", "test").timer()
-        assertNotNull(bufferTimer, "block buffer timer should be registered")
-        assertEquals(1L, bufferTimer!!.count(), "one block buffer window")
-        assertTrue(bufferTimer.totalTime(java.util.concurrent.TimeUnit.NANOSECONDS) >= 0)
-
-        val bufferedRecords = registry.find("xtdb.replica.block.buffered.records").tag("db", "test").summary()
-        assertNotNull(bufferedRecords, "buffered records summary should be registered")
-        assertEquals(1L, bufferedRecords!!.count())
-        assertEquals(0.0, bufferedRecords.totalAmount(), "no records buffered when BlockUploaded follows BlockBoundary directly")
-
-        proc.close()
+            val bufferedRecords = registry.find("xtdb.replica.block.buffered.records").tag("db", "test").summary()
+            assertNotNull(bufferedRecords, "buffered records summary should be registered")
+            assertEquals(1L, bufferedRecords!!.count())
+            assertEquals(
+                0.0,
+                bufferedRecords.totalAmount(),
+                "no records buffered when BlockUploaded follows BlockBoundary directly"
+            )
+        }
     }
 
     @Test
     fun `buffered records summary captures size when records arrive between boundary and uploaded`() = runTest {
         val registry = SimpleMeterRegistry()
-        val proc = makeProcessor(meterRegistry = registry)
+        withProcessor(meterRegistry = registry) { proc ->
+            val blockProto = block { blockIndex = 0 }.toByteArray()
+            every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
 
-        val blockProto = block { blockIndex = 0 }.toByteArray()
-        every { bufferPool.getByteArray(BlockCatalog.blockFilePath(0)) } returns blockProto
+            proc.processRecords(
+                listOf(
+                    record(0, ReplicaMessage.BlockBoundary(0, 0)),
+                    // these get buffered while we wait for BlockUploaded
+                    record(1, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap())),
+                    record(2, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap())),
+                    record(3, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 0, emptyList())),
+                )
+            )
 
-        proc.processRecords(listOf(
-            record(0, ReplicaMessage.BlockBoundary(0, 0)),
-            // these get buffered while we wait for BlockUploaded
-            record(1, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap())),
-            record(2, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap())),
-            record(3, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 0, emptyList())),
-        ))
-
-        val bufferedRecords = registry.find("xtdb.replica.block.buffered.records").tag("db", "test").summary()
-        assertNotNull(bufferedRecords)
-        assertEquals(1L, bufferedRecords!!.count())
-        assertEquals(2.0, bufferedRecords.totalAmount(), "two records buffered between boundary and uploaded")
-
-        proc.close()
+            val bufferedRecords = registry.find("xtdb.replica.block.buffered.records").tag("db", "test").summary()
+            assertNotNull(bufferedRecords)
+            assertEquals(1L, bufferedRecords!!.count())
+            assertEquals(2.0, bufferedRecords.totalAmount(), "two records buffered between boundary and uploaded")
+        }
     }
 }

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -4,8 +4,11 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -34,6 +37,7 @@ import xtdb.table.TableRef
 import xtdb.trie.TrieCatalog
 import java.time.Instant
 import java.time.InstantSource
+import kotlin.coroutines.coroutineContext
 
 class LeaderLogProcessorTest {
 
@@ -78,28 +82,43 @@ class LeaderLogProcessorTest {
         )
     }
 
+    // The leader is now a scope-managed Service: `runOn` a scope, run the body, then cancel-and-join
+    // that scope before `close()` frees the allocator.
+    private suspend fun LeaderLogProcessor.runScoped(block: suspend () -> Unit) {
+        val scope = CoroutineScope(coroutineContext + Job())
+        runOn(scope)
+        try {
+            block()
+        } finally {
+            scope.coroutineContext.job.cancelAndJoin()
+            close()
+        }
+    }
+
     @Test
     fun `TriesAdded forwarded to replica log`() = runTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val trieCatalog = mockk<TrieCatalog>(relaxed = true)
         val lp = leaderProc(StandardTestDispatcher(testScheduler), replicaLog = replicaLog, trieCatalog = trieCatalog)
 
-        val tries = listOf(
-            TrieDetails.newBuilder()
-                .setTableName("public/foo")
-                .setTrieKey("trie-key-1")
-                .setDataFileSize(100)
-                .setTrieMetadata(trieMetadata {})
-                .build()
-        )
+        lp.runScoped {
+            val tries = listOf(
+                TrieDetails.newBuilder()
+                    .setTableName("public/foo")
+                    .setTrieKey("trie-key-1")
+                    .setDataFileSize(100)
+                    .setTrieMetadata(trieMetadata {})
+                    .build()
+            )
 
-        val now = Instant.now()
-        lp.processRecords(listOf(
-            Log.Record(0, 0, now, SourceMessage.TriesAdded(Storage.VERSION, 0, tries))
-        ))
+            val now = Instant.now()
+            lp.processRecords(listOf(
+                Log.Record(0, 0, now, SourceMessage.TriesAdded(Storage.VERSION, 0, tries))
+            ))
 
-        verify { trieCatalog.addTries(any(), any(), any()) }
-        assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have received a message")
+            verify { trieCatalog.addTries(any(), any(), any()) }
+            assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have received a message")
+        }
     }
 
     @Test
@@ -132,15 +151,17 @@ class LeaderLogProcessorTest {
             partition = 0, afterReplicaMsgId = -1, afterToken = null,
         )
 
-        val now = Instant.now()
-        lp.processRecords(listOf(
-            Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
-        ))
+        lp.runScoped {
+            val now = Instant.now()
+            lp.processRecords(listOf(
+                Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
+            ))
 
-        verify { liveIndex.finishBlock(any(), eq(0)) }
-        verify { liveIndex.nextBlock() }
-        verify { compactor.signalBlock() }
-        assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have block messages")
+            verify { liveIndex.finishBlock(any(), eq(0)) }
+            verify { liveIndex.nextBlock() }
+            verify { compactor.signalBlock() }
+            assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have block messages")
+        }
     }
 
     @Test
@@ -148,12 +169,14 @@ class LeaderLogProcessorTest {
         val liveIndex = mockk<LiveIndex>(relaxed = true)
         val lp = leaderProc(StandardTestDispatcher(testScheduler), liveIndex = liveIndex)
 
-        val now = Instant.now()
-        lp.processRecords(listOf(
-            Log.Record(0, 0, now, SourceMessage.FlushBlock(5))
-        ))
+        lp.runScoped {
+            val now = Instant.now()
+            lp.processRecords(listOf(
+                Log.Record(0, 0, now, SourceMessage.FlushBlock(5))
+            ))
 
-        verify(exactly = 0) { liveIndex.finishBlock(any(), any()) }
+            verify(exactly = 0) { liveIndex.finishBlock(any(), any()) }
+        }
     }
 
     @Test
@@ -198,28 +221,30 @@ class LeaderLogProcessorTest {
             partition = 0, afterReplicaMsgId = -1, afterToken = null,
         )
 
-        val now = Instant.now()
-        lp.processRecords(listOf(
-            Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
-        ))
+        lp.runScoped {
+            val now = Instant.now()
+            lp.processRecords(listOf(
+                Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
+            ))
 
-        val replicaMessages = mutableListOf<ReplicaMessage>()
-        val job = launch { replicaLog.tailAll(-1) { records ->
-            replicaMessages.addAll(records.map { it.message })
-        } }
+            val replicaMessages = mutableListOf<ReplicaMessage>()
+            val job = launch { replicaLog.tailAll(-1) { records ->
+                replicaMessages.addAll(records.map { it.message })
+            } }
 
-        delay(200)
-        job.cancelAndJoin()
+            delay(200)
+            job.cancelAndJoin()
 
-        assertEquals(2, replicaMessages.size, "expected 2 replica messages, got: $replicaMessages")
-        assertTrue(replicaMessages[0] is ReplicaMessage.BlockBoundary)
-        assertTrue(replicaMessages[1] is ReplicaMessage.BlockUploaded)
+            assertEquals(2, replicaMessages.size, "expected 2 replica messages, got: $replicaMessages")
+            assertTrue(replicaMessages[0] is ReplicaMessage.BlockBoundary)
+            assertTrue(replicaMessages[1] is ReplicaMessage.BlockUploaded)
 
-        val boundary = replicaMessages[0] as ReplicaMessage.BlockBoundary
-        assertEquals(0, boundary.blockIndex)
+            val boundary = replicaMessages[0] as ReplicaMessage.BlockBoundary
+            assertEquals(0, boundary.blockIndex)
 
-        val uploaded = replicaMessages[1] as ReplicaMessage.BlockUploaded
-        assertEquals(0, uploaded.blockIndex)
-        assertTrue(uploaded.tries.isNotEmpty(), "BlockUploaded should contain trie details")
+            val uploaded = replicaMessages[1] as ReplicaMessage.BlockUploaded
+            assertEquals(0, uploaded.blockIndex)
+            assertTrue(uploaded.tries.isNotEmpty(), "BlockUploaded should contain trie details")
+        }
     }
 }

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -195,14 +195,10 @@ class LogProcessorSimTest : SimulationTestBase() {
                 partition = 0, afterReplicaMsgId = afterReplicaMsgId,
                 afterToken = null,
             )
-            val leaderScope = CoroutineScope(dispatcher + Job())
-            proc.runOn(leaderScope)
             return object : LogProcessor.LeaderSystem {
                 override val proc get() = proc
-                override suspend fun close() {
-                    leaderScope.coroutineContext.job.cancelAndJoin()
-                    proc.close()
-                }
+                override fun runOn(scope: CoroutineScope) = proc.runOn(scope)
+                override fun close() = proc.close()
             }
         }
 
@@ -372,8 +368,8 @@ class LogProcessorSimTest : SimulationTestBase() {
                             replicaLog.awaitAllDelivered()
                         }.join()
 
-                        groupJob.cancel()
-                        logProcScope.cancel()
+                        groupJob.cancelAndJoin()
+                        logProcScope.coroutineContext.job.cancelAndJoin()
 
                         assertReplicaTxInvariants()
                         assertEquals(
@@ -467,12 +463,12 @@ class LogProcessorSimTest : SimulationTestBase() {
                                             }
                                         }.join()
 
-                                        groupJobLeader.cancel()
-                                        groupJobA.cancel()
-                                        groupJobB.cancel()
-                                        leaderScope.cancel()
-                                        followerScopeA.cancel()
-                                        followerScopeB.cancel()
+                                        groupJobLeader.cancelAndJoin()
+                                        groupJobA.cancelAndJoin()
+                                        groupJobB.cancelAndJoin()
+                                        leaderScope.coroutineContext.job.cancelAndJoin()
+                                        followerScopeA.coroutineContext.job.cancelAndJoin()
+                                        followerScopeB.coroutineContext.job.cancelAndJoin()
 
                                         assertReplicaTxInvariants()
                                         assertEquals(
@@ -583,10 +579,10 @@ class LogProcessorSimTest : SimulationTestBase() {
                                     }
                                 }.join()
 
-                                groupJobA.cancel()
-                                groupJobB.cancel()
-                                scopeA.cancel()
-                                scopeB.cancel()
+                                groupJobA.cancelAndJoin()
+                                groupJobB.cancelAndJoin()
+                                scopeA.coroutineContext.job.cancelAndJoin()
+                                scopeB.coroutineContext.job.cancelAndJoin()
 
                                 assertReplicaTxInvariants()
                                 assertEquals(

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -4,6 +4,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -193,11 +194,15 @@ class LogProcessorSimTest : SimulationTestBase() {
                 skipTxs = emptySet(), dbCatalog = null,
                 partition = 0, afterReplicaMsgId = afterReplicaMsgId,
                 afterToken = null,
-                ctx = dispatcher
             )
+            val leaderScope = CoroutineScope(dispatcher + Job())
+            proc.runOn(leaderScope)
             return object : LogProcessor.LeaderSystem {
                 override val proc get() = proc
-                override suspend fun close() = proc.close()
+                override suspend fun close() {
+                    leaderScope.coroutineContext.job.cancelAndJoin()
+                    proc.close()
+                }
             }
         }
 

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -75,14 +75,10 @@ class LogProcessorTest {
                     partition = 0, afterReplicaMsgId = afterReplicaMsgId,
                     afterToken = null,
                 )
-                val leaderScope = CoroutineScope(SupervisorJob())
-                leaderProc.runOn(leaderScope)
                 return object : LogProcessor.LeaderSystem {
                     override val proc get() = leaderProc
-                    override suspend fun close() {
-                        leaderScope.coroutineContext.job.cancelAndJoin()
-                        leaderProc.close()
-                    }
+                    override fun runOn(scope: CoroutineScope) = leaderProc.runOn(scope)
+                    override fun close() = leaderProc.close()
                 }
             }
 
@@ -126,9 +122,9 @@ class LogProcessorTest {
             dbStorage, dbState, watchers, blockUploader, scope
         )
 
-        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
+        scope.launch { sourceLog.openGroupSubscription(logProc) }
 
-        job.cancelAndJoin()
+        scope.coroutineContext.job.cancelAndJoin()
         logProc.close()
         sourceLog.close()
         replicaLog.close()
@@ -150,9 +146,9 @@ class LogProcessorTest {
             dbStorage, dbState, watchers, blockUploader, scope
         )
 
-        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
+        scope.launch { sourceLog.openGroupSubscription(logProc) }
 
-        job.cancelAndJoin()
+        scope.coroutineContext.job.cancelAndJoin()
         logProc.close()
         sourceLog.close()
         replicaLog.close()
@@ -182,14 +178,14 @@ class LogProcessorTest {
             dbStorage, dbState, watchers, blockUploader, scope
         )
 
-        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
+        scope.launch { sourceLog.openGroupSubscription(logProc) }
 
         // wait for the follower→leader transition to complete (runs on Dispatchers.Default)
         watchers.awaitTx(1)
 
         verify { liveIndex.importTx(any()) }
 
-        job.cancelAndJoin()
+        scope.coroutineContext.job.cancelAndJoin()
         logProc.close()
         sourceLog.close()
         replicaLog.close()
@@ -217,13 +213,13 @@ class LogProcessorTest {
             dbStorage, dbState, watchers, blockUploader, scope
         )
 
-        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
+        scope.launch { sourceLog.openGroupSubscription(logProc) }
 
         watchers.awaitTx(1)
 
         verify { liveIndex.importTx(any()) }
 
-        job.cancelAndJoin()
+        scope.coroutineContext.job.cancelAndJoin()
         logProc.close()
         sourceLog.close()
         replicaLog.close()

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -75,9 +75,14 @@ class LogProcessorTest {
                     partition = 0, afterReplicaMsgId = afterReplicaMsgId,
                     afterToken = null,
                 )
+                val leaderScope = CoroutineScope(SupervisorJob())
+                leaderProc.runOn(leaderScope)
                 return object : LogProcessor.LeaderSystem {
                     override val proc get() = leaderProc
-                    override suspend fun close() = leaderProc.close()
+                    override suspend fun close() {
+                        leaderScope.coroutineContext.job.cancelAndJoin()
+                        leaderProc.close()
+                    }
                 }
             }
 

--- a/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
@@ -67,17 +67,14 @@ class BlockGarbageCollectorTest {
 
                 val gc = BlockGarbageCollector(
                     bufferPool, blockCat,
-                    blocksToKeep = 3,
-                    enabled = false,
                     dbName = "xtdb",
+                    enabled = false,
+                    blocksToKeep = 3,
                 )
 
                 // Validate that the latest block is correct
-                val latestBlockIndex = blockCat.currentBlockIndex
-                assertEquals(10L, latestBlockIndex)
-
-                val latestCompletedTx = blockCat.latestCompletedTx
-                assertEquals(10L, latestCompletedTx?.txId)
+                assertEquals(10L, blockCat.currentBlockIndex)
+                assertEquals(10L, blockCat.latestCompletedTx?.txId)
 
                 gc.garbageCollectBlocks()
 


### PR DESCRIPTION
**Draft / WIP — an umbrella PR that will grow.**

XTDB's Database-owned components carry two different lifecycles tangled together. This PR moves them onto one uniform model:

- **State** (catalogs, the live index) — a synchronous `AutoCloseable` holding resources hydrated at startup. Unchanged.
- **Service** (the background processes) — torn down by cancelling the `CoroutineScope` that owns it, rather than via its own `close()` / `AutoCloseable`.

Two slices have landed so far:

1. **Garbage collectors.** `BlockGarbageCollector` and `TrieGarbageCollector` become a `class` + `runOn(scope)`, launched into and cancelled via `LeaderLogProcessor`'s `gcScope` — a `SupervisorJob` child so one GC's failure doesn't take the other down — with no self-owned `Job` and no `AutoCloseable`.
2. **Compactor.** `Compactor.ForDatabase`'s loop becomes a `runOn(scope)` Service owned by `Database`. Its `close()` shrinks to freeing the driver's child Arrow allocator — the one piece of genuine State it holds. Teardown order is load-bearing: the loop is cancelled-and-joined before the allocator closes, and `Database` registers that teardown with `safelyOpening` so an aborted `open` stops the loop too.

This is a **behaviour-preserving refactor**. Later slices extend the same pattern to the persister and `Database.open`/`close`.

The full reasoning for each slice — the State/Service distinction, the deterministic-dispatcher constraint that shaped the dispatcher wiring, the allocator teardown ordering, and the alternatives tried and rejected — is in the per-slice comments below.
## Progress

**Status**: in-progress

- [x] Slice 1 — garbage collectors (`Block`/`Trie`GC → `runOn`, owned by `gcScope`)
- [x] Slice 2 — compactor (`ForDatabase` loop → `runOn`, owned by `Database`)
- [x] Slice 3 — `LeaderLogProcessor` → scope-managed Service (`runOn`, owner-cancelled, pure uniform cancellation)
- [x] Slice 4 — follower/transition procs + `LogProcessor` wrapper: per-term `SupervisorJob`, handler-owned cancels, de-suspend the `close()` chain
- [ ] Follow-on — resignation-on-failure (unify leader subtree + resign hook + Kafka relinquish)
- [ ] Follow-on — make `Database.close()` suspend, removing the last `runBlocking` teardown bridge

### Open Questions

- [ ] `compactAll()` parks its waiter in a single shared `compactAllPromise` that isn't cancelled if the loop is torn down mid-flight, so an in-flight caller waits out its `compactAllSync` timeout instead of failing fast. Fixing it is a genuine behaviour change (the GC loop already cancels its waiters), so it's deferred to its own slice — see the compactor comment.