### PR TITLE
feat: extract per-connection await-token into a node-level Connection

### DIFF
--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -128,9 +128,6 @@
          (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
            (xtp/prepare-sql this-node sql query-opts)))
 
-       (mergeAwaitToken [_ existing-token db-name tx-id]
-         (basis/merge-tx-tokens existing-token (basis/->tx-basis-str {db-name [tx-id]})))
-
        (getColumnTypes [_ table snap]
          (when-let [^Database db (.databaseOrNull db-cat (.getDbName table))]
            (.getColumnTypes db table snap)))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -119,24 +119,28 @@
        (submitTx [_ db-name ops opts] (.submitTx this-node db-name ops opts))
        (executeTx [_ db-name ops opts] (.executeTx this-node db-name ops opts))
 
-       (openSqlQuery [_ sql db-name]
-         (let [query-opts (-> {} (with-query-opts-defaults this-node db-name))]
+       (openSqlQuery [_ sql db-name await-token]
+         (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
            (-> (xtp/prepare-sql this-node sql query-opts)
                (.openQuery nil (QueryOpts. nil (:default-tz query-opts))))))
 
-       (prepareSql [_ sql db-name]
-         (let [query-opts (-> {} (with-query-opts-defaults this-node db-name))]
+       (prepareSql [_ sql db-name await-token]
+         (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
            (xtp/prepare-sql this-node sql query-opts)))
+
+       (mergeAwaitToken [_ existing-token db-name tx-id]
+         (basis/merge-tx-tokens existing-token (basis/->tx-basis-str {db-name [tx-id]})))
 
        (getColumnTypes [_ table snap]
          (when-let [^Database db (.databaseOrNull db-cat (.getDbName table))]
            (.getColumnTypes db table snap)))
 
-       (openSnapshot [_ db-name]
-         (-> (or (.databaseOrNull db-cat db-name)
-                 (throw (err/incorrect :xtdb/unknown-db (format "Unknown database: %s" db-name)
-                                       {:db-name db-name})))
-             (.openSnapshot))))))
+       (openSnapshot [_ db-name await-token]
+         (let [^Database db (or (.databaseOrNull db-cat db-name)
+                                (throw (err/incorrect :xtdb/unknown-db (format "Unknown database: %s" db-name)
+                                                      {:db-name db-name})))]
+           (.awaitAll db-cat await-token nil)
+           (.openSnapshot db))))))
 
   (addMeterRegistry [_ reg]
     (.add metrics-registry reg))

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -8,7 +8,6 @@
             [xtdb.antlr :as antlr]
             [xtdb.api :as xt]
             [xtdb.authn :as authn]
-            [xtdb.basis :as basis]
             [xtdb.db-catalog :as db]
             [xtdb.error :as err]
             [xtdb.expression :as expr]
@@ -42,6 +41,7 @@
            (org.apache.arrow.memory BufferAllocator)
            org.apache.arrow.vector.types.pojo.Field
            (xtdb.antlr Sql$DirectlyExecutableStatementContext SqlVisitor)
+           xtdb.AwaitToken
            (xtdb.api Authenticator DataSource DataSource$ConnectionBuilder OAuthResult ServerConfig Xtdb Xtdb$Config)
            xtdb.api.module.XtdbModule
            (xtdb.arrow Relation Relation$ILoader VectorType)
@@ -122,6 +122,9 @@
                        ;; a positive integer that identifies the connection on this server
                        ;; we will use this as the pg Process ID for messages that require it (such as cancellation)
                        cid
+
+                       ;; this connection's accumulated read-your-writes token (see xtdb.AwaitToken)
+                       ^AwaitToken await-token
 
                        !closing? conn-state]
 
@@ -534,12 +537,12 @@
 
     :else (throw (pgio/err-protocol-violation (format "invalid timezone '%s'" (str tz))))))
 
-(defn cmd-begin [{:keys [node conn-state]} tx-opts {:keys [args]}]
+(defn cmd-begin [{:keys [node conn-state ^AwaitToken await-token]} tx-opts {:keys [args]}]
   (swap! conn-state
-         (fn [{:keys [session await-token] :as st}]
+         (fn [{:keys [session] :as st}]
            (let [await-token (if-let [[_ tok] (find tx-opts :await-token)]
                                (apply-args tok args)
-                               await-token)
+                               (.getValue await-token))
                  {:keys [^Clock clock]} session]
 
              (when-not (= :read-write (:access-mode tx-opts))
@@ -570,7 +573,7 @@
   (swap! conn-state dissoc :transaction)
   (close-all-portals conn))
 
-(defn cmd-commit [{:keys [^Xtdb node conn-state default-db ^BufferAllocator allocator, tx-error-counter, tx-latency-timer, tx-submit-timer, tx-execute-timer] :as conn}]
+(defn cmd-commit [{:keys [^Xtdb node conn-state default-db ^AwaitToken await-token ^BufferAllocator allocator, tx-error-counter, tx-latency-timer, tx-submit-timer, tx-execute-timer] :as conn}]
   (let [{:keys [transaction session]} @conn-state
         {:keys [failed dml-buf system-time access-mode default-tz async? user-metadata]} transaction
         {:keys [parameters]} session]
@@ -596,22 +599,18 @@
                                                         (metrics/record-callable! tx-submit-timer
                                                                                   (.submitTx node default-db tx-ops tx-opts)))
                                                 msg-id (.getTxId tx-id)]
-                                            (swap! conn-state (fn [cs]
-                                                                (-> cs
-                                                                    (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {default-db [msg-id]}))
-                                                                    (assoc :latest-submitted-tx {:tx-id msg-id})))))
+                                            (.record await-token default-db msg-id)
+                                            (swap! conn-state assoc :latest-submitted-tx {:tx-id msg-id}))
 
                                           (let [tx (with-auth-check conn
                                                      (metrics/record-callable! tx-execute-timer
                                                                                (.executeTx node default-db tx-ops tx-opts)))
                                                 msg-id (.getTxId tx)]
-                                            (swap! conn-state (fn [cs]
-                                                                (-> cs
-                                                                    (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {default-db [msg-id]}))
-                                                                    (assoc :latest-submitted-tx {:tx-id msg-id
-                                                                                                 :system-time (.getSystemTime tx)
-                                                                                                 :committed? (.getCommitted tx)
-                                                                                                 :error (.getError tx)}))))
+                                            (.record await-token default-db msg-id)
+                                            (swap! conn-state assoc :latest-submitted-tx {:tx-id msg-id
+                                                                                          :system-time (.getSystemTime tx)
+                                                                                          :committed? (.getCommitted tx)
+                                                                                          :error (.getError tx)})
 
                                             (when-let [error (.getError tx)]
                                               (throw error))))))))
@@ -975,16 +974,16 @@
 
     [#xt/type :utf8]))
 
-(defn- prep-stmt [{:keys [node conn-state default-db] :as conn} {:keys [statement-type param-oids] :as stmt}]
+(defn- prep-stmt [{:keys [node conn-state default-db ^AwaitToken await-token] :as conn} {:keys [statement-type param-oids] :as stmt}]
   (case statement-type
     (:query :execute :show-variable)
     (try
       (let [{:keys [^Sql$DirectlyExecutableStatementContext parsed-query explain? explain-analyze?]} stmt
 
-            {:keys [session await-token]} @conn-state
+            {:keys [session]} @conn-state
             {:keys [^Clock clock]} session
 
-            query-opts {:await-token await-token
+            query-opts {:await-token (.getValue await-token)
                         :tx-timeout (Duration/ofMinutes 1)
                         :default-tz (.getZone clock)
                         :explain? explain?
@@ -1109,10 +1108,10 @@
           pg-types
           result-formats)))
 
-(defn bind-stmt [{:keys [node conn-state ^BufferAllocator allocator query-tracer] :as conn} {:keys [statement-type ^PreparedQuery prepared-query args result-format] :as stmt}]
-  (let [{:keys [session transaction await-token]} @conn-state
+(defn bind-stmt [{:keys [node conn-state ^AwaitToken await-token ^BufferAllocator allocator query-tracer] :as conn} {:keys [statement-type ^PreparedQuery prepared-query args result-format] :as stmt}]
+  (let [{:keys [session transaction]} @conn-state
         {:keys [^Clock clock], session-params :parameters} session
-        await-token (:await-token transaction await-token)
+        await-token (:await-token transaction (.getValue await-token))
 
         query-opts (QueryOpts. (or (some-> (or (:current-time stmt) (:current-time transaction))
                                             (time/->instant))
@@ -1289,10 +1288,9 @@
     (set-time-zone conn tz))
   (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET TIME ZONE"}))
 
-(defn cmd-set-await-token [{:keys [conn-state] :as conn} {:keys [await-token args]}]
-  (let [await-token (-> await-token (apply-args args))]
-    (swap! conn-state assoc :await-token await-token)
-    (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET AWAIT_TOKEN"})))
+(defn cmd-set-await-token [{:keys [^AwaitToken await-token] :as conn} {:keys [args], new-token :await-token}]
+  (.setValue await-token (-> new-token (apply-args args)))
+  (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET AWAIT_TOKEN"}))
 
 (defn cmd-set-session-characteristics [{:keys [conn-state] :as conn} session-characteristics]
   (swap! conn-state update-in [:session :characteristics] (fnil into {}) session-characteristics)
@@ -1447,7 +1445,7 @@
       (metrics/inc-counter! query-error-counter)
       (throw e))))
 
-(defn- attach-db [{:keys [node conn-state default-db] :as conn} {:keys [db-name db-config]}]
+(defn- attach-db [{:keys [node conn-state default-db ^AwaitToken await-token] :as conn} {:keys [db-name db-config]}]
   (when-not (= default-db "xtdb")
     (throw (err/incorrect ::attach-db-on-secondary "Can only attach databases when connected to the primary 'xtdb' database."
                           {:db default-db})))
@@ -1458,15 +1456,13 @@
 
   (with-auth-check conn
     (let [{:keys [tx-id error] :as tx} (xtp/attach-db node db-name db-config)]
-      (swap! conn-state (fn [cs]
-                          (-> cs
-                              (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {"xtdb" [tx-id]}))
-                              (assoc :latest-submitted-tx tx))))
+      (.record await-token "xtdb" tx-id)
+      (swap! conn-state assoc :latest-submitted-tx tx)
 
       (when error
         (throw error)))))
 
-(defn- detach-db [{:keys [node conn-state default-db] :as conn} {:keys [db-name]}]
+(defn- detach-db [{:keys [node conn-state default-db ^AwaitToken await-token] :as conn} {:keys [db-name]}]
   (when-not (= default-db "xtdb")
     (throw (err/incorrect ::detach-db-on-secondary "Can only detach databases when connected to the primary 'xtdb' database."
                           {:db default-db})))
@@ -1477,10 +1473,8 @@
 
   (with-auth-check conn
     (let [{:keys [tx-id error] :as tx} (xtp/detach-db node db-name)]
-      (swap! conn-state (fn [cs]
-                          (-> cs
-                              (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {"xtdb" [tx-id]}))
-                              (assoc :latest-submitted-tx tx))))
+      (.record await-token "xtdb" tx-id)
+      (swap! conn-state assoc :latest-submitted-tx tx)
 
       (when error
         (throw error)))))
@@ -1824,6 +1818,7 @@
                                                (-> (map->Connection {:cid cid, :node node, :authn authn, :server server,
                                                                      :frontend (pgio/->socket-frontend conn-socket),
                                                                      :!closing? !closing?
+                                                                     :await-token (AwaitToken.)
                                                                      :allocator (util/->child-allocator allocator (str "pg-conn-" cid))
                                                                      :conn-state !conn-state})
                                                    (cmd-startup))

--- a/core/src/main/kotlin/xtdb/AwaitToken.kt
+++ b/core/src/main/kotlin/xtdb/AwaitToken.kt
@@ -1,0 +1,21 @@
+package xtdb
+
+import xtdb.api.log.MessageId
+import xtdb.database.DatabaseName
+import xtdb.database.encodeTxBasisToken
+import xtdb.database.mergeTxBasisTokens
+
+/**
+ * A connection's accumulated basis token, providing read-your-writes: [record] folds each committed
+ * tx into [value], which the frontend threads into its subsequent reads so the planning snapshot can
+ * see this connection's own writes.
+ *
+ * [value] may also be replaced outright for `SET AWAIT_TOKEN`.
+ */
+class AwaitToken {
+    var value: String? = null
+
+    fun record(dbName: DatabaseName, txId: MessageId) {
+        value = mergeTxBasisTokens(value, mapOf(dbName to listOf(txId)).encodeTxBasisToken())
+    }
+}

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -21,6 +21,7 @@ import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.ResultCursor
 import xtdb.api.Xtdb
+import xtdb.api.log.MessageId
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorType
@@ -43,6 +44,14 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     private var dbName: DatabaseName = "xtdb"
     private var autoCommit = true
     private val pendingOps = mutableListOf<TxOp>()
+
+    private var awaitToken: String? = null
+
+    private fun runTx(ops: List<TxOp>): Xtdb.ExecutedTx {
+        val tx = node.executeTx(dbName, ops)
+        awaitToken = node.mergeAwaitToken(awaitToken, dbName, tx.txId)
+        return tx
+    }
 
     interface XtdbStatement : AdbcStatement {
         fun bind(rel: RelationReader): Unit = unsupported("bind(RelationReader) not supported")
@@ -73,7 +82,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun prepare() {
             val sql = this.sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
-            prepared = node.prepareSql(sql, dbName)
+            prepared = node.prepareSql(sql, dbName, awaitToken)
         }
 
         override fun getParameterSchema(): Schema {
@@ -115,7 +124,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
             val queryArgs = openQueryArgs()
             val cursor = try {
-                prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName)
+                prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName, awaitToken)
             } catch (t: Throwable) {
                 queryArgs?.close()
                 throw t
@@ -139,9 +148,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
     internal fun executeDml(op: TxOp) {
         if (autoCommit) {
-            listOf(op).useAll { ops ->
-                node.executeTx(dbName, ops)
-            }
+            listOf(op).useAll { ops -> runTx(ops) }
         } else {
             pendingOps.add(op)
         }
@@ -155,9 +162,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         val ops = pendingOps.toList()
         pendingOps.clear()
         if (ops.isNotEmpty()) {
-            ops.useAll {
-                node.executeTx(dbName, ops)
-            }
+            ops.useAll { runTx(it) }
         }
     }
 
@@ -209,8 +214,8 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
     }
 
-    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName)
-    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName)
+    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName, awaitToken)
+    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName, awaitToken)
 
     private fun cursorToArrowReader(cursor: ResultCursor, schema: Schema): ArrowReader =
         object : ArrowReader(node.allocator) {
@@ -301,7 +306,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             getTableSchema(TableRef(catalog ?: dbName, dbSchema ?: "public", tableName), snap)
         }
 
-    fun openSnapshot(): DatabaseSnapshot = node.openSnapshot(dbName)
+    fun openSnapshot(): DatabaseSnapshot = node.openSnapshot(dbName, awaitToken)
 
     fun getTableSchema(dbSchema: String, tableName: String, snap: DatabaseSnapshot): Schema =
         getTableSchema(TableRef(dbName, dbSchema, tableName), snap)
@@ -411,7 +416,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         if (depth == GetObjectsDepth.DB_SCHEMAS) {
             val sql = "SELECT DISTINCT table_schema FROM information_schema.tables $where ORDER BY table_schema"
             val result = linkedMapOf<String, List<TableInfo>>()
-            node.openSqlQuery(sql, dbName).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         result[rel.get("table_schema").getObject(i).toString()] = emptyList()
@@ -435,7 +440,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         if (needColumns) {
             val tableColumns = linkedMapOf<Pair<String, String>, MutableList<ColumnInfo>>()
-            node.openSqlQuery(sql, dbName).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -452,7 +457,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
                     .add(TableInfo(key.second, cols))
             }
         } else {
-            node.openSqlQuery(sql, dbName).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -479,10 +484,11 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         val databaseNames: Collection<DatabaseName>
         fun submitTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.SubmittedTx
         fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx
-        fun openSqlQuery(sql: String, dbName: DatabaseName): ResultCursor
-        fun prepareSql(sql: String, dbName: DatabaseName): PreparedQuery
+        fun openSqlQuery(sql: String, dbName: DatabaseName, awaitToken: String?): ResultCursor
+        fun prepareSql(sql: String, dbName: DatabaseName, awaitToken: String?): PreparedQuery
+        fun mergeAwaitToken(awaitToken: String?, dbName: DatabaseName, txId: MessageId): String
         fun getColumnTypes(table: TableRef, snap: DatabaseSnapshot): Map<String, VectorType>?
-        fun openSnapshot(dbName: DatabaseName): DatabaseSnapshot
+        fun openSnapshot(dbName: DatabaseName, awaitToken: String?): DatabaseSnapshot
     }
 
     override fun close() {

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -19,9 +19,9 @@ import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.complex.writer.VarCharWriter
 import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.Schema
+import xtdb.AwaitToken
 import xtdb.ResultCursor
 import xtdb.api.Xtdb
-import xtdb.api.log.MessageId
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorType
@@ -45,13 +45,10 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     private var autoCommit = true
     private val pendingOps = mutableListOf<TxOp>()
 
-    private var awaitToken: String? = null
+    private val awaitToken = AwaitToken()
 
-    private fun runTx(ops: List<TxOp>): Xtdb.ExecutedTx {
-        val tx = node.executeTx(dbName, ops)
-        awaitToken = node.mergeAwaitToken(awaitToken, dbName, tx.txId)
-        return tx
-    }
+    private fun runTx(ops: List<TxOp>): Xtdb.ExecutedTx =
+        node.executeTx(dbName, ops).also { awaitToken.record(dbName, it.txId) }
 
     interface XtdbStatement : AdbcStatement {
         fun bind(rel: RelationReader): Unit = unsupported("bind(RelationReader) not supported")
@@ -82,7 +79,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun prepare() {
             val sql = this.sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
-            prepared = node.prepareSql(sql, dbName, awaitToken)
+            prepared = node.prepareSql(sql, dbName, awaitToken.value)
         }
 
         override fun getParameterSchema(): Schema {
@@ -124,7 +121,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
             val queryArgs = openQueryArgs()
             val cursor = try {
-                prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName, awaitToken)
+                prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName, awaitToken.value)
             } catch (t: Throwable) {
                 queryArgs?.close()
                 throw t
@@ -214,8 +211,8 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
     }
 
-    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName, awaitToken)
-    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName, awaitToken)
+    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName, awaitToken.value)
+    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName, awaitToken.value)
 
     private fun cursorToArrowReader(cursor: ResultCursor, schema: Schema): ArrowReader =
         object : ArrowReader(node.allocator) {
@@ -306,7 +303,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             getTableSchema(TableRef(catalog ?: dbName, dbSchema ?: "public", tableName), snap)
         }
 
-    fun openSnapshot(): DatabaseSnapshot = node.openSnapshot(dbName, awaitToken)
+    fun openSnapshot(): DatabaseSnapshot = node.openSnapshot(dbName, awaitToken.value)
 
     fun getTableSchema(dbSchema: String, tableName: String, snap: DatabaseSnapshot): Schema =
         getTableSchema(TableRef(dbName, dbSchema, tableName), snap)
@@ -416,7 +413,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         if (depth == GetObjectsDepth.DB_SCHEMAS) {
             val sql = "SELECT DISTINCT table_schema FROM information_schema.tables $where ORDER BY table_schema"
             val result = linkedMapOf<String, List<TableInfo>>()
-            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken.value).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         result[rel.get("table_schema").getObject(i).toString()] = emptyList()
@@ -440,7 +437,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         if (needColumns) {
             val tableColumns = linkedMapOf<Pair<String, String>, MutableList<ColumnInfo>>()
-            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken.value).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -457,7 +454,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
                     .add(TableInfo(key.second, cols))
             }
         } else {
-            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
+            node.openSqlQuery(sql, dbName, awaitToken.value).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -486,7 +483,6 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx
         fun openSqlQuery(sql: String, dbName: DatabaseName, awaitToken: String?): ResultCursor
         fun prepareSql(sql: String, dbName: DatabaseName, awaitToken: String?): PreparedQuery
-        fun mergeAwaitToken(awaitToken: String?, dbName: DatabaseName, txId: MessageId): String
         fun getColumnTypes(table: TableRef, snap: DatabaseSnapshot): Map<String, VectorType>?
         fun openSnapshot(dbName: DatabaseName, awaitToken: String?): DatabaseSnapshot
     }

--- a/src/test/clojure/xtdb/pgwire/authn_test.clj
+++ b/src/test/clojure/xtdb/pgwire/authn_test.clj
@@ -39,6 +39,7 @@
                                       :frontend frontend
                                       :cid -1
                                       :!closing? (atom false)
+                                      :await-token (xtdb.AwaitToken.)
                                       :conn-state (atom {:session {:clock (Clock/systemUTC)}})
                                       :default-db "xtdb"})]
     (try

--- a/src/test/clojure/xtdb/pgwire_protocol_test.clj
+++ b/src/test/clojure/xtdb/pgwire_protocol_test.clj
@@ -75,6 +75,7 @@
                                        :frontend frontend
                                        :cid -1
                                        :!closing? (atom false)
+                                       :await-token (xtdb.AwaitToken.)
                                        :conn-state (atom {:session {:clock (Clock/systemUTC)}})
                                        :default-db "xtdb"})]
      (try

--- a/src/test/java/xtdb/api/AdbcTest.kt
+++ b/src/test/java/xtdb/api/AdbcTest.kt
@@ -304,4 +304,18 @@ class AdbcTest {
             }
         }
     }
+
+    @Test
+    fun `same-connection INSERT then getTableSchema sees the columns`() {
+        AdbcDriverFactory().getDriver(allocator).open(emptyMap()).use { db ->
+            db.connect().use { conn ->
+                conn.createStatement().use { ins ->
+                    ins.setSqlQuery("INSERT INTO same_conn_table (_id, n) VALUES (1, 100)")
+                    ins.executeUpdate()
+                }
+                conn.getTableSchema(null, "public", "same_conn_table")
+                    .fields.map { it.name }.toSet() shouldBe setOf("_id", "n")
+            }
+        }
+    }
 }

--- a/src/test/kotlin/xtdb/AwaitTokenTest.kt
+++ b/src/test/kotlin/xtdb/AwaitTokenTest.kt
@@ -1,0 +1,42 @@
+package xtdb
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import xtdb.database.decodeTxBasisToken
+import xtdb.database.encodeTxBasisToken
+
+class AwaitTokenTest {
+
+    private fun AwaitToken.decoded() = value?.decodeTxBasisToken()
+
+    @Test
+    fun `record folds a committed tx into the token`() {
+        val at = AwaitToken()
+        at.record("mydb", 7)
+        assertEquals(mapOf("mydb" to listOf(7L)), at.decoded())
+    }
+
+    @Test
+    fun `successive records on the same db keep the latest`() {
+        val at = AwaitToken()
+        at.record("mydb", 4)
+        at.record("mydb", 9)
+        assertEquals(mapOf("mydb" to listOf(9L)), at.decoded())
+    }
+
+    @Test
+    fun `records across dbs merge - the attach-detach case`() {
+        val at = AwaitToken()
+        at.record("secondary", 2)
+        at.record("xtdb", 5)
+        assertEquals(mapOf("secondary" to listOf(2L), "xtdb" to listOf(5L)), at.decoded())
+    }
+
+    @Test
+    fun `value can be replaced directly - for SET AWAIT_TOKEN`() {
+        val at = AwaitToken()
+        at.record("mydb", 1)
+        at.value = mapOf("mydb" to listOf(42L)).encodeTxBasisToken()
+        assertEquals(mapOf("mydb" to listOf(42L)), at.decoded())
+    }
+}

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -676,6 +676,19 @@ class FlightSqlAdbcTest {
         }
     }
 
+    @Test
+    fun `test same-connection INSERT then executeSchema sees real column names`() {
+        conn.createStatement().use { ins ->
+            ins.setSqlQuery("INSERT INTO same_conn_repro (_id, n) VALUES (1, 100)")
+            ins.executeUpdate()
+        }
+        conn.createStatement().use { stmt ->
+            stmt.setSqlQuery("SELECT n FROM same_conn_repro")
+            stmt.prepare()
+            assertEquals(listOf("n"), stmt.executeSchema().fields.map { it.name })
+        }
+    }
+
     // -- ADBC metadata (through FlightSQL ADBC client) --
 
     // getInfo via ADBC client hits a bug in GetInfoMetadataReader.processRootFromStream

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -114,9 +114,9 @@ class FlightSqlAdbcTest {
         xtdb.close()
     }
 
-    private fun FlightInfo.readRows(): List<Map<*, *>> {
+    private fun FlightInfo.readRows(client: FlightSqlClient = fsqlClient): List<Map<*, *>> {
         val ticket = endpoints.first().ticket
-        fsqlClient.getStream(ticket, *emptyCallOpts).use { stream ->
+        client.getStream(ticket, *emptyCallOpts).use { stream ->
             val root = stream.root
             Relation.fromRoot(al, root).use { rel ->
                 val rows = mutableListOf<Map<*, *>>()
@@ -687,6 +687,45 @@ class FlightSqlAdbcTest {
             stmt.prepare()
             assertEquals(listOf("n"), stmt.executeSchema().fields.map { it.name })
         }
+    }
+
+    // #5609 (per-connection await-token) composes with #5666 (per-session connections):
+    // each FSQL session has its own connection, so #5609's per-connection await-token
+    // is genuinely per-session. A session reads its own writes back immediately, and one
+    // session's write does not drag another session's await target (no cross-client coupling).
+    @Test
+    fun `test FlightSQL session reads its own writes and stays isolated from another session`() {
+        cookieAwareClient().use { sessionA ->
+            cookieAwareClient().use { sessionB ->
+                sessionA.setSessionOptions(catalogOpt("xtdb"), *emptyCallOpts)
+                sessionB.setSessionOptions(catalogOpt("xtdb"), *emptyCallOpts)
+
+                // read-your-writes within session A: INSERT then immediately SELECT on the
+                // same session must see the row — this is the race #5609 closes (the planner
+                // snapshot would otherwise outrun the indexer and miss the just-written row).
+                sessionA.executeUpdate("INSERT INTO ryw (_id, n) VALUES (1, 'a')", *emptyCallOpts)
+                assertEquals(
+                    listOf(mapOf("_id" to 1L, "n" to "a")),
+                    sessionA.execute("SELECT _id, n FROM ryw", *emptyCallOpts).readRows(sessionA),
+                    "session A must read its own write back (per-connection await-token)"
+                )
+
+                // session B writes its own row and reads it back — B's await target tracks
+                // only B's own write, independent of A's connection/token.
+                sessionB.executeUpdate("INSERT INTO ryw (_id, n) VALUES (2, 'b')", *emptyCallOpts)
+                assertEquals(
+                    listOf(mapOf("_id" to 2L, "n" to "b")),
+                    sessionB.execute("SELECT _id, n FROM ryw WHERE _id = 2", *emptyCallOpts).readRows(sessionB),
+                    "session B must read its own write back without coupling to session A"
+                )
+            }
+        }
+
+        // both committed writes are globally visible once the sessions close.
+        assertEquals(
+            listOf(mapOf("_id" to 1L, "n" to "a"), mapOf("_id" to 2L, "n" to "b")),
+            fsqlClient.execute("SELECT _id, n FROM ryw ORDER BY _id", *emptyCallOpts).readRows()
+        )
     }
 
     // -- ADBC metadata (through FlightSQL ADBC client) --


### PR DESCRIPTION
## Summary

Extracts per-connection await-token tracking out of `XtdbConnection` and `pgwire` into a shared `xtdb.Connection` primitive that lives at the node layer.
One implementation, two consumers, read-your-writes guaranteed by the `Connection` rather than re-derived by each frontend.

This is the **connection-level alternative to #5648** (the `Session` extraction), addressing @jarohen's review on #5609:
> if pgwire and ADBC both require the same behaviour (and a hypothetical third protocol might too) then it's worth instead moving this functionality down a layer.

#5648 is left open for side-by-side comparison.

## Shape

`xtdb.Connection` is a connection-scoped handle onto the node.
It owns an await-token, advances it on every write (`submitTx`/`executeTx`/`recordTx`), and threads it into every read (`prepareSql`/`openSqlQuery`/`openSnapshot`).
Callers issue token-free reads and writes and get read-your-writes for free; the token surfaces only via `awaitToken` for the pgwire `SET`/`SHOW AWAIT_TOKEN` SQL feature.

`Connection.Node` is a pure executor SPI implemented by a Clojure reify in `node/impl.clj` (where `db-cat` and the basis token math already live).
The factory is `xtp/open-connection` on the **internal** `xtdb.protocols/PNode` — alongside `attach-db`/`detach-db` — so it is reached the same way pgwire already reaches the node.

## How this differs from #5648

- **No public API growth.** Zero changes to `xtdb/api/Xtdb.kt`. #5648 added `openSession` to the `Xtdb.XtdbInternal` interface (the diff @jarohen reacted to); here the factory is on the internal `xtp/PNode` protocol, so the documented `Xtdb` surface is untouched.
- **No empty `AutoCloseable`.** `Connection` holds no resources, so it doesn't advertise a close contract nobody needs (a smell #5648 reintroduced).
- **pgwire `await_token` wire-surface is behaviour-preserving.** Every conn-state `:await-token` reader was rebound to source from the `Connection`; `SHOW AWAIT_TOKEN`, `SHOW latest_submitted_tx`, the per-transaction `WITH (AWAIT_TOKEN …)` override, and `SET AWAIT_TOKEN` are unchanged. The existing `test-show-await-token` / `in-tx-await-token` / `await-token+snapshot-token` tests are the regression guard and stay green.

## Commits

1. `feat(adbc): extract per-connection await-token into a node-level Connection` — `Connection` + `ConnectionTest`, `xtp/open-connection`, ADBC adopts it (`XtdbConnection.Node` extends `Connection.Node`, bespoke `awaitToken`/`runTx`/`mergeAwaitToken` deleted).
2. `feat(pgwire): migrate per-connection await-token to the shared Connection` — pgwire stores the `Connection` in `:conn-state`, routes writes through it, drops the inline `merge-tx-tokens` and the `xtdb.basis` require.

## Test plan

All green, no reflection / boxed-math warnings:

- `xtdb.ConnectionTest` (new): 6/6 — read-your-writes, monotonic accumulation, cross-db merge, dbName retargeting, direct token replacement.
- `xtdb.api.AdbcTest`: 11/11.
- `xtdb.FlightSqlAdbcTest`: 45/45.
- `xtdb.pgwire-test`: 144/144 (includes the `await_token` wire-surface tests).
- `xtdb.pgwire-protocol-test`: 11/11.

## Stack

Built on top of #5609 (`tim/5608-prepare-await-token`); base shows #5609's commits until it lands, then this rebases cleanly.
Iterates toward umbrella #5132.

## Scope

Out:

- Broader connection-state extraction (`autoCommit`, `pendingOps`, `currentCatalog`, pgwire session clock/params) — this PR scopes to await-token only, matching @jarohen's ask.
- Unifying with the node's `java.sql.Connection` — a larger piece, deliberately deferred.