### PR TITLE
feat(explain-analyze): scan rows/pages/files pruned and used

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -27,7 +27,7 @@
            (xtdb ICursor Bytes)
            (xtdb.indexer DatabaseSnapshot Snapshot Snapshot$Source TableSnapshot)
            (xtdb.metadata MetadataPredicate PageMetadata)
-           (xtdb.operator.scan MultiIidSelector ScanCursor SingleIidSelector)
+           (xtdb.operator.scan MultiIidSelector ScanCursor ScanMetrics SingleIidSelector)
            xtdb.query.IQuerySource$QueryCatalog
            (xtdb.segment BufferPoolSegment MergePlanner)
            xtdb.table.TableRef
@@ -317,25 +317,35 @@
 
                              (let [filter-opts {:query-bounds temporal-bounds
                                                 :projects-temporal-cols? (boolean (some #{"_valid_from" "_valid_to" "_system_from" "_system_to"} col-names))
-                                                :clamp-valid-time? (boolean (:clamp-valid-time? scan-opts))}]
+                                                :clamp-valid-time? (boolean (:clamp-valid-time? scan-opts))}
+                                   ^ScanMetrics metrics (ScanMetrics. (.getDbName table)
+                                                                      (str (.getSchemaName table) "." (.getTableName table)))
+                                   current-tries (cat/current-tries (.trieTableState snapshot table))
+                                   filtered-tries (cat/filter-tries current-tries filter-opts)]
 
-                               (doseq [{:keys [^String trie-key]} (-> (.trieTableState snapshot table)
-                                                                      (cat/current-tries)
-                                                                      (cat/filter-tries filter-opts))]
+                               (.addFiles metrics
+                                          (long (- (count current-tries) (count filtered-tries)))
+                                          (long (count filtered-tries)))
+
+                               (doseq [{:keys [^String trie-key]} filtered-tries]
                                  (.add !segments
                                        (BufferPoolSegment. allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
 
                                (doseq [^TableSnapshot live-table-snap live-table-snaps]
                                  (.add !segments (.getSegment live-table-snap)))
 
-                               (let [merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) #(trie/filter-pages % filter-opts))
-                                     scan-attrs {"scan_db" (.getDbName table)
-                                                 "scan_source" (str (.getSchemaName table) "." (.getTableName table))}]
+                               (let [count-pages (fn [pages]
+                                                   (let [survivors (trie/filter-pages pages filter-opts)]
+                                                     (.addPages metrics
+                                                                (long (- (count pages) (count survivors)))
+                                                                (long (count survivors)))
+                                                     survivors))
+                                     merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) count-pages)]
                                (cond-> (ScanCursor. allocator (vec col-names) col-preds
                                                     temporal-bounds (boolean (:clamp-valid-time? scan-opts))
                                                     !segments (.iterator ^Iterable merge-tasks)
                                                     schema args
-                                                    scan-attrs)
+                                                    metrics)
                                  (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer
                                                                                                     query-span
                                                                                                     (format "query.cursor.scan.%s" (.getTableName table))

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -242,7 +242,10 @@
   (LinkedHashMap. ^Map (identity {"depth" #xt/type :utf8
                                   "op" #xt/type :keyword
                                   ;; struct (not transit) so it renders as JSON over pgwire — readable in Metabase
-                                  "attributes" #xt/type [:struct {"scan_db" :utf8, "scan_source" :utf8}]
+                                  "attributes" #xt/type [:struct {"scan_db" :utf8, "scan_source" :utf8
+                                                                  "scan_files_pruned" :i64, "scan_files_used" :i64
+                                                                  "scan_pages_pruned" :i64, "scan_pages_used" :i64
+                                                                  "scan_rows_read" :i64}]
                                   "total_time" #xt/type [:duration :micro]
                                   "time_to_first_page" #xt/type [:duration :micro]
                                   "page_count" #xt/type :i64

--- a/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
@@ -32,7 +32,7 @@ class ScanCursor(
 
     private val schema: Map<String, Any>, private val args: RelationReader,
 
-    private val attributes: Map<String, Any>
+    private val metrics: ScanMetrics
 ) : ICursor {
 
     private val vtLower = temporalBounds.validTime.lower
@@ -40,7 +40,7 @@ class ScanCursor(
 
     override val cursorType get() = "scan"
     override val childCursors get() = emptyList<ICursor>()
-    override val cursorAttributes get() = attributes
+    override val cursorAttributes get() = metrics.toMap()
 
     private class LeafPointer(val evPtr: EventRowPointer, val relIdx: Int)
 
@@ -68,6 +68,10 @@ class ScanCursor(
 
             // we're not in coroutine land here, so it's a good boundary for runBlocking
             val loadedPages = runBlocking { task.pages.map { async { it.loadDataPage(al) } }.awaitAll() }
+
+            // rows physically read off the pages we loaded — the scan's throughput denominator,
+            // before iid-selection and bitemporal resolution whittle them down to the emitted rows
+            metrics.addRowsRead(loadedPages.sumOf { it.rowCount.toLong() })
 
             val leafReaders = loadedPages.map { it.maybeSelect(iidPred, taskPath) }
 

--- a/core/src/main/kotlin/xtdb/operator/scan/ScanMetrics.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/ScanMetrics.kt
@@ -1,0 +1,29 @@
+package xtdb.operator.scan
+
+/**
+ * Per-scan explain-analyze counters. Identity (db, source) is known when the scan is planned;
+ * the file/page counts accrue during planning as tries and pages are pruned vs kept; rows-read
+ * accrues as the cursor loads pages. Read once, after the cursor is fully consumed.
+ *
+ * `files`/`pages` pruned counts only ever cover metadata the planner already consulted — a pruned
+ * page is one we tested and rejected — so they're free, and we never touch files we skipped.
+ */
+class ScanMetrics(private val scanDb: String, private val scanSource: String) {
+    var filesPruned: Long = 0; private set
+    var filesUsed: Long = 0; private set
+    var pagesPruned: Long = 0; private set
+    var pagesUsed: Long = 0; private set
+    var rowsRead: Long = 0; private set
+
+    fun addFiles(pruned: Long, used: Long) { filesPruned += pruned; filesUsed += used }
+    fun addPages(pruned: Long, used: Long) { pagesPruned += pruned; pagesUsed += used }
+    fun addRowsRead(rows: Long) { rowsRead += rows }
+
+    fun toMap(): Map<String, Any> =
+        mapOf(
+            "scan_db" to scanDb, "scan_source" to scanSource,
+            "scan_files_pruned" to filesPruned, "scan_files_used" to filesUsed,
+            "scan_pages_pruned" to pagesPruned, "scan_pages_used" to pagesUsed,
+            "scan_rows_read" to rowsRead,
+        )
+}

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -481,10 +481,13 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
   (xt/submit-tx tu/*node* [[:put-docs :people {:xt/id 1 :name "Dave" :age 30}]
                            [:put-docs :people {:xt/id 2 :name "John" :age 40}]])
 
-  (letfn [(elide-durations [row]
+  (letfn [(elide [row]
             (-> row
                 (update :total-time class)
-                (update :time-to-first-page class)))]
+                (update :time-to-first-page class)
+                ;; the scan's runtime metrics vary with storage layout — asserted separately below
+                (cond-> (contains? row :attributes)
+                  (update :attributes select-keys [:scan-db :scan-source]))))]
 
     (t/is (= [{:depth "->", :op :project,
                :page-count 1, :row-count 1
@@ -497,7 +500,7 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
                         [(format "EXPLAIN ANALYZE XTQL ($$ %s $$, ?)"
                                  (pr-str '#(from :people [{:xt/id %} name age xt/valid-from xt/valid-to])))
                          1])
-                  (mapv elide-durations))))
+                  (mapv elide))))
 
     (t/is (= [{:depth "->", :op :project,
                :page-count 1, :row-count 1
@@ -511,7 +514,20 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
                :total-time Duration, :time-to-first-page Duration}]
              (->> (xt/q tu/*node*
                         ["EXPLAIN ANALYZE SELECT name, age, _valid_from, _valid_to FROM people WHERE _id = ?" 1])
-                  (mapv elide-durations))))))
+                  (mapv elide))))
+
+    (t/testing "scan attributes carry pruned/used/read metrics"
+      (let [scan-row (->> (xt/q tu/*node* ["EXPLAIN ANALYZE SELECT name FROM people WHERE _id = ?" 1])
+                          (filter #(= :scan (:op %)))
+                          first)
+            {:keys [scan-files-pruned scan-files-used scan-pages-pruned scan-pages-used scan-rows-read]
+             :as attrs} (:attributes scan-row)
+            metrics [scan-files-pruned scan-files-used scan-pages-pruned scan-pages-used scan-rows-read]]
+        (t/is (every? some? metrics) (str "all five metrics present: " attrs))
+        (t/is (every? #(and (int? %) (<= 0 %)) metrics) "metrics are non-negative integers")
+        ;; rows read off the pages is the throughput denominator — never fewer than the rows emitted
+        (t/is (>= scan-rows-read (:row-count scan-row)))
+        (t/is (pos? scan-rows-read) "read at least the row we emitted")))))
 
 (t/deftest test-explain-analyze-pushdowns
   (let [id1 #uuid "00000000-0000-0000-0000-000000000001"

--- a/src/test/clojure/xtdb/tracer_test.clj
+++ b/src/test/clojure/xtdb/tracer_test.clj
@@ -142,6 +142,16 @@
           (t/is (= "public.foo" (get-in scan-span [:attributes "scan_source"])))
           (t/is (= "xtdb" (get-in scan-span [:attributes "scan_db"]))))))))
 
+(defn- without-scan-metrics
+  "The scan's runtime metrics ride on its span as tags but vary with storage layout,
+   so strip them before asserting on an exact span tree."
+  [span]
+  (cond-> span
+    (:attributes span) (update :attributes #(apply dissoc % ["scan_files_pruned" "scan_files_used"
+                                                             "scan_pages_pruned" "scan_pages_used"
+                                                             "scan_rows_read"]))
+    (seq (:children span)) (update :children #(mapv without-scan-metrics %))))
+
 (t/deftest test-transaction-tracing
   (t/testing "multiple SQL operations in one transaction create separate spans"
     (let [!spans (atom [])
@@ -204,7 +214,7 @@
                              "scan_db" "xtdb",
                              "scan_source" "public.users"},
                             :children []}]}]}]}
-                     update-tx))))))))
+                     (without-scan-metrics update-tx)))))))))
 
 (t/deftest test-transaction-multiple-ops-tracing
   (t/testing "multiple SQL operations in one transaction create separate spans"


### PR DESCRIPTION
Resolves #5191.

EXPLAIN ANALYZE reported only the rows a scan *emitted*, never how many it read and discarded. A query yielding 8.3M rows from ~120k pages looks like 8.3M rows of work, but if those pages were full it chewed through ~123M — so a near-empty scan and a heavily-filtered one were indistinguishable, and there was no way to see whether page pruning was earning its keep. That's what made "is there more we can do here?" unanswerable for a slow customer query.

The scan's `attributes` now carry five counters: `scan_files_pruned` / `scan_files_used`, `scan_pages_pruned` / `scan_pages_used`, and `scan_rows_read`. `scan_rows_read` is the throughput denominator — rows physically read off the loaded pages, before iid-selection and bitemporal resolution whittle them down to the emitted `row_count`. Reading those two against each other tells you how selective the scan really was; pages used vs pruned tells you whether metadata pruning is doing any work.

The pruned/used split is deliberate, and free. A page is "pruned" precisely because we tested its metadata and rejected it — work the planner already does — so `pruned + used` only ever covers metadata we'd have consulted anyway, and we never open files we skipped. A "% of table" framing would have meant reading metadata for pruned files purely to count them, defeating the point. File counts come from `filter-tries`, page counts from the `filter-pages` planning closure, rows from the cursor's load loop; a typed `ScanMetrics` carries them rather than a loose map.

This PR is just the metrics — three tidy-first commits landed on `main` separately and set them up:

- `cursorAttributes` moved onto the cursor, evaluated at read-time and widened to `Map<String, Any>`, so it can carry runtime counters, not just construction-time strings;
- the scan's table/schema/db attributes consolidated into `scan_db` + `scan_source`;
- the `attributes` column re-rendered as a struct rather than transit, so over a json-fallback connection it reaches a plain Postgres client (Metabase) as a queryable object rather than an opaque blob.

## Usage

EXPLAIN ANALYZE over pgwire returns the scan row's `attributes` as nested JSON, e.g. `{"scan_db": "xtdb", "scan_source": "public.orders", "scan_pages_used": 118000, "scan_pages_pruned": 4200, "scan_rows_read": 121000000, ...}`. The metrics also ride on the scan's tracing span, so they surface in Tempo. No config or migration.

## Test plan

- `api_test/test-explain-analyze` — metric invariants (all five present, non-negative, `rows_read` positive and ≥ emitted `row_count`).
- `pgwire_test/test-explain-analyze-attributes-nested-5191` — attributes round-trip as nested data over pgwire.
- `tracer_test` — updated to tolerate the metrics now tagged on the scan span.
- Full `./gradlew test` green (1523 tests), no reflection / boxed-math warnings.