### PR TITLE
fix(join): preserve unmatched build rows when probe schema is empty

### DIFF
--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -213,7 +213,7 @@
                                        join-type cmp-factory)
 
                     (MemoryHashJoin. build-side probe-cursor
-                                     (some-> probe-vec-types keys vec) (map str probe-key-cols)
+                                     (vec (keys probe-vec-types)) (map str probe-key-cols)
                                      join-type cmp-factory)))))))
 
     (.tryAdvance hash-join-cursor c))

--- a/core/src/main/kotlin/xtdb/operator/join/MemoryHashJoin.kt
+++ b/core/src/main/kotlin/xtdb/operator/join/MemoryHashJoin.kt
@@ -8,7 +8,7 @@ import java.util.function.Consumer
 
 class MemoryHashJoin(
     private val buildSide: BuildSide, private val probeCursor: ICursor,
-    private val probeColNames: List<FieldName>?, private val probeKeyColNames: List<FieldName>,
+    private val probeColNames: List<FieldName>, private val probeKeyColNames: List<FieldName>,
     private val joinType: JoinType, private val comparatorFactory: ComparatorFactory,
 ) : ICursor {
 
@@ -33,7 +33,6 @@ class MemoryHashJoin(
 
         if (advanced) return true
 
-        if (probeColNames == null) return false // semi-join
         val unmatchedBuildIdxsRel = buildSide.unmatchedIdxsRel(probeColNames, joinType) ?: return false
         buildSide.clearMatches() // so that we don't keep yielding them
         c.accept(unmatchedBuildIdxsRel)

--- a/src/test/clojure/xtdb/operator/join_test.clj
+++ b/src/test/clojure/xtdb/operator/join_test.clj
@@ -568,6 +568,12 @@
                               {:preserve-pages? true, :with-types? true})
                  (update :res (partial mapv frequencies)))))))
 
+(t/deftest test-full-outer-join-empty-rhs-schema-5669
+  (t/is (= [{:a 1}]
+           (tu/query-ra [:full-outer-join '{:conditions [{a b}]}
+                         [::tu/pages [[{:a 1}]]]
+                         [::tu/pages '{} []]]))))
+
 (t/deftest test-full-outer-equi-join-multi-col
   (->> "multi column full outer"
        (t/is (= [{{:a 12 :b 42 :c 12 :d 42 :e 0} 2

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -2151,7 +2151,6 @@
   (t/is (= [] (xt/q tu/*node* "select users.first_name from users")))
   (t/is (= [] (xt/q tu/*node* "SELECT * FROM users"))))
 
-#_ ; FIXME #5669 - left-outer-join to a never-created table drops left rows after the block boundary
 (t/deftest left-join-to-non-existent-table-survives-block-boundary-5669
   (xt/execute-tx tu/*node* [[:sql "INSERT INTO a (_id) VALUES ('1')"]])
 


### PR DESCRIPTION
Resolves #5669.

`MemoryHashJoin` had a misleading null-check on `probeColNames` — `if (probeColNames == null) return false // semi-join` — that fired before the unmatched-build-idxs emission. The comment implied semi-join correctness depended on it, but the actual gating lives on `BuildSide`: semi/anti emit without setting `:track-unmatched-build-idxs?`, so `unmatchedBuildIdxs` is null and `unmatchedIdxsRel` returns null — the very next line short-circuits via `?: return false`. The null-check was dead defensive code with a misleading comment.

The only caller built that argument as `(some-> probe-vec-types keys vec)`, which evaluates to `nil` rather than `[]` when `probe-vec-types` is empty — `(keys {})` returns `nil` and `some->` short-circuits. Both `::left-outer-join-flipped` and `::full-outer-join` set `:track-unmatched-build-idxs?` and genuinely need to fall through to unmatched-build emission; both silently dropped unmatched LHS rows when the probe schema was empty (i.e. RHS scan of a never-created table). LOJ-flipped is what #5669 reported; FOJ has the same bug class but nobody happened to hit it.

Two commits:

1. **fix** — call site passes `(vec (keys probe-vec-types))` so an empty map yields `[]`. The SQL regression test from b447b9f43 is re-enabled, and a focused operator-level test is added for FOJ against an empty-schema RHS (FOJ hardcodes `:build-side :left`, so it exposes the bug without the block-flush staging the SQL repro needs).
2. **tidy** — `MemoryHashJoin.probeColNames` becomes non-nullable and the dead semi-join branch is dropped. The contract is now in the type system; an accidental nil from the Clojure side would become a construction-time NPE rather than a silent row drop.

The fix commit is intended to be cherry-pickable onto 2.1.0; the tidy stays on main.

## Test plan

- [x] Regression test from #5669 now passes.
- [x] New FOJ operator-level regression passes, and verified to fail when the fix is reverted.
- [x] `xtdb.sql_test*` green.
- [x] `*join*` in `xtdb-core` green.
