### PR TITLE
test(simulation): drive RepeatableSimulationTest with a TestTemplate

### DIFF
--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -100,7 +100,6 @@ class NodeSimulationTest : SimulationTestBase() {
 
     @BeforeEach
     fun setUp() {
-        super.setUpSimulation()
         setLogLevel.invoke("xtdb".symbol, logLevel)
 
         val jobCalculator = createJobCalculator()
@@ -135,7 +134,6 @@ class NodeSimulationTest : SimulationTestBase() {
 
     @AfterEach
     fun tearDown() {
-        super.tearDownSimulation()
         dbs.forEach { it.close() }
         sharedBufferPool.close()
         allocator.close()
@@ -153,7 +151,7 @@ class NodeSimulationTest : SimulationTestBase() {
 
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    fun `l1 compaction followed by garbage collection`(iteration: Int) {
+    fun `l1 compaction followed by garbage collection`() {
         val table = TableRef("xtdb", "public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val l1Tries = L1TrieKeys.take(4).toList()
@@ -206,7 +204,7 @@ class NodeSimulationTest : SimulationTestBase() {
 
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    fun `gc during compaction preserves files`(iteration: Int)  {
+    fun `gc during compaction preserves files`()  {
         val table = TableRef("xtdb", "public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val l1Tries = L1TrieKeys.take(8).toList()
@@ -274,7 +272,7 @@ class NodeSimulationTest : SimulationTestBase() {
 
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    fun `gc collects old garbage while compaction runs`(iteration: Int) {
+    fun `gc collects old garbage while compaction runs`() {
         val table = TableRef("xtdb", "public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val db = dbs[0]
@@ -352,7 +350,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @WithNumberOfSystems(2)
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    fun `multi-system compaction and gc`(iteration: Int) {
+    fun `multi-system compaction and gc`() {
         val table = TableRef("xtdb", "public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
 
@@ -433,7 +431,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @WithNumberOfSystems(2)
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    fun `staggered system startup during active compaction`(iteration: Int) {
+    fun `staggered system startup during active compaction`() {
         val table = TableRef("xtdb", "public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
 
@@ -525,7 +523,7 @@ class NodeSimulationTest : SimulationTestBase() {
 
     @RepeatableSimulationTest
     @Timeout(value = 15, unit = TimeUnit.SECONDS)
-    fun `l0 to l3 compaction and gc`(iteration: Int) {
+    fun `l0 to l3 compaction and gc`() {
         val table = TableRef("xtdb", "public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val db = dbs[0]
@@ -579,7 +577,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @WithNumberOfSystems(2)
     @Timeout(value = 15, unit = TimeUnit.SECONDS)
-    fun `l0 to 13 with concurrent compaction + gc`(iteration: Int) {
+    fun `l0 to 13 with concurrent compaction + gc`() {
         val table = TableRef("xtdb", "public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
 
@@ -666,7 +664,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @WithNumberOfSystems(2)
     @Timeout(value = 15, unit = TimeUnit.SECONDS)
-    fun `multi system l3 to l4 compaction`(iteration: Int) {
+    fun `multi system l3 to l4 compaction`() {
         val table = TableRef("xtdb", "public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
 

--- a/core/src/test/kotlin/xtdb/SimulationTestBase.kt
+++ b/core/src/test/kotlin/xtdb/SimulationTestBase.kt
@@ -1,45 +1,64 @@
 package xtdb
 
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider
 import xtdb.util.logger
 import xtdb.util.warn
-import java.util.concurrent.TimeUnit
+import java.util.stream.Stream
 import kotlin.random.Random
 
-@ParameterizedTest(name = "[iteration {0}]")
-@MethodSource("xtdb.SimulationTestBase#iterationSource")
-annotation class RepeatableSimulationTest
+private val DEFAULT_ITERATIONS: Int = System.getProperty("xtdb.simulation-test-iterations", "100").toInt()
+
+private val ExtensionContext.explicitSeed get() = requiredTestMethod.getAnnotation(WithSeed::class.java)?.seed
+
+@TestTemplate
+@ExtendWith(RepeatableSimulationTest.InvocationContextProvider::class)
+annotation class RepeatableSimulationTest(val iterations: Int = -1) {
+
+    object InvocationContext : TestTemplateInvocationContext {
+        override fun getDisplayName(invocationIndex: Int) = "[iteration $invocationIndex]"
+    }
+
+    class InvocationContextProvider : TestTemplateInvocationContextProvider {
+        override fun supportsTestTemplate(ctx: ExtensionContext) =
+            ctx.requiredTestMethod.isAnnotationPresent(RepeatableSimulationTest::class.java)
+
+        private val ExtensionContext.explicitIterations
+            get() =
+                requiredTestMethod.getAnnotation(RepeatableSimulationTest::class.java)
+                    .iterations
+                    .takeIf { it >= 0 }
+
+        override fun provideTestTemplateInvocationContexts(ctx: ExtensionContext): Stream<TestTemplateInvocationContext> {
+            val iterations = ctx.explicitIterations ?: if (ctx.explicitSeed != null) 1 else DEFAULT_ITERATIONS
+            return List<TestTemplateInvocationContext>(iterations) { InvocationContext }.stream()
+        }
+    }
+}
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class WithSeed(val seed: Int)
 
-class SeedExtension : BeforeEachCallback {
-    override fun beforeEach(context: ExtensionContext) {
-        val annotation = context.requiredTestMethod
-            .getAnnotation(WithSeed::class.java)
+class SeedExtension : BeforeEachCallback, TestExecutionExceptionHandler {
+    override fun beforeEach(ctx: ExtensionContext) {
+        val explicitSeed = ctx.explicitSeed
 
-        annotation?.let { withSeed ->
-            context.requiredTestInstance.let { testInstance ->
-                if (testInstance is SimulationTestBase) {
-                    testInstance.explicitSeed = withSeed.seed
-                }
+        ctx.requiredTestInstance.let { it as SimulationTestBase }
+            .also {
+                val seed = explicitSeed ?: Random.nextInt()
+                it.currentSeed = seed
+                it.rand = Random(seed)
+                it.dispatcher = DeterministicDispatcher(seed)
             }
-        }
     }
-}
 
-class SeedExceptionWrapper : TestExecutionExceptionHandler {
     override fun handleTestExecutionException(context: ExtensionContext, throwable: Throwable) {
         val testInstance = context.testInstance.orElse(null)
         if (testInstance is SimulationTestBase) {
@@ -51,40 +70,16 @@ class SeedExceptionWrapper : TestExecutionExceptionHandler {
     }
 }
 
-@ExtendWith(SeedExceptionWrapper::class, SeedExtension::class)
+@ExtendWith(SeedExtension::class)
 abstract class SimulationTestBase {
     var currentSeed: Int = 0
-    var explicitSeed: Int? = null
-    protected lateinit var rand: Random
-    protected lateinit var dispatcher: DeterministicDispatcher
-
-    @BeforeEach
-    open fun setUpSimulation() {
-        currentSeed = explicitSeed ?: Random.nextInt()
-        rand = Random(currentSeed)
-        dispatcher = DeterministicDispatcher(currentSeed)
-    }
-
-    @AfterEach
-    open fun tearDownSimulation() {
-        explicitSeed = null
-    }
+    lateinit var rand: Random
+    lateinit var dispatcher: DeterministicDispatcher
 
     protected fun assertInterleaved() {
-        assertTrue(dispatcher.interleavedPicks > 0,
-            "Dispatcher never had multiple concurrent jobs — simulation did not interleave (seed=$currentSeed)")
-    }
-
-    companion object SimulationIterations {
-        /**
-         * Returns iteration numbers for simulation tests.
-         * Override using:
-         *   -Dxtdb.simulation-test-iterations=N
-         */
-        private val testIterations: Int =
-            System.getProperty("xtdb.simulation-test-iterations", "100").toInt()
-
-        @JvmStatic
-        fun iterationSource(): List<Arguments> = (1..testIterations).map { Arguments.of(it) }
+        assertTrue(
+            dispatcher.interleavedPicks > 0,
+            "Dispatcher never had multiple concurrent jobs — simulation did not interleave (seed=$currentSeed)"
+        )
     }
 }

--- a/core/src/test/kotlin/xtdb/cache/CacheSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/cache/CacheSimulationTest.kt
@@ -8,14 +8,13 @@ import org.apache.arrow.memory.OutOfMemoryException
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import xtdb.RepeatableSimulationTest
 import xtdb.SimulationTestBase
 import xtdb.cache.MemoryCache.Slice
 import xtdb.symbol
 import xtdb.util.logger
-import xtdb.util.trace
 import xtdb.util.requiringResolve
+import xtdb.util.trace
 import java.lang.foreign.Arena
 import java.lang.foreign.MemorySegment
 import java.lang.foreign.ValueLayout.JAVA_BYTE
@@ -28,10 +27,6 @@ private val setLogLevel = requiringResolve("xtdb.logging/set-log-level!")
 private const val logLevel = "WARN"
 
 private val LOGGER = CacheSimulationTest::class.logger
-
-@ParameterizedTest(name = "[iteration {0}]")
-@MethodSource("xtdb.SimulationTestBase#iterationSource")
-annotation class RepeatableSimulationTest
 
 @Tag("property")
 class CacheSimulationTest : SimulationTestBase() {
@@ -50,21 +45,19 @@ class CacheSimulationTest : SimulationTestBase() {
     }
 
     @BeforeEach
-    override fun setUpSimulation() {
-        super.setUpSimulation()
+    fun setUpSimulation() {
         setLogLevel.invoke("xtdb.cache".symbol, logLevel)
         allocator = RootAllocator()
     }
 
     @AfterEach
-    override fun tearDownSimulation() {
+    fun tearDownSimulation() {
         allocator.close()
-        super.tearDownSimulation()
     }
 
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    fun `deterministic single fetch and evict`(iteration: Int) = runTest {
+    fun `deterministic single fetch and evict`() = runTest {
         val loader = TestPathLoader()
         MemoryCache(allocator, 250, loader, dispatcher).use { cache ->
             val sliceSize = rand.nextLong(1L, 250L)
@@ -87,7 +80,7 @@ class CacheSimulationTest : SimulationTestBase() {
 
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    fun `deterministic reuse of same path-slice`(iteration: Int) = runTest {
+    fun `deterministic reuse of same path-slice`() = runTest {
         val loader = TestPathLoader()
         MemoryCache(allocator, 250, loader, dispatcher).use { cache ->
             val sliceSize = rand.nextLong(1L, 250L)
@@ -121,7 +114,7 @@ class CacheSimulationTest : SimulationTestBase() {
 
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    fun `deterministic oom handling`(iteration: Int) = runTest {
+    fun `deterministic oom handling`() = runTest {
         val loader = TestPathLoader()
         MemoryCache(allocator, 100, loader, dispatcher).use { cache ->
             val tooBigSlice = rand.nextLong(101L, 200L)
@@ -143,7 +136,7 @@ class CacheSimulationTest : SimulationTestBase() {
 
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    fun `deterministic concurrent fetch of same path-slice`(iteration: Int) = runTest {
+    fun `deterministic concurrent fetch of same path-slice`() = runTest {
         val loader = TestPathLoader()
         MemoryCache(allocator, 250, loader, dispatcher).use { cache ->
             val sliceSize = rand.nextLong(1L, 250L)
@@ -209,7 +202,7 @@ class CacheSimulationTest : SimulationTestBase() {
 
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    fun `cancelled fetch on cache hit does not leak`(iteration: Int) = runTest {
+    fun `cancelled fetch on cache hit does not leak`() = runTest {
         val loader = TestPathLoader()
         MemoryCache(allocator, 250, loader, dispatcher).use { cache ->
             val path = Path.of("test/100")
@@ -223,7 +216,7 @@ class CacheSimulationTest : SimulationTestBase() {
                 }
                 yield()
                 jobs.forEach { it.cancel() }
-                jobs.forEach { it.join() }
+                jobs.joinAll()
             }.await()
 
             assertEquals(MemoryCache.Stats(0L, 250L), cache.stats0)

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
 import xtdb.RepeatableSimulationTest
 import xtdb.SimulationTestBase
 import xtdb.SimulationTestUtils.Companion.L0TrieKeys
@@ -22,8 +20,6 @@ import xtdb.SimulationTestUtils.Companion.createJobCalculator
 import xtdb.SimulationTestUtils.Companion.createTrieCatalog
 import xtdb.SimulationTestUtils.Companion.prefix
 import xtdb.SimulationTestUtils.Companion.setLogLevel
-import xtdb.WithSeed
-import xtdb.api.log.Log
 import xtdb.api.log.SourceMessage.TriesAdded
 import xtdb.api.log.Watchers
 import xtdb.api.storage.Storage
@@ -43,10 +39,10 @@ import xtdb.table.TableRef
 import xtdb.time.InstantUtil.asMicros
 import xtdb.trie.Trie
 import xtdb.trie.TrieCatalog
+import xtdb.util.debug
 import xtdb.util.logger
 import xtdb.util.safeMap
 import xtdb.util.useAll
-import xtdb.util.debug
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
@@ -288,7 +284,6 @@ class CompactorSimulationTest : SimulationTestBase() {
 
     @BeforeEach
     fun setUp() {
-        super.setUpSimulation()
         setLogLevel.invoke("xtdb.compactor".symbol, logLevel)
         mockDriver = CompactorMockDriver(dispatcher, currentSeed, driverConfig)
         jobCalculator = createJobCalculator()
@@ -312,7 +307,6 @@ class CompactorSimulationTest : SimulationTestBase() {
         driverConfig = CompactorDriverConfig()
         sharedBufferPool.close()
         allocator.close()
-        super.tearDownSimulation()
     }
 
     private fun seedTries(tableRef: TableRef, tries: List<TrieDetails>) {
@@ -328,7 +322,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    fun singleL0Compaction(iteration: Int) {
+    fun singleL0Compaction() {
         val docsTable = TableRef("xtdb", "public", "docs")
         val l0Trie = buildTrieDetails(docsTable.tableName, L0TrieKeys.first())
         val db = dbs[0]
@@ -352,12 +346,12 @@ class CompactorSimulationTest : SimulationTestBase() {
 
     @Test
     fun singleL0CompactionNotHanging() {
-        singleL0Compaction(0)
+        singleL0Compaction()
     }
 
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    fun multipleL0ToL1Compaction(iteration: Int) {
+    fun multipleL0ToL1Compaction() {
         val table = TableRef("xtdb", "public", "docs")
         val db = dbs[0]
 
@@ -413,7 +407,7 @@ class CompactorSimulationTest : SimulationTestBase() {
 
     @Test
     fun multipleL0ToL1CompactionIssue() {
-        multipleL0ToL1Compaction(0)
+        multipleL0ToL1Compaction()
     }
 
     @Test
@@ -440,7 +434,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @WithCompactorDriverConfig(temporalSplitting = CURRENT)
-    fun l1cToL2cCompaction(iteration: Int) {
+    fun l1cToL2cCompaction() {
         val docsTable = TableRef("xtdb", "public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val db = dbs[0]
@@ -466,7 +460,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @WithCompactorDriverConfig(temporalSplitting = CURRENT)
-    fun l1cToL2cWithPartialL2(iteration: Int) {
+    fun l1cToL2cWithPartialL2() {
         val docsTable = TableRef("xtdb", "public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val rand = Random(currentSeed)
@@ -506,7 +500,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @WithCompactorDriverConfig(temporalSplitting = CURRENT)
-    fun l2cGapFillingAndL3cCompaction(iteration: Int) {
+    fun l2cGapFillingAndL3cCompaction() {
         val docsTable = TableRef("xtdb", "public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val db = dbs[0]
@@ -593,7 +587,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @WithCompactorDriverConfig(temporalSplitting = CURRENT)
-    fun concurrentTableCompaction(iteration: Int) {
+    fun concurrentTableCompaction() {
         runConcurrentTableCompaction()
     }
 
@@ -601,14 +595,14 @@ class CompactorSimulationTest : SimulationTestBase() {
     @WithNumberOfSystems(2)
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @WithCompactorDriverConfig(temporalSplitting = CURRENT)
-    fun multiSystemConcurrentTableCompaction(iteration: Int) {
+    fun multiSystemConcurrentTableCompaction() {
         runConcurrentTableCompaction()
     }
 
     @RepeatableSimulationTest
     @WithNumberOfSystems(2)
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    fun multiSystemSingleL0Compaction(iteration: Int) {
+    fun multiSystemSingleL0Compaction() {
         val docsTable = TableRef("xtdb", "public", "docs")
         val l0Trie = buildTrieDetails(docsTable.tableName, L0TrieKeys.first())
 

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -14,11 +14,13 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestTemplate
 import xtdb.NodeBase
 import xtdb.NodeBase.Companion.openBase
 import xtdb.RepeatableSimulationTest
 import xtdb.SimulationTestBase
 import xtdb.SimulationTestUtils.Companion.createTrieCatalog
+import xtdb.WithSeed
 import xtdb.api.IndexerConfig
 import xtdb.api.log.*
 import xtdb.api.log.Log
@@ -334,7 +336,7 @@ class LogProcessorSimTest : SimulationTestBase() {
     }
 
     @RepeatableSimulationTest
-    fun `single node processes txs and flush-blocks with rebalances`(@Suppress("unused") iteration: Int) =
+    fun `single node processes txs and flush-blocks with rebalances`() =
         runTest(timeout = 5.seconds) {
             srcLog = SimLog("src", dispatcher + coroutineContext.job, rand)
             replicaLog = SimLog("replica", dispatcher + coroutineContext.job, rand)
@@ -410,7 +412,7 @@ class LogProcessorSimTest : SimulationTestBase() {
         }
 
     @RepeatableSimulationTest
-    fun `stable leader with sustained throughput`(@Suppress("unused") iteration: Int) =
+    fun `stable leader with sustained throughput`() =
         runTest(timeout = 5.seconds) {
             srcLog = SimLog("src", dispatcher + coroutineContext.job, rand)
             replicaLog = SimLog("replica", dispatcher + coroutineContext.job, rand)
@@ -530,7 +532,7 @@ class LogProcessorSimTest : SimulationTestBase() {
         }
 
     @RepeatableSimulationTest
-    fun `multi-node leadership changes preserve block catalog consistency`(@Suppress("unused") iteration: Int) =
+    fun `multi-node leadership changes preserve block catalog consistency`() =
         runTest(timeout = 5.seconds) {
             srcLog = SimLog("src", dispatcher + coroutineContext.job, rand)
             replicaLog = SimLog("replica", dispatcher + coroutineContext.job, rand)


### PR DESCRIPTION
Standalone dev-experience change — no tracking issue.

## Context

Our deterministic simulation tests (`CompactorSimulationTest`, `NodeSimulationTest`, `LogProcessorSimTest`, `CacheSimulationTest`) repeat each scenario across many random seeds to shake out concurrency bugs. `@RepeatableSimulationTest` drove that repetition as a `@ParameterizedTest` over a `@MethodSource`, which had two rough edges:

- Every repeatable test had to declare an `iteration: Int` parameter it never read, purely to satisfy the parameterized-test contract.
- The repeat count was a single global knob (`-PsimulationIterations`, default 100). A test couldn't ask for its own count, and a `@WithSeed`-pinned test — which is fully deterministic — still ran the full 100 identical iterations when all you wanted was to reproduce one failure.

## Approach

Reimplemented `@RepeatableSimulationTest` as a JUnit 5 `@TestTemplate` backed by a custom `TestTemplateInvocationContextProvider`. The repeat count is now resolved by the infrastructure rather than threaded through as a method argument, so the tests drop the unused parameter. The provider resolves the count with a clear precedence:

1. an inline `@RepeatableSimulationTest(iterations = N)` wins;
2. otherwise a `@WithSeed` collapses to a single invocation;
3. otherwise the `-PsimulationIterations` default of 100.

## Using it

```kotlin
// Default — repeats 100× with fresh random seeds.
// Override the global count with -PsimulationIterations=N.
@RepeatableSimulationTest
@Timeout(value = 5, unit = TimeUnit.SECONDS)
fun singleL0Compaction() { /* ... */ }

// NEW: pin one test's count, independent of the global default.
@RepeatableSimulationTest(iterations = 1000)
fun `stable leader with sustained throughput`() { /* ... */ }

// NEW: reproduce a specific failure. A fixed seed is deterministic,
// so this now runs exactly once instead of 100 identical times.
@RepeatableSimulationTest
@WithSeed(1234567)
fun `multi-node leadership changes preserve block catalog consistency`() { /* ... */ }
```

Running them is unchanged — the simulation suite is `@Tag("property")`:

```sh
./gradlew property-test                          # all sim tests, 100 iterations each
./gradlew property-test -PsimulationIterations=500   # crank the global count
```

## Behaviour-preserving cleanup

Folded `SeedExceptionWrapper` into `SeedExtension`, and moved seed setup out of the `@BeforeEach setUpSimulation()` hook into the extension's `beforeEach` callback. Subclasses no longer thread `super.setUpSimulation()`/`super.tearDownSimulation()` through their own lifecycle methods just to get a seeded `rand`/`dispatcher`. The seeding behaviour itself is unchanged.

## Test plan

Committed optimistically — CI runs `property-test`, which exercises all four simulation classes. A local run is in flight as a backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)