### PR TITLE
tidy(indexer): hand SimLog's lifecycle to the caller's scope

### DIFF
--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -36,6 +36,7 @@ import xtdb.database.DatabaseStorage
 import xtdb.database.ExternalSource
 import xtdb.database.ExternalSourceToken
 import xtdb.error.Incorrect
+import xtdb.indexer.SimLog.Companion.launchSimLog
 import xtdb.indexer.TxIndexer.TxResult
 import xtdb.storage.MemoryStorage
 import xtdb.table.TableRef
@@ -62,12 +63,25 @@ class LogProcessorSimTest : SimulationTestBase() {
     fun setUp() {
         nodeBase = openBase(openMeterRegistry = false)
         allocator = nodeBase.allocator.newChildAllocator("test", 0, Long.MAX_VALUE)
+        srcLog = SimLog("src", rand)
+        replicaLog = SimLog("replica", rand)
     }
 
     @AfterEach
     fun tearDown() {
+        replicaLog.close()
+        srcLog.close()
         allocator.close()
         nodeBase.close()
+    }
+
+    private inline fun <R> CoroutineScope.withLaunchedSimLogs(block: () -> R): R {
+        val job = launch(dispatcher) {
+            launchSimLog(srcLog)
+            launchSimLog(replicaLog)
+        }
+
+        return block().also { job.cancel() }
     }
 
     private val docsTable = TableRef("test-db", "public", "docs")
@@ -174,7 +188,8 @@ class LogProcessorSimTest : SimulationTestBase() {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
             .also { simExtSource.watch(it) }
         val dbStorage = DatabaseStorage(srcLog, replicaLog, bp, null)
-        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, uploadDispatcher = dispatcher)
+        val blockUploader =
+            BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, uploadDispatcher = dispatcher)
         val crashLogger = CrashLogger(allocator, bp, "sim-node")
 
         override fun openLeaderSystem(
@@ -330,84 +345,78 @@ class LogProcessorSimTest : SimulationTestBase() {
     @RepeatableSimulationTest
     fun `single node processes txs and flush-blocks with rebalances`() =
         runTest(timeout = 5.seconds) {
-            srcLog = SimLog("src", dispatcher + coroutineContext.job, rand)
-            replicaLog = SimLog("replica", dispatcher + coroutineContext.job, rand)
-            try {
-            val rowsPerBlock = rand.nextLong(15, 25)
-            val totalActions = rand.nextInt(50, 100)
-            val actions = buildActions(rand, totalActions)
-            val simExtSource = SimExtSource(actions)
-            val srcLogEventCount = rand.nextInt(20, 40)
-            LOG.debug("test: $totalActions actions, $srcLogEventCount srcLogEvents (rowsPerBlock=$rowsPerBlock)")
+            withLaunchedSimLogs {
+                val rowsPerBlock = rand.nextLong(15, 25)
+                val totalActions = rand.nextInt(50, 100)
+                val actions = buildActions(rand, totalActions)
+                val simExtSource = SimExtSource(actions)
+                val srcLogEventCount = rand.nextInt(20, 40)
+                LOG.debug("test: $totalActions actions, $srcLogEventCount srcLogEvents (rowsPerBlock=$rowsPerBlock)")
 
-            MemoryStorage(allocator, epoch = 0).use { bp ->
-                SimNode("test-db", bp, IndexerConfig(rowsPerBlock = rowsPerBlock), simExtSource).use { node ->
-                    val logProcScope = CoroutineScope(dispatcher + Job(coroutineContext.job))
-                    val logProc = node.openLogProcessor(logProcScope)
-                    try {
-                        val groupJob = launch(dispatcher) { srcLog.openGroupSubscription(logProc) }
+                MemoryStorage(allocator, epoch = 0).use { bp ->
+                    SimNode("test-db", bp, IndexerConfig(rowsPerBlock = rowsPerBlock), simExtSource).use { node ->
+                        val logProcScope = CoroutineScope(dispatcher + Job(coroutineContext.job))
+                        val logProc = node.openLogProcessor(logProcScope)
+                        try {
+                            val groupJob = launch(dispatcher) { srcLog.openGroupSubscription(logProc) }
 
-                        launch(dispatcher) {
-                            repeat(srcLogEventCount) {
-                                yield()
-                                if (rand.nextInt(100) < 50) {
-                                    srcLog.rebalanceTrigger.send(Unit)
-                                } else {
-                                    srcLog.appendMessage(SourceMessage.FlushBlock(null))
+                            launch(dispatcher) {
+                                repeat(srcLogEventCount) {
+                                    yield()
+                                    if (rand.nextInt(100) < 50) {
+                                        srcLog.rebalanceTrigger.send(Unit)
+                                    } else {
+                                        srcLog.appendMessage(SourceMessage.FlushBlock(null))
+                                    }
                                 }
-                            }
-                            simExtSource.awaitQuiescence()
-                            replicaLog.awaitAllDelivered()
-                        }.join()
+                                simExtSource.awaitQuiescence()
 
-                        groupJob.cancel()
-                        logProcScope.cancel()
+                                replicaLog.awaitAllDelivered()
+                            }.join()
 
-                        assertReplicaTxInvariants()
-                        assertEquals(
-                            totalActions, replicaTxIds().size,
-                            "all actions should appear on the replica"
-                        )
+                            groupJob.cancel()
+                            logProcScope.cancel()
 
-                        val replicaMessages = replicaLog.topic.map { it.message }
-                        assertBlockBoundariesMatchUploads(replicaMessages)
-
-                        val expectedBlockIndex =
-                            replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>().maxOfOrNull { it.blockIndex }
-                        assertEquals(
-                            expectedBlockIndex, node.blockCatalog.currentBlockIndex,
-                            "block catalog should match latest uploaded block"
-                        )
-
-                        val replicaTxIds = replicaTxIds()
-                        if (replicaTxIds.isNotEmpty()) {
-                            val lastReplicaTx = replicaMessages
-                                .filterIsInstance<ReplicaMessage.ResolvedTx>().last()
+                            assertReplicaTxInvariants()
                             assertEquals(
-                                lastReplicaTx.txId, node.liveIndex.latestCompletedTx?.txId,
-                                "live index latestCompletedTx should match last replica tx"
+                                totalActions, replicaTxIds().size,
+                                "all actions should appear on the replica"
                             )
-                        }
 
-                        assertBlockFilesExist(bp, "test-db", replicaMessages)
-                        assertSnapshotHasNoAbortedRows(node)
-                    } finally {
-                        logProc.cancelAndJoin()
+                            val replicaMessages = replicaLog.topic.map { it.message }
+                            assertBlockBoundariesMatchUploads(replicaMessages)
+
+                            val expectedBlockIndex =
+                                replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>()
+                                    .maxOfOrNull { it.blockIndex }
+                            assertEquals(
+                                expectedBlockIndex, node.blockCatalog.currentBlockIndex,
+                                "block catalog should match latest uploaded block"
+                            )
+
+                            val replicaTxIds = replicaTxIds()
+                            if (replicaTxIds.isNotEmpty()) {
+                                val lastReplicaTx = replicaMessages
+                                    .filterIsInstance<ReplicaMessage.ResolvedTx>().last()
+                                assertEquals(
+                                    lastReplicaTx.txId, node.liveIndex.latestCompletedTx?.txId,
+                                    "live index latestCompletedTx should match last replica tx"
+                                )
+                            }
+
+                            assertBlockFilesExist(bp, "test-db", replicaMessages)
+                            assertSnapshotHasNoAbortedRows(node)
+                        } finally {
+                            logProc.cancelAndJoin()
+                        }
                     }
                 }
-            }
-            } finally {
-                replicaLog.close()
-                srcLog.close()
             }
         }
 
     @RepeatableSimulationTest
-    fun `stable leader with sustained throughput`() =
-        runTest(timeout = 5.seconds) {
-            srcLog = SimLog("src", dispatcher + coroutineContext.job, rand)
-            replicaLog = SimLog("replica", dispatcher + coroutineContext.job, rand)
-            try {
+    fun `stable leader with sustained throughput`() = runTest(timeout = 5.seconds) {
+        withLaunchedSimLogs {
             val rowsPerBlock = rand.nextLong(15, 25)
             val indexerConfig = IndexerConfig(rowsPerBlock = rowsPerBlock)
             val totalActions = rand.nextInt(50, 100)
@@ -428,85 +437,85 @@ class LogProcessorSimTest : SimulationTestBase() {
                             val followerProcA = followerA.openLogProcessor(followerScopeA)
                             val followerProcB = followerB.openLogProcessor(followerScopeB)
                             try {
-                                        val groupJobLeader =
-                                            launch(dispatcher) { srcLog.openGroupSubscription(leaderProc) }
-                                        val groupJobA =
-                                            launch(dispatcher) { srcLog.openGroupSubscription(followerProcA) }
-                                        val groupJobB =
-                                            launch(dispatcher) { srcLog.openGroupSubscription(followerProcB) }
+                                val groupJobLeader =
+                                    launch(dispatcher) { srcLog.openGroupSubscription(leaderProc) }
+                                val groupJobA =
+                                    launch(dispatcher) { srcLog.openGroupSubscription(followerProcA) }
+                                val groupJobB =
+                                    launch(dispatcher) { srcLog.openGroupSubscription(followerProcB) }
 
-                                        launch(dispatcher) {
-                                            repeat(srcLogEventCount) {
-                                                yield()
-                                                srcLog.appendMessage(SourceMessage.FlushBlock(null))
-                                            }
-                                            simExtSource.awaitQuiescence()
-                                            replicaLog.awaitAllDelivered()
+                                launch(dispatcher) {
+                                    repeat(srcLogEventCount) {
+                                        yield()
+                                        srcLog.appendMessage(SourceMessage.FlushBlock(null))
+                                    }
+                                    simExtSource.awaitQuiescence()
+                                    replicaLog.awaitAllDelivered()
 
-                                            // Anchor the per-node `latestTxId` to the latest replica tx so the
-                                            // convergence assertions below see consistent state across nodes.
-                                            val lastReplicaTxId = replicaLog.topic.map { it.message }
-                                                .filterIsInstance<ReplicaMessage.ResolvedTx>()
-                                                .maxOfOrNull { it.txId }
-                                            if (lastReplicaTxId != null) {
-                                                leader.watchers.awaitTx(lastReplicaTxId)
-                                                followerA.watchers.awaitTx(lastReplicaTxId)
-                                                followerB.watchers.awaitTx(lastReplicaTxId)
-                                            }
-                                        }.join()
+                                    // Anchor the per-node `latestTxId` to the latest replica tx so the
+                                    // convergence assertions below see consistent state across nodes.
+                                    val lastReplicaTxId = replicaLog.topic.map { it.message }
+                                        .filterIsInstance<ReplicaMessage.ResolvedTx>()
+                                        .maxOfOrNull { it.txId }
+                                    if (lastReplicaTxId != null) {
+                                        leader.watchers.awaitTx(lastReplicaTxId)
+                                        followerA.watchers.awaitTx(lastReplicaTxId)
+                                        followerB.watchers.awaitTx(lastReplicaTxId)
+                                    }
+                                }.join()
 
-                                        groupJobLeader.cancel()
-                                        groupJobA.cancel()
-                                        groupJobB.cancel()
-                                        leaderScope.cancel()
-                                        followerScopeA.cancel()
-                                        followerScopeB.cancel()
+                                groupJobLeader.cancel()
+                                groupJobA.cancel()
+                                groupJobB.cancel()
+                                leaderScope.cancel()
+                                followerScopeA.cancel()
+                                followerScopeB.cancel()
 
-                                        assertReplicaTxInvariants()
-                                        assertEquals(
-                                            totalActions, replicaTxIds().size,
-                                            "all actions should appear on the replica"
-                                        )
+                                assertReplicaTxInvariants()
+                                assertEquals(
+                                    totalActions, replicaTxIds().size,
+                                    "all actions should appear on the replica"
+                                )
 
-                                        val replicaMessages = replicaLog.topic.map { it.message }
-                                        assertBlockBoundariesMatchUploads(replicaMessages)
+                                val replicaMessages = replicaLog.topic.map { it.message }
+                                assertBlockBoundariesMatchUploads(replicaMessages)
 
-                                        val nodes = listOf(leader, followerA, followerB)
+                                val nodes = listOf(leader, followerA, followerB)
 
-                                        val expectedBlockIndex =
-                                            replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>()
-                                                .maxOfOrNull { it.blockIndex }
-                                        for (node in nodes) {
-                                            assertEquals(
-                                                expectedBlockIndex, node.blockCatalog.currentBlockIndex,
-                                                "block catalog should match latest uploaded block"
-                                            )
-                                        }
+                                val expectedBlockIndex =
+                                    replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>()
+                                        .maxOfOrNull { it.blockIndex }
+                                for (node in nodes) {
+                                    assertEquals(
+                                        expectedBlockIndex, node.blockCatalog.currentBlockIndex,
+                                        "block catalog should match latest uploaded block"
+                                    )
+                                }
 
-                                        val expectedLatestCompletedTx = leader.liveIndex.latestCompletedTx
-                                        val expectedBlockCatalogTx = leader.blockCatalog.latestCompletedTx
-                                        val expectedProcessedMsgId = leader.blockCatalog.latestProcessedMsgId
+                                val expectedLatestCompletedTx = leader.liveIndex.latestCompletedTx
+                                val expectedBlockCatalogTx = leader.blockCatalog.latestCompletedTx
+                                val expectedProcessedMsgId = leader.blockCatalog.latestProcessedMsgId
 
-                                        for (node in nodes) {
-                                            assertEquals(
-                                                expectedProcessedMsgId, node.blockCatalog.latestProcessedMsgId,
-                                                "all nodes should agree on latestProcessedMsgId"
-                                            )
-                                            assertEquals(
-                                                expectedBlockCatalogTx, node.blockCatalog.latestCompletedTx,
-                                                "all nodes should agree on block catalog's latestCompletedTx"
-                                            )
-                                            assertEquals(
-                                                expectedLatestCompletedTx, node.liveIndex.latestCompletedTx,
-                                                "all nodes should agree on live index's latestCompletedTx"
-                                            )
-                                        }
+                                for (node in nodes) {
+                                    assertEquals(
+                                        expectedProcessedMsgId, node.blockCatalog.latestProcessedMsgId,
+                                        "all nodes should agree on latestProcessedMsgId"
+                                    )
+                                    assertEquals(
+                                        expectedBlockCatalogTx, node.blockCatalog.latestCompletedTx,
+                                        "all nodes should agree on block catalog's latestCompletedTx"
+                                    )
+                                    assertEquals(
+                                        expectedLatestCompletedTx, node.liveIndex.latestCompletedTx,
+                                        "all nodes should agree on live index's latestCompletedTx"
+                                    )
+                                }
 
-                                        assertBlockFilesExist(bp, "test-db", replicaMessages)
+                                assertBlockFilesExist(bp, "test-db", replicaMessages)
 
-                                        assertSnapshotHasNoAbortedRows(leader)
-                                        assertSnapshotHasNoAbortedRows(followerA)
-                                        assertSnapshotHasNoAbortedRows(followerB)
+                                assertSnapshotHasNoAbortedRows(leader)
+                                assertSnapshotHasNoAbortedRows(followerA)
+                                assertSnapshotHasNoAbortedRows(followerB)
                             } finally {
                                 leaderProc.cancelAndJoin()
                                 followerProcA.cancelAndJoin()
@@ -516,35 +525,30 @@ class LogProcessorSimTest : SimulationTestBase() {
                     }
                 }
             }
-            } finally {
-                replicaLog.close()
-                srcLog.close()
-            }
         }
+    }
 
     @RepeatableSimulationTest
     fun `multi-node leadership changes preserve block catalog consistency`() =
         runTest(timeout = 5.seconds) {
-            srcLog = SimLog("src", dispatcher + coroutineContext.job, rand)
-            replicaLog = SimLog("replica", dispatcher + coroutineContext.job, rand)
-            try {
-            val rowsPerBlock = rand.nextLong(15, 25)
-            val indexerConfig = IndexerConfig(rowsPerBlock = rowsPerBlock)
-            val totalActions = rand.nextInt(50, 100)
-            val actions = buildActions(rand, totalActions)
-            val simExtSource = SimExtSource(actions)
-            val srcLogEventCount = rand.nextInt(20, 40)
-            LOG.debug("test: multi-node $totalActions actions, $srcLogEventCount srcLogEvents (rowsPerBlock=$rowsPerBlock)")
+            withLaunchedSimLogs {
+                val rowsPerBlock = rand.nextLong(15, 25)
+                val indexerConfig = IndexerConfig(rowsPerBlock = rowsPerBlock)
+                val totalActions = rand.nextInt(50, 100)
+                val actions = buildActions(rand, totalActions)
+                val simExtSource = SimExtSource(actions)
+                val srcLogEventCount = rand.nextInt(20, 40)
+                LOG.debug("test: multi-node $totalActions actions, $srcLogEventCount srcLogEvents (rowsPerBlock=$rowsPerBlock)")
 
-            MemoryStorage(allocator, epoch = 0).use { bp ->
-                SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeA ->
-                    SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeB ->
-                        val scopeA = CoroutineScope(dispatcher + Job(coroutineContext.job))
-                        val scopeB = CoroutineScope(dispatcher + Job(coroutineContext.job))
+                MemoryStorage(allocator, epoch = 0).use { bp ->
+                    SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeA ->
+                        SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeB ->
+                            val scopeA = CoroutineScope(dispatcher + Job(coroutineContext.job))
+                            val scopeB = CoroutineScope(dispatcher + Job(coroutineContext.job))
 
-                        val logProcA = nodeA.openLogProcessor(scopeA)
-                        val logProcB = nodeB.openLogProcessor(scopeB)
-                        try {
+                            val logProcA = nodeA.openLogProcessor(scopeA)
+                            val logProcB = nodeB.openLogProcessor(scopeB)
+                            try {
                                 val groupJobA = launch(dispatcher) { srcLog.openGroupSubscription(logProcA) }
                                 val groupJobB = launch(dispatcher) { srcLog.openGroupSubscription(logProcB) }
 
@@ -617,16 +621,13 @@ class LogProcessorSimTest : SimulationTestBase() {
 
                                 assertSnapshotHasNoAbortedRows(nodeA)
                                 assertSnapshotHasNoAbortedRows(nodeB)
-                        } finally {
-                            logProcA.cancelAndJoin()
-                            logProcB.cancelAndJoin()
+                            } finally {
+                                logProcA.cancelAndJoin()
+                                logProcB.cancelAndJoin()
+                            }
                         }
                     }
                 }
-            }
-            } finally {
-                replicaLog.close()
-                srcLog.close()
             }
         }
 }

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -1,22 +1,16 @@
 package xtdb.indexer
 
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.job
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.yield
 import org.apache.arrow.memory.BufferAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.TestTemplate
 import xtdb.NodeBase
 import xtdb.NodeBase.Companion.openBase
 import xtdb.RepeatableSimulationTest
@@ -25,9 +19,6 @@ import xtdb.SimulationTestUtils.Companion.createTrieCatalog
 import xtdb.WithSeed
 import xtdb.api.IndexerConfig
 import xtdb.api.log.*
-import xtdb.api.log.Log
-import xtdb.api.log.MessageId
-import xtdb.api.log.ReplicaMessage
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
@@ -46,7 +37,7 @@ import xtdb.util.asIid
 import xtdb.util.debug
 import xtdb.util.logger
 import java.nio.ByteBuffer
-import java.util.UUID
+import java.util.*
 import kotlin.time.Duration.Companion.seconds
 
 private val LOG = LogProcessorSimTest::class.logger
@@ -73,15 +64,6 @@ class LogProcessorSimTest : SimulationTestBase() {
         srcLog.close()
         allocator.close()
         nodeBase.close()
-    }
-
-    private inline fun <R> CoroutineScope.withLaunchedSimLogs(block: () -> R): R {
-        val job = launch(dispatcher) {
-            launchSimLog(srcLog)
-            launchSimLog(replicaLog)
-        }
-
-        return block().also { job.cancel() }
     }
 
     private val docsTable = TableRef("test-db", "public", "docs")
@@ -345,78 +327,73 @@ class LogProcessorSimTest : SimulationTestBase() {
     @RepeatableSimulationTest
     fun `single node processes txs and flush-blocks with rebalances`() =
         runTest(timeout = 5.seconds) {
-            withLaunchedSimLogs {
-                val rowsPerBlock = rand.nextLong(15, 25)
-                val totalActions = rand.nextInt(50, 100)
-                val actions = buildActions(rand, totalActions)
-                val simExtSource = SimExtSource(actions)
-                val srcLogEventCount = rand.nextInt(20, 40)
-                LOG.debug("test: $totalActions actions, $srcLogEventCount srcLogEvents (rowsPerBlock=$rowsPerBlock)")
+            val rowsPerBlock = rand.nextLong(15, 25)
+            val totalActions = rand.nextInt(50, 100)
+            val actions = buildActions(rand, totalActions)
+            val simExtSource = SimExtSource(actions)
+            val srcLogEventCount = rand.nextInt(20, 40)
+            LOG.debug("test: $totalActions actions, $srcLogEventCount srcLogEvents (rowsPerBlock=$rowsPerBlock)")
 
-                MemoryStorage(allocator, epoch = 0).use { bp ->
-                    SimNode("test-db", bp, IndexerConfig(rowsPerBlock = rowsPerBlock), simExtSource).use { node ->
-                        val logProcScope = CoroutineScope(dispatcher + Job(coroutineContext.job))
-                        val logProc = node.openLogProcessor(logProcScope)
-                        try {
-                            val groupJob = launch(dispatcher) { srcLog.openGroupSubscription(logProc) }
+            MemoryStorage(allocator, epoch = 0).use { bp ->
+                SimNode("test-db", bp, IndexerConfig(rowsPerBlock = rowsPerBlock), simExtSource).use { node ->
+                    launch(dispatcher) {
+                        launchSimLog(srcLog)
+                        launchSimLog(replicaLog)
 
-                            launch(dispatcher) {
-                                repeat(srcLogEventCount) {
-                                    yield()
-                                    if (rand.nextInt(100) < 50) {
-                                        srcLog.rebalanceTrigger.send(Unit)
-                                    } else {
-                                        srcLog.appendMessage(SourceMessage.FlushBlock(null))
-                                    }
+                        launch { srcLog.openGroupSubscription(node.openLogProcessor(this)) }
+
+                        launch {
+                            repeat(srcLogEventCount) {
+                                yield()
+                                if (rand.nextInt(100) < 50) {
+                                    srcLog.rebalanceTrigger.send(Unit)
+                                } else {
+                                    srcLog.appendMessage(SourceMessage.FlushBlock(null))
                                 }
-                                simExtSource.awaitQuiescence()
-
-                                replicaLog.awaitAllDelivered()
-                            }.join()
-
-                            groupJob.cancel()
-                            logProcScope.cancel()
-
-                            assertReplicaTxInvariants()
-                            assertEquals(
-                                totalActions, replicaTxIds().size,
-                                "all actions should appear on the replica"
-                            )
-
-                            val replicaMessages = replicaLog.topic.map { it.message }
-                            assertBlockBoundariesMatchUploads(replicaMessages)
-
-                            val expectedBlockIndex =
-                                replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>()
-                                    .maxOfOrNull { it.blockIndex }
-                            assertEquals(
-                                expectedBlockIndex, node.blockCatalog.currentBlockIndex,
-                                "block catalog should match latest uploaded block"
-                            )
-
-                            val replicaTxIds = replicaTxIds()
-                            if (replicaTxIds.isNotEmpty()) {
-                                val lastReplicaTx = replicaMessages
-                                    .filterIsInstance<ReplicaMessage.ResolvedTx>().last()
-                                assertEquals(
-                                    lastReplicaTx.txId, node.liveIndex.latestCompletedTx?.txId,
-                                    "live index latestCompletedTx should match last replica tx"
-                                )
                             }
+                            simExtSource.awaitQuiescence()
 
-                            assertBlockFilesExist(bp, "test-db", replicaMessages)
-                            assertSnapshotHasNoAbortedRows(node)
-                        } finally {
-                            logProc.cancelAndJoin()
-                        }
+                            replicaLog.awaitAllDelivered()
+                        }.invokeOnCompletion { cancel() }
+                    }.join()
+
+                    assertReplicaTxInvariants()
+                    assertEquals(
+                        totalActions, replicaTxIds().size,
+                        "all actions should appear on the replica"
+                    )
+
+                    val replicaMessages = replicaLog.topic.map { it.message }
+                    assertBlockBoundariesMatchUploads(replicaMessages)
+
+                    val expectedBlockIndex =
+                        replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>()
+                            .maxOfOrNull { it.blockIndex }
+
+                    assertEquals(
+                        expectedBlockIndex, node.blockCatalog.currentBlockIndex,
+                        "block catalog should match latest uploaded block"
+                    )
+
+                    val replicaTxIds = replicaTxIds()
+
+                    if (replicaTxIds.isNotEmpty()) {
+                        assertEquals(
+                            replicaMessages.filterIsInstance<ReplicaMessage.ResolvedTx>().last().txId,
+                            node.liveIndex.latestCompletedTx?.txId,
+                            "live index latestCompletedTx should match last replica tx"
+                        )
                     }
+
+                    assertBlockFilesExist(bp, "test-db", replicaMessages)
+                    assertSnapshotHasNoAbortedRows(node)
                 }
             }
         }
 
     @RepeatableSimulationTest
-    fun `stable leader with sustained throughput`() = runTest(timeout = 5.seconds) {
-        withLaunchedSimLogs {
+    fun `stable leader with sustained throughput`() =
+        runTest(timeout = 5.seconds) {
             val rowsPerBlock = rand.nextLong(15, 25)
             val indexerConfig = IndexerConfig(rowsPerBlock = rowsPerBlock)
             val totalActions = rand.nextInt(50, 100)
@@ -429,22 +406,15 @@ class LogProcessorSimTest : SimulationTestBase() {
                 SimNode("test-db", bp, indexerConfig, simExtSource).use { leader ->
                     SimNode("test-db", bp, indexerConfig, simExtSource).use { followerA ->
                         SimNode("test-db", bp, indexerConfig, simExtSource).use { followerB ->
-                            val leaderScope = CoroutineScope(dispatcher + Job(coroutineContext.job))
-                            val followerScopeA = CoroutineScope(dispatcher + Job(coroutineContext.job))
-                            val followerScopeB = CoroutineScope(dispatcher + Job(coroutineContext.job))
+                            launch(dispatcher) {
+                                launchSimLog(srcLog)
+                                launchSimLog(replicaLog)
 
-                            val leaderProc = leader.openLogProcessor(leaderScope)
-                            val followerProcA = followerA.openLogProcessor(followerScopeA)
-                            val followerProcB = followerB.openLogProcessor(followerScopeB)
-                            try {
-                                val groupJobLeader =
-                                    launch(dispatcher) { srcLog.openGroupSubscription(leaderProc) }
-                                val groupJobA =
-                                    launch(dispatcher) { srcLog.openGroupSubscription(followerProcA) }
-                                val groupJobB =
-                                    launch(dispatcher) { srcLog.openGroupSubscription(followerProcB) }
+                                launch { srcLog.openGroupSubscription(leader.openLogProcessor(this)) }
+                                launch { srcLog.openGroupSubscription(followerA.openLogProcessor(this)) }
+                                launch { srcLog.openGroupSubscription(followerB.openLogProcessor(this)) }
 
-                                launch(dispatcher) {
+                                launch {
                                     repeat(srcLogEventCount) {
                                         yield()
                                         srcLog.appendMessage(SourceMessage.FlushBlock(null))
@@ -462,170 +432,146 @@ class LogProcessorSimTest : SimulationTestBase() {
                                         followerA.watchers.awaitTx(lastReplicaTxId)
                                         followerB.watchers.awaitTx(lastReplicaTxId)
                                     }
-                                }.join()
+                                }.invokeOnCompletion { cancel() }
+                            }.join()
 
-                                groupJobLeader.cancel()
-                                groupJobA.cancel()
-                                groupJobB.cancel()
-                                leaderScope.cancel()
-                                followerScopeA.cancel()
-                                followerScopeB.cancel()
+                            assertReplicaTxInvariants()
+                            assertEquals(
+                                totalActions, replicaTxIds().size,
+                                "all actions should appear on the replica"
+                            )
 
-                                assertReplicaTxInvariants()
+                            val replicaMessages = replicaLog.topic.map { it.message }
+                            assertBlockBoundariesMatchUploads(replicaMessages)
+
+                            val nodes = listOf(leader, followerA, followerB)
+
+                            val expectedBlockIndex =
+                                replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>()
+                                    .maxOfOrNull { it.blockIndex }
+                            for (node in nodes) {
                                 assertEquals(
-                                    totalActions, replicaTxIds().size,
-                                    "all actions should appear on the replica"
+                                    expectedBlockIndex, node.blockCatalog.currentBlockIndex,
+                                    "block catalog should match latest uploaded block"
                                 )
-
-                                val replicaMessages = replicaLog.topic.map { it.message }
-                                assertBlockBoundariesMatchUploads(replicaMessages)
-
-                                val nodes = listOf(leader, followerA, followerB)
-
-                                val expectedBlockIndex =
-                                    replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>()
-                                        .maxOfOrNull { it.blockIndex }
-                                for (node in nodes) {
-                                    assertEquals(
-                                        expectedBlockIndex, node.blockCatalog.currentBlockIndex,
-                                        "block catalog should match latest uploaded block"
-                                    )
-                                }
-
-                                val expectedLatestCompletedTx = leader.liveIndex.latestCompletedTx
-                                val expectedBlockCatalogTx = leader.blockCatalog.latestCompletedTx
-                                val expectedProcessedMsgId = leader.blockCatalog.latestProcessedMsgId
-
-                                for (node in nodes) {
-                                    assertEquals(
-                                        expectedProcessedMsgId, node.blockCatalog.latestProcessedMsgId,
-                                        "all nodes should agree on latestProcessedMsgId"
-                                    )
-                                    assertEquals(
-                                        expectedBlockCatalogTx, node.blockCatalog.latestCompletedTx,
-                                        "all nodes should agree on block catalog's latestCompletedTx"
-                                    )
-                                    assertEquals(
-                                        expectedLatestCompletedTx, node.liveIndex.latestCompletedTx,
-                                        "all nodes should agree on live index's latestCompletedTx"
-                                    )
-                                }
-
-                                assertBlockFilesExist(bp, "test-db", replicaMessages)
-
-                                assertSnapshotHasNoAbortedRows(leader)
-                                assertSnapshotHasNoAbortedRows(followerA)
-                                assertSnapshotHasNoAbortedRows(followerB)
-                            } finally {
-                                leaderProc.cancelAndJoin()
-                                followerProcA.cancelAndJoin()
-                                followerProcB.cancelAndJoin()
                             }
+
+                            val expectedLatestCompletedTx = leader.liveIndex.latestCompletedTx
+                            val expectedBlockCatalogTx = leader.blockCatalog.latestCompletedTx
+                            val expectedProcessedMsgId = leader.blockCatalog.latestProcessedMsgId
+
+                            for (node in nodes) {
+                                assertEquals(
+                                    expectedProcessedMsgId, node.blockCatalog.latestProcessedMsgId,
+                                    "all nodes should agree on latestProcessedMsgId"
+                                )
+                                assertEquals(
+                                    expectedBlockCatalogTx, node.blockCatalog.latestCompletedTx,
+                                    "all nodes should agree on block catalog's latestCompletedTx"
+                                )
+                                assertEquals(
+                                    expectedLatestCompletedTx, node.liveIndex.latestCompletedTx,
+                                    "all nodes should agree on live index's latestCompletedTx"
+                                )
+                            }
+
+                            assertBlockFilesExist(bp, "test-db", replicaMessages)
+
+                            assertSnapshotHasNoAbortedRows(leader)
+                            assertSnapshotHasNoAbortedRows(followerA)
+                            assertSnapshotHasNoAbortedRows(followerB)
                         }
                     }
                 }
             }
         }
-    }
 
     @RepeatableSimulationTest
     fun `multi-node leadership changes preserve block catalog consistency`() =
         runTest(timeout = 5.seconds) {
-            withLaunchedSimLogs {
-                val rowsPerBlock = rand.nextLong(15, 25)
-                val indexerConfig = IndexerConfig(rowsPerBlock = rowsPerBlock)
-                val totalActions = rand.nextInt(50, 100)
-                val actions = buildActions(rand, totalActions)
-                val simExtSource = SimExtSource(actions)
-                val srcLogEventCount = rand.nextInt(20, 40)
-                LOG.debug("test: multi-node $totalActions actions, $srcLogEventCount srcLogEvents (rowsPerBlock=$rowsPerBlock)")
+            val rowsPerBlock = rand.nextLong(15, 25)
+            val indexerConfig = IndexerConfig(rowsPerBlock = rowsPerBlock)
+            val totalActions = rand.nextInt(50, 100)
+            val actions = buildActions(rand, totalActions)
+            val simExtSource = SimExtSource(actions)
+            val srcLogEventCount = rand.nextInt(20, 40)
+            LOG.debug("test: multi-node $totalActions actions, $srcLogEventCount srcLogEvents (rowsPerBlock=$rowsPerBlock)")
 
-                MemoryStorage(allocator, epoch = 0).use { bp ->
-                    SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeA ->
-                        SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeB ->
-                            val scopeA = CoroutineScope(dispatcher + Job(coroutineContext.job))
-                            val scopeB = CoroutineScope(dispatcher + Job(coroutineContext.job))
+            MemoryStorage(allocator, epoch = 0).use { bp ->
+                SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeA ->
+                    SimNode("test-db", bp, indexerConfig, simExtSource).use { nodeB ->
+                        launch(dispatcher) {
+                            launchSimLog(srcLog)
+                            launchSimLog(replicaLog)
 
-                            val logProcA = nodeA.openLogProcessor(scopeA)
-                            val logProcB = nodeB.openLogProcessor(scopeB)
-                            try {
-                                val groupJobA = launch(dispatcher) { srcLog.openGroupSubscription(logProcA) }
-                                val groupJobB = launch(dispatcher) { srcLog.openGroupSubscription(logProcB) }
+                            launch { srcLog.openGroupSubscription(nodeA.openLogProcessor(this)) }
+                            launch { srcLog.openGroupSubscription(nodeB.openLogProcessor(this)) }
 
-                                launch(dispatcher) {
-                                    repeat(srcLogEventCount) {
-                                        yield()
-                                        if (rand.nextInt(100) < 50) {
-                                            srcLog.rebalanceTrigger.send(Unit)
-                                        } else {
-                                            srcLog.appendMessage(SourceMessage.FlushBlock(null))
-                                        }
+                            launch {
+                                repeat(srcLogEventCount) {
+                                    yield()
+                                    if (rand.nextInt(100) < 50) {
+                                        srcLog.rebalanceTrigger.send(Unit)
+                                    } else {
+                                        srcLog.appendMessage(SourceMessage.FlushBlock(null))
                                     }
-                                    simExtSource.awaitQuiescence()
-                                    replicaLog.awaitAllDelivered()
+                                }
+                                simExtSource.awaitQuiescence()
+                                replicaLog.awaitAllDelivered()
 
-                                    // Anchor the per-node `latestTxId` to the latest replica tx so the
-                                    // convergence assertions below see consistent state across nodes.
-                                    val lastReplicaTxId = replicaLog.topic.map { it.message }
-                                        .filterIsInstance<ReplicaMessage.ResolvedTx>()
-                                        .maxOfOrNull { it.txId }
-                                    if (lastReplicaTxId != null) {
-                                        nodeA.watchers.awaitTx(lastReplicaTxId)
-                                        nodeB.watchers.awaitTx(lastReplicaTxId)
-                                    }
-                                }.join()
+                                // Anchor the per-node `latestTxId` to the latest replica tx so the
+                                // convergence assertions below see consistent state across nodes.
+                                val lastReplicaTxId = replicaLog.topic.map { it.message }
+                                    .filterIsInstance<ReplicaMessage.ResolvedTx>()
+                                    .maxOfOrNull { it.txId }
+                                if (lastReplicaTxId != null) {
+                                    nodeA.watchers.awaitTx(lastReplicaTxId)
+                                    nodeB.watchers.awaitTx(lastReplicaTxId)
+                                }
+                            }.invokeOnCompletion { cancel() }
+                        }.join()
 
-                                groupJobA.cancel()
-                                groupJobB.cancel()
-                                scopeA.cancel()
-                                scopeB.cancel()
+                        assertReplicaTxInvariants()
+                        assertEquals(
+                            totalActions, replicaTxIds().size,
+                            "all actions should appear on the replica"
+                        )
 
-                                assertReplicaTxInvariants()
-                                assertEquals(
-                                    totalActions, replicaTxIds().size,
-                                    "all actions should appear on the replica"
-                                )
+                        val replicaMessages = replicaLog.topic.map { it.message }
+                        assertBlockBoundariesMatchUploads(replicaMessages)
 
-                                val replicaMessages = replicaLog.topic.map { it.message }
-                                assertBlockBoundariesMatchUploads(replicaMessages)
+                        val expectedBlockIndex = replicaMessages
+                            .filterIsInstance<ReplicaMessage.BlockUploaded>()
+                            .maxOfOrNull { it.blockIndex }
 
-                                val expectedBlockIndex = replicaMessages
-                                    .filterIsInstance<ReplicaMessage.BlockUploaded>()
-                                    .maxOfOrNull { it.blockIndex }
+                        assertEquals(
+                            expectedBlockIndex, nodeA.blockCatalog.currentBlockIndex,
+                            "node A block catalog should match latest uploaded block"
+                        )
+                        assertEquals(
+                            expectedBlockIndex, nodeB.blockCatalog.currentBlockIndex,
+                            "node B block catalog should match latest uploaded block"
+                        )
 
-                                assertEquals(
-                                    expectedBlockIndex, nodeA.blockCatalog.currentBlockIndex,
-                                    "node A block catalog should match latest uploaded block"
-                                )
-                                assertEquals(
-                                    expectedBlockIndex, nodeB.blockCatalog.currentBlockIndex,
-                                    "node B block catalog should match latest uploaded block"
-                                )
+                        assertEquals(
+                            nodeA.blockCatalog.latestProcessedMsgId, nodeB.blockCatalog.latestProcessedMsgId,
+                            "both nodes should agree on latestProcessedMsgId"
+                        )
 
-                                assertEquals(
-                                    nodeA.blockCatalog.latestProcessedMsgId, nodeB.blockCatalog.latestProcessedMsgId,
-                                    "both nodes should agree on latestProcessedMsgId"
-                                )
+                        assertEquals(
+                            nodeA.blockCatalog.latestCompletedTx, nodeB.blockCatalog.latestCompletedTx,
+                            "both nodes should agree on block catalog's latestCompletedTx"
+                        )
 
-                                assertEquals(
-                                    nodeA.blockCatalog.latestCompletedTx, nodeB.blockCatalog.latestCompletedTx,
-                                    "both nodes should agree on block catalog's latestCompletedTx"
-                                )
+                        assertEquals(
+                            nodeA.liveIndex.latestCompletedTx, nodeB.liveIndex.latestCompletedTx,
+                            "both nodes should agree on live index's latestCompletedTx"
+                        )
 
-                                assertEquals(
-                                    nodeA.liveIndex.latestCompletedTx, nodeB.liveIndex.latestCompletedTx,
-                                    "both nodes should agree on live index's latestCompletedTx"
-                                )
+                        assertBlockFilesExist(bp, "test-db", replicaMessages)
 
-                                assertBlockFilesExist(bp, "test-db", replicaMessages)
-
-                                assertSnapshotHasNoAbortedRows(nodeA)
-                                assertSnapshotHasNoAbortedRows(nodeB)
-                            } finally {
-                                logProcA.cancelAndJoin()
-                                logProcB.cancelAndJoin()
-                            }
-                        }
+                        assertSnapshotHasNoAbortedRows(nodeA)
+                        assertSnapshotHasNoAbortedRows(nodeB)
                     }
                 }
             }

--- a/core/src/test/kotlin/xtdb/indexer/SimLog.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLog.kt
@@ -17,7 +17,7 @@ import kotlin.random.Random
 
 private val LOG = SimLog::class.logger
 
-internal class SimLog<M>(private val name: String, ctx: CoroutineContext, private val rand: Random) : Log<M> {
+internal class SimLog<M>(private val name: String, private val rand: Random) : Log<M> {
     override val epoch: Int get() = 0
 
     override var latestSubmittedOffset: LogOffset = -1
@@ -48,9 +48,6 @@ internal class SimLog<M>(private val name: String, ctx: CoroutineContext, privat
 
     var leader: GroupConsumer<M>? = null
 
-    val job = Job(ctx[Job])
-    private val scope = CoroutineScope(ctx + job)
-
     /**
      * Unified group loop: delivers records and handles rebalances in a single coroutine.
      * Rebalances and record delivery are serialized via `select` — a rebalance can only
@@ -60,7 +57,7 @@ internal class SimLog<M>(private val name: String, ctx: CoroutineContext, privat
     suspend fun groupLoop() {
         while (true) {
             // Rebalance branch first: Kafka processes pending rebalances before fetching records.
-            select<Unit> {
+            select {
                 rebalanceTrigger.onReceive { doRebalance() }
                 wakeLeader.onReceive { deliverGroupRecords() }
             }
@@ -156,10 +153,13 @@ internal class SimLog<M>(private val name: String, ctx: CoroutineContext, privat
         }
     }
 
-    init {
-        LOG.debug("$name: starting loops")
-        scope.launch(CoroutineName("SimLog/group")) { groupLoop() }
-        scope.launch(CoroutineName("SimLog/plainConsumers")) { plainConsumerLoop() }
+    companion object {
+        fun CoroutineScope.launchSimLog(log: SimLog<*>) {
+            LOG.debug("${log.name}: starting loops")
+
+            launch(CoroutineName("SimLog/group")) { log.groupLoop() }
+            launch(CoroutineName("SimLog/plainConsumers")) { log.plainConsumerLoop() }
+        }
     }
 
     private fun appendSync(message: M): Log.MessageMetadata {
@@ -269,14 +269,5 @@ internal class SimLog<M>(private val name: String, ctx: CoroutineContext, privat
         }
     }
 
-    override fun close() {
-        LOG.debug("$name: closing")
-        job.cancel()
-        runBlocking {
-            LOG.debug("$name: waiting for loops to finish")
-            job.join()
-            LOG.debug("$name: loops finished")
-        }
-        LOG.debug("$name: closed")
-    }
+    override fun close() = Unit
 }

--- a/core/src/test/kotlin/xtdb/indexer/SimLogTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLogTest.kt
@@ -1,15 +1,15 @@
 package xtdb.indexer
 
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.yield
+import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import xtdb.SimulationTestBase
 import xtdb.api.log.Log
+import xtdb.indexer.SimLog.Companion.launchSimLog
 import kotlin.time.Duration.Companion.seconds
 
 class SimLogTest : SimulationTestBase() {
@@ -18,13 +18,12 @@ class SimLogTest : SimulationTestBase() {
     fun `plainConsumer processRecords failure propagates via the parent scope`() = runTest(timeout = 5.seconds) {
         val ex = assertThrows<IllegalStateException> {
             coroutineScope {
-                SimLog<String>("test", dispatcher + coroutineContext.job, rand).use { log ->
-                    launch(dispatcher) {
-                        log.tailAll(afterMsgId = -1) { _ -> error("plainConsumer failure") }
-                    }
+                SimLog<String>("test", rand).use { log ->
+                    launchSimLog(log)
+
+                    launch { log.tailAll(afterMsgId = -1) { _ -> error("plainConsumer failure") } }
 
                     log.appendMessage("trigger")
-                    yield()
                 }
             }
         }
@@ -36,18 +35,19 @@ class SimLogTest : SimulationTestBase() {
     fun `group consumer processRecords failure propagates via the parent scope`() = runTest(timeout = 5.seconds) {
         val ex = assertThrows<IllegalStateException> {
             coroutineScope {
-                SimLog<String>("test", dispatcher + coroutineContext.job, rand).use { log ->
-                    val listener = object : Log.SubscriptionListener<String> {
-                        override suspend fun onPartitionsAssigned(partitions: Collection<Int>) =
-                            Log.TailSpec<String>(afterMsgId = -1L) { _ -> error("groupConsumer failure") }
+                SimLog<String>("test", rand).use { log ->
+                    launchSimLog(log)
 
-                        override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+                    launch {
+                        log.openGroupSubscription(object : Log.SubscriptionListener<String> {
+                            override suspend fun onPartitionsAssigned(partitions: Collection<Int>) =
+                                Log.TailSpec<String>(afterMsgId = -1L) { _ -> error("groupConsumer failure") }
+
+                            override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+                        })
                     }
 
-                    launch(dispatcher) { log.openGroupSubscription(listener) }
-
                     log.appendMessage("trigger")
-                    yield()
                 }
             }
         }


### PR DESCRIPTION
## Summary

Make `SimLog` pure state and hand its lifecycle — and the simulation tests' — to the caller's coroutine scope, so teardown is structured-concurrency cancellation rather than a self-managed join.

## Motivation

`SimLog` is the in-memory `Log` the indexer simulation tests run against. It used to own its own coroutine machinery: it took a `CoroutineContext` in its constructor, built its own `Job` and `CoroutineScope`, started its group/plain-consumer delivery loops in an `init` block, and tore them down in `close()` with a `runBlocking { job.join() }`. That conflated two lifetimes behind one object — `SimLog` the `Log` (an `AutoCloseable` resource) and `SimLog` the *process* (its delivery loops) — and forced the synchronous `close()` to bridge into the coroutine world with `runBlocking`, which is the wrong thing to do on a `runTest` dispatcher.

## Approach

`SimLog` is now pure state. Construction takes just a name and the RNG; the delivery loops are launched explicitly onto a caller-owned scope via a `launchSimLog` extension, and `close()` becomes a no-op — there's nothing to release beyond the process, and the process belongs to the scope that launched it. Teardown is structured-concurrency cancellation of that scope rather than a self-managed join. This is the test-side mirror of the lifetime model the real `LogProcessor` uses (its `cancelAndJoin` rename landed separately and is already on main). `SimLogTest` is adapted to the new two-arg constructor and launches the loops on the test scope so a failing `processRecords` still propagates out through it.

With `SimLog` and `LogProcessor` both taking their scope from the caller, the simulation tests no longer track jobs by hand. Each test launches its `SimLog` loops, its group subscriptions (each opening its processor on its own coroutine), and its driver under a single `launch(dispatcher)` scope; when the driver quiesces, `invokeOnCompletion { cancel() }` cancels that scope and structured concurrency tears the whole tree down and joins it. The earlier per-node `CoroutineScope`s, per-subscription job cancellation, explicit `cancelAndJoin()` calls in `finally`, and the `withLaunchedSimLogs` helper are all gone. All three tests — `single node`, `stable leader`, `multi-node` — share this one shape now; the only difference between them is the scenario: node count, and rebalances vs a steady flush.

## Usage — writing a deterministic test against `SimLog`

Determinism rests on three things, and a new test stays reproducible only as long as it respects all three:

- **One seeded RNG.** `SimulationTestBase` hands you `rand`, and `@RepeatableSimulationTest` replays the test across seeds. Every nondeterministic choice must flow from `rand` — the action sequence (`buildActions(rand, …)`), and inside `SimLog` the delivery batch sizes (`rand.nextInt(1, lag + 1)`) and leader election (`groupConsumers.random(rand)`). Same seed in, same run out. Pull randomness from anywhere else — the wall clock, an unseeded `Random`, a real dispatcher — and replay breaks.
- **One test dispatcher.** Everything runs on `dispatcher` under `runTest`: the `SimLog` loops, every `LogProcessor`, and the driver. Interleaving is virtual-time and single-threaded, and `yield()` drives cooperative scheduling instead of real delays.
- **Quiesce, then cancel.** The driver does its work, waits for the system to settle (`simExtSource.awaitQuiescence()`, `replicaLog.awaitAllDelivered()`), and only then triggers teardown — so the assertions run against a stable final state.

The shape:

1. Create the logs as pure state (the `@BeforeEach` already does this): `srcLog = SimLog("src", rand)`.
2. Open storage and nodes: `MemoryStorage(...).use { bp → SimNode(...).use { node → … } }`.
3. Under a single `launch(dispatcher) { … }`:
   - `launchSimLog(srcLog)` / `launchSimLog(replicaLog)` to start the delivery loops on this scope;
   - one `launch { srcLog.openGroupSubscription(node.openLogProcessor(this)) }` per node;
   - a driver `launch { … }` that appends messages / triggers rebalances (with `yield()` between steps), then awaits quiescence — ending with `.invokeOnCompletion { cancel() }` so that finishing the driver cancels the whole scope.
4. `.join()` the outer launch, then assert against `replicaLog.topic`, the block catalogs, and the live-index snapshot.

```kotlin
@RepeatableSimulationTest
fun `my scenario`() = runTest(timeout = 5.seconds) {
    val actions = buildActions(rand, rand.nextInt(50, 100))
    val simExtSource = SimExtSource(actions)

    MemoryStorage(allocator, epoch = 0).use { bp →
        SimNode("test-db", bp, IndexerConfig(rowsPerBlock = rand.nextLong(15, 25)), simExtSource).use { node →
            launch(dispatcher) {
                launchSimLog(srcLog)
                launchSimLog(replicaLog)

                launch { srcLog.openGroupSubscription(node.openLogProcessor(this)) }

                launch {
                    repeat(rand.nextInt(20, 40)) {
                        yield()
                        if (rand.nextInt(100) < 50) srcLog.rebalanceTrigger.send(Unit)
                        else srcLog.appendMessage(SourceMessage.FlushBlock(null))
                    }
                    simExtSource.awaitQuiescence()
                    replicaLog.awaitAllDelivered()
                }.invokeOnCompletion { cancel() }
            }.join()

            assertReplicaTxInvariants()
            // … scenario-specific assertions …
        }
    }
}
```

## Follower-teardown fix

Building these deterministic tests surfaced a latent ordering bug in the leader/follower transition. `FollowerSystem.cancelAndJoin()` was tearing down the outgoing replica subscription with a fire-and-forget `cancel()`, so a trailing follower delivery could call `notifyMsg` after the node's new role had already advanced the shared `Watchers` — violating the source-msgId monotonicity the rebalance path assumes (`srcMsgId 17 < latestSourceMsgId 19`). It now `cancelAndJoin()`s the subscription, draining and unregistering the old follower before the transition proceeds — the "no concurrent processing during rebalance" invariant the code already documents. Latent since `cd8962983`; the teardown rework's scheduling shift is what made it reproduce (~50% of the time under a pinned seed, 10/10 with the fix).

## Source-watermark fix (found here, tracked in #5680)

The same simulation testing surfaced a second, deeper bug: in ext-source mode the source-log watermark can regress on a follower across rapid leadership churn. Both fixes — stamping ext-source `ResolvedTx`, and a `NoOp` carrying the source watermark on block-less flushes — are written up in full (mechanism, trace, rationale) in #5680.

## Behaviour

The `SimLog` and simulation-test changes are a pure refactor — same scenarios, same assertions. The production behaviour changes are the two fixes above (the follower-teardown `cancelAndJoin`, and the #5680 source-watermark stamping), each kept as its own commit.