### PR TITLE
ci(lang/js): provision yarn via corepack

### DIFF
--- a/lang/js/Dockerfile
+++ b/lang/js/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:24.14.0
+FROM node:24.16.0
+RUN corepack enable && corepack prepare yarn@1.22.22 --activate
 
 WORKDIR /app
 
@@ -11,4 +12,3 @@ COPY yarn.lock yarn.lock
 RUN yarn install
 
 COPY . .
-


### PR DESCRIPTION
The Node.js TSC endorsed removing yarn v1 from `docker-node` base images starting with Node 26 (nodejs/docker-node#2264). Node 26 became `:latest` in May 2026 — visible recently when a `2.1.x` branch (using `FROM node:latest`) hit "yarn: not found" in the lang-test job. Main currently sidesteps it by pinning to `node:24.14.0` (#5293), but the workaround is fragile: a bump past Node 24 LTS would hit the same wall and force whoever does the bump to rediscover the corepack pattern.

Corepack is the official mechanism for provisioning yarn regardless of the base image's bundled toolchain. It's bundled with Node since v16.9.0 — needs `corepack enable` to activate, then `corepack prepare yarn@1.22.22 --activate` installs the classic yarn matching this project's `yarn.lock` v1 format.

The Node pin stays — bumped to 24.16.0 (current Krypton patch). The structural change is that the image's bundled package managers no longer matter, so bumping past Node 24 LTS in the future becomes a one-line `FROM` swap. The added layer is ~2-3s on cold cache, zero with Docker's layer caching.

## Test plan

- [ ] CI `lang-test` job passes.