### PR TITLE
feat(flight-sql): implement session management

### DIFF
--- a/core/src/main/kotlin/xtdb/api/FlightSql.kt
+++ b/core/src/main/kotlin/xtdb/api/FlightSql.kt
@@ -5,6 +5,7 @@ import org.apache.arrow.flight.Location.forGrpcInsecure
 import xtdb.flight_sql.XtdbProducer
 import xtdb.flight_sql.withDatabaseMiddleware
 import xtdb.flight_sql.withErrorLoggingMiddleware
+import xtdb.flight_sql.withSessionMiddleware
 import xtdb.util.closeOnCatch
 import xtdb.util.info
 import xtdb.util.logger
@@ -23,6 +24,7 @@ interface FlightSql : AutoCloseable {
                 val server = builder(xtdb.allocator, forGrpcInsecure(host, config.port), producer)
                     .also { it.withErrorLoggingMiddleware() }
                     .also { it.withDatabaseMiddleware() }
+                    .also { it.withSessionMiddleware() }
                     .build()
                     .also { it.start() }
 

--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -43,6 +43,7 @@ import xtdb.util.requiringResolve
 import xtdb.util.serializeAsMessageInterruptibly
 import xtdb.util.warn
 import java.util.*
+import java.util.concurrent.Callable
 import java.util.concurrent.ConcurrentHashMap
 
 private fun resultTypesToSchema(types: SequencedMap<String, VectorType>) =
@@ -139,45 +140,97 @@ internal fun FlightServer.Builder.withDatabaseMiddleware(): FlightServer.Builder
         DatabaseMiddleware(incomingHeaders.get("x-xtdb-database"))
     }
 
-private fun dbNameFromContext(ctx: CallContext?): DatabaseName =
-    ctx?.getMiddleware(DatabaseMiddleware.KEY)?.dbName ?: "xtdb"
+val SESSION_KEY: FlightServerMiddleware.Key<ServerSessionMiddleware> =
+    FlightServerMiddleware.Key.of("flight-sql-session")
+
+internal fun FlightServer.Builder.withSessionMiddleware(): FlightServer.Builder =
+    this.middleware(SESSION_KEY, ServerSessionMiddleware.Factory(Callable { UUID.randomUUID().toString() }))
+
+private fun SessionOptionValue.asStringOrNull(): String? =
+    acceptVisitor(object : NoOpSessionOptionValueVisitor<String?>() {
+        override fun visit(value: String) = value
+    })
 
 class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoCloseable {
     private val allocator = node.allocator.newChildAllocator("flight-sql", 0, Long.MAX_VALUE)
 
-    private val txConnections = ConcurrentHashMap<TxHandle, XtdbConnection>()
-    private val defaultConnections = ConcurrentHashMap<DatabaseName, XtdbConnection>()
+    // key is (session id, db)
+    private val sessionConns = ConcurrentHashMap<Pair<String, DatabaseName>, XtdbConnection>()
+
+    // fallback for clients without a session cookie
+    private val defaultConns = ConcurrentHashMap<DatabaseName, XtdbConnection>()
+
+    // a tx owns a dedicated connection: autoCommit/pendingOps are connection-scoped, so flipping
+    // them on a pooled connection would buffer other clients' autocommit writes into this tx.
+    private data class TxConn(val sessionId: String?, val conn: XtdbConnection)
+    private val txConns = ConcurrentHashMap<TxHandle, TxConn>()
     private val stmts = ConcurrentHashMap<PreparedStatementHandle, PreparedStatement>()
     private val tickets = ConcurrentHashMap<TicketHandle, ResultCursor>()
 
-    private fun defaultConnectionFor(dbName: DatabaseName): XtdbConnection =
-        defaultConnections.computeIfAbsent(dbName) {
-            (node.connect() as XtdbConnection).also { it.setCurrentCatalog(dbName) }
-        }
+    private fun newConnection(dbName: DatabaseName): XtdbConnection =
+        (node.connect() as XtdbConnection).also { it.setCurrentCatalog(dbName) }
+
+    private fun sessionMiddleware(ctx: CallContext?): ServerSessionMiddleware? =
+        ctx?.getMiddleware(SESSION_KEY)
+
+    /**
+     * The database for this call: the `x-xtdb-database` header takes precedence (the
+     * explicit per-call selector used by the Java/raw clients), falling back to the
+     * session's `catalog` option (how the Go-driver-based ADBC clients select a db),
+     * and finally the default `xtdb`.
+     */
+    private fun resolveDb(ctx: CallContext?): DatabaseName {
+        ctx?.getMiddleware(DatabaseMiddleware.KEY)?.dbName?.let { return it }
+
+        sessionMiddleware(ctx)
+            ?.takeIf { it.hasSession() }
+            ?.session?.getSessionOption("catalog")?.asStringOrNull()
+            ?.let { return it }
+
+        return "xtdb"
+    }
+
+    /**
+     * The connection for an autocommit call: per-session when the caller carries a
+     * session cookie, otherwise the shared anonymous connection for the database.
+     */
+    private fun connectionFor(ctx: CallContext?, dbName: DatabaseName): XtdbConnection {
+        val mw = sessionMiddleware(ctx)
+        return if (mw != null && mw.hasSession())
+            sessionConns.computeIfAbsent(mw.session.id to dbName) { newConnection(dbName) }
+        else
+            defaultConns.computeIfAbsent(dbName) { newConnection(dbName) }
+    }
+
+    // the session presenting the call, or null for a cookieless caller.
+    private fun currentSessionId(ctx: CallContext?): String? =
+        sessionMiddleware(ctx)?.takeIf { it.hasSession() }?.session?.id
+
+    // a transaction is owned by the session that opened it: a handle only resolves under
+    // its own session (cookieless == cookieless). A handle presented under any other session
+    // is NOT_FOUND - from that session's view the transaction doesn't exist.
+    private fun txConnFor(ctx: CallContext?, txHandle: TxHandle): TxConn =
+        txConns[txHandle]
+            ?.takeIf { it.sessionId == currentSessionId(ctx) }
+            ?: throw CallStatus.NOT_FOUND.withDescription("unknown transaction").toRuntimeException()
+
+    private fun txOrSessionConnection(ctx: CallContext?, txHandle: TxHandle?): XtdbConnection =
+        if (txHandle != null) txConnFor(ctx, txHandle).conn
+        else connectionFor(ctx, resolveDb(ctx))
 
     override fun close() {
         stmts.closeAll()
-        txConnections.values.forEach { it.close() }
-        txConnections.clear()
-        defaultConnections.values.forEach { it.close() }
-        defaultConnections.clear()
+        txConns.values.forEach { it.conn.close() }
+        txConns.clear()
+        sessionConns.values.forEach { it.close() }
+        sessionConns.clear()
+        defaultConns.values.forEach { it.close() }
+        defaultConns.clear()
         allocator.close()
     }
 
-    private fun connectionFor(txHandle: TxHandle?, dbName: DatabaseName): XtdbConnection =
-        if (txHandle != null) {
-            requireNotNull(txConnections[txHandle]) { "unknown tx" }
-        } else {
-            defaultConnectionFor(dbName)
-        }
-
-    private fun execDml(op: TxOp, txHandle: TxHandle?, dbName: DatabaseName) {
-        try {
-            connectionFor(txHandle, dbName).executeDml(op)
-        } catch (t: Throwable) {
-            LOGGER.warn(t, "bang")
-            throw t
-        }
+    private fun execDml(op: TxOp, ctx: CallContext?, txHandle: TxHandle?) {
+        txOrSessionConnection(ctx, txHandle).executeDml(op)
     }
 
     private fun handleGetStream(cursor: ResultCursor, listener: ServerStreamListener) {
@@ -212,8 +265,8 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         try {
             execDml(
                 TxOp.Sql(cmd.query),
-                if (cmd.hasTransactionId()) cmd.transactionId else null,
-                dbNameFromContext(ctx)
+                ctx,
+                if (cmd.hasTransactionId()) cmd.transactionId else null
             )
 
             ackStream.sendDoPutUpdateRes(allocator)
@@ -245,7 +298,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
                     .toRuntimeException()
             }
 
-            val dbName = dbNameFromContext(ctx)
+            val dbName = resolveDb(ctx)
 
             if (cmd.hasCatalog() && cmd.catalog.isNotEmpty() && cmd.catalog != dbName)
                 throw CallStatus.INVALID_ARGUMENT
@@ -260,7 +313,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
             val dbSchemaName = if (cmd.hasSchema()) cmd.schema else "public"
             val txHandle = if (cmd.hasTransactionId()) cmd.transactionId else null
 
-            connectionFor(txHandle, dbName)
+            txOrSessionConnection(ctx, txHandle)
                 .bulkIngest("$dbSchemaName.$tableName", BulkIngestMode.CREATE_APPEND)
                 .use { stmt ->
                     while (flightStream.next()) {
@@ -318,7 +371,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
     ): FlightInfo {
         try {
             val sql = cmd.queryBytes.toStringUtf8()
-            val dbName = dbNameFromContext(ctx)
+            val dbName = resolveDb(ctx)
 
             // see #5082 — Python ADBC's cursor.execute() routes DML through the query path
             if (isDml(sql, dbName)) {
@@ -327,7 +380,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
                     .toRuntimeException()
             }
             val ticketHandle = newHandle()
-            val pq = defaultConnectionFor(dbName).prepareSql(sql)
+            val pq = connectionFor(ctx, dbName).prepareSql(sql)
             val cursor = pq.openQuery(null, QueryOpts())
             val ticket = Ticket(
                 ProtoAny.pack(
@@ -401,9 +454,9 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
     ) {
         val psId = newHandle()
         val sql = req.queryBytes.toStringUtf8()
-        val dbName = dbNameFromContext(ctx)
+        val dbName = resolveDb(ctx)
         val txHandle = if (req.hasTransactionId()) req.transactionId else null
-        connectionFor(txHandle, dbName).createStatement().closeOnCatch { xtdbStmt ->
+        txOrSessionConnection(ctx, txHandle).createStatement().closeOnCatch { xtdbStmt ->
             xtdbStmt.setSqlQuery(sql)
             xtdbStmt.prepare()
 
@@ -436,13 +489,13 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         cmd: CommandStatementQuery, ctx: CallContext?, descriptor: FlightDescriptor
     ): SchemaResult {
         val sql = cmd.query
-        val dbName = dbNameFromContext(ctx)
+        val dbName = resolveDb(ctx)
         if (isDml(sql, dbName)) {
             throw CallStatus.INVALID_ARGUMENT
                 .withDescription("executeSchema only supports queries (DML returns a row count, not a schema)")
                 .toRuntimeException()
         }
-        defaultConnectionFor(dbName).createStatement().use { stmt ->
+        connectionFor(ctx, dbName).createStatement().use { stmt ->
             stmt.setSqlQuery(sql)
             stmt.prepare()
             return SchemaResult(stmt.executeSchema())
@@ -459,19 +512,113 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
     }
 
     // -- Session options --
+    // `catalog` selects the db for Go-driver ADBC clients, which can't send the
+    // `x-xtdb-database` header. `schema` is not settable (resolved by qualification).
 
+    // must not mint a session: a cookieless client can't reclaim it, so it would leak per call.
     override fun getSessionOptions(
         request: GetSessionOptionsRequest,
         ctx: CallContext?,
         listener: StreamListener<GetSessionOptionsResult>
     ) {
-        val conn = defaultConnectionFor(dbNameFromContext(ctx))
-        val opts = mapOf(
-            "catalog" to SessionOptionValueFactory.makeSessionOptionValue(conn.currentCatalog),
-            "schema" to SessionOptionValueFactory.makeSessionOptionValue(conn.currentDbSchema),
-        )
-        listener.onNext(GetSessionOptionsResult(opts))
-        listener.onCompleted()
+        try {
+            val opts = mapOf(
+                "catalog" to SessionOptionValueFactory.makeSessionOptionValue(resolveDb(ctx)),
+                "schema" to SessionOptionValueFactory.makeSessionOptionValue("public"),
+            )
+            listener.onNext(GetSessionOptionsResult(opts))
+            listener.onCompleted()
+        } catch (t: Throwable) {
+            listener.onError(t)
+        }
+    }
+
+    override fun setSessionOptions(
+        request: SetSessionOptionsRequest,
+        ctx: CallContext?,
+        listener: StreamListener<SetSessionOptionsResult>
+    ) {
+        try {
+            // .session mints the session (emits Set-Cookie); a cookieless client can't persist it
+            val session = sessionMiddleware(ctx)?.session
+                ?: throw CallStatus.INTERNAL
+                    .withDescription("FlightSQL session middleware not configured")
+                    .toRuntimeException()
+
+            val knownDbs = (node as Xtdb.XtdbInternal).dbCatalog.databaseNames
+            val errors = mutableMapOf<String, SetSessionOptionsResult.Error>()
+
+            for ((name, value) in request.sessionOptions) {
+                when (name) {
+                    "catalog" -> {
+                        val catalog = value.asStringOrNull()
+                        when {
+                            catalog == null ->
+                                errors[name] = SetSessionOptionsResult.Error(SetSessionOptionsResult.ErrorValue.INVALID_VALUE)
+
+                            catalog.isEmpty() -> session.eraseSessionOption(name)
+
+                            catalog !in knownDbs ->
+                                errors[name] = SetSessionOptionsResult.Error(SetSessionOptionsResult.ErrorValue.INVALID_VALUE)
+
+                            else -> session.setSessionOption(name, SessionOptionValueFactory.makeSessionOptionValue(catalog))
+                        }
+                    }
+
+                    // not settable; tolerate a no-op confirming the fixed `public`
+                    "schema" -> {
+                        val schema = value.asStringOrNull()
+                        if (schema != "public")
+                            errors[name] = SetSessionOptionsResult.Error(SetSessionOptionsResult.ErrorValue.INVALID_VALUE)
+                    }
+
+                    else ->
+                        errors[name] = SetSessionOptionsResult.Error(SetSessionOptionsResult.ErrorValue.INVALID_NAME)
+                }
+            }
+
+            listener.onNext(SetSessionOptionsResult(errors))
+            listener.onCompleted()
+        } catch (t: Throwable) {
+            listener.onError(t)
+        }
+    }
+
+    override fun closeSession(
+        request: CloseSessionRequest,
+        ctx: CallContext?,
+        listener: StreamListener<CloseSessionResult>
+    ) {
+        try {
+            val mw = sessionMiddleware(ctx)
+            if (mw == null || !mw.hasSession()) {
+                listener.onError(
+                    CallStatus.NOT_FOUND
+                        .withDescription("No session to close")
+                        .toRuntimeException()
+                )
+                return
+            }
+
+            val sessionId = mw.session.id
+            // remove before close so an in-flight call can't resolve a connection being closed.
+            txConns.entries.removeIf { (_, txConn) ->
+                if (txConn.sessionId == sessionId) {
+                    txConn.conn.close()
+                    true
+                } else false
+            }
+            sessionConns.keys.filter { it.first == sessionId }.forEach { key ->
+                sessionConns.remove(key)?.close()
+            }
+
+            mw.closeSession()
+
+            listener.onNext(CloseSessionResult(CloseSessionResult.Status.CLOSED))
+            listener.onCompleted()
+        } catch (t: Throwable) {
+            listener.onError(t)
+        }
     }
 
     // -- Metadata endpoints --
@@ -504,7 +651,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
     ): FlightInfo = metadataFlightInfo(request, FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA, descriptor)
 
     override fun getStreamTableTypes(ctx: CallContext?, listener: ServerStreamListener) {
-        streamArrowReader(defaultConnectionFor(dbNameFromContext(ctx)).getTableTypes(), listener)
+        streamArrowReader(connectionFor(ctx, resolveDb(ctx)).getTableTypes(), listener)
     }
 
     override fun getFlightInfoSqlInfo(
@@ -563,7 +710,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
     override fun getStreamSchemas(
         command: CommandGetDbSchemas, ctx: CallContext?, listener: ServerStreamListener
     ) {
-        val dbName = dbNameFromContext(ctx)
+        val dbName = resolveDb(ctx)
         val catalogFilter = if (command.hasCatalog()) command.catalog else null
         val schemaFilter = if (command.hasDbSchemaFilterPattern()) command.dbSchemaFilterPattern else null
 
@@ -580,7 +727,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
             append(" ORDER BY table_schema")
         }
 
-        defaultConnectionFor(dbName).openSqlQuery(sql).use { cursor ->
+        connectionFor(ctx, dbName).openSqlQuery(sql).use { cursor ->
             singleBatchStream(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA, listener) { root ->
                 val catalogVec = root.getVector("catalog_name") as VarCharVector
                 val schemaVec = root.getVector("db_schema_name") as VarCharVector
@@ -608,7 +755,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
     override fun getStreamTables(
         command: CommandGetTables, ctx: CallContext?, listener: ServerStreamListener
     ) {
-        val dbName = dbNameFromContext(ctx)
+        val dbName = resolveDb(ctx)
         val catalogFilter = if (command.hasCatalog()) command.catalog else null
         val schemaFilter = if (command.hasDbSchemaFilterPattern()) command.dbSchemaFilterPattern else null
         val tableFilter = if (command.hasTableNameFilterPattern()) command.tableNameFilterPattern else null
@@ -636,7 +783,8 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
 
         val sql = "SELECT DISTINCT table_schema, table_name FROM information_schema.tables $where ORDER BY table_schema, table_name"
 
-        defaultConnectionFor(dbName).openSqlQuery(sql).use { cursor ->
+        val tablesConn = connectionFor(ctx, dbName)
+        tablesConn.openSqlQuery(sql).use { cursor ->
             val schema = if (command.includeSchema) FlightSqlProducer.Schemas.GET_TABLES_SCHEMA
             else FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA
 
@@ -648,7 +796,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
                 val tableSchemaVec =
                     if (command.includeSchema) root.getVector("table_schema") as VarBinaryVector else null
 
-                val conn = defaultConnectionFor(dbName)
+                val conn = tablesConn
                 val snap = if (command.includeSchema) conn.openSnapshot() else null
 
                 try {
@@ -697,10 +845,9 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         listener: StreamListener<ActionBeginTransactionResult>
     ) {
         val txHandle = newHandle()
-        val conn = node.connect() as XtdbConnection
-        conn.setCurrentCatalog(dbNameFromContext(ctx))
+        val conn = (node.connect() as XtdbConnection).also { it.setCurrentCatalog(resolveDb(ctx)) }
         conn.setAutoCommit(false)
-        txConnections[txHandle] = conn
+        txConns[txHandle] = TxConn(currentSessionId(ctx), conn)
 
         listener.onNext(
             ActionBeginTransactionResult.newBuilder()
@@ -717,20 +864,22 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         listener: StreamListener<Result>
     ) {
         val txHandle = req.transactionId
-        val conn = requireNotNull(txConnections.remove(txHandle)) { "unknown tx" }
+        // resolve under the calling session only, then claim it atomically (remove(k,v) lets
+        // exactly one concurrent ender win) - a wrong-session caller never reaches the remove.
+        val tx = txConnFor(ctx, txHandle)
+        if (!txConns.remove(txHandle, tx))
+            return listener.onError(
+                CallStatus.NOT_FOUND.withDescription("unknown transaction").toRuntimeException()
+            )
+        val conn = tx.conn
 
-        if (req.action == EndTransaction.END_TRANSACTION_COMMIT) {
-            try {
-                conn.commit()
-                listener.onCompleted()
-            } catch (t: Throwable) {
-                listener.onError(t)
-            } finally {
-                conn.close()
-            }
-        } else {
-            conn.close()
+        try {
+            if (req.action == EndTransaction.END_TRANSACTION_COMMIT) conn.commit() else conn.rollback()
             listener.onCompleted()
+        } catch (t: Throwable) {
+            listener.onError(t)
+        } finally {
+            conn.close()
         }
     }
 }

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -11,9 +11,21 @@ import org.apache.arrow.flight.FlightClient
 import org.apache.arrow.flight.FlightDescriptor
 import org.apache.arrow.flight.FlightInfo
 import org.apache.arrow.flight.FlightRuntimeException
+import org.apache.arrow.flight.CallHeaders
+import org.apache.arrow.flight.CallInfo
+import org.apache.arrow.flight.CallStatus
+import org.apache.arrow.flight.CloseSessionRequest
+import org.apache.arrow.flight.CloseSessionResult
+import org.apache.arrow.flight.FlightCallHeaders
+import org.apache.arrow.flight.FlightClientMiddleware
 import org.apache.arrow.flight.GetSessionOptionsRequest
+import org.apache.arrow.flight.HeaderCallOption
 import org.apache.arrow.flight.Location
 import org.apache.arrow.flight.NoOpSessionOptionValueVisitor
+import org.apache.arrow.flight.SessionOptionValueFactory
+import org.apache.arrow.flight.SetSessionOptionsRequest
+import org.apache.arrow.flight.SetSessionOptionsResult
+import org.apache.arrow.flight.client.ClientCookieMiddleware
 import org.apache.arrow.flight.sql.FlightSqlClient
 import org.apache.arrow.flight.sql.FlightSqlClient.ExecuteIngestOptions
 import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementIngest
@@ -54,6 +66,7 @@ class FlightSqlAdbcTest {
     private lateinit var conn: AdbcConnection
     private lateinit var flightClient: FlightClient
     private lateinit var fsqlClient: FlightSqlClient
+    private var flightPort: Int = -1
 
     private val emptyCallOpts = arrayOf<CallOption>()
 
@@ -64,7 +77,7 @@ class FlightSqlAdbcTest {
             flightSql { port = 0 }
         }
 
-        val flightPort = xtdb.flightSqlPort
+        flightPort = xtdb.flightSqlPort
 
         al = RootAllocator()
         db = FlightSqlDriver(al).open(mapOf("uri" to "grpc+tcp://127.0.0.1:${flightPort}"))
@@ -73,6 +86,24 @@ class FlightSqlAdbcTest {
         flightClient = FlightClient.builder(al, Location.forGrpcInsecure("127.0.0.1", flightPort)).build()
         fsqlClient = FlightSqlClient(flightClient)
     }
+
+    /**
+     * A FlightSQL client that carries the `arrow_flight_session_id` cookie across calls
+     * (the ClientCookieMiddleware) — mirrors how the real ADBC drivers behave, so the
+     * server-side ServerSessionMiddleware sees a stable session across the call sequence.
+     */
+    private fun cookieAwareClient(): FlightSqlClient =
+        FlightSqlClient(
+            FlightClient.builder(al, Location.forGrpcInsecure("127.0.0.1", flightPort))
+                .intercept(ClientCookieMiddleware.Factory())
+                .build()
+        )
+
+    /** A second cookieless FlightSQL client (distinct from `fsqlClient`). */
+    private fun plainClient(): FlightSqlClient =
+        FlightSqlClient(
+            FlightClient.builder(al, Location.forGrpcInsecure("127.0.0.1", flightPort)).build()
+        )
 
     @AfterEach
     fun tearDown() {
@@ -181,16 +212,417 @@ class FlightSqlAdbcTest {
         assertTrue(rows.isNotEmpty(), "Expected at least one info row")
     }
 
+    private val asString = object : NoOpSessionOptionValueVisitor<String?>() {
+        override fun visit(value: String) = value
+    }
+
     @Test
     fun `test FlightSQL getSessionOptions returns catalog and schema`() {
         val result = fsqlClient.getSessionOptions(GetSessionOptionsRequest(), *emptyCallOpts)
 
-        val asString = object : NoOpSessionOptionValueVisitor<String?>() {
-            override fun visit(value: String) = value
-        }
         val opts = result.sessionOptions
         assertEquals("xtdb", opts["catalog"]?.acceptVisitor(asString))
         assertEquals("public", opts["schema"]?.acceptVisitor(asString))
+    }
+
+    @Test
+    fun `test FlightSQL setSessionOptions rejects unknown option and bad catalog`() {
+        cookieAwareClient().use { client ->
+            val result = client.setSessionOptions(
+                SetSessionOptionsRequest(
+                    mapOf(
+                        "bogus" to SessionOptionValueFactory.makeSessionOptionValue("x"),
+                        "catalog" to SessionOptionValueFactory.makeSessionOptionValue("no-such-db"),
+                    )
+                ),
+                *emptyCallOpts
+            )
+            assertTrue(result.hasErrors())
+            assertEquals(
+                SetSessionOptionsResult.ErrorValue.INVALID_NAME,
+                result.errors["bogus"]?.value
+            )
+            assertEquals(
+                SetSessionOptionsResult.ErrorValue.INVALID_VALUE,
+                result.errors["catalog"]?.value
+            )
+        }
+    }
+
+    @Test
+    fun `test FlightSQL set then get catalog round-trips within a session`() {
+        val dbCat = (xtdb as Xtdb.XtdbInternal).dbCatalog
+        dbCat.attach("other-db", null)
+
+        cookieAwareClient().use { client ->
+            assertEquals(
+                "xtdb",
+                client.getSessionOptions(GetSessionOptionsRequest(), *emptyCallOpts)
+                    .sessionOptions["catalog"]?.acceptVisitor(asString)
+            )
+
+            val setResult = client.setSessionOptions(
+                SetSessionOptionsRequest(
+                    mapOf("catalog" to SessionOptionValueFactory.makeSessionOptionValue("other-db"))
+                ),
+                *emptyCallOpts
+            )
+            assertFalse(setResult.hasErrors(), "set catalog should succeed: ${setResult.errors}")
+
+            assertEquals(
+                "other-db",
+                client.getSessionOptions(GetSessionOptionsRequest(), *emptyCallOpts)
+                    .sessionOptions["catalog"]?.acceptVisitor(asString)
+            )
+        }
+    }
+
+    @Test
+    fun `test FlightSQL catalog session option routes queries to that database`() {
+        val dbCat = (xtdb as Xtdb.XtdbInternal).dbCatalog
+        dbCat.attach("other-db", null)
+
+        cookieAwareClient().use { client ->
+            client.setSessionOptions(
+                SetSessionOptionsRequest(
+                    mapOf("catalog" to SessionOptionValueFactory.makeSessionOptionValue("other-db"))
+                ),
+                *emptyCallOpts
+            )
+
+            assertEquals(
+                -1L,
+                client.executeUpdate("INSERT INTO t (_id, n) VALUES (1, 'a')", *emptyCallOpts)
+            )
+            assertEquals(
+                listOf(mapOf("_id" to 1L, "n" to "a")),
+                client.execute("SELECT _id, n FROM t", *emptyCallOpts).readRows()
+            )
+
+            assertEquals(
+                emptyList<Map<*, *>>(),
+                fsqlClient.execute("SELECT _id, n FROM t", *emptyCallOpts).readRows()
+            )
+        }
+    }
+
+    @Test
+    fun `test FlightSQL closeSession invalidates the session`() {
+        cookieAwareClient().use { client ->
+            // setSessionOptions is the mutating RPC that mints the session
+            client.setSessionOptions(
+                SetSessionOptionsRequest(
+                    mapOf("catalog" to SessionOptionValueFactory.makeSessionOptionValue("xtdb"))
+                ),
+                *emptyCallOpts
+            )
+
+            val result = client.closeSession(CloseSessionRequest(), *emptyCallOpts)
+            assertEquals(CloseSessionResult.Status.CLOSED, result.status)
+        }
+    }
+
+    @Test
+    fun `test FlightSQL closeSession with no session errors NOT_FOUND`() {
+        val ex = assertThrows(FlightRuntimeException::class.java) {
+            fsqlClient.closeSession(CloseSessionRequest(), *emptyCallOpts)
+        }
+        assertEquals(org.apache.arrow.flight.FlightStatusCode.NOT_FOUND, ex.status().code())
+    }
+
+    private fun dbCallOpts(db: String): Array<CallOption> =
+        arrayOf(HeaderCallOption(FlightCallHeaders().apply { insert("x-xtdb-database", db) }))
+
+    private fun catalogOpt(db: String) =
+        SetSessionOptionsRequest(mapOf("catalog" to SessionOptionValueFactory.makeSessionOptionValue(db)))
+
+    @Test
+    fun `test FlightSQL closeSession aborts an open session-bound transaction`() {
+        cookieAwareClient().use { client ->
+            // session must exist before beginTransaction for the tx to be session-bound
+            client.setSessionOptions(catalogOpt("xtdb"), *emptyCallOpts)
+
+            val txn = client.beginTransaction(*emptyCallOpts)
+            client.executeUpdate("INSERT INTO users (_id, n) VALUES (1, 'in-tx')", txn, *emptyCallOpts)
+
+            client.closeSession(CloseSessionRequest(), *emptyCallOpts)
+
+            // closeSession reclaimed the tx connection, so the handle is now unknown
+            val ex = assertThrows(FlightRuntimeException::class.java) {
+                client.commit(txn, *emptyCallOpts)
+            }
+            assertEquals(org.apache.arrow.flight.FlightStatusCode.NOT_FOUND, ex.status().code())
+        }
+
+        assertEquals(
+            emptyList<Map<*, *>>(),
+            fsqlClient.execute("SELECT _id, n FROM users", *emptyCallOpts).readRows()
+        )
+    }
+
+    @Test
+    fun `test FlightSQL endTransaction on a stale handle errors NOT_FOUND`() {
+        val txn = fsqlClient.beginTransaction(*emptyCallOpts)
+        fsqlClient.commit(txn, *emptyCallOpts)
+
+        val ex = assertThrows(FlightRuntimeException::class.java) {
+            fsqlClient.commit(txn, *emptyCallOpts)
+        }
+        assertEquals(org.apache.arrow.flight.FlightStatusCode.NOT_FOUND, ex.status().code())
+    }
+
+    @Test
+    fun `test FlightSQL a transaction is scoped to its own session`() {
+        cookieAwareClient().use { sessionA ->
+            cookieAwareClient().use { sessionB ->
+                // each client establishes its own session
+                sessionA.setSessionOptions(catalogOpt("xtdb"), *emptyCallOpts)
+                sessionB.setSessionOptions(catalogOpt("xtdb"), *emptyCallOpts)
+
+                val txnA = sessionA.beginTransaction(*emptyCallOpts)
+
+                // session B may not drive session A's transaction - it doesn't exist for B
+                val onCommit = assertThrows(FlightRuntimeException::class.java) {
+                    sessionB.commit(txnA, *emptyCallOpts)
+                }
+                assertEquals(org.apache.arrow.flight.FlightStatusCode.NOT_FOUND, onCommit.status().code())
+
+                val onDml = assertThrows(FlightRuntimeException::class.java) {
+                    sessionB.executeUpdate("INSERT INTO users (_id, n) VALUES (1, 'x')", txnA, *emptyCallOpts)
+                }
+                assertEquals(org.apache.arrow.flight.FlightStatusCode.NOT_FOUND, onDml.status().code())
+
+                // the owning session can still use and commit it
+                sessionA.executeUpdate("INSERT INTO users (_id, n) VALUES (2, 'a')", txnA, *emptyCallOpts)
+                sessionA.commit(txnA, *emptyCallOpts)
+            }
+        }
+
+        assertEquals(
+            listOf(mapOf("_id" to 2L, "n" to "a")),
+            fsqlClient.execute("SELECT _id, n FROM users", *emptyCallOpts).readRows()
+        )
+    }
+
+    @Test
+    fun `test FlightSQL empty catalog erases the session option back to default`() {
+        val dbCat = (xtdb as Xtdb.XtdbInternal).dbCatalog
+        dbCat.attach("other-db", null)
+
+        cookieAwareClient().use { client ->
+            client.setSessionOptions(catalogOpt("other-db"), *emptyCallOpts)
+            assertEquals(
+                "other-db",
+                client.getSessionOptions(GetSessionOptionsRequest(), *emptyCallOpts)
+                    .sessionOptions["catalog"]?.acceptVisitor(asString)
+            )
+
+            client.setSessionOptions(catalogOpt(""), *emptyCallOpts)
+            assertEquals(
+                "xtdb",
+                client.getSessionOptions(GetSessionOptionsRequest(), *emptyCallOpts)
+                    .sessionOptions["catalog"]?.acceptVisitor(asString)
+            )
+        }
+    }
+
+    @Test
+    fun `test FlightSQL setSessionOptions accepts schema public and rejects other schemas`() {
+        cookieAwareClient().use { client ->
+            val ok = client.setSessionOptions(
+                SetSessionOptionsRequest(
+                    mapOf("schema" to SessionOptionValueFactory.makeSessionOptionValue("public"))
+                ),
+                *emptyCallOpts
+            )
+            assertFalse(ok.hasErrors(), "schema=public should be a confirming no-op: ${ok.errors}")
+
+            val bad = client.setSessionOptions(
+                SetSessionOptionsRequest(
+                    mapOf("schema" to SessionOptionValueFactory.makeSessionOptionValue("other"))
+                ),
+                *emptyCallOpts
+            )
+            assertEquals(
+                SetSessionOptionsResult.ErrorValue.INVALID_VALUE,
+                bad.errors["schema"]?.value
+            )
+        }
+    }
+
+    @Test
+    fun `test FlightSQL two sessions keep independent catalog and data`() {
+        val dbCat = (xtdb as Xtdb.XtdbInternal).dbCatalog
+        dbCat.attach("other-db", null)
+
+        cookieAwareClient().use { sessionA ->
+            cookieAwareClient().use { sessionB ->
+                sessionA.setSessionOptions(catalogOpt("other-db"), *emptyCallOpts)
+                // sessionB deliberately left on the default catalog
+
+                assertEquals(
+                    "other-db",
+                    sessionA.getSessionOptions(GetSessionOptionsRequest(), *emptyCallOpts)
+                        .sessionOptions["catalog"]?.acceptVisitor(asString)
+                )
+                assertEquals(
+                    "xtdb",
+                    sessionB.getSessionOptions(GetSessionOptionsRequest(), *emptyCallOpts)
+                        .sessionOptions["catalog"]?.acceptVisitor(asString)
+                )
+
+                sessionA.executeUpdate("INSERT INTO t (_id, n) VALUES (1, 'A')", *emptyCallOpts)
+                sessionB.executeUpdate("INSERT INTO t (_id, n) VALUES (2, 'B')", *emptyCallOpts)
+
+                assertEquals(
+                    listOf(mapOf("_id" to 1L, "n" to "A")),
+                    sessionA.execute("SELECT _id, n FROM t", *emptyCallOpts).readRows()
+                )
+                assertEquals(
+                    listOf(mapOf("_id" to 2L, "n" to "B")),
+                    sessionB.execute("SELECT _id, n FROM t", *emptyCallOpts).readRows()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `test FlightSQL x-xtdb-database header beats the session catalog option`() {
+        val dbCat = (xtdb as Xtdb.XtdbInternal).dbCatalog
+        dbCat.attach("other-db", null)
+
+        cookieAwareClient().use { client ->
+            client.setSessionOptions(catalogOpt("other-db"), *emptyCallOpts)
+
+            // header must override the session catalog: write targets xtdb, not other-db
+            client.executeUpdate("INSERT INTO t (_id, n) VALUES (1, 'hdr')", *dbCallOpts("xtdb"))
+
+            assertEquals(
+                listOf(mapOf("_id" to 1L, "n" to "hdr")),
+                client.execute("SELECT _id, n FROM t", *dbCallOpts("xtdb")).readRows()
+            )
+            assertEquals(
+                emptyList<Map<*, *>>(),
+                client.execute("SELECT _id, n FROM t", *emptyCallOpts).readRows()
+            )
+        }
+    }
+
+    private class SetCookieRecorder : FlightClientMiddleware.Factory {
+        val values = mutableListOf<String>()
+
+        override fun onCallStarted(info: CallInfo) = object : FlightClientMiddleware {
+            override fun onBeforeSendingHeaders(outgoingHeaders: CallHeaders) {}
+            override fun onHeadersReceived(incomingHeaders: CallHeaders) {
+                incomingHeaders.getAll("set-cookie").forEach(values::add)
+            }
+            override fun onCallCompleted(status: CallStatus) {}
+        }
+    }
+
+    @Test
+    fun `test FlightSQL getSessionOptions does not mint a session`() {
+        val recorder = SetCookieRecorder()
+        FlightSqlClient(
+            FlightClient.builder(al, Location.forGrpcInsecure("127.0.0.1", flightPort))
+                .intercept(recorder)
+                .build()
+        ).use { client ->
+            client.getSessionOptions(GetSessionOptionsRequest(), *emptyCallOpts)
+            assertEquals(emptyList<String>(), recorder.values)
+
+            client.setSessionOptions(
+                SetSessionOptionsRequest(
+                    mapOf("catalog" to SessionOptionValueFactory.makeSessionOptionValue("xtdb"))
+                ),
+                *emptyCallOpts
+            )
+            assertTrue(
+                recorder.values.any { it.startsWith("arrow_flight_session_id=") },
+                "setSessionOptions should establish the Flight SQL session cookie; saw ${recorder.values}"
+            )
+        }
+    }
+
+    @Test
+    fun `test FlightSQL transaction does not capture another cookieless clients autocommit write`() {
+        val txn = fsqlClient.beginTransaction(*emptyCallOpts)
+        try {
+            assertEquals(
+                -1L,
+                fsqlClient.executeUpdate("INSERT INTO users (_id, n) VALUES (1, 'tx')", txn, *emptyCallOpts)
+            )
+
+            plainClient().use { other ->
+                assertEquals(
+                    -1L,
+                    other.executeUpdate("INSERT INTO users (_id, n) VALUES (2, 'auto')", *emptyCallOpts)
+                )
+            }
+
+            assertEquals(
+                listOf(mapOf("_id" to 2L, "n" to "auto")),
+                fsqlClient.execute("SELECT _id, n FROM users ORDER BY _id", *emptyCallOpts).readRows()
+            )
+
+            fsqlClient.commit(txn, *emptyCallOpts)
+
+            assertEquals(
+                listOf(
+                    mapOf("_id" to 1L, "n" to "tx"),
+                    mapOf("_id" to 2L, "n" to "auto"),
+                ),
+                fsqlClient.execute("SELECT _id, n FROM users ORDER BY _id", *emptyCallOpts).readRows()
+            )
+        } catch (t: Throwable) {
+            runCatching { fsqlClient.rollback(txn, *emptyCallOpts) }
+            throw t
+        }
+    }
+
+    @Test
+    fun `test FlightSQL open transaction does not poison autocommit path`() {
+        val txn = fsqlClient.beginTransaction(*emptyCallOpts)
+        try {
+            assertEquals(
+                -1L,
+                fsqlClient.executeUpdate("INSERT INTO users (_id, n) VALUES (1, 'tx')", txn, *emptyCallOpts)
+            )
+
+            assertEquals(
+                -1L,
+                fsqlClient.executeUpdate("INSERT INTO users (_id, n) VALUES (2, 'auto')", *emptyCallOpts)
+            )
+
+            assertEquals(
+                listOf(mapOf("_id" to 2L, "n" to "auto")),
+                fsqlClient.execute("SELECT _id, n FROM users ORDER BY _id", *emptyCallOpts).readRows()
+            )
+        } finally {
+            runCatching { fsqlClient.rollback(txn, *emptyCallOpts) }
+        }
+    }
+
+    @Test
+    fun `test FlightSQL double begin uses isolated transaction connections`() {
+        val tx1 = fsqlClient.beginTransaction(*emptyCallOpts)
+        val tx2 = fsqlClient.beginTransaction(*emptyCallOpts)
+        try {
+            assertEquals(-1L, fsqlClient.executeUpdate("INSERT INTO users (_id, n) VALUES (1, 'commit')", tx1, *emptyCallOpts))
+            assertEquals(-1L, fsqlClient.executeUpdate("INSERT INTO users (_id, n) VALUES (2, 'rollback')", tx2, *emptyCallOpts))
+
+            fsqlClient.commit(tx1, *emptyCallOpts)
+            fsqlClient.rollback(tx2, *emptyCallOpts)
+
+            assertEquals(
+                listOf(mapOf("_id" to 1L, "n" to "commit")),
+                fsqlClient.execute("SELECT _id, n FROM users ORDER BY _id", *emptyCallOpts).readRows()
+            )
+        } catch (t: Throwable) {
+            runCatching { fsqlClient.rollback(tx1, *emptyCallOpts) }
+            runCatching { fsqlClient.rollback(tx2, *emptyCallOpts) }
+            throw t
+        }
     }
 
     // -- executeSchema --


### PR DESCRIPTION
Resolves #5079.

Implements FlightSQL session management via Arrow's `ServerSessionMiddleware`, and replaces the improvised connection handling in `XtdbProducer` with per-session connection ownership.

## What it does

- Wires `ServerSessionMiddleware` into the FlightSQL server — session identity via the `arrow_flight_session_id` cookie (the mechanism the Go-driver-based ADBC clients already speak).
- `setSessionOptions` / `getSessionOptions` / `closeSession`:
  - `catalog` is settable and validated against known databases (how the Go-driver clients select a db, since they can't send the `x-xtdb-database` header).
  - `schema` is reported as `public`; only a confirming `public` no-op is accepted (XTDB resolves schema by qualification — settable schema/timezone params are a follow-up, not pretend-supported).
  - `getSessionOptions` is a pure getter and mints nothing.
  - `closeSession` evicts the session's connections and invalidates the cookie.
- DB resolution: `x-xtdb-database` header → session `catalog` option → default `xtdb`.
- Connection ownership: one autocommit/query connection per `(session, db)` for session-aware clients, with a bounded anonymous per-db fallback for cookieless clients. Transactions own a dedicated connection rather than flipping `autoCommit` on a pooled one — preventing cross-client buffering, abandoned-tx pool poisoning, and double-begin aliasing.

## Scope notes

- **No public node-API change.** Only consumes existing `node.connect()` / `allocator` / `XtdbInternal.dbCatalog`; the only `xtdb.api` edit is 2 lines of internal middleware wiring in `FlightSql.open()`.
- **Landing order.** Deliberately built on plain `main`, *before* the await-token stack (#5609 / #5648), so session-scoped state has a real session boundary to attach to before it's introduced. The per-`(session, db)` ownership is the seam #5648 can hang the await-token on without cross-client token drag. Recommend landing this first.

## Known follow-ups (not blocking)

- Abandoned-tx / cookieless-session reclamation (no TTL / disconnect hook today — bounded leak, strict improvement over the prior shared-connection corruption).
- `resolveDb` header-vs-catalog policy — harmless on this substrate (stateless conns), but wants deciding before #5648 puts a token on the connection.
- Concurrent DML on a single tx handle — belongs with #5648's per-connection serialisation.

## Tests

`xtdb.FlightSqlAdbcTest` (36) and `xtdb.flight-sql-test` (10) green, including regression guards for tx/autocommit isolation, open-tx not poisoning autocommit, double-begin isolation, `getSessionOptions` not minting, and catalog session routing.