### PR TITLE
refactor: job-owned lifecycle for Database services

### DIFF
--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -26,7 +26,6 @@ import xtdb.trie.*
 import xtdb.util.*
 import java.nio.channels.ClosedByInterruptException
 import java.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import kotlin.use
 
 typealias JobKey = Pair<TableRef, TrieKey>
@@ -51,7 +50,7 @@ interface Compactor : AutoCloseable {
         fun create(meterRegistry: MeterRegistry?, threads: Int): Compactor
     }
 
-    interface ForDatabase : AutoCloseable {
+    interface ForDatabase {
         fun signalBlock()
         suspend fun compactAll()
 
@@ -63,7 +62,7 @@ interface Compactor : AutoCloseable {
         }
     }
 
-    fun openForDatabase(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers): ForDatabase
+    fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers): ForDatabase
 
     interface Driver : AutoCloseable {
         suspend fun executeJob(job: Job): TriesAdded
@@ -165,10 +164,14 @@ interface Compactor : AutoCloseable {
         private val jobsDispatcher = dispatcher.limitedParallelism(threadCount, "compactor")
         private val jobsSemaphore = Semaphore(threadCount)
 
-        override fun openForDatabase(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
+        override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
 
-            private val dbJob = Job()
-            private val scope = CoroutineScope(dbJob + dispatcher)
+            // Child of the owner scope: cancelling that scope stops the loop and its per-job
+            // coroutines, and the driver's resources (child allocator + SegmentMerge temp dir) are
+            // freed when this job completes — leaf-first, after every in-flight compaction buffer's
+            // `.use` has released, so no buffer ever outlives its allocator.
+            private val dbJob = Job(scope.coroutineContext.job)
+            private val loopScope = CoroutineScope(dbJob + dispatcher)
 
             private val trieCatalog = dbState.trieCatalog
             private val liveIndex = dbState.liveIndexOrNull
@@ -198,9 +201,16 @@ interface Compactor : AutoCloseable {
             }
 
             init {
+                // Free the driver's resources when the compactor job completes — fires even if the
+                // job is cancelled before the loop is ever scheduled, so the driver never leaks.
+                dbJob.invokeOnCompletion {
+                    driver.close()
+                    LOGGER.debug("compactor closed")
+                }
+
                 val jobsScope = CoroutineScope(SupervisorJob(dbJob) + jobsDispatcher)
 
-                scope.launch(CoroutineName("outer loop")) {
+                loopScope.launch(CoroutineName("outer loop")) {
                     while (true) {
                         availableJobs =
                             jobCalculator.availableJobs(trieCatalog)
@@ -272,18 +282,6 @@ interface Compactor : AutoCloseable {
                 // catalog, so refresh the snap here rather than at every test/dev call-site.
                 liveIndex?.refreshSnap()
             }
-
-            override fun close() {
-
-                runBlocking {
-                    withTimeoutOrNull(10.seconds) { dbJob.cancelAndJoin() }
-                        ?: LOGGER.warn("failed to close compactor cleanly in 10s")
-                }
-
-                driver.close()
-
-                LOGGER.debug("compactor closed")
-            }
         }
     }
 
@@ -292,10 +290,9 @@ interface Compactor : AutoCloseable {
     companion object {
         @JvmField
         val NOOP = object : Compactor {
-            override fun openForDatabase(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
+            override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
                 override fun signalBlock() = Unit
                 override suspend fun compactAll() = Unit
-                override fun close() = Unit
             }
 
             override fun close() = Unit

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -133,11 +133,11 @@ class Database(
     override fun close() {
         meterRegistry?.let { reg -> registeredGauges.forEach { reg.remove(it) } }
         runBlocking {
-            // One cancel for the whole job tree. The compactor runs under `job`, so this also stops
-            // its loop and frees the driver's child allocator (via the compactor job's
-            // invokeOnCompletion) before `closeAll` frees the database allocator below.
+            // One cancel for the whole job tree: the compactor, the source-log subscription and the
+            // live leader/follower term all run under `job`, so cancelling and joining it stops them
+            // and runs their `invokeOnCompletion` frees (driver, allocator, replica producer, ext
+            // source) before `closeAll` frees the database allocator below.
             job?.cancelAndJoin()
-            processor?.cancelAndJoin()
         }
         (partitions.values + listOf(storage, allocator)).closeAll()
     }

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -293,38 +293,34 @@ class Database(
 
                 val procFactory = object : LogProcessor.ProcessorFactory {
                     override fun openFollower(
+                        termScope: CoroutineScope,
                         pendingBlock: PendingBlock?,
                         afterReplicaMsgId: MessageId,
                     ) = FollowerLogProcessor(
-                        allocator, storage.bufferPool, state, compactorForDb,
+                        termScope, allocator, storage.replicaLog, storage.bufferPool, state, compactorForDb,
                         watchers, dbCatalog, pendingBlock, afterReplicaMsgId,
                         hasExternalSource = hasExternalSource,
                         meterRegistry = base.meterRegistry,
                     )
 
-                    override fun openLeaderSystem(
+                    // The leader term owns its replica producer and ext source; both are freed by
+                    // LeaderLogProcessor's `invokeOnCompletion` when `termScope` is cancelled.
+                    override fun openLeader(
+                        termScope: CoroutineScope,
                         replicaProducer: Log.AtomicProducer<ReplicaMessage>,
                         afterReplicaMsgId: MessageId,
-                    ): LogProcessor.LeaderSystem {
-                        val extSource = dbConfig.externalSource?.open(dbName, base.remotes, base.meterRegistry)
-
-                        val leaderProc = LeaderLogProcessor(
-                            allocator, base, storage, crashLogger,
-                            state, blockUploader, watchers,
-                            extSource = extSource,
-                            replicaProducer = replicaProducer,
-                            skipTxs = indexerConfig.skipTxs.toSet(),
-                            dbCatalog = dbCatalog,
-                            partition = 0,
-                            afterReplicaMsgId = afterReplicaMsgId,
-                            flushTimeout = indexerConfig.flushDuration,
-                        )
-
-                        return object : LogProcessor.LeaderSystem {
-                            override val proc get() = leaderProc
-                            override suspend fun cancelAndJoin() { leaderProc.cancelAndJoin(); replicaProducer.close() }
-                        }
-                    }
+                    ) = LeaderLogProcessor(
+                        allocator, base, storage, crashLogger,
+                        state, blockUploader, watchers,
+                        extSource = dbConfig.externalSource?.open(dbName, base.remotes, base.meterRegistry),
+                        replicaProducer = replicaProducer,
+                        skipTxs = indexerConfig.skipTxs.toSet(),
+                        dbCatalog = dbCatalog,
+                        partition = 0,
+                        afterReplicaMsgId = afterReplicaMsgId,
+                        flushTimeout = indexerConfig.flushDuration,
+                        scope = termScope,
+                    )
 
                     override fun openTransition(
                         replicaProducer: Log.AtomicProducer<ReplicaMessage>,

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -133,6 +133,9 @@ class Database(
     override fun close() {
         meterRegistry?.let { reg -> registeredGauges.forEach { reg.remove(it) } }
         runBlocking {
+            // One cancel for the whole job tree. The compactor runs under `job`, so this also stops
+            // its loop and frees the driver's child allocator (via the compactor job's
+            // invokeOnCompletion) before `closeAll` frees the database allocator below.
             job?.cancelAndJoin()
             processor?.cancelAndJoin()
         }
@@ -262,13 +265,24 @@ class Database(
 
             val crashLogger = CrashLogger(allocator, storage.bufferPool, base.config.nodeId)
 
-            val compactorForDb = open {
-                if (readOnly) Compactor.NOOP.openForDatabase(allocator, storage, state, watchers)
-                else compactor.openForDatabase(allocator, storage, state, watchers)
+            val job = Job()
+
+            // A child of the database `job`, so `close()`'s single `job.cancelAndJoin()` stops the
+            // compactor and frees its driver (via the compactor job's invokeOnCompletion) before the
+            // database allocator closes. Also registered with safelyOpening so a failure later in
+            // `open` cancels the loop — it runs against the driver, which safelyOpening would
+            // otherwise free out from under it.
+            val compactorScope = CoroutineScope(Job(job))
+            open {
+                AutoCloseable {
+                    runBlocking { compactorScope.coroutineContext.job.cancelAndJoin() }
+                }
             }
+            val compactorForDb =
+                if (readOnly) Compactor.NOOP.openForDatabase(compactorScope, allocator, storage, state, watchers)
+                else compactor.openForDatabase(compactorScope, allocator, storage, state, watchers)
 
             var processor: LogProcessor? = null
-            val job = Job()
             val scope = CoroutineScope(job + CoroutineExceptionHandler { _, e ->
                 watchers.notifyError(e)
             })

--- a/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
@@ -7,7 +7,6 @@ import xtdb.compactor.Compactor
 import xtdb.indexer.LiveIndex
 import xtdb.indexer.Snapshot
 import xtdb.trie.TrieCatalog
-import xtdb.util.closeAll
 
 class DatabasePartition(
     val partition: Int,
@@ -26,7 +25,9 @@ class DatabasePartition(
 
     fun openSnapshot(): Snapshot = state.liveIndex.openSnapshot()
 
+    // The compactor is no longer closed here — its driver is freed when the compactor job
+    // completes (cancelled via the Database's compactorScope), not by an AutoCloseable call.
     override fun close() {
-        listOf(compactorOrNull, state).closeAll()
+        state.close()
     }
 }

--- a/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
@@ -17,7 +17,6 @@ import xtdb.util.debug
 import xtdb.util.logger
 import xtdb.util.warn
 import java.nio.file.Path
-import kotlin.time.Duration.Companion.seconds
 
 private val LOGGER = BlockGarbageCollector::class.logger
 
@@ -37,6 +36,8 @@ private const val DEFAULT_DELETE_PARALLELISM = 64
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class BlockGarbageCollector(
+    /** The owner's scope: supplies this collector's lifetime and the thread its loop runs on. Cancelling it stops the loop. */
+    scope: CoroutineScope,
     private val bufferPool: BufferPool,
     private val blockCatalog: BlockCatalog,
     private val blocksToKeep: Int,
@@ -45,12 +46,10 @@ class BlockGarbageCollector(
     private val meterRegistry: MeterRegistry? = null,
     tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
     deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
+    /** Base for the parallel delete fan-out pools; the loop itself runs on [scope]. Sims inject the seeded dispatcher so deletes stay on the simulation's thread. */
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     dbName: DatabaseName,
-) : AutoCloseable {
-
-    private val dbJob = Job()
-    private val scope = CoroutineScope(dispatcher + dbJob)
+) {
 
     // [signal] is fire-and-forget; bursts coalesce into one upcoming cycle.
     private val signalCh = Channel<Unit>(CONFLATED)
@@ -191,11 +190,4 @@ class BlockGarbageCollector(
     }
 
     fun awaitNoGarbageBlocking() = runBlocking { awaitNoGarbage() }
-
-    override fun close() {
-        runBlocking {
-            withTimeoutOrNull(5.seconds) { dbJob.cancelAndJoin() }
-                ?: LOGGER.warn("Block GC coroutine did not stop within 5s")
-        }
-    }
 }

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -21,7 +21,6 @@ import xtdb.util.logger
 import xtdb.util.warn
 import java.time.Duration
 import java.time.Instant
-import kotlin.time.Duration.Companion.seconds
 
 private val LOGGER = TrieGarbageCollector::class.logger
 
@@ -51,6 +50,8 @@ private const val TRIES_DELETED_CHUNK_SIZE = 1024
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class TrieGarbageCollector(
+    /** The owner's scope: supplies this collector's lifetime and the thread its loop runs on. Cancelling it stops the loop. */
+    scope: CoroutineScope,
     private val bufferPool: BufferPool,
     dbState: DatabaseState,
     /**
@@ -65,14 +66,12 @@ class TrieGarbageCollector(
     private val meterRegistry: MeterRegistry? = null,
     tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
     deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
+    /** Base for the parallel delete fan-out pools; the loop itself runs on [scope]. Sims inject the seeded dispatcher so deletes stay on the simulation's thread. */
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : AutoCloseable {
+) {
 
     private val blockCatalog = dbState.blockCatalog
     private val trieCatalog = dbState.trieCatalog
-
-    private val dbJob = Job()
-    private val scope = CoroutineScope(dispatcher + dbJob)
 
     // [signal] is fire-and-forget; bursts coalesce into one upcoming cycle.
     private val signalCh = Channel<Unit>(CONFLATED)
@@ -215,11 +214,4 @@ class TrieGarbageCollector(
     }
 
     fun awaitNoGarbageBlocking() = runBlocking { awaitNoGarbage() }
-
-    override fun close() {
-        runBlocking {
-            withTimeoutOrNull(5.seconds) { dbJob.cancelAndJoin() }
-                ?: LOGGER.warn("Trie GC coroutine did not stop within 5s")
-        }
-    }
 }

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -3,6 +3,9 @@ package xtdb.indexer
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import org.apache.arrow.memory.BufferAllocator
@@ -29,7 +32,9 @@ import xtdb.util.trace
 private val LOG = FollowerLogProcessor::class.logger
 
 class FollowerLogProcessor @JvmOverloads constructor(
+    scope: CoroutineScope,
     allocator: BufferAllocator,
+    replicaLog: Log<ReplicaMessage>,
     private val bufferPool: BufferPool,
     private val dbState: DatabaseState,
     private val compactor: Compactor.ForDatabase,
@@ -241,6 +246,10 @@ class FollowerLogProcessor @JvmOverloads constructor(
             try {
                 handleRecord(record)
                 replicaState.value = ReplicaState.Active(record.msgId)
+            } catch (e: CancellationException) {
+                // The owner cancelled the term — not a processing failure, so don't poison the
+                // shared watchers via notifyError.
+                throw e
             } catch (e: InterruptedException) {
                 throw e
             } catch (e: Interrupted) {
@@ -267,7 +276,20 @@ class FollowerLogProcessor @JvmOverloads constructor(
         replicaState.value = ReplicaState.Failed(latestReplicaMsgId, e)
     }
 
-    override suspend fun cancelAndJoin() {
-        allocator.close()
+    // Launched last, so every field the tail touches is initialised before the loop's first record;
+    // `tailAll` suspends immediately on subscribe. A cancel (role transition / shutdown) stops the
+    // tail and, once it has joined, the completion handler frees this processor's child allocator.
+    // `allocator` is `this@…`-qualified: bare `allocator` in an init lambda binds the ctor param.
+    init {
+        val tailJob = scope.launch {
+            try {
+                replicaLog.tailAll(afterReplicaMsgId, this@FollowerLogProcessor)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                notifyError(e); throw e
+            }
+        }
+        tailJob.invokeOnCompletion { this@FollowerLogProcessor.allocator.close() }
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -60,6 +60,8 @@ class LeaderLogProcessor(
     private val instantSource: InstantSource = InstantSource.system(),
     flushTimeout: Duration = Duration.ofMinutes(5),
     ctx: CoroutineContext = Dispatchers.Default,
+    // Base for the GCs' delete fan-out; defaults to IO in prod, sims inject the seeded dispatcher.
+    gcDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : LogProcessor.LeaderProcessor, TxIndexer {
 
     init {
@@ -82,12 +84,21 @@ class LeaderLogProcessor(
 
     private val sourceLogTxIndexer = SourceLogTxIndexer(this.allocator, nodeBase, dbState, crashLogger)
 
+    private val scope = CoroutineScope(ctx)
+
+    // The GCs run under a SupervisorJob child of the leader scope, so one GC's failure doesn't
+    // cancel its sibling or the persister. The owner ([close]) cancels it; once the leader process
+    // tree is itself scope-managed this nests and the explicit cancel goes away.
+    private val gcScope = CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext.job))
+
     internal val blockGc = nodeBase.config.garbageCollector.let { cfg ->
         BlockGarbageCollector(
+            gcScope,
             bufferPool, blockCatalog,
             blocksToKeep = cfg.blocksToKeep,
             enabled = cfg.enabled,
             meterRegistry = nodeBase.meterRegistry,
+            dispatcher = gcDispatcher,
             dbName = dbName
         )
     }
@@ -135,8 +146,6 @@ class LeaderLogProcessor(
         Channel<ExtSourceTask>(RENDEZVOUS, onUndeliveredElement = { it.onComplete.cancel() })
     private val gcCh =
         Channel<GcTask>(RENDEZVOUS, onUndeliveredElement = { it.onComplete.cancel() })
-
-    private val scope = CoroutineScope(ctx)
 
     private suspend fun handleSourceLogRecord(task: SourceLogTask.Record) {
         val record = task.record
@@ -317,10 +326,12 @@ class LeaderLogProcessor(
         }
 
         TrieGarbageCollector(
+            gcScope,
             bufferPool, dbState,
             commitTriesDeleted, cfg.blocksToKeep, cfg.garbageLifetime,
             cfg.enabled,
-            nodeBase.meterRegistry
+            nodeBase.meterRegistry,
+            dispatcher = gcDispatcher,
         )
     }
 
@@ -578,8 +589,10 @@ class LeaderLogProcessor(
     override suspend fun cancelAndJoin() {
         extJob?.cancelAndJoin()
         extSource?.close()
-        blockGc.close()
-        trieGc.close()
+        // The GCs' lifecycle moved up here from their own `close()`: they're pure scope-launched
+        // processes now, so stopping them is just cancelling the scope they run under. Folds into
+        // the leader scope's cancel once the leader process tree is itself scope-managed.
+        gcScope.coroutineContext.job.cancelAndJoin()
         sourceLogCh.close()
         extSourceCh.close()
         gcCh.close()

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -37,7 +37,6 @@ import xtdb.util.StringUtil.asLexDec
 import xtdb.util.StringUtil.asLexHex
 import java.nio.ByteBuffer
 import java.time.*
-import kotlin.coroutines.CoroutineContext
 
 private val SKIPPED_EXN: Throwable = Fault("Transaction was skipped", "xtdb/skipped-tx")
 
@@ -59,7 +58,8 @@ class LeaderLogProcessor(
     afterReplicaMsgId: MessageId,
     private val instantSource: InstantSource = InstantSource.system(),
     flushTimeout: Duration = Duration.ofMinutes(5),
-    ctx: CoroutineContext = Dispatchers.Default,
+    // The leader term's scope, owned by the LogProcessor wrapper; cancelling it tears the leader down.
+    scope: CoroutineScope,
     // Base for the GCs' delete fan-out; defaults to IO in prod, sims inject the seeded dispatcher.
     gcDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : LogProcessor.LeaderProcessor, TxIndexer {
@@ -84,11 +84,8 @@ class LeaderLogProcessor(
 
     private val sourceLogTxIndexer = SourceLogTxIndexer(this.allocator, nodeBase, dbState, crashLogger)
 
-    private val scope = CoroutineScope(ctx)
-
-    // The GCs run under a SupervisorJob child of the leader scope, so one GC's failure doesn't
-    // cancel its sibling or the persister. The owner ([close]) cancels it; once the leader process
-    // tree is itself scope-managed this nests and the explicit cancel goes away.
+    // The GCs run under a SupervisorJob child of the leader scope, so one GC's failure cancels
+    // neither its sibling nor the persister; cancelling the leader scope reaps them all.
     private val gcScope = CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext.job))
 
     internal val blockGc = nodeBase.config.garbageCollector.let { cfg ->
@@ -349,6 +346,18 @@ class LeaderLogProcessor(
         }
     }
 
+    init {
+        // Cleanup rides the job tree, not an explicit teardown call: once the leader term's scope is
+        // cancelled and its coroutines (persister, ext source, GCs) have joined, free what this term
+        // opened — leaf-first. `allocator` must be `this@…`-qualified: bare `allocator` in an init
+        // lambda binds the ctor param (the parent), not this child field.
+        scope.coroutineContext.job.invokeOnCompletion {
+            extSource?.close()
+            replicaProducer.close()
+            this@LeaderLogProcessor.allocator.close()
+        }
+    }
+
     private fun smoothSystemTime(systemTime: Instant): Instant {
         val lct = liveIndex.latestCompletedTx?.systemTime ?: return systemTime
         val floor = fromMicros(lct.asMicros + 1)
@@ -586,17 +595,4 @@ class LeaderLogProcessor(
         }
     }
 
-    override suspend fun cancelAndJoin() {
-        extJob?.cancelAndJoin()
-        extSource?.close()
-        // The GCs' lifecycle moved up here from their own `close()`: they're pure scope-launched
-        // processes now, so stopping them is just cancelling the scope they run under. Folds into
-        // the leader scope's cancel once the leader process tree is itself scope-managed.
-        gcScope.coroutineContext.job.cancelAndJoin()
-        sourceLogCh.close()
-        extSourceCh.close()
-        gcCh.close()
-        persisterJob.join()
-        allocator.close()
-    }
 }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -206,10 +206,6 @@ class LogProcessor(
         }
     }
 
-    suspend fun cancelAndJoin() {
-        sys.cancelAndJoin()
-    }
-
     /**
      * Run one cycle of every garbage collector owned by the leader (block + trie) and wait for
      * both. No-op on follower systems — GC only runs on the leader. Bypasses the collectors'

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -4,9 +4,9 @@ import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.job
 import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.database.DatabaseState
@@ -32,14 +32,15 @@ class LogProcessor(
 
     interface Processor<M> : Log.RecordProcessor<M> {
         val latestReplicaMsgId: MessageId
-        suspend fun cancelAndJoin()
     }
 
     interface LeaderProcessor : Processor<SourceMessage> {
         val pendingBlock: PendingBlock?
     }
 
-    interface TransitionProcessor : Processor<ReplicaMessage>
+    // State, not a Service: driven synchronously through the transition, no loop of its own — so
+    // it's a plain AutoCloseable, torn down via `use` rather than a scope cancel.
+    interface TransitionProcessor : Processor<ReplicaMessage>, AutoCloseable
 
     interface FollowerProcessor : Processor<ReplicaMessage> {
         val pendingBlock: PendingBlock?
@@ -51,10 +52,11 @@ class LogProcessor(
     private val replicaLog = dbStorage.replicaLog
 
     interface ProcessorFactory {
-        fun openLeaderSystem(
+        fun openLeader(
+            termScope: CoroutineScope,
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
             afterReplicaMsgId: MessageId,
-        ): LeaderSystem
+        ): LeaderProcessor
 
         fun openTransition(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
@@ -62,23 +64,33 @@ class LogProcessor(
         ): TransitionProcessor
 
         fun openFollower(
+            termScope: CoroutineScope,
             pendingBlock: PendingBlock?,
             afterReplicaMsgId: MessageId,
         ): FollowerProcessor
     }
 
-    sealed interface SubSystem {
-        suspend fun cancelAndJoin()
+    // The running term: the role-specific subsystem and the SupervisorJob its processor runs under (a
+    // child of the database scope). `sys` holds it as one atomically-swapped value — a job-less term
+    // is unrepresentable. Cancelling the job tears the term down; structured concurrency joins the
+    // term's coroutines and each processor frees what it opened via its own `invokeOnCompletion`.
+    private sealed class SubSystem(private val job: Job) {
+        suspend fun cancelAndJoin() = job.cancelAndJoin()
     }
 
-    interface LeaderSystem : SubSystem {
-        val proc: LeaderProcessor
-    }
+    private class LeaderSystem(val proc: LeaderProcessor, job: Job) : SubSystem(job)
+    private class FollowerSystem(val proc: FollowerProcessor, job: Job) : SubSystem(job)
 
-    private class FollowerSystem(val proc: FollowerProcessor, private val job: Job) : SubSystem {
-        override suspend fun cancelAndJoin() {
-            job.cancelAndJoin()
-            proc.cancelAndJoin()
+    // Open a fresh term: a SupervisorJob child of the database scope — so one role's failure surfaces
+    // via `notifyError` rather than cancelling the source-log subscription (its sibling) — and the
+    // subsystem built (by `build`) on a scope over that job.
+    private fun <S : SubSystem> openTerm(build: (CoroutineScope, Job) -> S): S {
+        val job = SupervisorJob(scope.coroutineContext.job)
+        return try {
+            build(CoroutineScope(scope.coroutineContext + job), job)
+        } catch (t: Throwable) {
+            job.cancel()
+            throw t
         }
     }
 
@@ -86,27 +98,17 @@ class LogProcessor(
         latestReplicaMsgId: MessageId,
         pendingBlock: PendingBlock? = null,
     ): FollowerSystem {
-        val proc = procFactory.openFollower(pendingBlock, latestReplicaMsgId)
-        return try {
-            LOG.info {
-                buildString {
-                    append("[$dbName] starting follower: ")
-                    append("pending block: ${pendingBlock != null}, ")
-                    append("src: ${watchers.latestSourceMsgId}, ")
-                    append("replica: $latestReplicaMsgId")
-                }
+        LOG.info {
+            buildString {
+                append("[$dbName] starting follower: ")
+                append("pending block: ${pendingBlock != null}, ")
+                append("src: ${watchers.latestSourceMsgId}, ")
+                append("replica: $latestReplicaMsgId")
             }
+        }
 
-            FollowerSystem(proc, scope.launch {
-                try {
-                    replicaLog.tailAll(latestReplicaMsgId, proc)
-                } catch (e: Throwable) {
-                    proc.notifyError(e); throw e
-                }
-            })
-        } catch (t: Throwable) {
-            runBlocking { proc.cancelAndJoin() }
-            throw t
+        return openTerm { termScope, job ->
+            FollowerSystem(procFactory.openFollower(termScope, pendingBlock, latestReplicaMsgId), job)
         }
     }
 
@@ -150,8 +152,7 @@ class LogProcessor(
 
                         val pendingBlock = followerProc.pendingBlock
 
-                        val transition = procFactory.openTransition(replicaProducer, followerProc.latestReplicaMsgId)
-                        try {
+                        procFactory.openTransition(replicaProducer, followerProc.latestReplicaMsgId).use { transition ->
                             if (pendingBlock != null) {
                                 LOG.debug("[$dbName] transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
                                 blockUploader.uploadBlock(
@@ -163,14 +164,14 @@ class LogProcessor(
 
                             LOG.debug("[$dbName] transition: opening leader processor")
 
-                            val sys = procFactory.openLeaderSystem(replicaProducer, replayTarget)
-                            this.sys = sys
+                            val leaderSys = openTerm { termScope, job ->
+                                LeaderSystem(procFactory.openLeader(termScope, replicaProducer, replayTarget), job)
+                            }
+                            this.sys = leaderSys
 
                             val resumeMsgId = watchers.latestSourceMsgId
                             LOG.info("[$dbName] leader startup complete, resuming after $resumeMsgId")
-                            Log.TailSpec(resumeMsgId, sys.proc)
-                        } finally {
-                            transition.cancelAndJoin()
+                            Log.TailSpec(resumeMsgId, leaderSys.proc)
                         }
                     }
                 } catch (e: InterruptedException) {
@@ -192,8 +193,8 @@ class LogProcessor(
         when (val oldSys = sys) {
             is LeaderSystem -> {
                 LOG.info("[$dbName] partitions revoked: $partitions — was leader, transitioning to follower")
-                // Close first: Kafka guarantees no concurrent processing during rebalance,
-                // and close() only releases the allocator — watermark fields remain readable.
+                // Cancel first: Kafka guarantees no concurrent processing during rebalance, and the
+                // leader's watermark fields stay readable after the cancel — they're not allocator-backed.
                 oldSys.cancelAndJoin()
                 val proc = oldSys.proc
                 this.sys = openFollowerSystem(proc.latestReplicaMsgId, proc.pendingBlock)

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -147,7 +147,7 @@ class TransitionLogProcessor(
         }
     }
 
-    override suspend fun cancelAndJoin() {
+    override fun close() {
         allocator.close()
     }
 }

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -57,12 +57,17 @@ data class MockDatabase(
     val compactorForDb: Compactor.ForDatabase,
     val garbageCollector: TrieGarbageCollector,
     val gcScope: CoroutineScope,
+    val compactorScope: CoroutineScope,
 ) {
     fun close() {
-        // The owner stops the GC process (the leaf is purely a process now); cancelling the scope
-        // it runs under is the whole teardown. runBlocking only because this teardown is non-suspend.
-        runBlocking { gcScope.coroutineContext.job.cancelAndJoin() }
-        compactorForDb.close()
+        // The owner stops the GC and compaction processes (the leaves are pure scope-launched
+        // processes now); cancelling the scopes they run under is the whole teardown. The compactor
+        // frees its driver's resources via invokeOnCompletion as its job completes. runBlocking only
+        // because this teardown is non-suspend.
+        runBlocking {
+            gcScope.coroutineContext.job.cancelAndJoin()
+            compactorScope.coroutineContext.job.cancelAndJoin()
+        }
         compactor.close()
     }
 }
@@ -118,7 +123,8 @@ class NodeSimulationTest : SimulationTestBase() {
             val compactor = Compactor.Impl(compactorDriver, null, jobCalculator, false, 2, dispatcher)
             val dbStorage = DatabaseStorage(null, null, sharedBufferPool, null)
             val dbState = DatabaseState("xtdb", blockCatalog, null, trieCatalog, null)
-            val compactorForDb = compactor.openForDatabase(allocator, dbStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+            val compactorScope = CoroutineScope(dispatcher)
+            val compactorForDb = compactor.openForDatabase(compactorScope, allocator, dbStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
             val gcScope = CoroutineScope(dispatcher)
             val garbageCollector = TrieGarbageCollector(
                 gcScope,
@@ -133,7 +139,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 enabled = false,
                 dispatcher = dispatcher,
             )
-            MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, garbageCollector, gcScope)
+            MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, garbageCollector, gcScope, compactorScope)
         }
     }
 

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -56,9 +56,12 @@ data class MockDatabase(
     val compactor: Compactor,
     val compactorForDb: Compactor.ForDatabase,
     val garbageCollector: TrieGarbageCollector,
+    val gcScope: CoroutineScope,
 ) {
     fun close() {
-        garbageCollector.close()
+        // The owner stops the GC process (the leaf is purely a process now); cancelling the scope
+        // it runs under is the whole teardown. runBlocking only because this teardown is non-suspend.
+        runBlocking { gcScope.coroutineContext.job.cancelAndJoin() }
         compactorForDb.close()
         compactor.close()
     }
@@ -116,7 +119,9 @@ class NodeSimulationTest : SimulationTestBase() {
             val dbStorage = DatabaseStorage(null, null, sharedBufferPool, null)
             val dbState = DatabaseState("xtdb", blockCatalog, null, trieCatalog, null)
             val compactorForDb = compactor.openForDatabase(allocator, dbStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+            val gcScope = CoroutineScope(dispatcher)
             val garbageCollector = TrieGarbageCollector(
+                gcScope,
                 sharedBufferPool, dbState,
                 commitTriesDeleted = { tableName, trieKeys ->
                     // No replica log in the mock — apply the catalog mutation directly so the
@@ -128,7 +133,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 enabled = false,
                 dispatcher = dispatcher,
             )
-            MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, garbageCollector)
+            MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, garbageCollector, gcScope)
         }
     }
 

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -41,8 +41,6 @@ import xtdb.trie.Trie
 import xtdb.trie.TrieCatalog
 import xtdb.util.debug
 import xtdb.util.logger
-import xtdb.util.safeMap
-import xtdb.util.useAll
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
@@ -320,6 +318,28 @@ class CompactorSimulationTest : SimulationTestBase() {
     }
 
 
+    // Open the compactor on a scope and tear it down by cancelling that scope — the driver's
+    // resources are freed when the compactor job completes (the job tree), not via a close() call.
+    private fun MockDb.withCompactor(block: (Compactor.ForDatabase) -> Unit) {
+        val scope = CoroutineScope(dispatcher)
+        try {
+            block(compactor.openForDatabase(scope, allocator, dbStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)))
+        } finally {
+            runBlocking { scope.coroutineContext.job.cancelAndJoin() }
+        }
+    }
+
+    private fun withCompactors(dbs: List<MockDb>, block: (List<Compactor.ForDatabase>) -> Unit) {
+        val scopes = dbs.map { CoroutineScope(dispatcher) }
+        try {
+            block(dbs.zip(scopes).map { (db, scope) ->
+                db.compactor.openForDatabase(scope, allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+            })
+        } finally {
+            runBlocking { scopes.forEach { it.coroutineContext.job.cancelAndJoin() } }
+        }
+    }
+
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     fun singleL0Compaction() {
@@ -327,7 +347,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         val l0Trie = buildTrieDetails(docsTable.tableName, L0TrieKeys.first())
         val db = dbs[0]
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use {
+        db.withCompactor {
             seedTries(docsTable, listOf(l0Trie))
             it.compactAllSync(null)
         }
@@ -355,7 +375,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         val table = TableRef("xtdb", "public", "docs")
         val db = dbs[0]
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use {
+        db.withCompactor {
             // Round 1: Add 3 L0 tries and compact
             seedTries(
                 table,
@@ -418,7 +438,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         val l0tries = L0TrieKeys.take(100).map { buildTrieDetails(docsTable.tableName, it, 10L * 1024L * 1024L) }
         val db = dbs[0]
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use { c ->
+        db.withCompactor { c ->
             seedTries(docsTable, l0tries.toList())
             c.compactAllSync(null)
             val liveTries = db.trieCatalog.listLiveAndNascentTrieKeys(docsTable)
@@ -441,7 +461,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
         val l1Tries = L1TrieKeys.take(4).map { buildTrieDetails(docsTable.tableName, it, defaultFileTarget) }
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use {
+        db.withCompactor {
             seedTries(docsTable, l1Tries.toList())
 
             it.compactAllSync(null)
@@ -479,7 +499,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
         val missingPartitions = (0..3).filterNot { it in existingPartitions }
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use {
+        db.withCompactor {
             seedTries(docsTable, l1Tries.toList() + existingL2Tries)
 
             it.compactAllSync(null)
@@ -526,7 +546,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         l2tries.add(buildTrieDetails(docsTable.tableName, "l02-rc-p3-b03", defaultFileTarget))
         l2tries.add(buildTrieDetails(docsTable.tableName, "l02-rc-p3-b07", defaultFileTarget))
 
-        db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1)).use {
+        db.withCompactor {
             seedTries(docsTable, l1Tries.toList() + l2tries)
 
             it.compactAllSync(null)
@@ -559,9 +579,7 @@ class CompactorSimulationTest : SimulationTestBase() {
         seedTries(usersTable, usersTries.toList())
         seedTries(ordersTable, ordersTries.toList())
 
-        dbs.safeMap { db ->
-            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
-        }.useAll { compactorsForDb ->
+        withCompactors(dbs) { compactorsForDb ->
             runBlocking {
                 compactorsForDb.shuffled(rand).map { c -> async { c.compactAll() } }.awaitAll()
             }
@@ -608,9 +626,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
         seedTries(docsTable, listOf(l0Trie))
 
-        dbs.safeMap { db ->
-            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
-        }.useAll { compactorsForDb ->
+        withCompactors(dbs) { compactorsForDb ->
             runBlocking {
                 compactorsForDb.shuffled(rand).map { c -> async { c.compactAll() } }.awaitAll()
             }
@@ -642,9 +658,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
         seedTries(docsTable, l0tries.toList())
 
-        dbs.safeMap { db ->
-            db.compactor.openForDatabase(allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
-        }.useAll { compactorsForDb ->
+        withCompactors(dbs) { compactorsForDb ->
             runBlocking {
                 compactorsForDb.shuffled(rand).map { c -> async { c.compactAll() } }.awaitAll()
             }

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -2,10 +2,10 @@ package xtdb.database
 
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
@@ -31,7 +31,6 @@ import xtdb.tx.TxOpts
 import java.time.Instant
 import java.time.InstantSource
 import java.time.ZoneId
-import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.milliseconds
 
 class ExternalSourceTest {
@@ -86,14 +85,16 @@ class ExternalSourceTest {
         }
     }
 
-    private fun leaderProc(
+    // The leader is launched into `backgroundScope`, which runTest cancels at the end of the test —
+    // that cancel is the teardown: it stops the persister and ext-source loop and, once they've
+    // joined, the leader's `invokeOnCompletion` frees its allocator and replica producer.
+    private fun TestScope.leaderProc(
         sourceLog: InMemoryLog<SourceMessage> = InMemoryLog(InstantSource.system(), 0),
         replicaLog: InMemoryLog<ReplicaMessage> = InMemoryLog(InstantSource.system(), 0),
-        liveIndex: LiveIndex = this.liveIndex,
+        liveIndex: LiveIndex = this@ExternalSourceTest.liveIndex,
         watchers: Watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
         extSource: ExternalSource = InMemoryExternalSource(),
         afterToken: ExternalSourceToken? = null,
-        ctx: CoroutineContext,
     ): LeaderLogProcessor {
         val blockCatalog = BlockCatalog("test", null)
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
@@ -110,7 +111,7 @@ class ExternalSourceTest {
             allocator, nodeBase, dbStorage, crashLogger,
             dbState, blockUploader, watchers, extSource, replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterReplicaMsgId = -1, ctx = ctx
+            partition = 0, afterReplicaMsgId = -1, scope = backgroundScope
         )
     }
 
@@ -119,33 +120,29 @@ class ExternalSourceTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val extSource = InMemoryExternalSource()
 
-        val lp = leaderProc(replicaLog = replicaLog, extSource = extSource, ctx = coroutineContext)
-        try {
-            extSource.channel.send(null)
-            delay(500.milliseconds)
+        leaderProc(replicaLog = replicaLog, extSource = extSource)
 
-            assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have received a message")
+        extSource.channel.send(null)
+        delay(500.milliseconds)
 
-            val replicaMessages = mutableListOf<ReplicaMessage>()
-            val job = launch {
-                replicaLog.tailAll(-1) { records ->
-                    replicaMessages.addAll(records.map { it.message })
-                }
+        assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have received a message")
+
+        val replicaMessages = mutableListOf<ReplicaMessage>()
+        backgroundScope.launch {
+            replicaLog.tailAll(-1) { records ->
+                replicaMessages.addAll(records.map { it.message })
             }
-            delay(200.milliseconds)
-            job.cancelAndJoin()
-
-            assertEquals(1, replicaMessages.size)
-            val resolved = replicaMessages[0] as ReplicaMessage.ResolvedTx
-            assertEquals(true, resolved.committed)
-            assertEquals(0L, resolved.txId)
-            assertEquals(
-                -1L, resolved.srcMsgId,
-                "ext-source ResolvedTx carries the leader's source-log watermark (-1 — no source-log records yet)"
-            )
-        } finally {
-            lp.cancelAndJoin()
         }
+        delay(200.milliseconds)
+
+        assertEquals(1, replicaMessages.size)
+        val resolved = replicaMessages[0] as ReplicaMessage.ResolvedTx
+        assertEquals(true, resolved.committed)
+        assertEquals(0L, resolved.txId)
+        assertEquals(
+            -1L, resolved.srcMsgId,
+            "ext-source ResolvedTx carries the leader's source-log watermark (-1 — no source-log records yet)"
+        )
     }
 
     @Test
@@ -153,69 +150,56 @@ class ExternalSourceTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val extSource = InMemoryExternalSource()
 
-        val lp = leaderProc(replicaLog = replicaLog, extSource = extSource, ctx = coroutineContext)
+        leaderProc(replicaLog = replicaLog, extSource = extSource)
 
-        try {
-            extSource.channel.send(null)
-            extSource.channel.send(null)
-            delay(500.milliseconds)
+        extSource.channel.send(null)
+        extSource.channel.send(null)
+        delay(500.milliseconds)
 
-            val resolvedTxs = mutableListOf<ReplicaMessage.ResolvedTx>()
-            val job = launch {
-                replicaLog.tailAll(-1) { records ->
-                    records.forEach { (it.message as? ReplicaMessage.ResolvedTx)?.let(resolvedTxs::add) }
-                }
+        val resolvedTxs = mutableListOf<ReplicaMessage.ResolvedTx>()
+        backgroundScope.launch {
+            replicaLog.tailAll(-1) { records ->
+                records.forEach { (it.message as? ReplicaMessage.ResolvedTx)?.let(resolvedTxs::add) }
             }
-            delay(200.milliseconds)
-            job.cancelAndJoin()
-
-            assertEquals(listOf(0L, 1L), resolvedTxs.map { it.txId })
-            assertTrue(resolvedTxs.all { it.committed }, "both txs should be committed")
-        } finally {
-            lp.cancelAndJoin()
         }
+        delay(200.milliseconds)
+
+        assertEquals(listOf(0L, 1L), resolvedTxs.map { it.txId })
+        assertTrue(resolvedTxs.all { it.committed }, "both txs should be committed")
     }
 
     @Test
     fun `processRecords flows source records through the leader processor`() = runTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
-        val lp = leaderProc(replicaLog = replicaLog, ctx = coroutineContext)
+        val lp = leaderProc(replicaLog = replicaLog)
 
-        try {
-            val now = Instant.now()
+        val now = Instant.now()
 
-            lp.processRecords(
-                listOf(
-                    Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
-                )
+        lp.processRecords(
+            listOf(
+                Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
             )
+        )
 
-            delay(500.milliseconds)
+        delay(500.milliseconds)
 
-            assertTrue(replicaLog.latestSubmittedOffset >= 0, "source records should flow through to the leader")
-        } finally {
-            lp.cancelAndJoin()
-        }
+        assertTrue(replicaLog.latestSubmittedOffset >= 0, "source records should flow through to the leader")
     }
 
     @Test
     fun `indexTx threads resumeToken to watchers`() = runTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
         val extSource = InMemoryExternalSource()
-        val lp = leaderProc(watchers = watchers, extSource = extSource, ctx = coroutineContext)
+        leaderProc(watchers = watchers, extSource = extSource)
 
-        try {
-            val token = "kafka-offset:42".toByteArray()
-            extSource.channel.send(token)
+        val token = "kafka-offset:42".toByteArray()
+        extSource.channel.send(token)
 
-            delay(500.milliseconds)
+        delay(500.milliseconds)
 
-            val watcherToken = watchers.externalSourceToken
-            assertNotNull(watcherToken)
-            assertArrayEquals(token, watcherToken)
-        } finally {
-            lp.cancelAndJoin()
-        }
+        val watcherToken = watchers.externalSourceToken
+        assertNotNull(watcherToken)
+        assertArrayEquals(token, watcherToken)
     }
 
     @Test
@@ -234,13 +218,9 @@ class ExternalSourceTest {
             override fun close() {}
         }
 
-        val lp = leaderProc(watchers = watchers, extSource = failingSource, ctx = coroutineContext)
-        try {
-            delay(500.milliseconds)
-            assertNotNull(watchers.exception, "watchers should be in failed state")
-        } finally {
-            lp.cancelAndJoin()
-        }
+        leaderProc(watchers = watchers, extSource = failingSource)
+        delay(500.milliseconds)
+        assertNotNull(watchers.exception, "watchers should be in failed state")
     }
 
     @Test
@@ -251,15 +231,11 @@ class ExternalSourceTest {
         }
 
         val extSource = InMemoryExternalSource()
-        val lp = leaderProc(watchers = watchers, liveIndex = liveIndex, extSource = extSource, ctx = coroutineContext)
+        leaderProc(watchers = watchers, liveIndex = liveIndex, extSource = extSource)
 
-        try {
-            extSource.channel.send(null)
-            delay(500.milliseconds)
-            assertNotNull(watchers.exception, "watchers should be in failed state")
-        } finally {
-            lp.cancelAndJoin()
-        }
+        extSource.channel.send(null)
+        delay(500.milliseconds)
+        assertNotNull(watchers.exception, "watchers should be in failed state")
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -3,9 +3,11 @@ package xtdb.indexer
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.*
+import kotlinx.coroutines.awaitCancellation
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -41,6 +43,7 @@ class FollowerLogProcessorTest {
     private lateinit var tableCatalog: TableCatalog
     private lateinit var trieCatalog: TrieCatalog
     private lateinit var dbState: DatabaseState
+    private lateinit var replicaLog: Log<ReplicaMessage>
 
     @BeforeEach
     fun setUp() {
@@ -54,6 +57,11 @@ class FollowerLogProcessorTest {
         dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
+        // The processor self-launches its replica tail; park it so it idles while the test drives
+        // processRecords directly — a relaxed mock would return immediately and tear the proc down.
+        replicaLog = mockk(relaxed = true)
+        coEvery { replicaLog.tailAll(any(), any()) } coAnswers { awaitCancellation() }
+
         every { bufferPool.epoch } returns 1
     }
 
@@ -62,13 +70,13 @@ class FollowerLogProcessorTest {
         allocator.close()
     }
 
-    private fun makeProcessor(
+    private fun TestScope.makeProcessor(
         maxBufferedRecords: Int = 1024,
         hasExternalSource: Boolean = false,
         meterRegistry: MeterRegistry? = null,
     ) =
         FollowerLogProcessor(
-            allocator, bufferPool, dbState,
+            backgroundScope, allocator, replicaLog, bufferPool, dbState,
             compactor, watchers, null, null, afterReplicaMsgId = -1L,
             hasExternalSource = hasExternalSource,
             meterRegistry = meterRegistry,
@@ -89,9 +97,7 @@ class FollowerLogProcessorTest {
             record(3, ReplicaMessage.ResolvedTx(3, Instant.now(), true, null, emptyMap())),
         )
 
-        assertThrows<Fault> { proc.processRecords(records) }
-        proc.cancelAndJoin()
-    }
+        assertThrows<Fault> { proc.processRecords(records) }    }
 
     @Test
     fun `ResolvedTx skips already-applied transactions`() = runTest {
@@ -107,8 +113,6 @@ class FollowerLogProcessorTest {
         verify(exactly = 0) { liveIndex.importTx(tx40) }
         verify(exactly = 0) { liveIndex.importTx(tx42) }
         verify { liveIndex.importTx(tx43) }
-
-        proc.cancelAndJoin()
     }
 
     @Test
@@ -135,8 +139,6 @@ class FollowerLogProcessorTest {
 
         verify(exactly = 0) { liveIndex.importTx(any()) }
         assert(watchers.latestSourceMsgId == 1000L) { "latestSourceMsgId should not have changed" }
-
-        proc.cancelAndJoin()
     }
 
     @Test
@@ -160,8 +162,6 @@ class FollowerLogProcessorTest {
 
         assertEquals(0L, blockCatalog.currentBlockIndex,
             "block catalog should advance to block 0 even when BlockBoundary.latestProcessedMsgId == last txId")
-
-        proc.cancelAndJoin()
     }
 
     @Test
@@ -180,8 +180,6 @@ class FollowerLogProcessorTest {
 
         verify { liveIndex.importTx(tx1001) }
         assert(watchers.latestSourceMsgId == 1001L)
-
-        proc.cancelAndJoin()
     }
 
     @Test
@@ -205,8 +203,6 @@ class FollowerLogProcessorTest {
         assertEquals(-1L, watchers.latestSourceMsgId,
             "ext-source ResolvedTx must not bump latestSourceMsgId")
         assertEquals(0L, blockCatalog.currentBlockIndex)
-
-        proc.cancelAndJoin()
     }
 
     @Test
@@ -224,8 +220,6 @@ class FollowerLogProcessorTest {
         verify { liveIndex.importTx(ext2) }
         assertEquals(1L, watchers.latestSourceMsgId,
             "latestSourceMsgId reflects only the source-log tx; ext-source txs leave it alone")
-
-        proc.cancelAndJoin()
     }
 
     @Test
@@ -260,8 +254,6 @@ class FollowerLogProcessorTest {
         assertNotNull(bufferedRecords, "buffered records summary should be registered")
         assertEquals(1L, bufferedRecords!!.count())
         assertEquals(0.0, bufferedRecords.totalAmount(), "no records buffered when BlockUploaded follows BlockBoundary directly")
-
-        proc.cancelAndJoin()
     }
 
     @Test
@@ -284,7 +276,5 @@ class FollowerLogProcessorTest {
         assertNotNull(bufferedRecords)
         assertEquals(1L, bufferedRecords!!.count())
         assertEquals(2.0, bufferedRecords.totalAmount(), "two records buffered between boundary and uploaded")
-
-        proc.cancelAndJoin()
     }
 }

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -4,10 +4,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.apache.arrow.memory.BufferAllocator
 import org.junit.jupiter.api.AfterEach
@@ -52,7 +52,7 @@ class LeaderLogProcessorTest {
         nodeBase.close()
     }
 
-    private fun leaderProc(
+    private fun TestScope.leaderProc(
         uploadDispatcher: CoroutineDispatcher,
         sourceLog: InMemoryLog<SourceMessage> = InMemoryLog(InstantSource.system(), 0),
         replicaLog: InMemoryLog<ReplicaMessage> = InMemoryLog(InstantSource.system(), 0),
@@ -75,6 +75,7 @@ class LeaderLogProcessorTest {
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
             partition = 0, afterReplicaMsgId = -1,
+            scope = backgroundScope,
         )
     }
 
@@ -130,6 +131,7 @@ class LeaderLogProcessorTest {
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
             partition = 0, afterReplicaMsgId = -1,
+            scope = backgroundScope,
         )
 
         val now = Instant.now()
@@ -196,6 +198,7 @@ class LeaderLogProcessorTest {
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
             partition = 0, afterReplicaMsgId = -1,
+            scope = backgroundScope,
         )
 
         val now = Instant.now()
@@ -204,12 +207,11 @@ class LeaderLogProcessorTest {
         ))
 
         val replicaMessages = mutableListOf<ReplicaMessage>()
-        val job = launch { replicaLog.tailAll(-1) { records ->
+        backgroundScope.launch { replicaLog.tailAll(-1) { records ->
             replicaMessages.addAll(records.map { it.message })
         } }
 
         delay(200)
-        job.cancelAndJoin()
 
         assertEquals(2, replicaMessages.size, "expected 2 replica messages, got: $replicaMessages")
         assertTrue(replicaMessages[0] is ReplicaMessage.BlockBoundary)

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -184,7 +184,8 @@ class LogProcessorSimTest : SimulationTestBase() {
                 extSource = simExtSource, replicaProducer = replicaProducer,
                 skipTxs = emptySet(), dbCatalog = null,
                 partition = 0, afterReplicaMsgId = afterReplicaMsgId,
-                ctx = dispatcher
+                ctx = dispatcher,
+                gcDispatcher = dispatcher,
             )
             return object : LogProcessor.LeaderSystem {
                 override val proc get() = proc

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -95,11 +95,11 @@ class LogProcessorSimTest : SimulationTestBase() {
      * Putting `indexTx` inside `onPartitionAssigned` (rather than calling it from the test
      * driver against a stale `TxIndexer` reference) is what keeps the leader's allocator
      * accounting clean across rebalances: `indexTx` allocates an `OpenTx` from the
-     * leader's allocator; if `LeaderLogProcessor.close()` runs while that `OpenTx` is still
-     * live, `allocator.close()` throws on the outstanding allocation. Holding the call
-     * inside `onPartitionAssigned` ties its lifetime to the leader's scope — `extJob.cancel()`
-     * propagates cancellation through `indexTx`'s inner catch, which closes the `OpenTx`
-     * before the allocator does.
+     * leader's allocator; if the leader term's scope were cancelled while that `OpenTx` is
+     * still live, the leader's `invokeOnCompletion` `allocator.close()` would throw on the
+     * outstanding allocation. Holding the call inside `onPartitionAssigned` ties its lifetime
+     * to the leader's scope — cancelling that scope propagates cancellation through `indexTx`'s
+     * inner catch, which closes the `OpenTx` before the allocator does.
      */
     private inner class SimExtSource(private val actions: List<SimAction>) : ExternalSource {
         private val watchersList = mutableListOf<Watchers>()
@@ -174,24 +174,19 @@ class LogProcessorSimTest : SimulationTestBase() {
             BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, uploadDispatcher = dispatcher)
         val crashLogger = CrashLogger(allocator, bp, "sim-node")
 
-        override fun openLeaderSystem(
+        override fun openLeader(
+            termScope: CoroutineScope,
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
             afterReplicaMsgId: MessageId,
-        ): LogProcessor.LeaderSystem {
-            val proc = LeaderLogProcessor(
-                allocator, nodeBase, dbStorage, crashLogger,
-                dbState, blockUploader, watchers,
-                extSource = simExtSource, replicaProducer = replicaProducer,
-                skipTxs = emptySet(), dbCatalog = null,
-                partition = 0, afterReplicaMsgId = afterReplicaMsgId,
-                ctx = dispatcher,
-                gcDispatcher = dispatcher,
-            )
-            return object : LogProcessor.LeaderSystem {
-                override val proc get() = proc
-                override suspend fun cancelAndJoin() = proc.cancelAndJoin()
-            }
-        }
+        ) = LeaderLogProcessor(
+            allocator, nodeBase, dbStorage, crashLogger,
+            dbState, blockUploader, watchers,
+            extSource = simExtSource, replicaProducer = replicaProducer,
+            skipTxs = emptySet(), dbCatalog = null,
+            partition = 0, afterReplicaMsgId = afterReplicaMsgId,
+            scope = termScope,
+            gcDispatcher = dispatcher,
+        )
 
         override fun openTransition(
             replicaProducer: Log.AtomicProducer<ReplicaMessage>,
@@ -206,11 +201,12 @@ class LogProcessorSimTest : SimulationTestBase() {
             )
 
         override fun openFollower(
+            termScope: CoroutineScope,
             pendingBlock: PendingBlock?,
             afterReplicaMsgId: MessageId,
         ): LogProcessor.FollowerProcessor =
             FollowerLogProcessor(
-                allocator, bp, dbState,
+                termScope, allocator, replicaLog, bp, dbState,
                 mockk<Compactor.ForDatabase>(relaxed = true),
                 watchers, null, pendingBlock,
                 afterReplicaMsgId,

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -61,23 +61,21 @@ class LogProcessorTest {
         watchers: Watchers,
     ) =
         object : LogProcessor.ProcessorFactory {
-            override fun openLeaderSystem(
+            override fun openLeader(
+                termScope: CoroutineScope,
                 replicaProducer: Log.AtomicProducer<ReplicaMessage>,
                 afterReplicaMsgId: MessageId,
-            ): LogProcessor.LeaderSystem {
+            ): LogProcessor.LeaderProcessor {
                 val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
                 val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null)
-                val leaderProc = LeaderLogProcessor(
+                return LeaderLogProcessor(
                     allocator, nodeBase, dbStorage, mockk(relaxed = true),
                     dbState, blockUploader, watchers,
                     extSource = null, replicaProducer = replicaProducer,
                     skipTxs = emptySet(), dbCatalog = null,
                     partition = 0, afterReplicaMsgId = afterReplicaMsgId,
+                    scope = termScope,
                 )
-                return object : LogProcessor.LeaderSystem {
-                    override val proc get() = leaderProc
-                    override suspend fun cancelAndJoin() = leaderProc.cancelAndJoin()
-                }
             }
 
             override fun openTransition(
@@ -93,11 +91,12 @@ class LogProcessorTest {
                 )
 
             override fun openFollower(
+                termScope: CoroutineScope,
                 pendingBlock: PendingBlock?,
                 afterReplicaMsgId: MessageId,
             ): LogProcessor.FollowerProcessor =
                 FollowerLogProcessor(
-                    allocator, bufferPool, dbState,
+                    termScope, allocator, dbStorage.replicaLog, bufferPool, dbState,
                     mockk(relaxed = true), watchers, null, pendingBlock,
                     afterReplicaMsgId,
                     hasExternalSource = false,

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -119,10 +119,10 @@ class LogProcessorTest {
             dbStorage, dbState, watchers, blockUploader, scope
         )
 
-        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
+        scope.launch { sourceLog.openGroupSubscription(logProc) }
 
-        job.cancelAndJoin()
-        logProc.cancelAndJoin()
+        // Teardown is the owner cancelling its own scope — reaps the subscription and the live term.
+        scope.coroutineContext.job.cancelAndJoin()
         sourceLog.close()
         replicaLog.close()
     }
@@ -143,10 +143,10 @@ class LogProcessorTest {
             dbStorage, dbState, watchers, blockUploader, scope
         )
 
-        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
+        scope.launch { sourceLog.openGroupSubscription(logProc) }
 
-        job.cancelAndJoin()
-        logProc.cancelAndJoin()
+        // Teardown is the owner cancelling its own scope — reaps the subscription and the live term.
+        scope.coroutineContext.job.cancelAndJoin()
         sourceLog.close()
         replicaLog.close()
     }
@@ -175,15 +175,15 @@ class LogProcessorTest {
             dbStorage, dbState, watchers, blockUploader, scope
         )
 
-        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
+        scope.launch { sourceLog.openGroupSubscription(logProc) }
 
         // wait for the follower→leader transition to complete (runs on Dispatchers.Default)
         watchers.awaitTx(1)
 
         verify { liveIndex.importTx(any()) }
 
-        job.cancelAndJoin()
-        logProc.cancelAndJoin()
+        // Teardown is the owner cancelling its own scope — reaps the subscription and the live term.
+        scope.coroutineContext.job.cancelAndJoin()
         sourceLog.close()
         replicaLog.close()
     }
@@ -210,14 +210,14 @@ class LogProcessorTest {
             dbStorage, dbState, watchers, blockUploader, scope
         )
 
-        val job = scope.launch { sourceLog.openGroupSubscription(logProc) }
+        scope.launch { sourceLog.openGroupSubscription(logProc) }
 
         watchers.awaitTx(1)
 
         verify { liveIndex.importTx(any()) }
 
-        job.cancelAndJoin()
-        logProc.cancelAndJoin()
+        // Teardown is the owner cancelling its own scope — reaps the subscription and the live term.
+        scope.coroutineContext.job.cancelAndJoin()
         sourceLog.close()
         replicaLog.close()
     }

--- a/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
@@ -74,7 +74,7 @@ class TransitionLogProcessorTest {
 
         coVerify { blockUploader.uploadBlock(replicaProducer, 1, any()) }
 
-        proc.cancelAndJoin()
+        proc.close()
     }
 
     @Test
@@ -94,6 +94,6 @@ class TransitionLogProcessorTest {
         assertEquals(-1L, watchers.latestSourceMsgId,
             "ext-source ResolvedTx must not bump latestSourceMsgId")
 
-        proc.cancelAndJoin()
+        proc.close()
     }
 }

--- a/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
@@ -66,6 +66,7 @@ class BlockGarbageCollectorTest {
                 val blockCat = BlockCatalog("xtdb", bufferPool.latestBlock)
 
                 val gc = BlockGarbageCollector(
+                    backgroundScope,
                     bufferPool, blockCat,
                     blocksToKeep = 3,
                     enabled = false,


### PR DESCRIPTION
Rebuilds the lifecycle of the Database's background services onto one model — **the coroutine job tree is the ownership tree.** Everything the Database owns is one of two kinds:

**Service** — has a background loop (the garbage collectors, the compactor, the log processors):

- takes a `CoroutineScope` from its owner and launches its loop in `init`;
- frees only what it itself opened via `job.invokeOnCompletion` — *not* a body `finally`, which leaks if the job is cancelled before its body runs;
- is **not** `AutoCloseable` and has **no** `close()` — owners cancel the scope, never closing a service by hand.

**State** — a synchronous holder with no loop (catalogs, `LiveIndex`, `TransitionLogProcessor`): stays `AutoCloseable`, closed explicitly.

Teardown then falls out of the tree: one cancel cascades leaf-first, each node freeing what it owns as it completes. The single synchronous bridge (`runBlocking { … cancelAndJoin() }`) migrates up one level per phase until only `Database.close()` holds it — `job.cancelAndJoin()`, then `closeAll()` of the State.

Builds on #5679 (merged), which made `SimLog` pure state and moved the simulation tests onto a single scope-cancellation teardown.

## Changes

1. **`refactor(gc)`** — the block & trie collectors take their lifetime scope from the owner instead of self-creating a `Job`, and drop `AutoCloseable`/`close()`. The loop runs on the injected scope; the delete fan-out keeps a separate injectable dispatcher.
2. **`refactor(compactor)`** — `openForDatabase(scope, …)`; the driver's child allocator + `SegmentMerge` temp dir are freed via `dbJob.invokeOnCompletion`; `ForDatabase` is no longer `AutoCloseable`; `compactorScope` is a child of the database `job`.
3. **`refactor(indexer)`** — `LeaderLogProcessor`/`FollowerLogProcessor` own their lifetime (injected term scope, `invokeOnCompletion`, no `cancelAndJoin()`); the follower absorbs its own replica tail. `TransitionLogProcessor` becomes synchronous `AutoCloseable` State (used via `.use`). The `LogProcessor` wrapper models the running term as one value — `SubSystem` carries its own `SupervisorJob`, swapped atomically on each role transition; the factory builds bare processors and the wrapper assembles the term.
4. **`refactor(database)`** — `Database.close()` becomes a single `job.cancelAndJoin()` that reaps the compactor, the source-log subscription and the live term leaf-first, then `closeAll()` of State. No Service retains a teardown method of its own.

Behaviour-preserving throughout: indexing, leader↔follower transitions, block finishing and GC behave exactly as before; only the lifecycle mechanism moves.

## Implementation notes

- **Unbounded teardown** — no `withTimeoutOrNull`/defensive bounds; structured concurrency does the ordering the hand-written teardown used to spell out.
- **Two dispatchers per IO service** — the loop rides the injected scope (in sims, the seeded deterministic dispatcher, so a cancel joins it on that same thread); the IO/delete fan-out takes a separate injectable dispatcher. Both default at the service boundary — the only caller that varies them (the simulations) injects there directly.
- **`invokeOnCompletion`, not `finally`** — a completion handler fires even if the job is cancelled before its body runs. Child allocators are freed `this@…`-qualified, since a bare `allocator` in an `init` lambda binds the constructor parameter (the parent), not the child field.

## Test plan

`:xtdb-core` unit suite + `ExternalSourceTest` + `DatabaseCatalogTest`; `LogProcessorSimTest` (≥300 rebalance iterations), `NodeSimulationTest`, `CompactorSimulationTest` — all green, no `UncompletedCoroutinesError`, allocator leaks, or dispatcher livelock. Whole-project `./gradlew test` + Kafka `integration-test` run on CI.

The migrating-entry-point model, the binding lessons, and a post-completion adversarial audit are in the comments below.

## Progress

**Status:** ready for review (base #5679 merged; full suite + Kafka integration on CI)

- [x] The pattern — job-tree-is-ownership-tree + migrating entry point
- [x] Phase 1 — garbage collectors
- [x] Phase 2 — compactor
- [x] Phase 3 — leader/follower processors + wrapper (the running term is `SubSystem`)
- [x] Phase 4 — `Database` single teardown cancel
- [x] Adversarial audit — aims confirmed; removed the orphaned `LogProcessor.cancelAndJoin()` (no Service retains a teardown method)
- [ ] Follow-up (separate, not blocking) — `NodeSimulationTest` over-specification + `CompactorMockDriver` fixture soundness
