### PR TITLE
tidy(database): DatabaseSnapshot composite + per-partition basis (#5557)

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -26,7 +26,7 @@
            (xtdb.antlr Sql$DirectlyExecutableStatementContext)
            (xtdb.api DataSource TransactionKey TransactionResult TransactionResult$Committed TransactionResult$Aborted Xtdb Xtdb$CompactorNode Xtdb$Config Xtdb$ExecutedTx Xtdb$SubmittedTx Xtdb$XtdbInternal)
            xtdb.api.module.XtdbModule$Factory
-           (xtdb.database Database Database$Catalog)
+           (xtdb.database Database Database$Catalog DatabasePartition)
            xtdb.error.Anomaly
            xtdb.table.TableRef
            (xtdb.query IQuerySource PreparedQuery QueryOpts)))
@@ -224,25 +224,35 @@
   (latest-completed-txs [_]
     (->> (.getDatabaseNames db-cat)
          (into {} (map (fn [^String db-name]
-                         ;; TODO multi-part
-                         [db-name [(-> (.databaseOrNull db-cat db-name)
-                                       (.getLiveIndex)
-                                       (.getLatestCompletedTx))]])))))
+                         (let [^Database db (.databaseOrNull db-cat db-name)]
+                           [db-name (->> (.getPartitions db)
+                                         (sort-by key)
+                                         (mapv (fn [[_ part]]
+                                                 (-> ^DatabasePartition part
+                                                     .getLiveIndex
+                                                     .getLatestCompletedTx))))]))))))
 
   (latest-submitted-msg-ids [_]
     (->> (.getDatabaseNames db-cat)
          (into {} (map (fn [^String db-name]
-                         ;; TODO multi-part
-                         [db-name [(-> (.databaseOrNull db-cat db-name)
-                                       (.getSourceLog)
-                                       (.getLatestSubmittedMsgId))]])))))
+                         (let [^Database db (.databaseOrNull db-cat db-name)
+                               ;; TODO (#5557 unit 5) source log gains a per-partition
+                               ;; `latestSubmittedMsgId` once `Log<M>` is widened; until then it's
+                               ;; database-level and multi-partition is gated, so the same value
+                               ;; appears in every slot.
+                               latest (-> db .getSourceLog .getLatestSubmittedMsgId)]
+                           [db-name (vec (repeat (count (.getPartitions db)) latest))]))))))
 
   (latest-processed-msg-ids [_]
     (->> (.getDatabaseNames db-cat)
          (into {} (map (fn [^String db-name]
-                         ;; TODO multi-part
-                         [db-name [(-> (.databaseOrNull db-cat db-name)
-                                       (.getLatestProcessedMsgId))]])))))
+                         (let [^Database db (.databaseOrNull db-cat db-name)]
+                           [db-name (->> (.getPartitions db)
+                                         (sort-by key)
+                                         (mapv (fn [[_ part]]
+                                                 (-> ^DatabasePartition part
+                                                     .getWatchers
+                                                     .getLatestSourceMsgId))))]))))))
 
   (await-token [this]
     (basis/->tx-basis-str (xtp/latest-submitted-msg-ids this)))

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -25,7 +25,7 @@
            xtdb.arrow.RelationReader
            (xtdb.bloom BloomUtils)
            (xtdb ICursor Bytes)
-           (xtdb.indexer Snapshot Snapshot$Source TableSnapshot)
+           (xtdb.indexer DatabaseSnapshot Snapshot Snapshot$Source TableSnapshot)
            (xtdb.metadata MetadataPredicate PageMetadata)
            (xtdb.operator.scan MultiIidSelector ScanCursor SingleIidSelector)
            xtdb.query.IQuerySource$QueryCatalog
@@ -205,7 +205,10 @@
                   (let [db-name (.getDbName table)
                         state (.getQueryState (.databaseOrNull db-catalog db-name))
                         table-catalog (.getTableCatalog state)
-                        ^Snapshot snap (get snaps db-name)]
+                        ^DatabaseSnapshot db-snap (get snaps db-name)
+                        ;; TODO (#5557 unit 7) reduce types/merge-types over per-partition live
+                        ;; types here; for now we only allow single-partition databases.
+                        ^Snapshot snap (first (.getPartitions db-snap))]
                     (types/merge-types (.getType table-catalog table col-name)
                                        (.columnType snap table col-name))))))]
     (->> scan-cols
@@ -266,7 +269,10 @@
          :vec-types (->> vec-types (into {} (keep (fn [[k v]] (when v [k v])))))
          :stats {:row-count row-count}
          :->cursor (fn [{:keys [allocator, snaps, snapshot-token, schema, args pushdown-blooms pushdown-iids explain-analyze? tracer query-span] :as opts}]
-                     (let [^Snapshot snapshot (get snaps db-name)
+                     (let [^DatabaseSnapshot db-snapshot (get snaps db-name)
+                           ;; TODO (#5557 unit 7) walk every partition's Snapshot and UNION at scan,
+                           ;; instead of picking the only partition.
+                           ^Snapshot snapshot (first (.getPartitions db-snapshot))
                            derived-table-schema (info-schema/derived-table table)]
                        (cond
                          (log-tables/log-table table)

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -142,12 +142,10 @@
     expr))
 
 (defn- validate-basis-not-before [basis snaps]
-  (doseq [[db-name ^DatabaseSnapshot snap] snaps]
-    ;; TODO (#5557 unit 3) iterate `snap.partitions` and validate each partition's basis against
-    ;; the corresponding position. For now we're still single-partition, so the size-1 vector
-    ;; collapses to its first element.
-    (let [snap-tx (first (.getTxBasis snap))
-          system-time (get-in basis [db-name 0])]
+  (doseq [[db-name ^DatabaseSnapshot snap] snaps
+          [partition-idx ^Snapshot part-snap] (map-indexed vector (.getPartitions snap))]
+    (let [snap-tx (.getTxBasis part-snap)
+          system-time (get-in basis [db-name partition-idx])]
       (when (and system-time
                  (or (nil? snap-tx)
                      (neg? (compare (.getSystemTime snap-tx) system-time))))
@@ -159,11 +157,11 @@
 
 (defn- default-basis [snaps]
   (->> (for [[db-name ^DatabaseSnapshot snap] snaps
-             ;; TODO (#5557 unit 3) the singleton wrap is left over from the pre-multi-partition
-             ;; world; once basis iteration is partition-aware we'll emit one entry per partition.
-             :let [sys-time (some-> (.getTxBasis snap) first (.getSystemTime))]
-             :when sys-time]
-         [db-name [sys-time]])
+             :let [sys-times (->> (.getPartitions snap)
+                                  (mapv (fn [^Snapshot part-snap]
+                                          (some-> (.getTxBasis part-snap) (.getSystemTime)))))]
+             :when (some identity sys-times)]
+         [db-name sys-times])
        (into {})
        (not-empty)))
 

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -49,7 +49,7 @@
            (xtdb.antlr Sql$DirectlyExecutableStatementContext)
            (xtdb.api.query IKeyFn)
            (xtdb.arrow RelationReader VectorReader VectorType)
-           (xtdb.indexer Snapshot)
+           (xtdb.indexer DatabaseSnapshot Snapshot)
            xtdb.NodeBase
            xtdb.operator.scan.IScanEmitter
            (xtdb.query IQuerySource IQuerySource$Factory PreparedDmlQuery PreparedDmlQuery$Assert PreparedDmlQuery$Delete PreparedDmlQuery$Erase PreparedDmlQuery$Patch PreparedDmlQuery$Put PreparedQuery)
@@ -142,8 +142,11 @@
     expr))
 
 (defn- validate-basis-not-before [basis snaps]
-  (doseq [[db-name ^Snapshot snap] snaps]
-    (let [snap-tx (.getTxBasis snap)
+  (doseq [[db-name ^DatabaseSnapshot snap] snaps]
+    ;; TODO (#5557 unit 3) iterate `snap.partitions` and validate each partition's basis against
+    ;; the corresponding position. For now we're still single-partition, so the size-1 vector
+    ;; collapses to its first element.
+    (let [snap-tx (first (.getTxBasis snap))
           system-time (get-in basis [db-name 0])]
       (when (and system-time
                  (or (nil? snap-tx)
@@ -155,8 +158,10 @@
                                :system-time system-time}))))))
 
 (defn- default-basis [snaps]
-  (->> (for [[db-name ^Snapshot snap] snaps
-             :let [sys-time (some-> (.getTxBasis snap) (.getSystemTime))]
+  (->> (for [[db-name ^DatabaseSnapshot snap] snaps
+             ;; TODO (#5557 unit 3) the singleton wrap is left over from the pre-multi-partition
+             ;; world; once basis iteration is partition-aware we'll emit one entry per partition.
+             :let [sys-time (some-> (.getTxBasis snap) first (.getSystemTime))]
              :when sys-time]
          [db-name [sys-time]])
        (into {})
@@ -333,8 +338,8 @@
                 ;; TODO this, too, gets the schema for *every* db in the catalog
                 (->> (.getDatabaseNames db-cat)
                      (into {} (mapcat (fn [db-name]
-                                        (util/with-open [snap (.openSnapshot (.databaseOrNull db-cat db-name))]
-                                          (update-vals (.getTableInfo snap) set)))))))
+                                        (util/with-open [^DatabaseSnapshot snap (.openSnapshot (.databaseOrNull db-cat db-name))]
+                                          (update-vals (.tableInfo snap) set)))))))
 
               (plan-query* [table-info]
                 (-plan-query this parsed-query query-opts table-info))]
@@ -456,8 +461,8 @@
 
   (preparePatchDocsQuery [this table valid-from valid-to db-cat opts]
     (let [default-db (:default-db opts)
-          table-info (-> (util/with-open [snap (.openSnapshot (.databaseOrNull db-cat default-db))]
-                           (.getTableInfo snap))
+          table-info (-> (util/with-open [^DatabaseSnapshot snap (.openSnapshot (.databaseOrNull db-cat default-db))]
+                           (.tableInfo snap))
                          (sql/xform-table-info [default-db] default-db))
           plan (-> (sql/plan-patch {:table-info table-info}
                                    {:table table

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -32,7 +32,7 @@ import xtdb.database.DatabaseName
 import xtdb.error.Incorrect
 import xtdb.query.PreparedQuery
 import xtdb.query.QueryOpts
-import xtdb.indexer.Snapshot
+import xtdb.indexer.DatabaseSnapshot
 import xtdb.table.TableRef
 import xtdb.tx.TxOp
 import xtdb.tx.TxOpts
@@ -301,12 +301,12 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             getTableSchema(TableRef(catalog ?: dbName, dbSchema ?: "public", tableName), snap)
         }
 
-    fun openSnapshot(): Snapshot = node.openSnapshot(dbName)
+    fun openSnapshot(): DatabaseSnapshot = node.openSnapshot(dbName)
 
-    fun getTableSchema(dbSchema: String, tableName: String, snap: Snapshot): Schema =
+    fun getTableSchema(dbSchema: String, tableName: String, snap: DatabaseSnapshot): Schema =
         getTableSchema(TableRef(dbName, dbSchema, tableName), snap)
 
-    private fun getTableSchema(table: TableRef, snap: Snapshot): Schema {
+    private fun getTableSchema(table: TableRef, snap: DatabaseSnapshot): Schema {
         val types = node.getColumnTypes(table, snap) ?: return Schema(emptyList())
         return Schema(types.entries.map { (name, type) -> type.toField(name) })
     }
@@ -481,8 +481,8 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx
         fun openSqlQuery(sql: String, dbName: DatabaseName): ResultCursor
         fun prepareSql(sql: String, dbName: DatabaseName): PreparedQuery
-        fun getColumnTypes(table: TableRef, snap: Snapshot): Map<String, VectorType>?
-        fun openSnapshot(dbName: DatabaseName): Snapshot
+        fun getColumnTypes(table: TableRef, snap: DatabaseSnapshot): Map<String, VectorType>?
+        fun openSnapshot(dbName: DatabaseName): DatabaseSnapshot
     }
 
     override fun close() {

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -444,7 +444,6 @@ class Database(
 
     interface Catalog : ILookup, Seqable, Iterable<Database>, IQuerySource.QueryCatalog {
         companion object {
-            private suspend fun Database.awaitSource(msgId: MessageId) = watchers.awaitSource(msgId)
             private suspend fun Database.sync() = watchers.awaitSource(sourceLog.latestSubmittedMsgId)
 
             private suspend fun Catalog.awaitAll0(token: String) = coroutineScope {
@@ -453,7 +452,15 @@ class Database(
                 databaseNames
                     .mapNotNull { databaseOrNull(it) }
                     .filter { it.isIndexing }
-                    .map { db -> launch { basis[db.name]?.first()?.let { db.awaitSource(it) } } }
+                    .map { db ->
+                        launch {
+                            val basisVec = basis[db.name] ?: return@launch
+                            db.partitions.entries.sortedBy { it.key }
+                                .forEach { (partIdx, part) ->
+                                    basisVec.getOrNull(partIdx)?.let { part.watchers.awaitSource(it) }
+                                }
+                        }
+                    }
                     .joinAll()
             }
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -80,14 +80,18 @@ class Database(
     val watchers: Watchers get() = partition0.watchers
     val compactorOrNull: Compactor.ForDatabase? get() = partition0.compactorOrNull
 
-    override fun openSnapshot(): Snapshot = partition0.openSnapshot()
+    override fun openSnapshot(): DatabaseSnapshot =
+        // List position = partition index, so basis-vector slot N matches `partitions[N]`.
+        DatabaseSnapshot(partitions.entries.sortedBy { it.key }.map { it.value.openSnapshot() })
 
     val blockCatalog: BlockCatalog get() = partition0.blockCatalog
     val tableCatalog: TableCatalog get() = partition0.tableCatalog
 
-    fun getColumnTypes(table: TableRef, snap: Snapshot): Map<ColumnName, VectorType>? {
+    fun getColumnTypes(table: TableRef, snap: DatabaseSnapshot): Map<ColumnName, VectorType>? {
         val historical = tableCatalog.getTypes(table)
-        val live = snap.allColumnTypes[table]
+        // TODO (#5557 unit 7) iterate `snap.partitions` and merge per-partition live types;
+        // for now single-partition is the only allowed shape, so pick the only Snapshot.
+        val live = snap.partitions.first().allColumnTypes[table]
         return if (historical == null && live == null) null
         else (historical ?: emptyMap()) + (live ?: emptyMap())
     }

--- a/core/src/main/kotlin/xtdb/indexer/DatabaseSnapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/DatabaseSnapshot.kt
@@ -1,0 +1,41 @@
+package xtdb.indexer
+
+import xtdb.api.TransactionKey
+import xtdb.table.TableRef
+import xtdb.trie.ColumnName
+import xtdb.util.closeAll
+
+/**
+ * Database-level snapshot composed of one [Snapshot] per [xtdb.database.DatabasePartition].
+ *
+ * Per the stage-4 multi-partition design (issue #5557): cross-partition concepts like
+ * `tableInfo` and `txBasis` are unions / per-partition vectors over [partitions]; per-partition
+ * reads stay on the underlying [Snapshot] for that partition.
+ *
+ * For `partitions.size == 1` this is a thin wrapper — every method reduces to the single
+ * partition's behaviour.
+ */
+class DatabaseSnapshot(val partitions: List<Snapshot>) : AutoCloseable {
+
+    interface Source {
+        fun openSnapshot(): DatabaseSnapshot
+    }
+
+    init {
+        require(partitions.isNotEmpty()) { "DatabaseSnapshot must have at least one partition" }
+    }
+
+    /** Union of `{table → columns}` across [partitions]. */
+    fun tableInfo(): Map<TableRef, Set<ColumnName>> =
+        if (partitions.size == 1) partitions[0].tableInfo
+        else partitions.fold(emptyMap()) { acc, snap ->
+            snap.tableInfo.entries.fold(acc) { a, (table, cols) ->
+                a + (table to (a[table].orEmpty() + cols))
+            }
+        }
+
+    /** One [TransactionKey] per partition, in partition-index order. */
+    val txBasis: List<TransactionKey?> get() = partitions.map { it.txBasis }
+
+    override fun close() = partitions.closeAll()
+}

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -140,14 +140,11 @@ class OpenTx(
     private fun queryCatalog(): IQuerySource.QueryCatalog {
         val liveIndex = dbState.liveIndex
 
-        val snapSource = object : Snapshot.Source {
-            override fun openSnapshot() = liveIndex.openSnapshot(this@OpenTx)
-        }
-
         val queryDb = object : IQuerySource.QueryDatabase {
             override val storage get() = dbStorage
             override val queryState get() = dbState
-            override fun openSnapshot() = snapSource.openSnapshot()
+            override fun openSnapshot() =
+                DatabaseSnapshot(listOf(liveIndex.openSnapshot(this@OpenTx)))
         }
         return object : IQuerySource.QueryCatalog {
             override val databaseNames: Collection<DatabaseName> get() = setOf(dbState.name)

--- a/core/src/main/kotlin/xtdb/query/IQuerySource.kt
+++ b/core/src/main/kotlin/xtdb/query/IQuerySource.kt
@@ -5,7 +5,7 @@ import org.apache.arrow.memory.BufferAllocator
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
-import xtdb.indexer.Snapshot
+import xtdb.indexer.DatabaseSnapshot
 import xtdb.table.TableRef
 import java.time.Instant
 
@@ -16,7 +16,7 @@ interface IQuerySource : AutoCloseable {
         fun databaseOrNull(dbName: DatabaseName): QueryDatabase?
     }
 
-    interface QueryDatabase : Snapshot.Source {
+    interface QueryDatabase : DatabaseSnapshot.Source {
         val storage: DatabaseStorage
         val queryState: DatabaseState
     }


### PR DESCRIPTION
Part of #5557 (multi-DB stage 4: multi-partition external source logs).

## Summary

Two tidy units of the stage-4 plan, both behaviour-preserving at `partitions == 1` (the only allowed shape today). They prepare the read-side API for multi-partition without enabling it; `partitions > 1` is still rejected at attach.

## Commits

- `23a3edd0f` `tidy(database): introduce DatabaseSnapshot composite type (#5557)` — the per-database snapshot type.
- `1d3e6ad1f` `tidy(database): iterate basis per partition (#5557)` — replaces `.first()` / `[0]` collapses with per-partition iteration.

The design is settled in the [stage-4 design-pass comment](https://github.com/xtdb/xtdb/issues/5557#issuecomment-4577521264) on #5557 (Q3a + Q3b); these commits walk the call sites.

## Composite shape (Q3a)

`Database.openSnapshot()` returns a new `DatabaseSnapshot(partitions: List<Snapshot>)` exposing:

- `tableInfo()` — union of `{table → columns}` across partitions, the planner's schema view.
- `txBasis: List<TransactionKey?>` — one entry per partition, aligned with the basis-token wire format (`Map<DbName, List<MessageId>>`).
- `AutoCloseable.close()` — fans out across partitions.

`Snapshot` itself stays per-`DatabasePartition`. Same instance methods (`table`, `columnType`, `allColumnTypes`, `trieTableState`), same semantics. `IQuerySource.QueryDatabase` extends `DatabaseSnapshot.Source`, threading the composite through ADBC (`XtdbConnection`), Flight SQL (`XtdbProducer`), and the in-process `OpenTx` query path.

## Per-partition basis iteration (Q3b)

The basis-token wire format was already correct (`Map<DbName, List<MessageId>>`); call sites had been wrapping/unwrapping size-1 vectors with `.first()` and `;; TODO multi-part` markers. Those came out:

- `query.clj`'s `validate-basis-not-before` and `default-basis` iterate `(.getPartitions snap)` per partition.
- `node/impl.clj`'s `latest-completed-txs` / `latest-processed-msg-ids` walk `(.getPartitions db)` sorted by partition index.
- `Database.awaitAll0` iterates `db.partitions` and awaits each per-partition `Watchers.awaitSource(basisVec[i])`.

At N=1 every iteration produces a one-element vector with the same value the old singleton wrap produced — behaviour-identical.

## Deferred

Marked at call sites with TODO comments pointing at the later unit:

- **Unit 5 (`Log<M>` widening).** `latest-submitted-msg-ids` iterates `db.partitions`, but `sourceLog.latestSubmittedMsgId` is still database-level; every slot carries the same value until unit 5 surfaces per-partition Kafka offsets.
- **Unit 7 (`TableCatalog` wrapper + UNION-at-scan).** `Database.getColumnTypes`, `scan-vec-types`, and the scan `->cursor` closure pick `(first (.getPartitions db-snap))` rather than iterating. `scan.clj:308`'s `(get-in basis [db-name 0])` keeps its hardcoded `0` for the same reason — the cursor is single-partition until unit 7 fans it out.
- **Unit 10 (observability).** Per-partition labelling on the `unindexed-tx` error message and `:partition` in its ex-data; per-partition rows in `awaitAll`'s timeout diagnostic; per-partition gauge tags. I tried adding `:partition` to the ex-data here but strict-comparison assertions in `pgwire_test` flagged it as an unexpected key — backed out so unit 10 lands the label and the test updates together.

## Test plan

- [x] `./gradlew :test :xtdb-core:test` — green.

No new tests. Per the design pass on #5557, tidy units (1–4) verify by "existing test suite passes throughout"; multi-partition unit tests start landing at unit 5 (`InMemoryLog(partitions = N)`) and unit 7 (UNION-at-scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)