### PR TITLE
test(simulation): resume the sim external source from its tokens

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -303,9 +303,6 @@ class Database(
                             dbCatalog = dbCatalog,
                             partition = 0,
                             afterReplicaMsgId = afterReplicaMsgId,
-                            // watchers has the latest token from replica log replay,
-                            // which may be ahead of blockCatalog if no block boundary was flushed.
-                            afterToken = watchers.externalSourceToken,
                             flushTimeout = indexerConfig.flushDuration,
                         )
 

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -57,7 +57,6 @@ class LeaderLogProcessor(
     private val dbCatalog: Database.Catalog?,
     partition: Int,
     afterReplicaMsgId: MessageId,
-    afterToken: ExternalSourceToken?,
     private val instantSource: InstantSource = InstantSource.system(),
     flushTimeout: Duration = Duration.ofMinutes(5),
     ctx: CoroutineContext = Dispatchers.Default,
@@ -323,7 +322,7 @@ class LeaderLogProcessor(
     private val extJob = extSource?.let { source ->
         scope.launch {
             try {
-                source.onPartitionAssigned(partition, afterToken, this@LeaderLogProcessor)
+                source.onPartitionAssigned(partition, watchers.externalSourceToken, this@LeaderLogProcessor)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -110,7 +110,7 @@ class ExternalSourceTest {
             allocator, nodeBase, dbStorage, crashLogger,
             dbState, blockUploader, watchers, extSource, replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterReplicaMsgId = -1, afterToken = afterToken, ctx = ctx
+            partition = 0, afterReplicaMsgId = -1, ctx = ctx
         )
     }
 

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -74,7 +74,7 @@ class LeaderLogProcessorTest {
             dbState, blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterReplicaMsgId = -1, afterToken = null,
+            partition = 0, afterReplicaMsgId = -1,
         )
     }
 
@@ -129,7 +129,7 @@ class LeaderLogProcessorTest {
             dbState, blockUploader, Watchers(latestTxId = -1, latestSourceMsgId = -1),
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterReplicaMsgId = -1, afterToken = null,
+            partition = 0, afterReplicaMsgId = -1,
         )
 
         val now = Instant.now()
@@ -195,7 +195,7 @@ class LeaderLogProcessorTest {
             dbState, blockUploader, Watchers(latestTxId = -1, latestSourceMsgId = -1),
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterReplicaMsgId = -1, afterToken = null,
+            partition = 0, afterReplicaMsgId = -1,
         )
 
         val now = Instant.now()

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -4,6 +4,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -103,61 +105,52 @@ class LogProcessorSimTest : SimulationTestBase() {
      * propagates cancellation through `indexTx`'s inner catch, which closes the `OpenTx`
      * before the allocator does.
      */
-    private inner class SimExtSource(actions: List<SimAction>) : ExternalSource {
-        private val iterator = actions.iterator()
+    private inner class SimExtSource(private val actions: List<SimAction>) : ExternalSource {
         private val watchersList = mutableListOf<Watchers>()
 
         fun watch(watchers: Watchers) {
             watchersList += watchers
         }
 
-        var indexedCount = 0
-            private set
+        private val nextActionIdxState = MutableStateFlow(0)
 
-        var inFlight = 0
-            private set
-
-        val isQuiescent: Boolean
-            get() {
-                watchersList.forEach { it.exception?.let { ex -> throw ex } }
-                return !iterator.hasNext() && inFlight == 0
-            }
+        suspend fun awaitQuiescence() = nextActionIdxState.first { it == actions.size }
 
         override suspend fun onPartitionAssigned(
             partition: Int,
             afterToken: ExternalSourceToken?,
             txIndexer: TxIndexer,
         ) {
-            while (iterator.hasNext()) {
+            var actionIdx = afterToken?.let { ByteBuffer.wrap(it).getInt() + 1 } ?: 0
+            nextActionIdxState.value = actionIdx
+            while (actionIdx < actions.size) {
                 yield()
-                val action = iterator.next()
-                inFlight++
-                try {
-                    txIndexer.indexTx(externalSourceToken = null) { openTx ->
-                        when (action) {
-                            is SimAction.Commit -> {
-                                val table = openTx.table(docsTable)
-                                for (id in action.rows) {
-                                    table.logPut(
-                                        ByteBuffer.wrap(id.asIid),
-                                        openTx.systemFrom,
-                                        Long.MAX_VALUE,
-                                    ) {
-                                        table.docWriter.writeObject(
-                                            mapOf("_id" to id, "tx_id" to openTx.txKey.txId),
-                                        )
-                                    }
-                                }
-                                TxResult.Committed()
-                            }
+                val action = actions[actionIdx]
 
-                            SimAction.Abort -> TxResult.Aborted(Incorrect("aborted"))
+                val externalSourceToken = ByteArray(Integer.BYTES).also { ByteBuffer.wrap(it).putInt(actionIdx) }
+                txIndexer.indexTx(externalSourceToken = externalSourceToken) { openTx ->
+                    when (action) {
+                        is SimAction.Commit -> {
+                            val table = openTx.table(docsTable)
+                            for (id in action.rows) {
+                                table.logPut(
+                                    ByteBuffer.wrap(id.asIid),
+                                    openTx.systemFrom,
+                                    Long.MAX_VALUE,
+                                ) {
+                                    table.docWriter.writeObject(
+                                        mapOf("_id" to id, "tx_id" to openTx.txKey.txId),
+                                    )
+                                }
+                            }
+                            TxResult.Committed()
                         }
+
+                        SimAction.Abort -> TxResult.Aborted(Incorrect("aborted"))
                     }
-                    indexedCount++
-                } finally {
-                    inFlight--
                 }
+
+                nextActionIdxState.value = ++actionIdx
             }
         }
 
@@ -194,7 +187,6 @@ class LogProcessorSimTest : SimulationTestBase() {
                 extSource = simExtSource, replicaProducer = replicaProducer,
                 skipTxs = emptySet(), dbCatalog = null,
                 partition = 0, afterReplicaMsgId = afterReplicaMsgId,
-                afterToken = null,
                 ctx = dispatcher
             )
             return object : LogProcessor.LeaderSystem {
@@ -364,8 +356,7 @@ class LogProcessorSimTest : SimulationTestBase() {
                                     srcLog.appendMessage(SourceMessage.FlushBlock(null))
                                 }
                             }
-                            while (!simExtSource.isQuiescent) yield()
-
+                            simExtSource.awaitQuiescence()
                             replicaLog.awaitAllDelivered()
                         }.join()
 
@@ -374,8 +365,8 @@ class LogProcessorSimTest : SimulationTestBase() {
 
                         assertReplicaTxInvariants()
                         assertEquals(
-                            simExtSource.indexedCount, replicaTxIds().size,
-                            "every successfully-indexed action should appear on the replica"
+                            totalActions, replicaTxIds().size,
+                            "all actions should appear on the replica"
                         )
 
                         val replicaMessages = replicaLog.topic.map { it.message }
@@ -449,7 +440,7 @@ class LogProcessorSimTest : SimulationTestBase() {
                                                 yield()
                                                 srcLog.appendMessage(SourceMessage.FlushBlock(null))
                                             }
-                                            while (!simExtSource.isQuiescent) yield()
+                                            simExtSource.awaitQuiescence()
                                             replicaLog.awaitAllDelivered()
 
                                             // Anchor the per-node `latestTxId` to the latest replica tx so the
@@ -473,8 +464,8 @@ class LogProcessorSimTest : SimulationTestBase() {
 
                                         assertReplicaTxInvariants()
                                         assertEquals(
-                                            simExtSource.indexedCount, replicaTxIds().size,
-                                            "every successfully-indexed action should appear on the replica"
+                                            totalActions, replicaTxIds().size,
+                                            "all actions should appear on the replica"
                                         )
 
                                         val replicaMessages = replicaLog.topic.map { it.message }
@@ -566,7 +557,7 @@ class LogProcessorSimTest : SimulationTestBase() {
                                             srcLog.appendMessage(SourceMessage.FlushBlock(null))
                                         }
                                     }
-                                    while (!simExtSource.isQuiescent) yield()
+                                    simExtSource.awaitQuiescence()
                                     replicaLog.awaitAllDelivered()
 
                                     // Anchor the per-node `latestTxId` to the latest replica tx so the
@@ -587,8 +578,8 @@ class LogProcessorSimTest : SimulationTestBase() {
 
                                 assertReplicaTxInvariants()
                                 assertEquals(
-                                    simExtSource.indexedCount, replicaTxIds().size,
-                                    "every successfully-indexed action should appear on the replica"
+                                    totalActions, replicaTxIds().size,
+                                    "all actions should appear on the replica"
                                 )
 
                                 val replicaMessages = replicaLog.topic.map { it.message }

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -73,7 +73,6 @@ class LogProcessorTest {
                     extSource = null, replicaProducer = replicaProducer,
                     skipTxs = emptySet(), dbCatalog = null,
                     partition = 0, afterReplicaMsgId = afterReplicaMsgId,
-                    afterToken = null,
                 )
                 return object : LogProcessor.LeaderSystem {
                     override val proc get() = leaderProc


### PR DESCRIPTION
The simulation's external source held a single iterator over its action list, shared across every partition assignment (and across the leader and its followers), and ignored the token it was handed. On a leader reassignment its `onPartitionAssigned` continued from wherever that in-memory cursor had reached — it never resumed from a persisted position. A real external source has no such in-memory cursor to fall back on: a freshly-assigned leader is handed a token recording the position and must resume from there. Worse, an action pulled from the iterator but cancelled mid-flight, before its `indexTx` committed, was skipped — the `next()` call had already advanced the iterator past it — so the assertions could only check that the *successfully-indexed* actions reached the replica, tolerating that silent loss.

`SimExtSource` now encodes the action index into each transaction's external source token and, on assignment, resumes from the index the token carries, defaulting to the start when there's none. A leader cancelled mid-action leaves no committed token for it, so the next leader resumes at that action and retries it rather than skipping past. Every action therefore reaches the replica, and the assertions move from counting only the successfully-indexed actions to expecting all of them.

This is coupled in both directions to dropping the `afterToken` parameter on `LeaderLogProcessor`: the sim couldn't resume from a token while it was handed `null`, and removing the parameter is what feeds it the real one. In production `afterToken` only ever carried `watchers.externalSourceToken`, and no test passed anything but `null`. Reading the token straight from the watchers — which already hold the latest value from replica-log replay, possibly ahead of the block catalog — gives the sim (and any future test) the same token production uses, with one fewer thing to thread through.

The production change is behaviour-preserving: `LeaderLogProcessor` already used `watchers.externalSourceToken` in practice, so dropping the redundant parameter changes nothing at runtime — the behavioural change is confined to the test.

Quiescence detection also moves off busy-polling `isQuiescent` onto a `MutableStateFlow` tracking the next action index, so the test suspends until the source drains rather than spinning on `yield()`.