### PR TITLE
feat(authn): statically-configured users via !UserList

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     api(libs.clj.yaml)
 
     api(libs.commons.codec)
+    api(libs.bouncycastle)
     api(libs.hppc)
 
     api(libs.caffeine)

--- a/core/src/main/clojure/xtdb/authn.clj
+++ b/core/src/main/clojure/xtdb/authn.clj
@@ -5,19 +5,13 @@
             [xtdb.error :as err])
   (:import [java.io Writer]
            (xtdb.api Authenticator Authenticator$DeviceAuthResponse Authenticator$Factory Authenticator$Factory$OpenIdConnect
-                     Authenticator$Factory$SingleRootUser
+                     Authenticator$Factory$SingleRootUser Authenticator$Factory$UserList
                      Authenticator$Method Authenticator$MethodRule Xtdb$Config
-                     OAuthPasswordResult OAuthClientCredentialsResult OAuthResult)
+                     OAuthPasswordResult OAuthClientCredentialsResult OAuthResult
+                     PasswordHash PasswordHash$Argon2id PasswordHash$BCrypt)
            xtdb.NodeBase
            [java.net URI]
            [java.time Duration Instant InstantSource]))
-
-(defn- method-for [rules {:keys [remote-addr user]}]
-  (some (fn [{rule-user :user, rule-address :address, :keys [method]}]
-          (when (and (or (nil? rule-user) (= user rule-user))
-                     (or (nil? rule-address) (= remote-addr rule-address)))
-            method))
-        rules))
 
 (defn read-authn-method [method]
   (case method
@@ -39,23 +33,35 @@
      (Authenticator$MethodRule. (read-authn-method method)
                                 user remote-addr))))
 
-(defn <-rules-cfg [rules-cfg]
-  (vec
-   (for [^Authenticator$MethodRule auth-rule rules-cfg]
-     {:method (.getMethod auth-rule)
-      :user (.getUser auth-rule)
-      :remote-addr (.getRemoteAddress auth-rule)})))
-
 (defmethod xtn/apply-config! :xtdb/authn [^Xtdb$Config config, _, [tag opts]]
   (xtn/apply-config! config
                      (case tag
                        :single-root-user ::single-root-user-authn
+                       :user-list ::user-list-authn
                        :openid-connect ::openid-connect-authn
                        tag)
                      opts))
 
 (defmethod xtn/apply-config! ::single-root-user-authn [^Xtdb$Config config, _, {:keys [password]}]
   (.authn config (Authenticator$Factory$SingleRootUser. password)))
+
+(defn- ->password-hash ^PasswordHash [hash-spec]
+  (if (instance? PasswordHash hash-spec)
+    hash-spec
+    (let [[algo encoded] hash-spec]
+      (case algo
+        :argon2id (PasswordHash$Argon2id. encoded)
+        :bcrypt (PasswordHash$BCrypt. encoded)
+        (throw (err/incorrect :xtdb/unknown-password-hash-algorithm
+                              (format "unknown password hash algorithm: %s" algo)
+                              {:algorithm algo}))))))
+
+(defmethod xtn/apply-config! ::user-list-authn [^Xtdb$Config config, _, {:keys [users rules]}]
+  (let [users-map (update-vals users ->password-hash)]
+    (.authn config
+            (if rules
+              (Authenticator$Factory$UserList. users-map (->rules-cfg rules))
+              (Authenticator$Factory$UserList. users-map)))))
 
 (defmethod ig/expand-key :xtdb/authn [k opts]
   {k (into {:base (ig/ref :xtdb/base)
@@ -216,7 +222,7 @@
 (defrecord OpenIdConnect [oidc-config client-id client-secret rules ^InstantSource instant-src]
   Authenticator
   (methodFor [_ user remote-addr]
-    (method-for rules {:user user, :remote-addr remote-addr}))
+    (Authenticator$MethodRule/methodFor rules user remote-addr))
 
   (verifyPassword [this user password]
     (let [{:keys [status body]} (oauth-token this {:grant_type "password", :scope "openid"
@@ -256,7 +262,7 @@
     (->OpenIdConnect oidc-config
                      (.getClientId cfg)
                      (.getClientSecret cfg)
-                     (<-rules-cfg (.getRules cfg))
+                     (.getRules cfg)
                      (.getInstantSource cfg))))
 
 (defmethod xtn/apply-config! ::openid-connect-authn [^Xtdb$Config config, _, {:keys [issuer-url client-id client-secret rules ^InstantSource instant-src]}]

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -15,6 +15,7 @@
            [java.util Map]
            (org.apache.arrow.memory BufferAllocator)
            (xtdb ICursor)
+           xtdb.api.Authenticator$Factory
            xtdb.api.query.IKeyFn
            (xtdb.arrow Relation RelationReader VectorType VectorReader)
            xtdb.pgwire.PgType
@@ -332,11 +333,12 @@
     {:name setting-name
      :setting setting}))
 
-(defn pg-user []
-  ;; Read-only view; always shows the single `xtdb` root user.
-  ;; `passwd` is NULL — Postgres redacts stored credentials from pg_user too, and
-  ;; the !SingleRootUser authenticator holds its password in config, not here.
-  [{:username "xtdb", :usesuper true, :passwd nil}])
+(defn pg-user [^Authenticator$Factory authn]
+  ;; Read-only view of the configured users.
+  ;; `passwd` is NULL — Postgres redacts stored credentials from pg_user too, and the
+  ;; authenticator holds the hashes in config, not here.
+  (for [username (.knownUsers authn)]
+    {:username username, :usesuper true, :passwd nil}))
 
 (defn trie-stats [^TrieCatalog trie-catalog]
   (for [^TableRef table (.getTables trie-catalog)
@@ -431,7 +433,7 @@
              table col-names col-preds
              schema params]))
 
-(defn ->info-schema [_allocator metrics-registry]
+(defn ->info-schema [_allocator metrics-registry ^Authenticator$Factory authn]
   (reify InfoSchema
     (->cursor [_ allocator db db-cat snap derived-table-schema
                table col-names col-preds
@@ -474,7 +476,7 @@
                                      pg_catalog/pg_settings (pg-settings)
                                      pg_catalog/pg_range (pg-range)
                                      pg_catalog/pg_am (pg-am)
-                                     pg_catalog/pg_user (pg-user)
+                                     pg_catalog/pg_user (pg-user authn)
                                      xt/trie_stats (trie-stats trie-catalog)
                                      xt/live_tables (live-tables snap)
                                      xt/live_columns (live-columns snap)

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -338,7 +338,7 @@
   ;; `passwd` is NULL — Postgres redacts stored credentials from pg_user too, and the
   ;; authenticator holds the hashes in config, not here.
   (for [username (.knownUsers authn)]
-    {:username username, :usesuper true, :passwd nil}))
+    {:username username, :usesuper (.isSuperuser authn username), :passwd nil}))
 
 (defn trie-stats [^TrieCatalog trie-catalog]
   (for [^TableRef table (.getTables trie-catalog)

--- a/core/src/main/kotlin/xtdb/NodeBase.kt
+++ b/core/src/main/kotlin/xtdb/NodeBase.kt
@@ -85,7 +85,7 @@ class NodeBase(
 
                 val compactor = open { compactorFactory.create(meterReg, config.compactor.threads) }
 
-                val infoSchema = infoSchemaFactory.invoke(al, meterReg)
+                val infoSchema = infoSchemaFactory.invoke(al, meterReg, config.authn)
                 val scanEmitter = scanEmitterFactory.invoke(infoSchema)
                 val querySource = open { querySourceFactory.create(al, meterReg, scanEmitter) }
 

--- a/core/src/main/kotlin/xtdb/api/Authenticator.kt
+++ b/core/src/main/kotlin/xtdb/api/Authenticator.kt
@@ -59,7 +59,7 @@ data class OAuthClientCredentialsResult(
 val DEFAULT_RULES = listOf(MethodRule(TRUST))
 
 interface Authenticator : AutoCloseable {
-    fun methodFor(user: String?, remoteAddress: String?): Method
+    fun methodFor(user: String?, remoteAddress: String?): Method?
 
     fun verifyPassword(user: String, password: String): AuthResult =
         throw Unsupported(errorCode="verifyPassword")
@@ -93,11 +93,26 @@ interface Authenticator : AutoCloseable {
         val method: Method,
         val user: String? = null,
         val remoteAddress: String? = null
-    )
+    ) {
+        companion object {
+            // Rules are matched in order; the first whose constraints all hold wins.
+            // A null constraint matches anything. Null result => no rule matched => reject the connection.
+            @JvmStatic
+            fun methodFor(rules: List<MethodRule>, user: String?, remoteAddress: String?): Method? =
+                rules.firstOrNull { rule ->
+                    (rule.user == null || rule.user == user)
+                            && (rule.remoteAddress == null || rule.remoteAddress == remoteAddress)
+                }?.method
+        }
+    }
 
     @Serializable
     sealed interface Factory {
         fun open(allocator: BufferAllocator, querySource: IQuerySource, dbCatalog: Database.Catalog): Authenticator
+
+        // The configured users, surfaced through the read-only `pg_user` view.
+        // Defaults to the single root user; authenticators with an explicit user set override it.
+        fun knownUsers(): List<String> = listOf(SingleRootUserAuthenticator.ROOT_USER)
 
         // One root user (`xtdb`) whose password is resolved at config-construction time:
         // the explicit YAML/Kotlin value first, then `XTDB_PASSWORD` env var.
@@ -129,6 +144,37 @@ interface Authenticator : AutoCloseable {
                 requiringResolve("xtdb.authn/->oidc-authn")
                     .invoke(this) as Authenticator
         }
+
+        // A fixed set of users with pre-hashed passwords, configured at startup.
+        // No mutation path: the only way to change the user set is to edit the config and restart.
+        @Serializable
+        @SerialName("!UserList")
+        data class UserList @JvmOverloads constructor(
+            val users: Map<String, PasswordHash>,
+            var rules: List<MethodRule> = listOf(MethodRule(PASSWORD)),
+        ) : Factory {
+            fun rules(rules: List<MethodRule>) = apply { this.rules = rules }
+
+            override fun knownUsers() = users.keys.toList()
+
+            override fun open(allocator: BufferAllocator, querySource: IQuerySource, dbCatalog: Database.Catalog): Authenticator =
+                UserListAuthenticator(users, rules)
+        }
+    }
+}
+
+class UserListAuthenticator(
+    private val users: Map<String, PasswordHash>,
+    private val rules: List<MethodRule>,
+) : Authenticator {
+
+    override fun methodFor(user: String?, remoteAddress: String?) =
+        MethodRule.methodFor(rules, user, remoteAddress)
+
+    override fun verifyPassword(user: String, password: String): AuthResult {
+        // Unknown user and wrong password fail identically — don't leak which usernames exist.
+        if (users[user]?.verify(password) == true) return SimpleResult(user)
+        throw Incorrect(errorCode = "xtdb/authn-failed", message = "password authentication failed for user: $user")
     }
 }
 

--- a/core/src/main/kotlin/xtdb/api/Authenticator.kt
+++ b/core/src/main/kotlin/xtdb/api/Authenticator.kt
@@ -114,6 +114,11 @@ interface Authenticator : AutoCloseable {
         // Defaults to the single root user; authenticators with an explicit user set override it.
         fun knownUsers(): List<String> = listOf(SingleRootUserAuthenticator.ROOT_USER)
 
+        // Superuser-only operations gate on this; `pg_user`'s `usesuper` reflects it.
+        // On the factory (like `knownUsers`) so info-schema can read it without an init-ordering problem.
+        // Defaults to no one; authenticators with a notion of a privileged user override it.
+        fun isSuperuser(userId: String): Boolean = false
+
         // One root user (`xtdb`) whose password is resolved at config-construction time:
         // the explicit YAML/Kotlin value first, then `XTDB_PASSWORD` env var.
         // With no password, connections run TRUST; with a password, PASSWORD is required.
@@ -122,6 +127,8 @@ interface Authenticator : AutoCloseable {
         data class SingleRootUser @JvmOverloads constructor(
             val password: String? = System.getenv("XTDB_PASSWORD"),
         ) : Factory {
+            override fun isSuperuser(userId: String) = userId == SingleRootUserAuthenticator.ROOT_USER
+
             override fun open(allocator: BufferAllocator, querySource: IQuerySource, dbCatalog: Database.Catalog): Authenticator =
                 SingleRootUserAuthenticator(password)
         }
@@ -156,6 +163,9 @@ interface Authenticator : AutoCloseable {
             fun rules(rules: List<MethodRule>) = apply { this.rules = rules }
 
             override fun knownUsers() = users.keys.toList()
+
+            // Same superuser convention as !SingleRootUser: the `xtdb` user, if configured.
+            override fun isSuperuser(userId: String) = userId == SingleRootUserAuthenticator.ROOT_USER
 
             override fun open(allocator: BufferAllocator, querySource: IQuerySource, dbCatalog: Database.Catalog): Authenticator =
                 UserListAuthenticator(users, rules)

--- a/core/src/main/kotlin/xtdb/api/PasswordHash.kt
+++ b/core/src/main/kotlin/xtdb/api/PasswordHash.kt
@@ -1,0 +1,143 @@
+package xtdb.api
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator
+import org.bouncycastle.crypto.generators.OpenBSDBCrypt
+import org.bouncycastle.crypto.params.Argon2Parameters
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+/**
+ * A stored password hash, tagged in YAML with the algorithm that produced it (`!Argon2id`, `!BCrypt`).
+ *
+ * The tag — not a sniffed prefix on the string — selects the algorithm, so a new algorithm is a new
+ * tag and existing hashes never need re-encoding. Each variant owns the encoding of its [encoded] string
+ * and knows how to [verify] a plaintext against it.
+ */
+@Serializable
+sealed interface PasswordHash {
+    val encoded: String
+
+    fun verify(password: String): Boolean
+
+    companion object {
+        private val secureRandom = SecureRandom()
+
+        fun randomSalt(length: Int): ByteArray = ByteArray(length).also(secureRandom::nextBytes)
+
+        @JvmStatic
+        fun argon2id(password: String): Argon2id = Argon2id.derive(password)
+
+        @JvmStatic
+        fun bcrypt(password: String): BCrypt = BCrypt.derive(password)
+    }
+
+    @Serializable(with = Argon2id.Serde::class)
+    @SerialName("!Argon2id")
+    data class Argon2id(override val encoded: String) : PasswordHash {
+
+        override fun verify(password: String): Boolean {
+            val parsed = parse(encoded) ?: return false
+            val actual = hash(password.toCharArray(), parsed.params, parsed.hash.size)
+            return MessageDigest.isEqual(actual, parsed.hash)
+        }
+
+        // PHC string format: $argon2id$v=19$m=<mem>,t=<iters>,p=<par>$<b64-salt>$<b64-hash>
+        internal object Serde : KSerializer<Argon2id> {
+            override val descriptor = PrimitiveSerialDescriptor("!Argon2id", PrimitiveKind.STRING)
+            override fun serialize(encoder: Encoder, value: Argon2id) = encoder.encodeString(value.encoded)
+            override fun deserialize(decoder: Decoder) = Argon2id(decoder.decodeString())
+        }
+
+        private class Parsed(val params: Argon2Parameters, val hash: ByteArray)
+
+        companion object {
+            // OWASP-recommended argon2id parameters (64 MiB, 3 iterations, single lane).
+            private const val MEMORY_KB = 65536
+            private const val ITERATIONS = 3
+            private const val PARALLELISM = 1
+            private const val HASH_LENGTH = 32
+            private const val SALT_LENGTH = 16
+
+            private val b64Encoder = Base64.getEncoder().withoutPadding()
+            private val b64Decoder = Base64.getDecoder()
+
+            private fun paramsBuilder() =
+                Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
+                    .withVersion(Argon2Parameters.ARGON2_VERSION_13)
+                    .withMemoryAsKB(MEMORY_KB)
+                    .withIterations(ITERATIONS)
+                    .withParallelism(PARALLELISM)
+
+            private fun hash(password: CharArray, params: Argon2Parameters, length: Int): ByteArray =
+                ByteArray(length).also { out ->
+                    Argon2BytesGenerator().apply { init(params) }.generateBytes(password, out)
+                }
+
+            fun derive(password: String): Argon2id {
+                val salt = randomSalt(SALT_LENGTH)
+                val params = paramsBuilder().withSalt(salt).build()
+                val hash = hash(password.toCharArray(), params, HASH_LENGTH)
+                val encoded = "\$argon2id\$v=${Argon2Parameters.ARGON2_VERSION_13}" +
+                        "\$m=$MEMORY_KB,t=$ITERATIONS,p=$PARALLELISM" +
+                        "\$${b64Encoder.encodeToString(salt)}\$${b64Encoder.encodeToString(hash)}"
+                return Argon2id(encoded)
+            }
+
+            private fun parse(encoded: String): Parsed? {
+                // $argon2id$v=19$m=65536,t=3,p=1$<salt>$<hash>
+                val parts = encoded.split('$')
+                if (parts.size != 6 || parts[0].isNotEmpty() || parts[1] != "argon2id") return null
+                return try {
+                    val version = parts[2].removePrefix("v=").toInt()
+                    val perf = parts[3].split(',').associate { it.split('=').let { (k, v) -> k to v.toInt() } }
+                    val salt = b64Decoder.decode(parts[4])
+                    val hash = b64Decoder.decode(parts[5])
+                    val params = Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
+                        .withVersion(version)
+                        .withMemoryAsKB(perf.getValue("m"))
+                        .withIterations(perf.getValue("t"))
+                        .withParallelism(perf.getValue("p"))
+                        .withSalt(salt)
+                        .build()
+                    Parsed(params, hash)
+                } catch (_: Exception) {
+                    null
+                }
+            }
+        }
+    }
+
+    @Serializable(with = BCrypt.Serde::class)
+    @SerialName("!BCrypt")
+    data class BCrypt(override val encoded: String) : PasswordHash {
+
+        override fun verify(password: String): Boolean =
+            try {
+                OpenBSDBCrypt.checkPassword(encoded, password.toCharArray())
+            } catch (_: Exception) {
+                false
+            }
+
+        internal object Serde : KSerializer<BCrypt> {
+            override val descriptor = PrimitiveSerialDescriptor("!BCrypt", PrimitiveKind.STRING)
+            override fun serialize(encoder: Encoder, value: BCrypt) = encoder.encodeString(value.encoded)
+            override fun deserialize(decoder: Decoder) = BCrypt(decoder.decodeString())
+        }
+
+        companion object {
+            private const val COST = 12
+            private const val SALT_LENGTH = 16
+
+            fun derive(password: String): BCrypt =
+                BCrypt(OpenBSDBCrypt.generate(password.toCharArray(), randomSalt(SALT_LENGTH), COST))
+        }
+    }
+}

--- a/core/src/test/kotlin/xtdb/api/PasswordHashTest.kt
+++ b/core/src/test/kotlin/xtdb/api/PasswordHashTest.kt
@@ -1,0 +1,47 @@
+package xtdb.api
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PasswordHashTest {
+
+    @Test
+    fun `argon2id round-trips`() {
+        val hash = PasswordHash.argon2id("hunter2")
+
+        assertTrue(hash.encoded.startsWith("\$argon2id\$"), "encodes as a PHC string")
+        assertTrue(hash.verify("hunter2"))
+        assertFalse(hash.verify("wrong"))
+    }
+
+    @Test
+    fun `bcrypt round-trips`() {
+        val hash = PasswordHash.bcrypt("hunter2")
+
+        assertTrue(hash.encoded.startsWith("\$2"), "encodes as a modular-crypt bcrypt string")
+        assertTrue(hash.verify("hunter2"))
+        assertFalse(hash.verify("wrong"))
+    }
+
+    @Test
+    fun `distinct salts produce distinct encodings for the same password`() {
+        assertNotEquals(PasswordHash.argon2id("hunter2").encoded, PasswordHash.argon2id("hunter2").encoded)
+        assertNotEquals(PasswordHash.bcrypt("hunter2").encoded, PasswordHash.bcrypt("hunter2").encoded)
+    }
+
+    @Test
+    fun `a stored encoding keeps verifying — the parse-then-rederive contract holds`() {
+        val encoded = PasswordHash.argon2id("correct horse").encoded
+
+        assertTrue(PasswordHash.Argon2id(encoded).verify("correct horse"))
+        assertFalse(PasswordHash.Argon2id(encoded).verify("correct horse battery"))
+    }
+
+    @Test
+    fun `verify returns false rather than throwing on a malformed encoding`() {
+        assertFalse(PasswordHash.Argon2id("not-a-real-hash").verify("hunter2"))
+        assertFalse(PasswordHash.BCrypt("not-a-real-hash").verify("hunter2"))
+    }
+}

--- a/core/src/test/kotlin/xtdb/api/UserListAuthenticatorTest.kt
+++ b/core/src/test/kotlin/xtdb/api/UserListAuthenticatorTest.kt
@@ -62,4 +62,12 @@ class UserListAuthenticatorTest {
     fun `knownUsers lists the configured users`() {
         assertEquals(setOf("alice", "bob"), UserList(users).knownUsers().toSet())
     }
+
+    @Test
+    fun `only the xtdb user is the superuser`() {
+        val factory = UserList(users + ("xtdb" to PasswordHash.argon2id("xtdb-pw")))
+
+        assertEquals(true, factory.isSuperuser("xtdb"))
+        assertEquals(false, factory.isSuperuser("alice"))
+    }
 }

--- a/core/src/test/kotlin/xtdb/api/UserListAuthenticatorTest.kt
+++ b/core/src/test/kotlin/xtdb/api/UserListAuthenticatorTest.kt
@@ -1,0 +1,65 @@
+package xtdb.api
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import xtdb.api.Authenticator.Factory.UserList
+import xtdb.api.Authenticator.Method.PASSWORD
+import xtdb.api.Authenticator.Method.TRUST
+import xtdb.api.Authenticator.MethodRule
+import xtdb.error.Incorrect
+
+class UserListAuthenticatorTest {
+
+    private val users = mapOf(
+        "alice" to PasswordHash.argon2id("alice-pw"),
+        "bob" to PasswordHash.bcrypt("bob-pw"),
+    )
+
+    @Test
+    fun `verifyPassword accepts configured users with the right password`() {
+        val authn = UserListAuthenticator(users, listOf(MethodRule(PASSWORD)))
+
+        assertEquals(SimpleResult("alice"), authn.verifyPassword("alice", "alice-pw"))
+        assertEquals(SimpleResult("bob"), authn.verifyPassword("bob", "bob-pw"))
+    }
+
+    @Test
+    fun `verifyPassword rejects a wrong password and an unknown user identically`() {
+        val authn = UserListAuthenticator(users, listOf(MethodRule(PASSWORD)))
+
+        assertEquals(
+            "password authentication failed for user: alice",
+            assertThrows<Incorrect> { authn.verifyPassword("alice", "wrong") }.message
+        )
+        assertEquals(
+            "password authentication failed for user: carol",
+            assertThrows<Incorrect> { authn.verifyPassword("carol", "whatever") }.message
+        )
+    }
+
+    @Test
+    fun `methodFor matches rules in order — including remoteAddress`() {
+        val authn = UserListAuthenticator(
+            users,
+            listOf(MethodRule(TRUST, remoteAddress = "127.0.0.1"), MethodRule(PASSWORD)),
+        )
+
+        assertEquals(TRUST, authn.methodFor("alice", "127.0.0.1"))
+        assertEquals(PASSWORD, authn.methodFor("alice", "10.0.0.1"))
+    }
+
+    @Test
+    fun `methodFor returns null when no rule matches`() {
+        val authn = UserListAuthenticator(users, listOf(MethodRule(PASSWORD, user = "alice")))
+
+        assertEquals(PASSWORD, authn.methodFor("alice", "127.0.0.1"))
+        assertNull(authn.methodFor("bob", "127.0.0.1"))
+    }
+
+    @Test
+    fun `knownUsers lists the configured users`() {
+        assertEquals(setOf("alice", "bob"), UserList(users).knownUsers().toSet())
+    }
+}

--- a/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/YamlSerdeTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import xtdb.api.Authenticator.Factory.OpenIdConnect
 import xtdb.api.Authenticator.Factory.SingleRootUser
+import xtdb.api.Authenticator.Factory.UserList
 import xtdb.api.Authenticator.Method.*
 import xtdb.api.Authenticator.MethodRule
 import xtdb.api.log.KafkaCluster
@@ -409,6 +410,52 @@ class YamlSerdeTest {
         )
 
         unmockkObject(EnvironmentVariableProvider)
+    }
+
+    @Test
+    fun testUserListDecoding() {
+        // each user's hash is a tagged scalar — the tag picks the algorithm
+        val alice = PasswordHash.argon2id("alice-pw")
+        val bob = PasswordHash.bcrypt("bob-pw")
+
+        val input = """
+        authn: !UserList
+          users:
+            alice: !Argon2id "${alice.encoded}"
+            bob: !BCrypt "${bob.encoded}"
+          rules:
+            - user: alice
+              method: PASSWORD
+            - remoteAddress: 127.0.0.1
+              method: TRUST
+        """.trimIndent()
+
+        assertEquals(
+            UserList(
+                users = mapOf("alice" to alice, "bob" to bob),
+                rules = listOf(
+                    MethodRule(PASSWORD, user = "alice"),
+                    MethodRule(TRUST, remoteAddress = "127.0.0.1"),
+                )
+            ),
+            nodeConfig(input).authn
+        )
+    }
+
+    @Test
+    fun testUserListDefaultRules() {
+        val alice = PasswordHash.argon2id("alice-pw")
+
+        val input = """
+        authn: !UserList
+          users:
+            alice: !Argon2id "${alice.encoded}"
+        """.trimIndent()
+
+        assertEquals(
+            UserList(users = mapOf("alice" to alice)),
+            nodeConfig(input).authn
+        )
     }
 
     @Test

--- a/docs/src/content/docs/ops/config/authentication.md
+++ b/docs/src/content/docs/ops/config/authentication.md
@@ -11,7 +11,7 @@ XTDB supports three authentication providers:
 
 - **Single Root User** (`!SingleRootUser`, v2.2+): a single user (`xtdb`) whose password is configured at startup.
   This is the default.
-- **User Table** (`!UserTable`): uses an internal user table with password-based authentication.
+- **User List** (`!UserList`, v2.2+): a fixed set of users with pre-hashed passwords, configured at startup.
 - **OpenID Connect** (`!OpenIdConnect`): integrates with external identity providers like Keycloak, Auth0, AWS Cognito or Azure Entra.
 
 ## Single root user (v2.2+)
@@ -48,48 +48,56 @@ authn: !SingleRootUser
   password: hunter2
 ```
 
-## User table
+## User list (v2.2+)
 
-The `!UserTable` authentication method uses an internal user table with password-based authentication.
+The `!UserList` method authenticates against a fixed set of users configured at startup.
+It suits simple deployments that want password authentication for more than one user without running an external identity provider.
+
+The user set is static.
+It's read from the configuration when the node starts, and the only way to change it is to edit the configuration and restart — there is no SQL or runtime API to add, alter, or remove users.
 
 ### Configuration
 
+Each user maps to a pre-hashed password, tagged with the algorithm that produced it:
+
 ``` yaml
-authn: !UserTable
+authn: !UserList
+  users:
+    alice: !Argon2id "$argon2id$v=19$m=65536,t=3,p=1$c29tZXNhbHRzYWx0$RdescudvJCsgt3ub+b+dWRWJTmaaJObG"
+    bob: !BCrypt "$2y$12$mc.G6e7uChPgZW2NfY0XQOQ0qN6Q0o3Yv0bFv6kKQXmnq7nqQk0K"
   rules:
-    # admin always requires a password
-    - user: admin
-      method: PASSWORD
-    # We trust local connections
+    # local connections are trusted
     - remoteAddress: 127.0.0.1
       method: TRUST
-    # Everything else requires a password
+    # everyone else must supply a password
     - method: PASSWORD
 ```
 
-### User management
+If `rules` is omitted, every connection requires a password.
 
-**Default User**
-: The `pg_user` table contains a default user `xtdb` with password
-    `xtdb`.
+The configured users appear in the read-only `pg_user` view (with `passwd` redacted to `NULL`), so Postgres tooling that lists users sees them.
 
-**Creating Users**
-:
+### Hash algorithms
 
-``` sql
-CREATE USER alan WITH PASSWORD 'TURING'
+Each password carries its own algorithm tag, so a node can hold a mix and you can move to a new algorithm without re-hashing the existing entries:
+
+- `!Argon2id` — argon2id, the recommended default.
+- `!BCrypt` — bcrypt, in standard modular-crypt (`$2…`) form.
+
+### Hashing a password
+
+Pre-hash passwords with the `hash-password` command and paste the output into the config:
+
+``` bash
+xtdb hash-password [--argon2id | --bcrypt] 'my-password'
 ```
 
-**Modifying Users**
-:
+`--argon2id` is the current default; pass `--bcrypt` to use bcrypt instead.
+Omit the password argument to read it from stdin, which keeps the plaintext out of your shell history:
 
-``` sql
-ALTER USER ada WITH PASSWORD 'LOVELACE'
+``` bash
+echo 'my-password' | xtdb hash-password
 ```
-
-**Password Validation**
-: When `PASSWORD` method is specified, credentials are validated
-    against the `pg_user` table entries.
 
 ## OpenID Connect (OIDC)
 
@@ -112,7 +120,7 @@ For complete OIDC configuration, setup guides, and troubleshooting, see [OpenID 
 
 ## Rule configuration
 
-`!UserTable` and `!OpenIdConnect` control database access through authentication rules that match users and IP addresses to determine the required authentication method.
+`!UserList` and `!OpenIdConnect` control database access through authentication rules that match users and IP addresses to determine the required authentication method.
 `!SingleRootUser` doesn't use rules — its method is determined by whether a password is configured.
 
 ### Authentication Rules

--- a/docs/src/content/docs/ops/config/authentication.md
+++ b/docs/src/content/docs/ops/config/authentication.md
@@ -76,6 +76,7 @@ authn: !UserList
 If `rules` is omitted, every connection requires a password.
 
 The configured users appear in the read-only `pg_user` view (with `passwd` redacted to `NULL`), so Postgres tooling that lists users sees them.
+`usesuper` is `true` only for a user named `xtdb` — the same superuser convention as `!SingleRootUser` — and `false` for everyone else.
 
 ### Hash algorithms
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ roaring-bitmap = { group = "org.roaringbitmap", name = "RoaringBitmap", version 
 hppc = { group = "com.carrotsearch", name = "hppc", version = "0.10.0" }
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version = "3.2.3" }
 commons-codec = { group = "commons-codec", name = "commons-codec", version = "1.21.0" }
+bouncycastle = { group = "org.bouncycastle", name = "bcprov-jdk18on", version = "1.84" }
 
 antlr = { group = "org.antlr", name = "antlr4", version.ref = "antlr" }
 antlr-runtime = { group = "org.antlr", name = "antlr4-runtime", version.ref = "antlr" }

--- a/main/src/main/clojure/xtdb/main.clj
+++ b/main/src/main/clojure/xtdb/main.clj
@@ -10,7 +10,8 @@
             [xtdb.error :as err]
             [xtdb.logging :as logging]
             [xtdb.util :as util])
-  (:import java.io.File))
+  (:import java.io.File
+           (xtdb.api PasswordHash)))
 
 (defn print-help []
   (println (str "--- " (util/xtdb-version-string) " ---"))
@@ -21,6 +22,7 @@
   (println " * `playground`: starts a 'playground', an in-memory node which accepts any database name, creating it if required")
   (println " * `reset-compactor <db-name>`: resets the compacted files on the given node.")
   (println " * `export-snapshot <db-name>`: exports a consistent snapshot of object storage for the given database.")
+  (println " * `hash-password [--bcrypt] <password>`: hashes a password for an `!UserList` authn config entry (reads stdin if no password given).")
   (newline)
   (println "For more information about any command, run `<command> --help`, e.g. `playground --help`"))
 
@@ -176,6 +178,30 @@
 
     ((requiring-resolve 'xtdb.export/export-snapshot!) (file->node-opts file) db-name {:dry-run? dry-run?})))
 
+(def hash-password-cli-spec
+  [[nil "--argon2id" "Hash with argon2id (the current default)" :id :argon2id?]
+   [nil "--bcrypt" "Hash with bcrypt" :id :bcrypt?]
+   ["-h" "--help"]])
+
+(defn- hash-password! [args]
+  (let [{{:keys [argon2id? bcrypt?]} :options, [password] :arguments} (-> (parse-args args hash-password-cli-spec)
+                                                                         (handling-arg-errors-or-help))]
+    (when (and argon2id? bcrypt?)
+      (binding [*out* *err*]
+        (println "Choose one of --argon2id or --bcrypt")
+        (System/exit 2)))
+
+    ;; positional arg first; otherwise read a line from stdin (so the plaintext can stay out of shell history)
+    (let [password (or password (some-> (read-line) not-empty))]
+      (when-not password
+        (binding [*out* *err*]
+          (println "Missing password: `hash-password [--argon2id|--bcrypt] <password>` (or pipe it on stdin)")
+          (System/exit 2)))
+
+      (println (.getEncoded (if bcrypt?
+                              (PasswordHash/bcrypt password)
+                              (PasswordHash/argon2id password)))))))
+
 (def read-arrow-file-cli-spec
   [["-h" "--help"]])
 
@@ -290,6 +316,10 @@
         "export-snapshot" (do
                             (export-snapshot! more-args)
                             (System/exit 0))
+
+        "hash-password" (do
+                          (hash-password! more-args)
+                          (System/exit 0))
 
         "read-arrow-file" (do
                             (read-arrow-file more-args)

--- a/src/test/clojure/xtdb/authn_test.clj
+++ b/src/test/clojure/xtdb/authn_test.clj
@@ -96,7 +96,7 @@
   (let [issuer-url (.toURL (URI. (str (.getAuthServerUrl container) "/realms/master")))
         oidc-config (authn/discover-oidc-config issuer-url)
         authn (authn/->OpenIdConnect oidc-config "xtdb" "xtdb-secret"
-                                     [{:method #xt.authn/method :password}]
+                                     (authn/->rules-cfg [{:method :password}])
                                      (InstantSource/system))]
 
     (t/is (anomalous? [:incorrect :xtdb/authn-failed "No valid token or refresh token available for refresh"]
@@ -109,7 +109,7 @@
         after-expiry (.plusSeconds base-time 7200)
         mock-instant-source (tu/->mock-clock [base-time base-time base-time after-expiry after-expiry]) 
         ^Authenticator authn (authn/->OpenIdConnect oidc-config "xtdb" "xtdb-secret"
-                                                    [{:method #xt.authn/method :client-credentials}]
+                                                    (authn/->rules-cfg [{:method :client-credentials}])
                                                     mock-instant-source)
         clients (:clients (seed! container {:access-token-lifespan (int 3600)})) 
         {:keys [client-id client-secret]} (:test clients)]
@@ -131,7 +131,7 @@
         issuer-url (.toURL (URI. (str (.getAuthServerUrl container) "/realms/master")))
         oidc-config (authn/discover-oidc-config issuer-url)
         ^Authenticator authn (authn/->OpenIdConnect oidc-config "xtdb" "xtdb-secret"
-                                                    [{:method #xt.authn/method :password}]
+                                                    (authn/->rules-cfg [{:method :password}])
                                                     (InstantSource/system))]
     
     (t/testing "method routing"
@@ -152,7 +152,7 @@
         issuer-url (.toURL (URI. (str (.getAuthServerUrl container) "/realms/master")))
         oidc-config (authn/discover-oidc-config issuer-url)
         ^Authenticator authn (authn/->OpenIdConnect oidc-config "xtdb" "xtdb-secret"
-                                                    [{:method #xt.authn/method :client-credentials}]
+                                                    (authn/->rules-cfg [{:method :client-credentials}])
                                                     (InstantSource/system))]
     
     (t/testing "method routing"

--- a/src/test/clojure/xtdb/pgwire/authn_test.clj
+++ b/src/test/clojure/xtdb/pgwire/authn_test.clj
@@ -26,8 +26,8 @@
         authn (authn/->OpenIdConnect oidc-config
                                      "xtdb"
                                      "xtdb-secret"
-                                     [{:user "test-user" :method #xt.authn/method :password :address "127.0.0.1"}
-                                      {:user "oid-client" :method #xt.authn/method :client-credentials}]
+                                     (authn/->rules-cfg [{:user "test-user" :method :password :remote-addr "127.0.0.1"}
+                                                         {:user "oid-client" :method :client-credentials}])
                                      (InstantSource/system))
         conn (pgwire/map->Connection {:server {:server-state (atom {:parameters {"server_encoding" "UTF8"
                                                                                  "client_encoding" "UTF8"

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -30,7 +30,7 @@
            (org.postgresql.util PGobject PSQLException)
            (xtdb.pgwire PgType)
            (xtdb JsonSerde JsonLdSerde)
-           (xtdb.api DataSource$ConnectionBuilder)
+           (xtdb.api DataSource$ConnectionBuilder PasswordHash)
            xtdb.api.log.SourceMessage$FlushBlock
            xtdb.pgwire.Server
            xtdb.tx.Sql))
@@ -2252,6 +2252,30 @@ ORDER BY t.oid DESC LIMIT 1"
         (t/is (thrown-with-msg? PSQLException #"ERROR: password authentication failed for user: fin"
                                 (with-open [_ (jdbc-conn {"user" "fin", "password" "hunter2"})]))
               "non-root users are rejected even with the right password")))))
+
+(deftest pg-user-list-authentication
+  (let [alice (PasswordHash/argon2id "alice-pw")
+        bob (PasswordHash/bcrypt "bob-pw")]
+    (with-open [node (xtn/start-node {:authn [:user-list {:users {"alice" alice, "bob" bob}
+                                                          :rules [{:method :password}]}]})]
+      (binding [*port* (.getServerPort node)]
+        (t/testing "each configured user authenticates with its own password, argon2id and bcrypt alike"
+          (with-open [_ (jdbc-conn {"user" "alice", "password" "alice-pw"})])
+          (with-open [_ (jdbc-conn {"user" "bob", "password" "bob-pw"})]))
+
+        (t/is (thrown-with-msg? PSQLException #"ERROR: password authentication failed for user: alice"
+                                (with-open [_ (jdbc-conn {"user" "alice", "password" "bob-pw"})]))
+              "a configured user is rejected with the wrong password")
+
+        (t/is (thrown-with-msg? PSQLException #"ERROR: password authentication failed for user: carol"
+                                (with-open [_ (jdbc-conn {"user" "carol", "password" "alice-pw"})]))
+              "an unconfigured user is rejected")
+
+        (t/testing "pg_user lists the configured users"
+          (with-open [conn (jdbc-conn {"user" "alice", "password" "alice-pw"})]
+            (t/is (= [{:username "alice", :usesuper true}
+                      {:username "bob", :usesuper true}]
+                     (q conn ["SELECT username, usesuper FROM pg_user ORDER BY username"])))))))))
 
 (t/deftest test-keywordize-nested-values-3910
   (with-open [conn (jdbc-conn)]

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2255,8 +2255,9 @@ ORDER BY t.oid DESC LIMIT 1"
 
 (deftest pg-user-list-authentication
   (let [alice (PasswordHash/argon2id "alice-pw")
-        bob (PasswordHash/bcrypt "bob-pw")]
-    (with-open [node (xtn/start-node {:authn [:user-list {:users {"alice" alice, "bob" bob}
+        bob (PasswordHash/bcrypt "bob-pw")
+        xtdb (PasswordHash/argon2id "xtdb-pw")]
+    (with-open [node (xtn/start-node {:authn [:user-list {:users {"alice" alice, "bob" bob, "xtdb" xtdb}
                                                           :rules [{:method :password}]}]})]
       (binding [*port* (.getServerPort node)]
         (t/testing "each configured user authenticates with its own password, argon2id and bcrypt alike"
@@ -2271,10 +2272,11 @@ ORDER BY t.oid DESC LIMIT 1"
                                 (with-open [_ (jdbc-conn {"user" "carol", "password" "alice-pw"})]))
               "an unconfigured user is rejected")
 
-        (t/testing "pg_user lists the configured users"
+        (t/testing "pg_user lists the configured users; only the xtdb user is the superuser"
           (with-open [conn (jdbc-conn {"user" "alice", "password" "alice-pw"})]
-            (t/is (= [{:username "alice", :usesuper true}
-                      {:username "bob", :usesuper true}]
+            (t/is (= [{:username "alice", :usesuper false}
+                      {:username "bob", :usesuper false}
+                      {:username "xtdb", :usesuper true}]
                      (q conn ["SELECT username, usesuper FROM pg_user ORDER BY username"])))))))))
 
 (t/deftest test-keywordize-nested-values-3910


### PR DESCRIPTION
Resolves #4667.

## Summary

Adds `!UserList`, a third authentication provider: a fixed set of users with pre-hashed passwords, configured in YAML at startup. It sits between `!SingleRootUser` (one `xtdb` user, for dev / single-container use) and `!OpenIdConnect` (full multi-user via an external IdP) — for simple deployments that want password auth for a handful of users without running Keycloak.

It's deliberately static: no `CREATE`/`ALTER USER`, no mutable table. That distinguishes it from the `!UserTable` authenticator removed in #4365, whose mutable credential table and seeded `xtdb`/`xtdb` row were the reasons it went. None of those reasons apply to a config-only user set, so this isn't a revert of that decision.

## Usage

Each user maps to a pre-hashed password, tagged with the algorithm that produced it:

```yaml
authn: !UserList
  users:
    alice: !Argon2id "$argon2id$v=19$m=65536,t=3,p=1$c29tZXNhbHQ$aGFzaA"
    bob: !BCrypt "$2y$12$mc.../G6e"
  rules:
    - remoteAddress: 127.0.0.1
      method: TRUST
    - method: PASSWORD
```

Generate the hashes with the new CLI command — argon2id is the default, `--bcrypt` selects bcrypt, and it reads the password from stdin when none is given so the plaintext can stay out of shell history:

```bash
xtdb hash-password 'alice-password'
echo 'bob-password' | xtdb hash-password --bcrypt
```

If `rules` is omitted, every connection requires a password. The configured users appear in the read-only `pg_user` view with `passwd` redacted to `NULL`; `usesuper` is `true` only for a user named `xtdb` — the same superuser convention as `!SingleRootUser`.

Clojure/EDN configuration expresses the user map directly: `:users {:alice [:argon2id "alice-pw"], :bob [:bcrypt "bob-pw"]}`. Here the string is the *plaintext* password, hashed at config-load — unlike the YAML form, which takes a pre-computed hash. The programmatic path derives because config-as-code already holds the secret, whereas a checked-in YAML file should never carry plaintext.

## Implementation notes

**Tagged-scalar hashes.** Each hash names its own algorithm via the YAML tag rather than a sniffed string prefix, so adding an algorithm later is just a new tag and existing hashes never need re-encoding. `PasswordHash` is a sealed Kotlin type with `!Argon2id` and `!BCrypt` variants, each carrying a custom primitive-string serializer so kaml decodes the tagged scalar. Verification runs in-process on BouncyCastle (`Argon2BytesGenerator`, `OpenBSDBCrypt`) — the one dependency `buddy-hashers` used to wrap — matching how `!SingleRootUser` verifies without a node, query, or HTTP hop.

**pg_user.** The authenticator *factory* now answers `knownUsers()`, threaded into the information-schema scan. It's taken from the factory rather than the opened authenticator because info-schema is built before the `:xtdb/authn` integrant component — and the factory already holds the configured user set, so there's no init-ordering problem.

**Superuser convention.** `Authenticator.Factory` answers `isSuperuser(userId)` alongside `knownUsers()` (same init-ordering rationale), and `pg_user`'s `usesuper` now reflects it instead of being hardcoded `true`. The superuser is the `xtdb` user across providers — `!SingleRootUser`'s root user, and a configured `xtdb` user under `!UserList`; the default is no one, so OIDC's default root-user row reads `usesuper false`. Pulled forward from the role-membership branch (#5683), where GRANT/REVOKE role gates on it — the gate itself stays on that branch; here the observable surface is `pg_user`.

**Rule-matching consolidation + bug fix (behaviour change).** Auth rule-matching now lives in a single Kotlin matcher, `Authenticator.MethodRule.methodFor`, used by both `!UserList` and the OIDC authenticator. This fixes a latent bug: the old Clojure `method-for` read an `:address` key from each rule while the rules actually carried `:remote-addr`, so `remoteAddress` rule-matching was silently dead. `methodFor` is now nullable (`Method?`) — a no-match is a real outcome that pgwire already rejects, rather than a sentinel the matcher had to invent. The OIDC `OpenIdConnect` record now holds `MethodRule` objects instead of Clojure maps; behaviour is otherwise unchanged.

## Out of scope

Dynamic user management: there's deliberately no SQL or runtime API to add, alter, or remove users — editing the config and restarting is the only path. And any algorithm beyond argon2id and bcrypt — the sealed type makes adding one a small, isolated change when it's wanted.

Configurable superusers: `!UserList` treats only a user named `xtdb` as a superuser, matching `!SingleRootUser`. Designating arbitrary users as superusers (e.g. a `superusers` config list) is deferred to #5683, where the superuser concept actually gates GRANT/REVOKE — on this branch it only feeds `pg_user.usesuper`, so the config shape is better settled against the authorization model that consumes it.

## Test plan

- **Kotlin unit:** `PasswordHashTest` (derive/verify round-trips, malformed-encoding handling), `UserListAuthenticatorTest` (accept/reject, unknown-user parity, rule ordering including `remoteAddress`, `xtdb`-only superuser), `YamlSerdeTest` (tagged-scalar `!UserList` decoding + default rules).
- **Clojure:** `pgwire_test/pg-user-list-authentication` (argon2id + bcrypt users over pgwire, accept/reject, `pg_user` listing with truthful `usesuper`); existing `pg-authentication` and `information_schema_test/test-pg-user` still green.
- **OIDC regression:** `authn_test` and `pgwire/authn_test` updated for the `MethodRule` contract — the integration test now genuinely exercises `remoteAddress` matching, where before it only passed because of the bug.
- **CLI:** `xtdb hash-password` smoke for `--argon2id` / `--bcrypt` / default; output verifies.
- Full `./gradlew test` green; affected `./gradlew :integration-test --tests 'xtdb.pgwire.authn_test*'` green. No reflection or boxed-math warnings.
