### PR TITLE
tidy(database): introduce DatabasePartition for per-partition state #5557

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -59,20 +59,31 @@ class Database(
     val allocator: BufferAllocator,
     val config: Config,
     override val storage: DatabaseStorage,
-    override val queryState: DatabaseState,
     val isIndexing: Boolean,
-    val watchers: Watchers,
+    val partitions: Map<Int, DatabasePartition>,
     private val meterRegistry: MeterRegistry?,
-    val compactorOrNull: Compactor.ForDatabase? = null,
     private val job: Job? = null,
     private val processor: LogProcessor? = null,
     private val registeredGauges: List<Gauge> = emptyList(),
 ) : IQuerySource.QueryDatabase, AutoCloseable {
-    val name: DatabaseName get() = queryState.name
-    override fun openSnapshot(): Snapshot = queryState.liveIndex.openSnapshot()
 
-    val blockCatalog: BlockCatalog get() = queryState.blockCatalog
-    val tableCatalog: TableCatalog get() = queryState.tableCatalog
+    init {
+        require(partitions.isNotEmpty()) { "Database must have at least one partition" }
+    }
+
+    // Single-partition delegate. Per the stage-4 design, this becomes a per-partition
+    // lookup once `partitions > 1` is enabled; for now every Database has exactly one.
+    private val partition0: DatabasePartition get() = partitions.getValue(0)
+
+    val name: DatabaseName get() = partition0.state.name
+    override val queryState: DatabaseState get() = partition0.state
+    val watchers: Watchers get() = partition0.watchers
+    val compactorOrNull: Compactor.ForDatabase? get() = partition0.compactorOrNull
+
+    override fun openSnapshot(): Snapshot = partition0.openSnapshot()
+
+    val blockCatalog: BlockCatalog get() = partition0.blockCatalog
+    val tableCatalog: TableCatalog get() = partition0.tableCatalog
 
     fun getColumnTypes(table: TableRef, snap: Snapshot): Map<ColumnName, VectorType>? {
         val historical = tableCatalog.getTypes(table)
@@ -80,15 +91,15 @@ class Database(
         return if (historical == null && live == null) null
         else (historical ?: emptyMap()) + (live ?: emptyMap())
     }
-    val trieCatalog: TrieCatalog get() = queryState.trieCatalog
-    val liveIndex: LiveIndex get() = queryState.liveIndex
+    val trieCatalog: TrieCatalog get() = partition0.trieCatalog
+    val liveIndex: LiveIndex get() = partition0.liveIndex
 
     val sourceLog: Log<SourceMessage> get() = storage.sourceLog
     val replicaLog: Log<ReplicaMessage> get() = storage.replicaLog
     val bufferPool: BufferPool get() = storage.bufferPool
     val metadataManager: PageMetadata.Factory get() = storage.metadataManager
 
-    val compactor: Compactor.ForDatabase get() = compactorOrNull ?: error("compactor not initialised")
+    val compactor: Compactor.ForDatabase get() = partition0.compactor
 
     val latestProcessedMsgId: MessageId get() = watchers.latestSourceMsgId
     val ingestionError: IngestionStoppedException? get() = watchers.exception
@@ -121,7 +132,7 @@ class Database(
             job?.cancelAndJoin()
             processor?.close()
         }
-        listOf(compactorOrNull, queryState, storage, allocator).closeAll()
+        (partitions.values + listOf(storage, allocator)).closeAll()
     }
 
     fun submitTxBlocking(ops: List<TxOp>, opts: TxOpts): Xtdb.SubmittedTx {
@@ -343,15 +354,20 @@ class Database(
                 )
             } ?: emptyList()
 
+            val partition = DatabasePartition(
+                partition = 0,
+                state = state,
+                watchers = watchers,
+                compactorOrNull = compactorForDb,
+            )
+
             Database(
                 allocator = allocator,
                 config = dbConfig,
                 storage = storage,
-                queryState = state,
                 isIndexing = indexerConfig.enabled,
-                watchers = watchers,
+                partitions = mapOf(0 to partition),
                 meterRegistry = meterRegistry,
-                compactorOrNull = compactorForDb,
                 job = job,
                 processor = processor,
                 registeredGauges = gauges,

--- a/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
@@ -1,0 +1,32 @@
+package xtdb.database
+
+import xtdb.api.log.Watchers
+import xtdb.catalog.BlockCatalog
+import xtdb.catalog.TableCatalog
+import xtdb.compactor.Compactor
+import xtdb.indexer.LiveIndex
+import xtdb.indexer.Snapshot
+import xtdb.trie.TrieCatalog
+import xtdb.util.closeAll
+
+class DatabasePartition(
+    val partition: Int,
+    val state: DatabaseState,
+    val watchers: Watchers,
+    val compactorOrNull: Compactor.ForDatabase? = null,
+) : AutoCloseable {
+
+    val blockCatalog: BlockCatalog get() = state.blockCatalog
+    val tableCatalog: TableCatalog get() = state.tableCatalog
+    val trieCatalog: TrieCatalog get() = state.trieCatalog
+    val liveIndex: LiveIndex get() = state.liveIndex
+
+    val compactor: Compactor.ForDatabase
+        get() = compactorOrNull ?: error("compactor not initialised")
+
+    fun openSnapshot(): Snapshot = state.liveIndex.openSnapshot()
+
+    override fun close() {
+        listOf(compactorOrNull, state).closeAll()
+    }
+}

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -265,13 +265,17 @@ class ExternalSourceTest {
         val config = Database.Config(externalSource = extFactory)
 
         // note: not .use — Database.close() would close `allocator`, which @AfterEach also closes
+        val partition = DatabasePartition(
+            partition = 0,
+            state = DatabaseState("cdc", null, null, null, null),
+            watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
+        )
         val db = Database(
             allocator = allocator,
             config = config,
             storage = DatabaseStorage(null, null, null, null),
-            queryState = DatabaseState("cdc", null, null, null, null),
             isIndexing = false,
-            watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
+            partitions = mapOf(0 to partition),
             meterRegistry = null,
         )
 


### PR DESCRIPTION
First of the stage-4 (#5557) tidy units.
Per-partition state — Watchers, the catalogs and live-index bundle in DatabaseState, and the Compactor.ForDatabase handle — needs an explicit home before we can have N of them per database, so it moves into a new DatabasePartition aggregate. Database delegates the existing accessors (`blockCatalog`, `tableCatalog`, `watchers`, `compactor`, `liveIndex`, …) to `partitions[0]` so callers carry on unchanged.

Pure equivalence change: size is always 1, every external observation is identical.

The `LogProcessor` is left on Database for now — it relocates to DatabasePartition in a later unit, which keeps this diff small. `DatabaseStorage` similarly stays put; splitting the per-partition bufferPool/metadataManager out pairs with the partition-aware object-store layout work in a later unit.

The `partition0` accessor is private and called inline at every delegation site — once `partitions > 1` is real, those sites stop being trivial delegations, so leaving them visible avoids hiding the per-partition lookups behind a single helper.

Refs #5557.