### PR TITLE
test(postgres-source): add a CDC simulation test

### DIFF
--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceSimulationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceSimulationTest.kt
@@ -1,0 +1,190 @@
+package xtdb.postgres
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.*
+import io.kotest.property.checkAll
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import xtdb.api.Xtdb
+import java.nio.file.Files
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives random programs of mutations + lifecycle events (insert/update/delete, batches, block
+ * flushes, restarts) against a real Postgres container, keeping a reference model and asserting
+ * XTDB's CDC pipeline converges to it.
+ */
+@Tag("property")
+class PostgresSourceSimulationTest : PostgresSourceTestBase() {
+
+    // --- program model ---
+
+    private sealed interface Op {
+        data class Insert(val id: Int, val name: String) : Op
+        data class Update(val id: Int, val name: String) : Op
+        data class Delete(val id: Int) : Op
+    }
+
+    private sealed interface Cmd {
+        data class Mutate(val op: Op) : Cmd
+        data class Batch(val ops: List<Op>) : Cmd
+        data object FlushBlock : Cmd
+        data object Restart : Cmd
+        data class RestartWith(val downOps: List<Op>) : Cmd
+    }
+
+    // --- reference model + oracle ---
+
+    // id -> name; an UPDATE of a missing row is a no-op in PG, so the model mirrors that
+    private fun applyOp(model: Map<Int, String>, op: Op): Map<Int, String> = when (op) {
+        is Op.Insert -> model + (op.id to op.name)
+        is Op.Update -> if (op.id in model) model + (op.id to op.name) else model
+        is Op.Delete -> model - op.id
+    }
+
+    private fun opSql(table: String, op: Op): String = when (op) {
+        // ON CONFLICT so a generated INSERT of an existing id behaves like the model's overwrite
+        is Op.Insert -> "INSERT INTO $table (_id, name) VALUES (${op.id}, '${op.name}') " +
+            "ON CONFLICT (_id) DO UPDATE SET name = EXCLUDED.name"
+        is Op.Update -> "UPDATE $table SET name = '${op.name}' WHERE _id = ${op.id}"
+        is Op.Delete -> "DELETE FROM $table WHERE _id = ${op.id}"
+    }
+
+    private fun cdcIngestionError(node: Xtdb) =
+        (node as Xtdb.XtdbInternal).dbCatalog["cdc"]?.ingestionError
+
+    private fun qRows(node: Xtdb, table: String): List<Pair<Int, String?>> =
+        xtQuery(node, "SELECT _id, name FROM public.$table ORDER BY _id")
+            .map { (it["_id"] as Number).toInt() to (it["name"] as String?) }
+
+    /** The oracle: waits for the cdc pipeline to drain, then asserts the cdc table matches the
+     *  reference model. Bails fast if ingestion has stopped — a poisoned db can never catch up — and
+     *  on timeout asserts so the failure surfaces the expected-vs-actual diff rather than a bare wait. */
+    private suspend fun assertFinalState(node: Xtdb, table: String, model: Map<Int, String>, timeout: Duration = 60.seconds) {
+        val expected = model.toSortedMap().map { (id, name) -> id to name }
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+        while (true) {
+            cdcIngestionError(node)?.let { fail("cdc ingestion stopped for $table: ${it.message}") }
+            val actual = runCatching { qRows(node, table) }.getOrNull()
+            when {
+                actual == expected -> return
+                System.currentTimeMillis() > deadline ->
+                    return assertEquals(expected, actual, "cdc table never converged to the model for $table")
+                else -> runInterruptible { Thread.sleep(200) }
+            }
+        }
+    }
+
+    // --- interpreter ---
+
+    /** Creates the table + publication, attaches cdc, drives `program` against Postgres while keeping
+     *  the reference model in step, and finally asserts convergence. The node lives in a `var` because
+     *  restarts close and reopen it; the initial snapshot is flushed so the snapshotCompleted token is
+     *  durable and restarts resume streaming rather than re-running the (uninterruptible) snapshot. */
+    private suspend fun runProgram(program: List<Cmd>) {
+        val table = unique("pg"); val pub = unique("pub"); val slot = unique("slot")
+        // log, storage, cdc-log, cdc-storage
+        val dirs = List(4) { Files.createTempDirectory("pg-sim") }
+        pgExecute(
+            "CREATE TABLE $table (_id INT PRIMARY KEY, name TEXT)",
+            "CREATE PUBLICATION $pub FOR TABLE $table",
+        )
+        var node = openNode(dirs[0], dirs[1])
+        var model = emptyMap<Int, String>()
+        try {
+            attachCdc(node, dirs[2], dirs[3], slot, pub)
+            awaitStreaming(node)
+            flushBlock(node)
+
+            for (cmd in program) {
+                when (cmd) {
+                    is Cmd.Mutate -> {
+                        pgExecute(opSql(table, cmd.op))
+                        model = applyOp(model, cmd.op)
+                    }
+                    is Cmd.Batch -> {
+                        // one PG transaction => one commit
+                        pgExecute(*(listOf("BEGIN") + cmd.ops.map { opSql(table, it) } + "COMMIT").toTypedArray())
+                        model = cmd.ops.fold(model, ::applyOp)
+                    }
+                    Cmd.FlushBlock -> flushBlock(node)
+                    Cmd.Restart -> { node.close(); node = openNode(dirs[0], dirs[1]); awaitStreaming(node) }
+                    is Cmd.RestartWith -> {
+                        // mutate while CDC is down, so streaming has to catch up on resume
+                        node.close()
+                        if (cmd.downOps.isNotEmpty()) {
+                            pgExecute(*cmd.downOps.map { opSql(table, it) }.toTypedArray())
+                            model = cmd.downOps.fold(model, ::applyOp)
+                        }
+                        node = openNode(dirs[0], dirs[1])
+                        // wait for the cdc db to re-attach + resume before touching it again
+                        awaitStreaming(node)
+                    }
+                }
+                // bail the moment the db is poisoned rather than running on
+                cdcIngestionError(node)?.let { fail("cdc poisoned after $cmd: ${it.message}") }
+            }
+            assertFinalState(node, table, model)
+        } finally {
+            node.close()
+            runCatching { dropSlot(slot) }
+            dirs.forEach { it.toFile().deleteRecursively() }
+        }
+    }
+
+    // --- generators ---
+
+    private val opGen: Arb<Op> = arbitrary {
+        val id = Arb.int(1..8).bind()
+        val name = Arb.string(0..8, Codepoint.alphanumeric()).bind()
+        when (Arb.int(0..2).bind()) {
+            0 -> Op.Insert(id, name)
+            1 -> Op.Update(id, name)
+            else -> Op.Delete(id)
+        }
+    }
+
+    // weighted to favour mutations, with the occasional batch / flush / restart; convergence is
+    // checked once at the end rather than at mid-program checkpoints
+    private val cmdGen: Arb<Cmd> = arbitrary {
+        when (Arb.int(0 until 12).bind()) {
+            in 0..6 -> Cmd.Mutate(opGen.bind())
+            in 7..8 -> Cmd.Batch(Arb.list(opGen, 1..5).bind())
+            9 -> Cmd.FlushBlock
+            10 -> Cmd.Restart
+            else -> Cmd.RestartWith(Arb.list(opGen, 0..3).bind())
+        }
+    }
+
+    private val programGen: Arb<List<Cmd>> = Arb.list(cmdGen, 1..20)
+
+    // --- tests ---
+
+    @Test
+    fun `simulation smoke`() = runTest(timeout = 30.minutes) {
+        runProgram(
+            listOf(
+                Cmd.Mutate(Op.Insert(1, "Alice")),
+                Cmd.Batch((3..21).map { Op.Insert(it, "row$it") }),
+                Cmd.FlushBlock,
+                Cmd.Restart,
+                Cmd.RestartWith(listOf(Op.Insert(100, "Charlie"))),
+                Cmd.Mutate(Op.Update(1, "AliceUpdated")),
+                Cmd.Mutate(Op.Delete(2)),
+            )
+        )
+    }
+
+    @Test
+    fun `random programs converge to the reference model`() = runTest(timeout = 30.minutes) {
+        checkAll(ITERATIONS, programGen) { program -> runProgram(program) }
+    }
+
+    companion object {
+        private const val ITERATIONS = 50
+    }
+}

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceTestBase.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceTestBase.kt
@@ -115,8 +115,12 @@ abstract class PostgresSourceTestBase {
 
     protected suspend fun flushBlock(node: Xtdb) {
         val cdc = (node as Xtdb.XtdbInternal).dbCatalog["cdc"]!!
+        val before = cdc.blockCatalog.currentBlockIndex
         cdc.sendFlushBlockMessage()
-        awaitCondition("block persisted for cdc", timeout = 30.seconds) { cdc.blockCatalog.currentBlockIndex != null }
+        // wait for *this* flush's block, not just any block — matters when flushing repeatedly
+        awaitCondition("block persisted for cdc", timeout = 30.seconds) {
+            cdc.blockCatalog.currentBlockIndex.let { it != null && (before == null || it > before) }
+        }
     }
 
     /** Waits until the source has finished its initial snapshot and switched to streaming, so a
@@ -128,12 +132,13 @@ abstract class PostgresSourceTestBase {
      *  final `snapshotCompleted = true` marker before streaming begins; the cdc db's watchers track
      *  the latest applied token, so `snapshotCompleted` going true means the whole snapshot is in
      *  (indexTx awaits application) and streaming is live. */
-    protected suspend fun awaitStreaming(node: Xtdb) {
-        val cdc = (node as Xtdb.XtdbInternal).dbCatalog["cdc"]!!
+    protected suspend fun awaitStreaming(node: Xtdb) =
+        // cdc may be momentarily absent right after a restart (it re-attaches from the replayed log),
+        // so resolve it inside the poll rather than up front
         awaitCondition("cdc snapshot complete, streaming live", timeout = 30.seconds) {
-            cdc.watchers.externalSourceToken?.let { PostgresSourceToken.parseFrom(it).snapshotCompleted } == true
+            val cdc = (node as Xtdb.XtdbInternal).dbCatalog["cdc"]
+            cdc?.watchers?.externalSourceToken?.let { PostgresSourceToken.parseFrom(it).snapshotCompleted } == true
         }
-    }
 
     companion object {
         // slots are dropped per run, but keep headroom across the whole property suite

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceTestBase.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceTestBase.kt
@@ -1,0 +1,147 @@
+package xtdb.postgres
+
+import kotlinx.coroutines.runInterruptible
+import org.junit.jupiter.api.fail
+import org.testcontainers.postgresql.PostgreSQLContainer
+import xtdb.api.Xtdb
+import xtdb.api.log.Log.Companion.localLog
+import xtdb.api.storage.Storage
+import xtdb.postgres.proto.PostgresSourceToken
+import java.nio.file.Path
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.PreparedStatement
+import java.util.UUID
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Shared plumbing for the Postgres-source CDC tests: a logical-replication Postgres container plus
+ * helpers to drive it (pg writes), stand up a local-log/storage XTDB node with the cdc db attached,
+ * query the cdc db over pgwire, and await streaming / block flushes.
+ *
+ * The container is a singleton — started once on first use and reaped by Ryuk at JVM exit — so the
+ * whole module's CDC tests share one instance rather than each paying a start/stop.
+ */
+abstract class PostgresSourceTestBase {
+
+    // --- pg ---
+
+    protected fun pgConn(): Connection =
+        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
+
+    protected fun pgExecute(vararg statements: String) =
+        pgConn().use { c -> c.createStatement().use { s -> statements.forEach { s.execute(it) } } }
+
+    protected fun unique(prefix: String) = "${prefix}_${UUID.randomUUID().toString().replace("-", "_")}"
+
+    /** Runs a single prepared write in its own connection wrapped in an explicit BEGIN/COMMIT, so
+     * it lands as its own transaction — and, since the source stamps valid-time from the PG commit
+     * time, its own valid-time version. */
+    protected fun commitTx(sql: String, bindParams: (PreparedStatement) -> Unit) =
+        pgConn().use { c ->
+            c.createStatement().use { it.execute("BEGIN") }
+            c.prepareStatement(sql).use { ps -> bindParams(ps); ps.executeUpdate() }
+            c.createStatement().use { it.execute("COMMIT") }
+        }
+
+    protected fun dropSlot(slot: String) =
+        pgExecute("SELECT pg_drop_replication_slot('$slot') FROM pg_replication_slots WHERE slot_name = '$slot'")
+
+    // --- node ---
+
+    protected fun openNode(logDir: Path, storageDir: Path): Xtdb = Xtdb.openNode {
+        server { port = 0 }
+        log(localLog(logDir))
+        storage(Storage.local(storageDir))
+        remote("pg", PostgresRemote.Factory(
+            hostname = postgres.host, port = postgres.firstMappedPort,
+            database = "testdb", username = "testuser", password = "testpass",
+        ))
+    }
+
+    protected fun attachCdc(node: Xtdb, cdcLog: Path, cdcStorage: Path, slot: String, pub: String) {
+        node.createConnectionBuilder().build().use { c ->
+            c.createStatement().use { s ->
+                s.execute(
+                    """
+                    ATTACH DATABASE cdc WITH $$
+                        storage: !Local
+                          path: $cdcStorage
+                        log: !Local
+                          path: $cdcLog
+                        externalSource: !Postgres
+                          remote: pg
+                          slotName: $slot
+                          publicationName: $pub
+                    $$""".trimIndent()
+                )
+            }
+        }
+    }
+
+    protected fun xtQuery(node: Xtdb, sql: String): List<Map<String, Any?>> =
+        node.createConnectionBuilder().database("cdc").build().use { c ->
+            c.createStatement().use { s ->
+                s.executeQuery(sql).use { rs ->
+                    val cols = (1..rs.metaData.columnCount).map { rs.metaData.getColumnName(it) }
+                    buildList { while (rs.next()) add(cols.associateWith { rs.getObject(it) }) }
+                }
+            }
+        }
+
+    // --- awaits ---
+
+    protected suspend fun awaitCondition(description: String, timeout: Duration = 10.seconds, check: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+        while (System.currentTimeMillis() < deadline) {
+            if (check()) return
+            runInterruptible { Thread.sleep(200) }
+        }
+        fail("Timed out waiting for: $description")
+    }
+
+    /** Polls `f` until `done` holds or the timeout elapses, returning the last value either way —
+     * so a caller can assert on it and surface what actually showed up rather than a bare timeout. */
+    protected suspend fun <T> await(timeout: Duration = 30.seconds, done: (T) -> Boolean, f: () -> T): T {
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+        var v = f()
+        while (!done(v) && System.currentTimeMillis() < deadline) {
+            runInterruptible { Thread.sleep(200) }
+            v = f()
+        }
+        return v
+    }
+
+    protected suspend fun flushBlock(node: Xtdb) {
+        val cdc = (node as Xtdb.XtdbInternal).dbCatalog["cdc"]!!
+        cdc.sendFlushBlockMessage()
+        awaitCondition("block persisted for cdc", timeout = 30.seconds) { cdc.blockCatalog.currentBlockIndex != null }
+    }
+
+    /** Waits until the source has finished its initial snapshot and switched to streaming, so a
+     *  write won't race the snapshot→stream handoff (a row committed ahead of the slot's consistent
+     *  point would only be seen as the snapshot's current-state read, not streamed as its own
+     *  valid-time version).
+     *
+     *  The source stamps each snapshot batch with a `snapshotCompleted = false` token and writes a
+     *  final `snapshotCompleted = true` marker before streaming begins; the cdc db's watchers track
+     *  the latest applied token, so `snapshotCompleted` going true means the whole snapshot is in
+     *  (indexTx awaits application) and streaming is live. */
+    protected suspend fun awaitStreaming(node: Xtdb) {
+        val cdc = (node as Xtdb.XtdbInternal).dbCatalog["cdc"]!!
+        awaitCondition("cdc snapshot complete, streaming live", timeout = 30.seconds) {
+            cdc.watchers.externalSourceToken?.let { PostgresSourceToken.parseFrom(it).snapshotCompleted } == true
+        }
+    }
+
+    companion object {
+        // slots are dropped per run, but keep headroom across the whole property suite
+        private val postgres = PostgreSQLContainer("postgres:17-alpine")
+            .withDatabaseName("testdb")
+            .withUsername("testuser")
+            .withPassword("testpass")
+            .withCommand("postgres", "-c", "wal_level=logical", "-c", "max_replication_slots=50")
+            .also { it.start() }
+    }
+}

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceTypesPropertyTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceTypesPropertyTest.kt
@@ -3,29 +3,18 @@ package xtdb.postgres
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.*
 import io.kotest.property.checkAll
-import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.testcontainers.postgresql.PostgreSQLContainer
 import xtdb.api.Xtdb
-import xtdb.api.log.Log.Companion.localLog
-import xtdb.api.storage.Storage
-import xtdb.postgres.proto.PostgresSourceToken
 import java.math.BigDecimal
 import java.nio.file.Files
-import java.nio.file.Path
-import java.sql.Connection
-import java.sql.DriverManager
-import java.sql.PreparedStatement
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import java.util.UUID
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -37,24 +26,9 @@ import kotlin.time.Duration.Companion.seconds
  * column types/values.
  */
 @Tag("property")
-class PostgresSourceTypesPropertyTest {
+class PostgresSourceTypesPropertyTest : PostgresSourceTestBase() {
 
     companion object {
-        private val postgres = PostgreSQLContainer("postgres:17-alpine")
-            .withDatabaseName("testdb")
-            .withUsername("testuser")
-            .withPassword("testpass")
-            // slots are dropped per iteration, but keep headroom for the property run
-            .withCommand("postgres", "-c", "wal_level=logical", "-c", "max_replication_slots=50")
-
-        @JvmStatic
-        @BeforeAll
-        fun beforeAll() = postgres.start()
-
-        @JvmStatic
-        @AfterAll
-        fun afterAll() = postgres.stop()
-
         private const val ITERATIONS = 50
 
         // --- generator bounds ---
@@ -193,25 +167,7 @@ class PostgresSourceTypesPropertyTest {
     private fun normalizeRow(cols: List<Col>, vals: Map<String, Any?>) =
         cols.associate { it.name to normalize(vals[it.name]) }
 
-    // --- pg / node plumbing ---------------------------------------------------------------
-
-    private fun pgConn(): Connection =
-        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
-
-    private fun pgExecute(vararg statements: String) =
-        pgConn().use { c -> c.createStatement().use { s -> statements.forEach { s.execute(it) } } }
-
-    private fun unique(prefix: String) = "${prefix}_${UUID.randomUUID().toString().replace("-", "_")}"
-
-    /** Runs a single prepared write in its own connection wrapped in an explicit BEGIN/COMMIT, so
-     * it lands as its own transaction — and, since the source stamps valid-time from the PG commit
-     * time, its own valid-time version. */
-    private fun commitTx(sql: String, bindParams: (PreparedStatement) -> Unit) =
-        pgConn().use { c ->
-            c.createStatement().use { it.execute("BEGIN") }
-            c.prepareStatement(sql).use { ps -> bindParams(ps); ps.executeUpdate() }
-            c.createStatement().use { it.execute("COMMIT") }
-        }
+    // --- writes -----------------------------------------------------------------------------
 
     private fun insertRow(cols: List<Col>, table: String, row: Row) {
         val names = listOf("_id") + cols.map { it.name }
@@ -227,92 +183,6 @@ class PostgresSourceTypesPropertyTest {
         commitTx(sql) { ps ->
             cols.forEachIndexed { i, col -> ps.setObject(i + 1, vals[col.name]) }
             ps.setObject(cols.size + 1, id)
-        }
-    }
-
-    private fun dropSlot(slot: String) =
-        pgExecute("SELECT pg_drop_replication_slot('$slot') FROM pg_replication_slots WHERE slot_name = '$slot'")
-
-    private fun openNode(logDir: Path, storageDir: Path): Xtdb = Xtdb.openNode {
-        server { port = 0 }
-        log(localLog(logDir))
-        storage(Storage.local(storageDir))
-        remote("pg", PostgresRemote.Factory(
-            hostname = postgres.host, port = postgres.firstMappedPort,
-            database = "testdb", username = "testuser", password = "testpass",
-        ))
-    }
-
-    private fun attachCdc(node: Xtdb, cdcLog: Path, cdcStorage: Path, slot: String, pub: String) {
-        node.createConnectionBuilder().build().use { c ->
-            c.createStatement().use { s ->
-                s.execute(
-                    """
-                    ATTACH DATABASE cdc WITH $$
-                        storage: !Local
-                          path: $cdcStorage
-                        log: !Local
-                          path: $cdcLog
-                        externalSource: !Postgres
-                          remote: pg
-                          slotName: $slot
-                          publicationName: $pub
-                    $$""".trimIndent()
-                )
-            }
-        }
-    }
-
-    private fun xtQuery(node: Xtdb, sql: String): List<Map<String, Any?>> =
-        node.createConnectionBuilder().database("cdc").build().use { c ->
-            c.createStatement().use { s ->
-                s.executeQuery(sql).use { rs ->
-                    val cols = (1..rs.metaData.columnCount).map { rs.metaData.getColumnName(it) }
-                    buildList { while (rs.next()) add(cols.associateWith { rs.getObject(it) }) }
-                }
-            }
-        }
-
-    private suspend fun awaitCondition(description: String, timeout: Duration = 10.seconds, check: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
-        while (System.currentTimeMillis() < deadline) {
-            if (check()) return
-            runInterruptible { Thread.sleep(200) }
-        }
-        fail("Timed out waiting for: $description")
-    }
-
-    /** Polls `f` until `done` holds or the timeout elapses, returning the last value either way —
-     * so a caller can assert on it and surface what actually showed up rather than a bare timeout. */
-    private suspend fun <T> await(timeout: Duration = 30.seconds, done: (T) -> Boolean, f: () -> T): T {
-        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
-        var v = f()
-        while (!done(v) && System.currentTimeMillis() < deadline) {
-            runInterruptible { Thread.sleep(200) }
-            v = f()
-        }
-        return v
-    }
-
-    private suspend fun flushBlock(node: Xtdb) {
-        val cdc = (node as Xtdb.XtdbInternal).dbCatalog["cdc"]!!
-        cdc.sendFlushBlockMessage()
-        awaitCondition("block persisted for cdc", timeout = 30.seconds) { cdc.blockCatalog.currentBlockIndex != null }
-    }
-
-    /** Waits until the source has finished its initial snapshot and switched to streaming, so a
-     *  write won't race the snapshot→stream handoff (a row committed ahead of the slot's consistent
-     *  point would only be seen as the snapshot's current-state read, not streamed as its own
-     *  valid-time version).
-     *
-     *  The source stamps each snapshot batch with a `snapshotCompleted = false` token and writes a
-     *  final `snapshotCompleted = true` marker before streaming begins; the cdc db's watchers track
-     *  the latest applied token, so `snapshotCompleted` going true means the whole snapshot is in
-     *  (indexTx awaits application) and streaming is live. */
-    private suspend fun awaitStreaming(node: Xtdb) {
-        val cdc = (node as Xtdb.XtdbInternal).dbCatalog["cdc"]!!
-        awaitCondition("cdc snapshot complete, streaming live", timeout = 30.seconds) {
-            cdc.watchers.externalSourceToken?.let { PostgresSourceToken.parseFrom(it).snapshotCompleted } == true
         }
     }
 


### PR DESCRIPTION
Adds a model-based CDC simulation test to `postgres-source`, on the kotest + testcontainers stack the rest of the module's CDC tests use.

## What

Tidy-first, in two commits:

1. **Extract `PostgresSourceTestBase`** — an equivalence refactor pulling the shared CDC test plumbing out of `PostgresSourceTypesPropertyTest` into a base both tests extend: the Postgres container, pg writes, node open/attach, cdc-db query, and the await helpers (including the `snapshotCompleted`-token `awaitStreaming`).
2. **Add `PostgresSourceSimulationTest`** — drives random programs of mutations and lifecycle events (single writes, batched transactions, block flushes, node restarts) against a real Postgres, keeping a reference model and asserting the CDC pipeline converges to it.

## Why

- Keeps the simulation test on the same Kotlin stack as the module's other CDC tests, rather than in the root module's `src/test/clojure` — which would drag `testcontainers-postgresql` (and its `DriverManager` pollution) back into root.

## Notes

- **Not** built on the existing `SimulationTestBase` / `DeterministicDispatcher` framework: that's for deterministic, in-process, *mocked* simulation of node internals and can't host a real container with real streaming and restarts. This is a model-based property test, closer in shape to `PostgresSourceTypesPropertyTest`.
- Convergence is checked once, by a single end-of-program oracle (`assertFinalState`), not at mid-program checkpoints: the small id space means later ops overwrite earlier ones, so a mid-program check caught little the final state didn't. History-level regressions stay covered by the separate distinct-valid-time-version property test.
- `awaitStreaming` gates writes on the `snapshotCompleted` token (no dummy-row barrier), with a flush so the token is durable and restarts resume streaming rather than re-running the (uninterruptible) snapshot.
- `awaitStreaming` runs after every restart and resolves the cdc db *inside* its poll: the db re-attaches asynchronously from the replayed log, so a restart immediately followed by a flush would otherwise hit a null cdc db.
- `flushBlock` waits for *this* flush's block to land (advance), not just any block, now that programs flush repeatedly.

## Testing

`./gradlew :modules:xtdb-postgres-source:property-test` green locally, including the shrunk `[RestartWith, FlushBlock]` seed that surfaced the post-restart null-cdc NPE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
