### PR TITLE
 fix(aws): resolve credential-less !S3 attach storage via the default chain

### DIFF
--- a/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
@@ -370,7 +370,9 @@ class S3(
                     region = config.region.takeIf { it.isNotEmpty() },
                     bucket = config.bucket,
                     prefix = config.prefix.takeIf { it.isNotEmpty() }?.asPath,
-                    credentials = config.credentials?.let { BasicCredentials(it.accessKey, it.secretKey) },
+                    credentials = if (config.hasCredentials())
+                        BasicCredentials(config.credentials.accessKey, config.credentials.secretKey)
+                    else null,
                     endpoint = config.endpoint.takeIf { it.isNotEmpty() },
                     pathStyleAccessEnabled = config.pathStyleAccessEnabled
                 )

--- a/src/test/kotlin/xtdb/aws/MinioTest.kt
+++ b/src/test/kotlin/xtdb/aws/MinioTest.kt
@@ -26,6 +26,7 @@ import java.util.*
 import kotlin.io.path.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -130,6 +131,45 @@ class MinioTest : S3Test() {
                     assertFalse(rs.next())
                 }
             }
+        }
+    }
+
+    @Test
+    fun `attach with credential-less S3 storage resolves via the default chain`(@TempDir nodeDir: Path) = runTest {
+        // the attach !S3 block omits credentials, so the object store must fall through to the
+        // default AWS provider chain (IRSA in production) - seed that chain via system properties
+        val prevAccessKey = System.setProperty("aws.accessKeyId", container.userName)
+        val prevSecretKey = System.setProperty("aws.secretAccessKey", container.password)
+        try {
+            Xtdb.openNode {
+                diskCache(DiskCache.factory(nodeDir.resolve("disk-cache")))
+                log(Log.localLog(nodeDir.resolve("xt-log")))
+                storage(Storage.local(nodeDir.resolve("xt-objs")))
+                compactor { threads(0) }
+            }.use { node ->
+                node.connection.use { conn ->
+                    conn.createStatement().use { stmt ->
+                        stmt.execute("""ATTACH DATABASE foo WITH $$
+                            log: !Local { path: "${nodeDir.resolve("foo-log")}" }
+                            storage: !Remote
+                              objectStore: !S3
+                                bucket: "$bucket"
+                                endpoint: "${container.s3URL}"
+                                region: "${AWS_ISO_GLOBAL.id()}"
+                                pathStyleAccessEnabled: true
+                                prefix: "${UUID.randomUUID()}"
+                            $$"""
+                        )
+                    }
+                }
+
+                val cat = (node as Xtdb.XtdbInternal).dbCatalog
+                assertEquals(setOf("xtdb", "foo"), cat.databaseNames.toSet())
+                assertNull(cat["foo"]?.ingestionError)
+            }
+        } finally {
+            prevAccessKey?.let { System.setProperty("aws.accessKeyId", it) } ?: System.clearProperty("aws.accessKeyId")
+            prevSecretKey?.let { System.setProperty("aws.secretAccessKey", it) } ?: System.clearProperty("aws.secretAccessKey")
         }
     }
 }

--- a/src/test/kotlin/xtdb/aws/S3Test.kt
+++ b/src/test/kotlin/xtdb/aws/S3Test.kt
@@ -10,6 +10,7 @@ import java.lang.System.getProperty
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @Tag("s3")
 open class S3Test : ObjectStoreTest() {
@@ -37,5 +38,12 @@ open class S3Test : ObjectStoreTest() {
         val deserializedFactory = registration.fromProto(proto)
 
         assertEquals(originalFactory, deserializedFactory)
+    }
+
+    @Test
+    fun `proto round trip without credentials leaves the default chain to resolve them`() = runTest {
+        val deserializedFactory = S3.Registration().fromProto(s3("test-bucket").configProto) as S3.Factory
+
+        assertNull(deserializedFactory.credentials)
     }
 }


### PR DESCRIPTION
## Problem

A node whose own `storage` is a credential-less `!S3` block (bucket + prefix, no explicit keys) resolves credentials through the default AWS provider chain — IRSA on EKS — and works fine.
Reusing that same storage shape under `ATTACH DATABASE` failed on the leader while opening the attached database's storage:

```
java.lang.NullPointerException: Access key ID cannot be blank.
  at xtdb.aws.S3$Factory.openObjectStore(S3.kt)
```

This makes S3-backed attached databases unusable under IRSA (the standard EKS setup), blocking CDC / external-source attach.

## Root cause

The two paths build the `S3.Factory` differently:

- **Node config** deserialises YAML straight into the `@Serializable` factory — `credentials` defaults to `null`, so `openObjectStore` skips the static-credentials branch and falls through to the default chain.
- **`ATTACH DATABASE`** packs the storage config to protobuf and unpacks it via `S3.Registration.fromProto`.

The unpack guarded on `config.credentials?.let { ... }` — but a proto3 message getter is *never* null; it returns an empty default instance when the field was never set.
So the guard always fired and produced `BasicCredentials("", "")`, whose blank access key then threw in `AwsBasicCredentials.create`.

The pack side was already correct (it only writes the field when `credentials != null`); only the unpack was missing the matching presence check.

## Fix

Guard the unpack on `config.hasCredentials()` so an unset block stays `null` and falls through to the default chain — matching node-config behaviour.

## Tests

- `S3Test` — factory proto round-trip asserting a credential-less factory deserialises with `credentials == null` (the unit-level reproduction; red before the fix).
- `MinioTest` — integration test attaching a credential-less `!S3` database, with the default chain seeded via `aws.accessKeyId`/`aws.secretAccessKey` system properties so MinIO accepts the request.

Closes #5681

🤖 Generated with [Claude Code](https://claude.com/claude-code)