### PR TITLE
feat: extract per-connection read-your-writes into a NodeConnection

### DIFF
--- a/api/src/main/clojure/xtdb/protocols.clj
+++ b/api/src/main/clojure/xtdb/protocols.clj
@@ -6,7 +6,8 @@
   (^long submit-tx [node tx-ops tx-opts])
   (^xtdb.api.Xtdb$ExecutedTx execute-tx [node tx-ops tx-opts])
   (^xtdb.api.Xtdb$ExecutedTx attach-db [node db-name db-config])
-  (^xtdb.api.Xtdb$ExecutedTx detach-db [node db-name]))
+  (^xtdb.api.Xtdb$ExecutedTx detach-db [node db-name])
+  (^xtdb.NodeConnection open-connection [node db-name]))
 
 (defprotocol PLocalNode
   (^xtdb.query.PreparedQuery prepare-sql [node query query-opts])

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -22,6 +22,7 @@
            [java.util.concurrent.atomic AtomicReference]
            (org.apache.arrow.memory BufferAllocator)
            xtdb.NodeBase
+           (xtdb NodeConnection NodeConnection$Node)
            (xtdb.adbc XtdbConnection XtdbConnection$Node)
            (xtdb.antlr Sql$DirectlyExecutableStatementContext)
            (xtdb.api DataSource TransactionKey TransactionResult TransactionResult$Committed TransactionResult$Aborted Xtdb Xtdb$CompactorNode Xtdb$Config Xtdb$ExecutedTx Xtdb$SubmittedTx Xtdb$XtdbInternal)
@@ -83,6 +84,29 @@
            :committed? committed?
            :error error}))))
 
+(defn- ->node-connection ^NodeConnection [this-node ^Database$Catalog db-cat db-name]
+  (NodeConnection.
+   (reify NodeConnection$Node
+     (submitTx [_ db-name ops opts] (.submitTx this-node db-name ops opts))
+     (executeTx [_ db-name ops opts] (.executeTx this-node db-name ops opts))
+
+     (openSqlQuery [_ sql db-name await-token]
+       (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
+         (-> (xtp/prepare-sql this-node sql query-opts)
+             (.openQuery nil (QueryOpts. nil (:default-tz query-opts))))))
+
+     (prepareSql [_ sql db-name await-token]
+       (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
+         (xtp/prepare-sql this-node sql query-opts)))
+
+     (openSnapshot [_ db-name await-token]
+       (let [^Database db (or (.databaseOrNull db-cat db-name)
+                              (throw (err/incorrect :xtdb/unknown-db (format "Unknown database: %s" db-name)
+                                                    {:db-name db-name})))]
+         (.awaitAll db-cat await-token nil)
+         (.openSnapshot db))))
+   db-name))
+
 (defrecord Node [^BufferAllocator allocator, ^Database$Catalog db-cat
                  ^IQuerySource q-src
                  ^CompositeMeterRegistry metrics-registry
@@ -116,31 +140,10 @@
      (reify XtdbConnection$Node
        (getAllocator [_] allocator)
        (getDatabaseNames [_] (.getDatabaseNames db-cat))
-       (submitTx [_ db-name ops opts] (.submitTx this-node db-name ops opts))
-       (executeTx [_ db-name ops opts] (.executeTx this-node db-name ops opts))
-
-       (openSqlQuery [_ sql db-name await-token]
-         (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
-           (-> (xtp/prepare-sql this-node sql query-opts)
-               (.openQuery nil (QueryOpts. nil (:default-tz query-opts))))))
-
-       (prepareSql [_ sql db-name await-token]
-         (let [query-opts (-> {:await-token await-token} (with-query-opts-defaults this-node db-name))]
-           (xtp/prepare-sql this-node sql query-opts)))
-
-       (mergeAwaitToken [_ existing-token db-name tx-id]
-         (basis/merge-tx-tokens existing-token (basis/->tx-basis-str {db-name [tx-id]})))
-
        (getColumnTypes [_ table snap]
          (when-let [^Database db (.databaseOrNull db-cat (.getDbName table))]
-           (.getColumnTypes db table snap)))
-
-       (openSnapshot [_ db-name await-token]
-         (let [^Database db (or (.databaseOrNull db-cat db-name)
-                                (throw (err/incorrect :xtdb/unknown-db (format "Unknown database: %s" db-name)
-                                                      {:db-name db-name})))]
-           (.awaitAll db-cat await-token nil)
-           (.openSnapshot db))))))
+           (.getColumnTypes db table snap))))
+     (xtp/open-connection this-node "xtdb")))
 
   (addMeterRegistry [_ reg]
     (.add metrics-registry reg))
@@ -223,6 +226,9 @@
     (let [primary-db (.getPrimary db-cat)
           msg-id (xt-log/send-detach-db! primary-db db-name)]
       (await-msg-result this primary-db msg-id)))
+
+  (open-connection [this-node db-name]
+    (->node-connection this-node db-cat db-name))
 
   xtp/PStatus
   (latest-completed-txs [_]

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -8,7 +8,6 @@
             [xtdb.antlr :as antlr]
             [xtdb.api :as xt]
             [xtdb.authn :as authn]
-            [xtdb.basis :as basis]
             [xtdb.db-catalog :as db]
             [xtdb.error :as err]
             [xtdb.expression :as expr]
@@ -42,6 +41,7 @@
            (org.apache.arrow.memory BufferAllocator)
            org.apache.arrow.vector.types.pojo.Field
            (xtdb.antlr Sql$DirectlyExecutableStatementContext SqlVisitor)
+           xtdb.NodeConnection
            (xtdb.api Authenticator DataSource DataSource$ConnectionBuilder OAuthResult ServerConfig Xtdb Xtdb$Config)
            xtdb.api.module.XtdbModule
            (xtdb.arrow Relation Relation$ILoader VectorType)
@@ -369,7 +369,9 @@
                  (.databaseOrNull db-cat db-name))
                (throw (err-invalid-catalog db-name)))
         user (get startup-opts "user")
-        conn (assoc conn :node node, :authn authn, :default-db db-name, :db db)]
+        node-conn (xtp/open-connection node db-name)
+        conn (assoc conn :node node, :authn authn, :default-db db-name, :db db)
+        _ (swap! (:conn-state conn) assoc :node-conn node-conn)]
     (if authn
       (condp = (.methodFor authn user (pgio/host-address frontend))
         #xt.authn/method :trust
@@ -536,10 +538,10 @@
 
 (defn cmd-begin [{:keys [node conn-state]} tx-opts {:keys [args]}]
   (swap! conn-state
-         (fn [{:keys [session await-token] :as st}]
+         (fn [{:keys [session ^NodeConnection node-conn] :as st}]
            (let [await-token (if-let [[_ tok] (find tx-opts :await-token)]
                                (apply-args tok args)
-                               await-token)
+                               (.getAwaitToken node-conn))
                  {:keys [^Clock clock]} session]
 
              (when-not (= :read-write (:access-mode tx-opts))
@@ -570,8 +572,8 @@
   (swap! conn-state dissoc :transaction)
   (close-all-portals conn))
 
-(defn cmd-commit [{:keys [^Xtdb node conn-state default-db ^BufferAllocator allocator, tx-error-counter, tx-latency-timer, tx-submit-timer, tx-execute-timer] :as conn}]
-  (let [{:keys [transaction session]} @conn-state
+(defn cmd-commit [{:keys [conn-state ^BufferAllocator allocator, tx-error-counter, tx-latency-timer, tx-submit-timer, tx-execute-timer] :as conn}]
+  (let [{:keys [transaction session ^NodeConnection node-conn]} @conn-state
         {:keys [failed dml-buf system-time access-mode default-tz async? user-metadata]} transaction
         {:keys [parameters]} session]
     (if failed
@@ -594,24 +596,18 @@
                                         (if async?
                                           (let [tx-id (with-auth-check conn
                                                         (metrics/record-callable! tx-submit-timer
-                                                                                  (.submitTx node default-db tx-ops tx-opts)))
+                                                                                  (.submitTx node-conn tx-ops tx-opts)))
                                                 msg-id (.getTxId tx-id)]
-                                            (swap! conn-state (fn [cs]
-                                                                (-> cs
-                                                                    (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {default-db [msg-id]}))
-                                                                    (assoc :latest-submitted-tx {:tx-id msg-id})))))
+                                            (swap! conn-state assoc :latest-submitted-tx {:tx-id msg-id}))
 
                                           (let [tx (with-auth-check conn
                                                      (metrics/record-callable! tx-execute-timer
-                                                                               (.executeTx node default-db tx-ops tx-opts)))
+                                                                               (.executeTx node-conn tx-ops tx-opts)))
                                                 msg-id (.getTxId tx)]
-                                            (swap! conn-state (fn [cs]
-                                                                (-> cs
-                                                                    (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {default-db [msg-id]}))
-                                                                    (assoc :latest-submitted-tx {:tx-id msg-id
-                                                                                                 :system-time (.getSystemTime tx)
-                                                                                                 :committed? (.getCommitted tx)
-                                                                                                 :error (.getError tx)}))))
+                                            (swap! conn-state assoc :latest-submitted-tx {:tx-id msg-id
+                                                                                          :system-time (.getSystemTime tx)
+                                                                                          :committed? (.getCommitted tx)
+                                                                                          :error (.getError tx)})
 
                                             (when-let [error (.getError tx)]
                                               (throw error))))))))
@@ -990,10 +986,10 @@
     (try
       (let [{:keys [^Sql$DirectlyExecutableStatementContext parsed-query explain? explain-analyze?]} stmt
 
-            {:keys [session await-token]} @conn-state
+            {:keys [session ^NodeConnection node-conn]} @conn-state
             {:keys [^Clock clock]} session
 
-            query-opts {:await-token await-token
+            query-opts {:await-token (.getAwaitToken node-conn)
                         :tx-timeout (Duration/ofMinutes 1)
                         :default-tz (.getZone clock)
                         :explain? explain?
@@ -1119,9 +1115,9 @@
           result-formats)))
 
 (defn bind-stmt [{:keys [node conn-state ^BufferAllocator allocator query-tracer] :as conn} {:keys [statement-type ^PreparedQuery prepared-query args result-format] :as stmt}]
-  (let [{:keys [session transaction await-token]} @conn-state
+  (let [{:keys [session transaction ^NodeConnection node-conn]} @conn-state
         {:keys [^Clock clock], session-params :parameters} session
-        await-token (:await-token transaction await-token)
+        await-token (:await-token transaction (.getAwaitToken node-conn))
 
         query-opts (QueryOpts. (or (some-> (or (:current-time stmt) (:current-time transaction))
                                             (time/->instant))
@@ -1298,10 +1294,9 @@
     (set-time-zone conn tz))
   (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET TIME ZONE"}))
 
-(defn cmd-set-await-token [{:keys [conn-state] :as conn} {:keys [await-token args]}]
-  (let [await-token (-> await-token (apply-args args))]
-    (swap! conn-state assoc :await-token await-token)
-    (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET AWAIT_TOKEN"})))
+(defn cmd-set-await-token [{:keys [conn-state] :as conn} {:keys [args], new-token :await-token}]
+  (.setAwaitToken ^NodeConnection (:node-conn @conn-state) (-> new-token (apply-args args)))
+  (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET AWAIT_TOKEN"}))
 
 (defn cmd-set-session-characteristics [{:keys [conn-state] :as conn} session-characteristics]
   (swap! conn-state update-in [:session :characteristics] (fnil into {}) session-characteristics)
@@ -1470,10 +1465,8 @@
 
   (with-auth-check conn
     (let [{:keys [tx-id error] :as tx} (xtp/attach-db node db-name db-config)]
-      (swap! conn-state (fn [cs]
-                          (-> cs
-                              (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {"xtdb" [tx-id]}))
-                              (assoc :latest-submitted-tx tx))))
+      (.recordTx ^NodeConnection (:node-conn @conn-state) "xtdb" tx-id)
+      (swap! conn-state assoc :latest-submitted-tx tx)
 
       (when error
         (throw error)))))
@@ -1489,10 +1482,8 @@
 
   (with-auth-check conn
     (let [{:keys [tx-id error] :as tx} (xtp/detach-db node db-name)]
-      (swap! conn-state (fn [cs]
-                          (-> cs
-                              (update :await-token basis/merge-tx-tokens (basis/->tx-basis-str {"xtdb" [tx-id]}))
-                              (assoc :latest-submitted-tx tx))))
+      (.recordTx ^NodeConnection (:node-conn @conn-state) "xtdb" tx-id)
+      (swap! conn-state assoc :latest-submitted-tx tx)
 
       (when error
         (throw error)))))

--- a/core/src/main/kotlin/xtdb/NodeConnection.kt
+++ b/core/src/main/kotlin/xtdb/NodeConnection.kt
@@ -1,0 +1,47 @@
+package xtdb
+
+import xtdb.api.Xtdb
+import xtdb.api.log.MessageId
+import xtdb.database.DatabaseName
+import xtdb.database.encodeTxBasisToken
+import xtdb.database.mergeTxBasisTokens
+import xtdb.indexer.DatabaseSnapshot
+import xtdb.query.PreparedQuery
+import xtdb.tx.TxOp
+import xtdb.tx.TxOpts
+
+/**
+ * A connection-scoped handle onto the node, shared by the protocol frontends (ADBC's [XtdbConnection],
+ * pgwire) so that read-your-writes is maintained in one place rather than re-derived at every callsite.
+ *
+ * Each write advances [awaitToken]; each read threads it through, so the planning snapshot can see this
+ * connection's own writes. Because writes and reads go through here, no callsite can forget to do either.
+ *
+ * [awaitToken] is exposed only for the pgwire `SET`/`SHOW AWAIT_TOKEN` SQL feature.
+ */
+class NodeConnection(private val node: Node, var dbName: DatabaseName) {
+
+    interface Node {
+        fun submitTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.SubmittedTx
+        fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx
+        fun openSqlQuery(sql: String, dbName: DatabaseName, awaitToken: String?): ResultCursor
+        fun prepareSql(sql: String, dbName: DatabaseName, awaitToken: String?): PreparedQuery
+        fun openSnapshot(dbName: DatabaseName, awaitToken: String?): DatabaseSnapshot
+    }
+
+    var awaitToken: String? = null
+
+    fun recordTx(dbName: DatabaseName, txId: MessageId) {
+        awaitToken = mergeTxBasisTokens(awaitToken, mapOf(dbName to listOf(txId)).encodeTxBasisToken())
+    }
+
+    fun submitTx(ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.SubmittedTx =
+        node.submitTx(dbName, ops, opts).also { recordTx(dbName, it.txId) }
+
+    fun executeTx(ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx =
+        node.executeTx(dbName, ops, opts).also { recordTx(dbName, it.txId) }
+
+    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName, awaitToken)
+    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName, awaitToken)
+    fun openSnapshot(): DatabaseSnapshot = node.openSnapshot(dbName, awaitToken)
+}

--- a/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
+++ b/core/src/main/kotlin/xtdb/adbc/XtdbConnection.kt
@@ -19,9 +19,8 @@ import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.complex.writer.VarCharWriter
 import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.Schema
+import xtdb.NodeConnection
 import xtdb.ResultCursor
-import xtdb.api.Xtdb
-import xtdb.api.log.MessageId
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorType
@@ -36,22 +35,13 @@ import xtdb.query.QueryOpts
 import xtdb.indexer.DatabaseSnapshot
 import xtdb.table.TableRef
 import xtdb.tx.TxOp
-import xtdb.tx.TxOpts
 import xtdb.util.useAll
 
-class XtdbConnection(private val node: Node) : AdbcConnection {
+class XtdbConnection(private val node: Node, private val connection: NodeConnection) : AdbcConnection {
 
-    private var dbName: DatabaseName = "xtdb"
+    private val dbName get() = connection.dbName
     private var autoCommit = true
     private val pendingOps = mutableListOf<TxOp>()
-
-    private var awaitToken: String? = null
-
-    private fun runTx(ops: List<TxOp>): Xtdb.ExecutedTx {
-        val tx = node.executeTx(dbName, ops)
-        awaitToken = node.mergeAwaitToken(awaitToken, dbName, tx.txId)
-        return tx
-    }
 
     interface XtdbStatement : AdbcStatement {
         fun bind(rel: RelationReader): Unit = unsupported("bind(RelationReader) not supported")
@@ -82,7 +72,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         override fun prepare() {
             val sql = this.sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
-            prepared = node.prepareSql(sql, dbName, awaitToken)
+            prepared = connection.prepareSql(sql)
         }
 
         override fun getParameterSchema(): Schema {
@@ -124,7 +114,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
             val queryArgs = openQueryArgs()
             val cursor = try {
-                prepared?.openQuery(queryArgs, QueryOpts()) ?: node.openSqlQuery(sql, dbName, awaitToken)
+                prepared?.openQuery(queryArgs, QueryOpts()) ?: connection.openSqlQuery(sql)
             } catch (t: Throwable) {
                 queryArgs?.close()
                 throw t
@@ -148,7 +138,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
     internal fun executeDml(op: TxOp) {
         if (autoCommit) {
-            listOf(op).useAll { ops -> runTx(ops) }
+            listOf(op).useAll { ops -> connection.executeTx(ops) }
         } else {
             pendingOps.add(op)
         }
@@ -162,7 +152,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         val ops = pendingOps.toList()
         pendingOps.clear()
         if (ops.isNotEmpty()) {
-            ops.useAll { runTx(it) }
+            ops.useAll { connection.executeTx(it) }
         }
     }
 
@@ -214,8 +204,8 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         }
     }
 
-    fun prepareSql(sql: String): PreparedQuery = node.prepareSql(sql, dbName, awaitToken)
-    fun openSqlQuery(sql: String): ResultCursor = node.openSqlQuery(sql, dbName, awaitToken)
+    fun prepareSql(sql: String): PreparedQuery = connection.prepareSql(sql)
+    fun openSqlQuery(sql: String): ResultCursor = connection.openSqlQuery(sql)
 
     private fun cursorToArrowReader(cursor: ResultCursor, schema: Schema): ArrowReader =
         object : ArrowReader(node.allocator) {
@@ -306,7 +296,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
             getTableSchema(TableRef(catalog ?: dbName, dbSchema ?: "public", tableName), snap)
         }
 
-    fun openSnapshot(): DatabaseSnapshot = node.openSnapshot(dbName, awaitToken)
+    fun openSnapshot(): DatabaseSnapshot = connection.openSnapshot()
 
     fun getTableSchema(dbSchema: String, tableName: String, snap: DatabaseSnapshot): Schema =
         getTableSchema(TableRef(dbName, dbSchema, tableName), snap)
@@ -416,7 +406,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
         if (depth == GetObjectsDepth.DB_SCHEMAS) {
             val sql = "SELECT DISTINCT table_schema FROM information_schema.tables $where ORDER BY table_schema"
             val result = linkedMapOf<String, List<TableInfo>>()
-            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
+            connection.openSqlQuery(sql).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         result[rel.get("table_schema").getObject(i).toString()] = emptyList()
@@ -440,7 +430,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
 
         if (needColumns) {
             val tableColumns = linkedMapOf<Pair<String, String>, MutableList<ColumnInfo>>()
-            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
+            connection.openSqlQuery(sql).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -457,7 +447,7 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
                     .add(TableInfo(key.second, cols))
             }
         } else {
-            node.openSqlQuery(sql, dbName, awaitToken).use { cursor ->
+            connection.openSqlQuery(sql).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     for (i in 0 until rel.rowCount) {
                         val schema = rel.get("table_schema").getObject(i).toString()
@@ -475,20 +465,14 @@ class XtdbConnection(private val node: Node) : AdbcConnection {
     override fun getCurrentCatalog(): String = dbName
 
     override fun setCurrentCatalog(catalog: String) {
-        dbName = catalog
+        connection.dbName = catalog
     }
     override fun getCurrentDbSchema(): String = "public"
 
     interface Node {
         val allocator: BufferAllocator
         val databaseNames: Collection<DatabaseName>
-        fun submitTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.SubmittedTx
-        fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts = TxOpts()): Xtdb.ExecutedTx
-        fun openSqlQuery(sql: String, dbName: DatabaseName, awaitToken: String?): ResultCursor
-        fun prepareSql(sql: String, dbName: DatabaseName, awaitToken: String?): PreparedQuery
-        fun mergeAwaitToken(awaitToken: String?, dbName: DatabaseName, txId: MessageId): String
         fun getColumnTypes(table: TableRef, snap: DatabaseSnapshot): Map<String, VectorType>?
-        fun openSnapshot(dbName: DatabaseName, awaitToken: String?): DatabaseSnapshot
     }
 
     override fun close() {

--- a/src/test/kotlin/xtdb/NodeConnectionTest.kt
+++ b/src/test/kotlin/xtdb/NodeConnectionTest.kt
@@ -1,0 +1,116 @@
+package xtdb
+
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import xtdb.api.Xtdb
+import xtdb.api.log.MessageId
+import xtdb.database.DatabaseName
+import xtdb.database.decodeTxBasisToken
+import xtdb.database.encodeTxBasisToken
+import xtdb.indexer.DatabaseSnapshot
+import xtdb.query.PreparedQuery
+import xtdb.tx.TxOp
+import xtdb.tx.TxOpts
+import java.time.Instant
+
+class NodeConnectionTest {
+
+    private class FakeNode : NodeConnection.Node {
+        var nextTxId: MessageId = 0
+        val submittedDbs = mutableListOf<DatabaseName>()
+        val queryTokens = mutableListOf<Pair<DatabaseName, String?>>()
+        val snapshotTokens = mutableListOf<Pair<DatabaseName, String?>>()
+
+        override fun submitTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts) =
+            Xtdb.SubmittedTx(nextTxId).also { submittedDbs += dbName }
+
+        override fun executeTx(dbName: DatabaseName, ops: List<TxOp>, opts: TxOpts) =
+            Xtdb.ExecutedTx(nextTxId, Instant.EPOCH, true, null).also { submittedDbs += dbName }
+
+        override fun openSqlQuery(sql: String, dbName: DatabaseName, awaitToken: String?): ResultCursor {
+            queryTokens += (dbName to awaitToken); return mockk()
+        }
+
+        override fun prepareSql(sql: String, dbName: DatabaseName, awaitToken: String?): PreparedQuery {
+            queryTokens += (dbName to awaitToken); return mockk()
+        }
+
+        override fun openSnapshot(dbName: DatabaseName, awaitToken: String?): DatabaseSnapshot {
+            snapshotTokens += (dbName to awaitToken); return mockk()
+        }
+    }
+
+    private fun tokenOf(awaitToken: String?) = awaitToken?.decodeTxBasisToken()
+
+    @Test
+    fun `a write is awaited by the next read on the same connection`() {
+        val node = FakeNode().apply { nextTxId = 7 }
+        val conn = NodeConnection(node, "mydb")
+
+        conn.submitTx(emptyList())
+        conn.openSqlQuery("SELECT 1")
+        conn.openSnapshot()
+
+        val expected = mapOf("mydb" to listOf(7L))
+        assertEquals(expected, tokenOf(node.queryTokens.single().second))
+        assertEquals(expected, tokenOf(node.snapshotTokens.single().second))
+    }
+
+    @Test
+    fun `executeTx records its tx like submitTx`() {
+        val node = FakeNode().apply { nextTxId = 11 }
+        val conn = NodeConnection(node, "mydb")
+
+        conn.executeTx(emptyList())
+
+        assertEquals(mapOf("mydb" to listOf(11L)), tokenOf(conn.awaitToken))
+    }
+
+    @Test
+    fun `successive writes accumulate monotonically`() {
+        val node = FakeNode()
+        val conn = NodeConnection(node, "mydb")
+
+        node.nextTxId = 4; conn.submitTx(emptyList())
+        node.nextTxId = 9; conn.submitTx(emptyList())
+
+        assertEquals(mapOf("mydb" to listOf(9L)), tokenOf(conn.awaitToken))
+    }
+
+    @Test
+    fun `retargeting dbName moves both writes and token onto the new db`() {
+        val node = FakeNode().apply { nextTxId = 3 }
+        val conn = NodeConnection(node, "xtdb")
+
+        conn.dbName = "other"
+        conn.submitTx(emptyList())
+        conn.openSqlQuery("SELECT 1")
+
+        assertEquals(listOf("other"), node.submittedDbs)
+        assertEquals("other", node.queryTokens.single().first)
+        assertEquals(mapOf("other" to listOf(3L)), tokenOf(conn.awaitToken))
+    }
+
+    @Test
+    fun `recordTx merges a foreign db without disturbing the connection db - the attach-detach case`() {
+        val node = FakeNode().apply { nextTxId = 2 }
+        val conn = NodeConnection(node, "secondary")
+
+        conn.submitTx(emptyList())
+        conn.recordTx("xtdb", 5)
+
+        assertEquals(mapOf("secondary" to listOf(2L), "xtdb" to listOf(5L)), tokenOf(conn.awaitToken))
+    }
+
+    @Test
+    fun `the await token can be replaced directly - for SET AWAIT_TOKEN`() {
+        val node = FakeNode().apply { nextTxId = 8 }
+        val conn = NodeConnection(node, "mydb")
+
+        conn.submitTx(emptyList())
+        conn.awaitToken = mapOf("mydb" to listOf(42L)).encodeTxBasisToken()
+
+        assertEquals(mapOf("mydb" to listOf(42L)), tokenOf(conn.awaitToken))
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the per-connection read-your-writes handling — previously re-derived at every callsite in ADBC's `XtdbConnection` and pgwire — into a shared `xtdb.NodeConnection`: a per-connection handle onto the node that bundles the transaction/query methods with await-token tracking.

Each write advances the connection's await-token; each read threads it through, so the planning snapshot sees the connection's own writes.
Because writes and reads go through the handle, no callsite can forget to do either — the read-your-writes invariant holds by construction.

## Design

`NodeConnection` exposes token-free `submitTx`/`executeTx`/`openSqlQuery`/`prepareSql`/`openSnapshot`, delegating to a small `NodeConnection.Node` executor SPI (implemented by a reify in `node/impl.clj`, where the basis token math and `db-cat` already live).

It's reached via a new internal `xtp/open-connection` factory on `xtdb.protocols/PNode` — alongside `attach-db`/`detach-db` — so **nothing lands on the public `Xtdb` interface**.

- **ADBC** — `connect()` composes `open-connection`: the reify drops to the three node-level bits (`allocator`/`databaseNames`/`getColumnTypes`) and wraps the `NodeConnection`. `XtdbConnection` delegates prepare/query/tx to the injected handle; `mergeAwaitToken` drops off its `Node` SPI.
- **pgwire** — opens a `NodeConnection` at startup and stores it in `:conn-state` (`:node-conn`). Writes route through `.submitTx`/`.executeTx` (auto-recording), reads through `.getAwaitToken`, `SET AWAIT_TOKEN` through `.setAwaitToken`. The `xtdb.basis` require drops.

## Naming

Called `NodeConnection` (a connection *to the node*) so it doesn't collide with pgwire's `Connection` record or ADBC's `XtdbConnection` — the frontends are adapters that wrap it, and `connect()` reads as `wrap(open-connection)`. No public-interface growth, no `AutoCloseable` it doesn't need.

## History

Supersedes the earlier `Connection`/`Session` extraction (#5648, #5694) and a minimal `AwaitToken` accumulator that this PR previously held: the accumulator was honest but too thin — it gave up the bundling that makes the read-your-writes invariant hold by construction. This restores that, while keeping the dedup off the public API surface (the substance of @jarohen's "move it down a layer" review on #5609).

## Test plan

All green, no reflection / boxed-math warnings:

- `xtdb.NodeConnectionTest` (new): 6/6 — read-your-writes, monotonic accumulation, cross-db merge, dbName retargeting, direct token replacement.
- `xtdb.api.AdbcTest`: 11/11.
- `xtdb.FlightSqlAdbcTest`: 45/45.
- `xtdb.pgwire-test`: 144/144 — including the wire-surface guards `test-show-await-token`, `in-tx-await-token`, `await-token+snapshot-token`.
- `xtdb.pgwire-protocol-test`: 11/11.

## Stack

Built on #5609 (`tim/5608-prepare-await-token`); base shows #5609's commits until it lands. Iterates toward umbrella #5132.